### PR TITLE
feat: 온보딩 API 구현 (#3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ logs/
 docs/
 .claude
 .codex
+CLAUDE.md

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -29,10 +29,10 @@ public enum ErrorCode {
 
     // Onboarding
     ONBOARDING_STEP_NOT_COMPLETED(HttpStatus.UNPROCESSABLE_ENTITY, "BUSINESS_RULE_VIOLATION", "이전 온보딩 단계를 완료해야 합니다."),
-    INVALID_CHARACTER_ID(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 캐릭터 ID입니다."),
-    INVALID_EMOTION_STATE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 감정 상태입니다."),
-    INVALID_CONCERN_TYPE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 고민 유형입니다."),
-    INVALID_PREFERRED_STYLE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 상담 스타일입니다."),
+    INVALID_CHARACTER_ID(HttpStatus.BAD_REQUEST, "INVALID_CHARACTER_ID", "유효하지 않은 캐릭터 ID입니다."),
+    INVALID_EMOTION_STATE(HttpStatus.BAD_REQUEST, "INVALID_EMOTION_STATE", "유효하지 않은 감정 상태입니다."),
+    INVALID_CONCERN_TYPE(HttpStatus.BAD_REQUEST, "INVALID_CONCERN_TYPE", "유효하지 않은 고민 유형입니다."),
+    INVALID_PREFERRED_STYLE(HttpStatus.BAD_REQUEST, "INVALID_PREFERRED_STYLE", "유효하지 않은 상담 스타일입니다."),
 
     // Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -27,6 +27,13 @@ public enum ErrorCode {
     USER_WITHDRAWN(HttpStatus.GONE, "USER_WITHDRAWN", "탈퇴한 계정입니다."),
     ONBOARDING_REQUIRED(HttpStatus.FORBIDDEN, "ONBOARDING_REQUIRED", "온보딩을 먼저 완료해야 합니다."),
 
+    // Onboarding
+    ONBOARDING_STEP_NOT_COMPLETED(HttpStatus.UNPROCESSABLE_ENTITY, "BUSINESS_RULE_VIOLATION", "이전 온보딩 단계를 완료해야 합니다."),
+    INVALID_CHARACTER_ID(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 캐릭터 ID입니다."),
+    INVALID_EMOTION_STATE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 감정 상태입니다."),
+    INVALID_CONCERN_TYPE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 고민 유형입니다."),
+    INVALID_PREFERRED_STYLE(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "유효하지 않은 상담 스타일입니다."),
+
     // Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
     SESSION_ALREADY_ENDED(HttpStatus.CONFLICT, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/health",
             "/v1/auth/**",
+            "/v1/onboarding/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"

--- a/src/main/java/com/mio/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/mio/onboarding/controller/OnboardingController.java
@@ -1,0 +1,53 @@
+package com.mio.onboarding.controller;
+
+import com.mio.common.response.ApiResponse;
+import com.mio.onboarding.dto.*;
+import com.mio.onboarding.service.OnboardingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/onboarding")
+@RequiredArgsConstructor
+public class OnboardingController {
+
+    private final OnboardingService onboardingService;
+
+    @PostMapping("/step/1")
+    public ResponseEntity<ApiResponse<OnboardingStepResponse>> submitStep1(
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody OnboardingStep1Request request) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.submitStep1(userId, request)));
+    }
+
+    @PostMapping("/step/2")
+    public ResponseEntity<ApiResponse<OnboardingStepResponse>> submitStep2(
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody OnboardingStep2Request request) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.submitStep2(userId, request)));
+    }
+
+    @PostMapping("/step/3")
+    public ResponseEntity<ApiResponse<OnboardingStep3Response>> submitStep3(
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody OnboardingStep3Request request) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.submitStep3(userId, request)));
+    }
+
+    @PostMapping("/character")
+    public ResponseEntity<ApiResponse<CharacterSelectResponse>> selectCharacter(
+            @RequestHeader("X-User-Id") UUID userId,
+            @Valid @RequestBody CharacterSelectRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.selectCharacter(userId, request)));
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<ApiResponse<OnboardingStatusResponse>> getStatus(
+            @RequestHeader("X-User-Id") UUID userId) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.getStatus(userId)));
+    }
+}

--- a/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
@@ -1,0 +1,10 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CharacterRecommendationDto(
+        @JsonProperty("character_id") String characterId,
+        String name,
+        @JsonProperty("match_score") double matchScore,
+        String reason
+) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
@@ -1,0 +1,8 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record CharacterSelectRequest(
+        @JsonProperty("character_id") @NotBlank String characterId
+) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
@@ -1,0 +1,8 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CharacterSelectResponse(
+        @JsonProperty("preferred_character_id") String preferredCharacterId,
+        @JsonProperty("signup_step") String signupStep
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
@@ -1,0 +1,11 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record OnboardingStatusResponse(
+        @JsonProperty("onboarding_step") int onboardingStep,
+        @JsonProperty("signup_step") String signupStep,
+        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
@@ -1,0 +1,11 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record OnboardingStep1Request(
+        @JsonProperty("emotion_state") @NotBlank String emotionState,
+        List<QuestionResponse> responses
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
@@ -1,0 +1,11 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record OnboardingStep2Request(
+        @JsonProperty("concern_types") @NotEmpty List<String> concernTypes,
+        List<QuestionResponse> responses
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
@@ -1,0 +1,11 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.List;
+
+public record OnboardingStep3Request(
+        @JsonProperty("preferred_style") @NotBlank String preferredStyle,
+        List<QuestionResponse> responses
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
@@ -1,0 +1,10 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record OnboardingStep3Response(
+        @JsonProperty("onboarding_step") int onboardingStep,
+        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
+) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
@@ -1,0 +1,7 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OnboardingStepResponse(
+        @JsonProperty("onboarding_step") int onboardingStep
+) {}

--- a/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
@@ -1,0 +1,8 @@
+package com.mio.onboarding.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record QuestionResponse(
+        @JsonProperty("question_id") String questionId,
+        String answer
+) {}

--- a/src/main/java/com/mio/onboarding/service/CharacterRecommender.java
+++ b/src/main/java/com/mio/onboarding/service/CharacterRecommender.java
@@ -1,0 +1,124 @@
+package com.mio.onboarding.service;
+
+import com.mio.onboarding.dto.CharacterRecommendationDto;
+import org.springframework.stereotype.Component;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class CharacterRecommender {
+
+    private static final List<CharacterProfile> PROFILES = List.of(
+        new CharacterProfile("mio", "미오",
+            Map.of("empathetic", 1.0, "balanced", 0.6, "analytical", 0.3, "solution", 0.3),
+            Map.of("anxious", 1.0, "sad", 1.0, "happy", 0.5, "calm", 0.6,
+                   "angry", 0.3, "ashamed", 0.6, "numb", 0.5, "tired", 0.6, "confused", 0.5),
+            Map.of("relationship", 1.0, "family", 1.0, "romance", 1.0,
+                   "career", 0.5, "workload", 0.5, "financial", 0.4,
+                   "lifestyle", 0.6, "health", 0.5, "other", 0.5),
+            List.of(
+                "불안하고 복잡한 감정 상태에서 공감형 접근이 효과적이에요.",
+                "관계와 감정 문제에 따뜻하게 함께해드려요.",
+                "감정을 있는 그대로 인정하며 차근차근 풀어가요."
+            )
+        ),
+        new CharacterProfile("bau", "바우",
+            Map.of("empathetic", 0.6, "balanced", 1.0, "analytical", 0.6, "solution", 0.7),
+            Map.of("anxious", 0.7, "sad", 0.7, "happy", 0.7, "calm", 0.7,
+                   "angry", 0.7, "ashamed", 0.7, "numb", 0.7, "tired", 0.7, "confused", 0.7),
+            Map.of("relationship", 0.7, "family", 0.7, "romance", 0.7,
+                   "career", 0.7, "workload", 0.7, "financial", 0.7,
+                   "lifestyle", 0.7, "health", 0.7, "other", 0.7),
+            List.of(
+                "어떤 상황에도 균형 잡힌 시각으로 함께해요.",
+                "다양한 고민을 폭넓게 다루는 든든한 파트너예요.",
+                "상황에 맞게 유연하게 접근 방식을 조율해드려요."
+            )
+        ),
+        new CharacterProfile("rumi", "루미",
+            Map.of("empathetic", 0.4, "balanced", 0.6, "analytical", 1.0, "solution", 0.7),
+            Map.of("anxious", 0.7, "sad", 0.5, "happy", 0.6, "calm", 0.8,
+                   "angry", 0.5, "ashamed", 0.4, "numb", 0.5, "tired", 0.5, "confused", 1.0),
+            Map.of("relationship", 0.5, "family", 0.5, "romance", 0.4,
+                   "career", 1.0, "workload", 0.8, "financial", 1.0,
+                   "lifestyle", 0.6, "health", 0.6, "other", 0.5),
+            List.of(
+                "인지 재구성으로 불안한 사고 패턴을 정리해드려요.",
+                "논리적으로 고민을 분석하고 명확한 방향을 제시해요.",
+                "커리어와 재정 문제를 체계적으로 접근해요."
+            )
+        ),
+        new CharacterProfile("momo", "모모",
+            Map.of("empathetic", 0.9, "balanced", 0.9, "analytical", 0.4, "solution", 0.5),
+            Map.of("anxious", 0.7, "sad", 0.8, "happy", 0.5, "calm", 0.5,
+                   "angry", 0.5, "ashamed", 1.0, "numb", 1.0, "tired", 1.0, "confused", 0.6),
+            Map.of("relationship", 0.7, "family", 0.7, "romance", 0.7,
+                   "career", 0.6, "workload", 0.7, "financial", 0.5,
+                   "lifestyle", 0.7, "health", 0.7, "other", 0.6),
+            List.of(
+                "자책과 감정 과부하에 수용전념치료(ACT) 방식으로 접근해요.",
+                "지치고 무기력한 감정을 따뜻하게 감싸드려요.",
+                "스스로를 너무 몰아붙이는 당신 곁에 있을게요."
+            )
+        ),
+        new CharacterProfile("chichi", "치치",
+            Map.of("empathetic", 0.4, "balanced", 0.5, "analytical", 0.7, "solution", 1.0),
+            Map.of("anxious", 0.6, "sad", 0.4, "happy", 0.7, "calm", 0.6,
+                   "angry", 1.0, "ashamed", 0.4, "numb", 0.4, "tired", 0.6, "confused", 0.5),
+            Map.of("relationship", 0.5, "family", 0.5, "romance", 0.4,
+                   "career", 1.0, "workload", 1.0, "financial", 0.7,
+                   "lifestyle", 0.6, "health", 0.6, "other", 0.5),
+            List.of(
+                "명확한 목표와 실행 계획으로 변화를 이끌어요.",
+                "업무 스트레스와 번아웃을 실용적으로 해결해드려요.",
+                "분노와 답답함을 건강한 행동 변화로 전환해요."
+            )
+        )
+    );
+
+    public List<CharacterRecommendationDto> recommend(
+            String emotionState, List<String> concernTypes, String preferredStyle) {
+        return PROFILES.stream()
+                .map(p -> score(p, emotionState, concernTypes, preferredStyle))
+                .sorted(Comparator.comparingDouble(Scored::score).reversed())
+                .limit(3)
+                .map(s -> new CharacterRecommendationDto(
+                        s.profile().characterId(),
+                        s.profile().name(),
+                        Math.round(s.score() * 100.0) / 100.0,
+                        selectReason(s.profile(), s.score())
+                ))
+                .toList();
+    }
+
+    private Scored score(CharacterProfile p, String emotion, List<String> concerns, String style) {
+        double styleScore = p.styleScores().getOrDefault(style, 0.3);
+        double emotionScore = p.emotionScores().getOrDefault(emotion, 0.5);
+        double concernScore = concerns.stream()
+                .mapToDouble(c -> p.concernScores().getOrDefault(c, 0.5))
+                .max()
+                .orElse(0.5);
+        double total = styleScore * 0.4 + emotionScore * 0.35 + concernScore * 0.25;
+        return new Scored(p, total);
+    }
+
+    private String selectReason(CharacterProfile profile, double score) {
+        List<String> reasons = profile.reasons();
+        if (score >= 0.85) return reasons.get(0);
+        if (score >= 0.70) return reasons.get(1);
+        return reasons.get(2);
+    }
+
+    private record CharacterProfile(
+            String characterId,
+            String name,
+            Map<String, Double> styleScores,
+            Map<String, Double> emotionScores,
+            Map<String, Double> concernScores,
+            List<String> reasons
+    ) {}
+
+    private record Scored(CharacterProfile profile, double score) {}
+}

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -1,0 +1,160 @@
+package com.mio.onboarding.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.onboarding.dto.*;
+import com.mio.user.domain.User;
+import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.user.repository.UserOnboardingAnswerRepository;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingService {
+
+    private static final Set<String> VALID_EMOTION_STATES = Set.of(
+            "happy", "calm", "anxious", "sad", "angry", "ashamed", "numb", "tired", "confused"
+    );
+    private static final Set<String> VALID_CONCERN_TYPES = Set.of(
+            "relationship", "career", "workload", "financial", "family", "romance",
+            "lifestyle", "health", "other"
+    );
+    private static final Set<String> VALID_PREFERRED_STYLES = Set.of(
+            "empathetic", "analytical", "solution", "balanced"
+    );
+    private static final Set<String> VALID_CHARACTER_IDS = Set.of(
+            "mio", "bau", "rumi", "momo", "chichi"
+    );
+
+    private final UserRepository userRepository;
+    private final UserOnboardingAnswerRepository onboardingAnswerRepository;
+    private final CharacterRecommender characterRecommender;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public OnboardingStepResponse submitStep1(UUID userId, OnboardingStep1Request request) {
+        if (!VALID_EMOTION_STATES.contains(request.emotionState())) {
+            throw new BusinessException(ErrorCode.INVALID_EMOTION_STATE);
+        }
+
+        User user = findUser(userId);
+        UserOnboardingAnswer answer = findOrCreateAnswer(user);
+        answer.updateStep1(request.emotionState(), toJson(request.responses()));
+        user.updateOnboardingStep(1);
+
+        onboardingAnswerRepository.save(answer);
+        return new OnboardingStepResponse(1);
+    }
+
+    @Transactional
+    public OnboardingStepResponse submitStep2(UUID userId, OnboardingStep2Request request) {
+        for (String type : request.concernTypes()) {
+            if (!VALID_CONCERN_TYPES.contains(type)) {
+                throw new BusinessException(ErrorCode.INVALID_CONCERN_TYPE);
+            }
+        }
+
+        User user = findUser(userId);
+        if (user.getOnboardingStep() < 1) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
+
+        UserOnboardingAnswer answer = findOrCreateAnswer(user);
+        answer.updateStep2(toJson(request.concernTypes()), toJson(request.responses()));
+        user.updateOnboardingStep(2);
+
+        onboardingAnswerRepository.save(answer);
+        return new OnboardingStepResponse(2);
+    }
+
+    @Transactional
+    public OnboardingStep3Response submitStep3(UUID userId, OnboardingStep3Request request) {
+        if (!VALID_PREFERRED_STYLES.contains(request.preferredStyle())) {
+            throw new BusinessException(ErrorCode.INVALID_PREFERRED_STYLE);
+        }
+
+        User user = findUser(userId);
+        if (user.getOnboardingStep() < 2) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
+
+        UserOnboardingAnswer answer = findOrCreateAnswer(user);
+        List<String> concernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
+        List<CharacterRecommendationDto> recommendations = characterRecommender.recommend(
+                answer.getEmotionState(), concernTypes, request.preferredStyle()
+        );
+
+        answer.updateStep3(request.preferredStyle(), toJson(recommendations), toJson(request.responses()));
+        user.updateOnboardingStep(3);
+
+        onboardingAnswerRepository.save(answer);
+        return new OnboardingStep3Response(3, recommendations);
+    }
+
+    @Transactional
+    public CharacterSelectResponse selectCharacter(UUID userId, CharacterSelectRequest request) {
+        if (!VALID_CHARACTER_IDS.contains(request.characterId())) {
+            throw new BusinessException(ErrorCode.INVALID_CHARACTER_ID);
+        }
+
+        User user = findUser(userId);
+        if (user.getOnboardingStep() < 3) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
+
+        user.completeOnboarding(request.characterId());
+        return new CharacterSelectResponse(user.getPreferredCharacterId(), user.getSignupStep());
+    }
+
+    @Transactional(readOnly = true)
+    public OnboardingStatusResponse getStatus(UUID userId) {
+        User user = findUser(userId);
+        List<CharacterRecommendationDto> recommendations = null;
+
+        if (user.getOnboardingStep() >= 3) {
+            recommendations = onboardingAnswerRepository.findByUser_Id(userId)
+                    .map(a -> fromJson(a.getCharacterRecommendations(), new TypeReference<List<CharacterRecommendationDto>>() {}))
+                    .orElse(null);
+        }
+
+        return new OnboardingStatusResponse(user.getOnboardingStep(), user.getSignupStep(), recommendations);
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private UserOnboardingAnswer findOrCreateAnswer(User user) {
+        return onboardingAnswerRepository.findByUser_Id(user.getId())
+                .orElseGet(() -> UserOnboardingAnswer.builder().user(user).build());
+    }
+
+    private String toJson(Object value) {
+        if (value == null) return "[]";
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private <T> T fromJson(String json, TypeReference<T> type) {
+        if (json == null || json.isBlank()) return null;
+        try {
+            return objectMapper.readValue(json, type);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -89,7 +89,8 @@ public class OnboardingService {
         }
 
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
-        List<String> concernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
+        List<String> rawConcernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
+        List<String> concernTypes = rawConcernTypes != null ? rawConcernTypes : List.of();
         List<CharacterRecommendationDto> recommendations = characterRecommender.recommend(
                 answer.getEmotionState(), concernTypes, request.preferredStyle()
         );

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -89,6 +89,15 @@ public class User {
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
 
+    public void updateOnboardingStep(int step) {
+        this.onboardingStep = step;
+    }
+
+    public void completeOnboarding(String characterId) {
+        this.preferredCharacterId = characterId;
+        this.signupStep = "ONBOARDING_COMPLETED";
+    }
+
     @PrePersist
     protected void onCreate() {
         createdAt = OffsetDateTime.now();

--- a/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
+++ b/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
@@ -48,4 +48,21 @@ public class UserOnboardingAnswer {
     /** step 3 완료 시점 */
     @Column(name = "submitted_at")
     private OffsetDateTime submittedAt;
+
+    public void updateStep1(String emotionState, String responsesJson) {
+        this.emotionState = emotionState;
+        this.responses = responsesJson;
+    }
+
+    public void updateStep2(String concernTypesJson, String responsesJson) {
+        this.concernTypes = concernTypesJson;
+        this.responses = responsesJson;
+    }
+
+    public void updateStep3(String preferredStyle, String characterRecommendationsJson, String responsesJson) {
+        this.preferredStyle = preferredStyle;
+        this.characterRecommendations = characterRecommendationsJson;
+        this.responses = responsesJson;
+        this.submittedAt = OffsetDateTime.now();
+    }
 }

--- a/src/main/java/com/mio/user/repository/UserOnboardingAnswerRepository.java
+++ b/src/main/java/com/mio/user/repository/UserOnboardingAnswerRepository.java
@@ -1,0 +1,12 @@
+package com.mio.user.repository;
+
+import com.mio.user.domain.UserOnboardingAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface UserOnboardingAnswerRepository extends JpaRepository<UserOnboardingAnswer, UUID> {
+
+    Optional<UserOnboardingAnswer> findByUser_Id(UUID userId);
+}

--- a/src/main/java/com/mio/user/repository/UserRepository.java
+++ b/src/main/java/com/mio/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.mio.user.repository;
+
+import com.mio.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserRepository extends JpaRepository<User, UUID> {
+}

--- a/src/test/java/com/mio/onboarding/controller/OnboardingControllerTest.java
+++ b/src/test/java/com/mio/onboarding/controller/OnboardingControllerTest.java
@@ -1,0 +1,152 @@
+package com.mio.onboarding.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.onboarding.dto.*;
+import com.mio.onboarding.service.OnboardingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = OnboardingController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(GlobalExceptionHandler.class)
+class OnboardingControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private OnboardingService onboardingService;
+
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("POST /v1/onboarding/step/1 - 성공 시 200 반환")
+    void submitStep1_success_returns200() throws Exception {
+        when(onboardingService.submitStep1(eq(TEST_USER_ID), any()))
+                .thenReturn(new OnboardingStepResponse(1));
+
+        mockMvc.perform(post("/v1/onboarding/step/1")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new OnboardingStep1Request("anxious", List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.onboarding_step").value(1));
+    }
+
+    @Test
+    @DisplayName("POST /v1/onboarding/step/1 - emotion_state 누락 시 400 반환")
+    void submitStep1_blankEmotionState_returns400() throws Exception {
+        mockMvc.perform(post("/v1/onboarding/step/1")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"emotion_state\": \"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /v1/onboarding/step/2 - 성공 시 200 반환")
+    void submitStep2_success_returns200() throws Exception {
+        when(onboardingService.submitStep2(eq(TEST_USER_ID), any()))
+                .thenReturn(new OnboardingStepResponse(2));
+
+        mockMvc.perform(post("/v1/onboarding/step/2")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new OnboardingStep2Request(List.of("career", "family"), List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.onboarding_step").value(2));
+    }
+
+    @Test
+    @DisplayName("POST /v1/onboarding/step/2 - 1단계 미완료 시 422 반환")
+    void submitStep2_step1NotCompleted_returns422() throws Exception {
+        when(onboardingService.submitStep2(eq(TEST_USER_ID), any()))
+                .thenThrow(new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+
+        mockMvc.perform(post("/v1/onboarding/step/2")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new OnboardingStep2Request(List.of("career"), List.of())
+                        )))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    @DisplayName("POST /v1/onboarding/step/3 - 성공 시 character_recommendations 반환")
+    void submitStep3_success_returnsRecommendations() throws Exception {
+        List<CharacterRecommendationDto> recs = List.of(
+                new CharacterRecommendationDto("mio", "미오", 0.92, "공감형 접근이 효과적이에요."),
+                new CharacterRecommendationDto("momo", "모모", 0.84, "수용전념치료 방식으로 접근해요."),
+                new CharacterRecommendationDto("rumi", "루미", 0.71, "인지 재구성으로 정리해드려요.")
+        );
+        when(onboardingService.submitStep3(eq(TEST_USER_ID), any()))
+                .thenReturn(new OnboardingStep3Response(3, recs));
+
+        mockMvc.perform(post("/v1/onboarding/step/3")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new OnboardingStep3Request("empathetic", List.of())
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.onboarding_step").value(3))
+                .andExpect(jsonPath("$.data.character_recommendations").isArray())
+                .andExpect(jsonPath("$.data.character_recommendations.length()").value(3));
+    }
+
+    @Test
+    @DisplayName("POST /v1/onboarding/character - 성공 시 200 반환")
+    void selectCharacter_success_returns200() throws Exception {
+        when(onboardingService.selectCharacter(eq(TEST_USER_ID), any()))
+                .thenReturn(new CharacterSelectResponse("mio", "ONBOARDING_COMPLETED"));
+
+        mockMvc.perform(post("/v1/onboarding/character")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new CharacterSelectRequest("mio")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.preferred_character_id").value("mio"))
+                .andExpect(jsonPath("$.data.signup_step").value("ONBOARDING_COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/onboarding/status - 성공 시 상태 반환")
+    void getStatus_success_returnsStatus() throws Exception {
+        when(onboardingService.getStatus(TEST_USER_ID))
+                .thenReturn(new OnboardingStatusResponse(2, "PROFILE_COMPLETED", null));
+
+        mockMvc.perform(get("/v1/onboarding/status")
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.onboarding_step").value(2))
+                .andExpect(jsonPath("$.data.signup_step").value("PROFILE_COMPLETED"));
+    }
+}

--- a/src/test/java/com/mio/onboarding/service/CharacterRecommenderTest.java
+++ b/src/test/java/com/mio/onboarding/service/CharacterRecommenderTest.java
@@ -1,0 +1,81 @@
+package com.mio.onboarding.service;
+
+import com.mio.onboarding.dto.CharacterRecommendationDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CharacterRecommenderTest {
+
+    private CharacterRecommender recommender;
+
+    @BeforeEach
+    void setUp() {
+        recommender = new CharacterRecommender();
+    }
+
+    @Test
+    @DisplayName("추천 결과는 항상 3개를 반환한다")
+    void recommend_alwaysReturnsThreeResults() {
+        List<CharacterRecommendationDto> result = recommender.recommend("anxious", List.of("relationship"), "empathetic");
+        assertThat(result).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("결과는 match_score 내림차순으로 정렬된다")
+    void recommend_sortedByScoreDescending() {
+        List<CharacterRecommendationDto> result = recommender.recommend("anxious", List.of("relationship"), "empathetic");
+        assertThat(result.get(0).matchScore()).isGreaterThanOrEqualTo(result.get(1).matchScore());
+        assertThat(result.get(1).matchScore()).isGreaterThanOrEqualTo(result.get(2).matchScore());
+    }
+
+    @Test
+    @DisplayName("공감형 스타일 + 불안 감정 + 관계 고민 → 미오(mio)가 1위")
+    void recommend_empathetic_anxious_relationship_mioFirst() {
+        List<CharacterRecommendationDto> result = recommender.recommend("anxious", List.of("relationship"), "empathetic");
+        assertThat(result.get(0).characterId()).isEqualTo("mio");
+    }
+
+    @Test
+    @DisplayName("분석형 스타일 + 혼란 감정 + 커리어 고민 → 루미(rumi)가 1위")
+    void recommend_analytical_confused_career_rumiFirst() {
+        List<CharacterRecommendationDto> result = recommender.recommend("confused", List.of("career"), "analytical");
+        assertThat(result.get(0).characterId()).isEqualTo("rumi");
+    }
+
+    @Test
+    @DisplayName("해결형 스타일 + 분노 감정 + 업무 고민 → 치치(chichi)가 1위")
+    void recommend_solution_angry_workload_chichiFirst() {
+        List<CharacterRecommendationDto> result = recommender.recommend("angry", List.of("workload"), "solution");
+        assertThat(result.get(0).characterId()).isEqualTo("chichi");
+    }
+
+    @Test
+    @DisplayName("match_score는 0 이상 1 이하여야 한다")
+    void recommend_scoreInRange() {
+        List<CharacterRecommendationDto> result = recommender.recommend("calm", List.of("lifestyle"), "balanced");
+        result.forEach(r -> {
+            assertThat(r.matchScore()).isBetween(0.0, 1.0);
+        });
+    }
+
+    @Test
+    @DisplayName("모든 결과에 reason이 존재한다")
+    void recommend_allResultsHaveReason() {
+        List<CharacterRecommendationDto> result = recommender.recommend("tired", List.of("health"), "empathetic");
+        result.forEach(r -> assertThat(r.reason()).isNotBlank());
+    }
+
+    @Test
+    @DisplayName("복수 고민 유형 선택 시 가장 높은 매칭 고민 유형이 점수에 반영된다")
+    void recommend_multipleConcernTypes_takesMaxScore() {
+        List<CharacterRecommendationDto> withCareer = recommender.recommend("confused", List.of("career"), "analytical");
+        List<CharacterRecommendationDto> withCareerAndRelationship = recommender.recommend("confused", List.of("career", "relationship"), "analytical");
+        assertThat(withCareerAndRelationship.get(0).matchScore())
+                .isGreaterThanOrEqualTo(withCareer.get(0).matchScore());
+    }
+}

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -1,0 +1,214 @@
+package com.mio.onboarding.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.onboarding.dto.*;
+import com.mio.user.domain.User;
+import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.user.repository.UserOnboardingAnswerRepository;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private UserOnboardingAnswerRepository onboardingAnswerRepository;
+
+    private OnboardingService onboardingService;
+    private UUID userId;
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        CharacterRecommender recommender = new CharacterRecommender();
+        ObjectMapper objectMapper = new ObjectMapper();
+        onboardingService = new OnboardingService(userRepository, onboardingAnswerRepository, recommender, objectMapper);
+        userId = UUID.randomUUID();
+        mockUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-social-id")
+                .privacyConsent(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("1단계 제출 성공 시 onboarding_step이 1을 반환한다")
+    void submitStep1_success_returnsStep1() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStepResponse response = onboardingService.submitStep1(
+                userId, new OnboardingStep1Request("anxious", List.of())
+        );
+
+        assertThat(response.onboardingStep()).isEqualTo(1);
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 emotion_state는 INVALID_EMOTION_STATE 예외를 발생시킨다")
+    void submitStep1_invalidEmotionState_throws() {
+        assertThatThrownBy(() -> onboardingService.submitStep1(
+                userId, new OnboardingStep1Request("invalid_emotion", List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_EMOTION_STATE));
+    }
+
+    @Test
+    @DisplayName("2단계는 1단계 미완료 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
+    void submitStep2_step1NotCompleted_throws() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+
+        assertThatThrownBy(() -> onboardingService.submitStep2(
+                userId, new OnboardingStep2Request(List.of("career"), List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("2단계 제출 성공 시 onboarding_step이 2를 반환한다")
+    void submitStep2_success_returnsStep2() {
+        mockUser.updateOnboardingStep(1);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStepResponse response = onboardingService.submitStep2(
+                userId, new OnboardingStep2Request(List.of("career", "family"), List.of())
+        );
+
+        assertThat(response.onboardingStep()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 concern_type은 INVALID_CONCERN_TYPE 예외를 발생시킨다")
+    void submitStep2_invalidConcernType_throws() {
+        assertThatThrownBy(() -> onboardingService.submitStep2(
+                userId, new OnboardingStep2Request(List.of("invalid_type"), List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_CONCERN_TYPE));
+    }
+
+    @Test
+    @DisplayName("3단계 제출 성공 시 character_recommendations 3개를 반환한다")
+    void submitStep3_success_returnsRecommendations() {
+        mockUser.updateOnboardingStep(2);
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(mockUser)
+                .emotionState("anxious")
+                .concernTypes("[\"relationship\"]")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStep3Response response = onboardingService.submitStep3(
+                userId, new OnboardingStep3Request("empathetic", List.of())
+        );
+
+        assertThat(response.onboardingStep()).isEqualTo(3);
+        assertThat(response.characterRecommendations()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("3단계는 2단계 미완료 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
+    void submitStep3_step2NotCompleted_throws() {
+        mockUser.updateOnboardingStep(1);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.submitStep3(
+                userId, new OnboardingStep3Request("empathetic", List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("캐릭터 선택 성공 시 preferred_character_id와 signup_step을 반환한다")
+    void selectCharacter_success_returnsResponse() {
+        mockUser.updateOnboardingStep(3);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        CharacterSelectResponse response = onboardingService.selectCharacter(
+                userId, new CharacterSelectRequest("mio")
+        );
+
+        assertThat(response.preferredCharacterId()).isEqualTo("mio");
+        assertThat(response.signupStep()).isEqualTo("ONBOARDING_COMPLETED");
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 character_id는 INVALID_CHARACTER_ID 예외를 발생시킨다")
+    void selectCharacter_invalidId_throws() {
+        assertThatThrownBy(() -> onboardingService.selectCharacter(
+                userId, new CharacterSelectRequest("invalid_char")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_CHARACTER_ID));
+    }
+
+    @Test
+    @DisplayName("캐릭터 선택은 3단계 미완료 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
+    void selectCharacter_step3NotCompleted_throws() {
+        mockUser.updateOnboardingStep(2);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.selectCharacter(
+                userId, new CharacterSelectRequest("mio")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("상태 조회 시 3단계 미완료면 character_recommendations는 null이다")
+    void getStatus_step2Completed_recommendationsNull() {
+        mockUser.updateOnboardingStep(2);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        OnboardingStatusResponse response = onboardingService.getStatus(userId);
+
+        assertThat(response.onboardingStep()).isEqualTo(2);
+        assertThat(response.characterRecommendations()).isNull();
+    }
+
+    @Test
+    @DisplayName("사용자를 찾을 수 없으면 USER_NOT_FOUND 예외를 발생시킨다")
+    void submitStep1_userNotFound_throws() {
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> onboardingService.submitStep1(
+                userId, new OnboardingStep1Request("anxious", List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -135,6 +135,48 @@ class OnboardingServiceTest {
     }
 
     @Test
+    @DisplayName("3단계 concernTypes가 null이어도 NPE 없이 추천 결과를 반환한다")
+    void submitStep3_concernTypesNull_doesNotThrow() {
+        mockUser.updateOnboardingStep(2);
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(mockUser)
+                .emotionState("anxious")
+                .concernTypes(null)
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStep3Response response = onboardingService.submitStep3(
+                userId, new OnboardingStep3Request("empathetic", List.of())
+        );
+
+        assertThat(response.onboardingStep()).isEqualTo(3);
+        assertThat(response.characterRecommendations()).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("3단계 concernTypes가 빈 문자열이어도 NPE 없이 추천 결과를 반환한다")
+    void submitStep3_concernTypesBlank_doesNotThrow() {
+        mockUser.updateOnboardingStep(2);
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(mockUser)
+                .emotionState("anxious")
+                .concernTypes("")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStep3Response response = onboardingService.submitStep3(
+                userId, new OnboardingStep3Request("empathetic", List.of())
+        );
+
+        assertThat(response.onboardingStep()).isEqualTo(3);
+        assertThat(response.characterRecommendations()).hasSize(3);
+    }
+
+    @Test
     @DisplayName("3단계는 2단계 미완료 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
     void submitStep3_step2NotCompleted_throws() {
         mockUser.updateOnboardingStep(1);


### PR DESCRIPTION
## Summary

- 온보딩 3단계(감정 상태 → 고민 유형 → 선호 스타일) + 캐릭터 선택 + 상태 조회 API 구현
- X-User-Id 헤더로 userId 수신 (개발환경 임시 방식 — JWT 완성 후 `@AuthenticationPrincipal`로 교체 예정)
- 규칙 기반 CharacterRecommender: style×0.4 + emotion×0.35 + concern×0.25 점수로 Top 3 추천
- 온보딩 답변은 UserOnboardingAnswer에 upsert 방식으로 저장 (JSONB 컬럼)

## API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | /v1/onboarding/step/1 | 감정 상태 제출 |
| POST | /v1/onboarding/step/2 | 고민 유형 제출 |
| POST | /v1/onboarding/step/3 | 선호 스타일 제출 + 캐릭터 추천 반환 |
| POST | /v1/onboarding/character | 캐릭터 선택 완료 |
| GET  | /v1/onboarding/status | 온보딩 진행 상태 조회 |

## Test Plan

- [x] CharacterRecommenderTest (8개): 추천 결과 3개, 점수 내림차순, 각 시나리오별 1위 캐릭터, 점수 범위 [0,1], reason 존재
- [x] OnboardingServiceTest (12개): 단계별 성공/실패, 유효하지 않은 입력 검증, 단계 순서 강제, 사용자 미존재 처리
- [x] OnboardingControllerTest (7개): 각 엔드포인트 200/400/422 반환 확인

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched a 3-step onboarding flow (emotion, concerns, style), including character selection and an onboarding status endpoint
  * Added a character recommendation engine that suggests up to three matches based on onboarding answers

* **Bug Fixes / Validation**
  * Improved input validation with clearer error responses for invalid onboarding inputs

* **Tests**
  * Added comprehensive unit and controller tests covering onboarding flows and recommendation logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->