### PR TITLE
feat: 채팅 세션 도메인 뼈대 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ FCM_CREDENTIALS_JSON=
 
 # AES-256 암호화 키 (32 bytes base64)
 APP_ENCRYPTION_KEY=your-32-byte-base64-encoded-encryption-key
+APP_ENCRYPTION_DEK_ID=app-key-v1
 
 # HIRA API
 HIRA_API_KEY=

--- a/src/main/java/com/mio/common/crypto/AesGcmMessageEncryptor.java
+++ b/src/main/java/com/mio/common/crypto/AesGcmMessageEncryptor.java
@@ -1,0 +1,83 @@
+package com.mio.common.crypto;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+@Component
+@Profile("!local & !test")
+public class AesGcmMessageEncryptor implements MessageEncryptor {
+
+    private static final String ALGORITHM = "AES";
+    private static final String TRANSFORMATION = "AES/GCM/NoPadding";
+    private static final int IV_LENGTH_BYTES = 12;
+    private static final int TAG_LENGTH_BITS = 128;
+
+    private final SecretKey secretKey;
+    private final String dekId;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public AesGcmMessageEncryptor(
+            @Value("${APP_ENCRYPTION_KEY}") String encodedKey,
+            @Value("${APP_ENCRYPTION_DEK_ID:app-key-v1}") String dekId) {
+        this.secretKey = new SecretKeySpec(decodeKey(encodedKey), ALGORITHM);
+        this.dekId = dekId;
+    }
+
+    @Override
+    public byte[] encrypt(byte[] plaintext) {
+        byte[] iv = new byte[IV_LENGTH_BYTES];
+        secureRandom.nextBytes(iv);
+        byte[] ciphertext = doCipher(Cipher.ENCRYPT_MODE, iv, plaintext);
+        byte[] combined = new byte[iv.length + ciphertext.length];
+        System.arraycopy(iv, 0, combined, 0, iv.length);
+        System.arraycopy(ciphertext, 0, combined, iv.length, ciphertext.length);
+        return combined;
+    }
+
+    @Override
+    public byte[] decrypt(byte[] ciphertext) {
+        if (ciphertext.length <= IV_LENGTH_BYTES) {
+            throw new IllegalStateException("Ciphertext is too short.");
+        }
+        byte[] iv = Arrays.copyOfRange(ciphertext, 0, IV_LENGTH_BYTES);
+        byte[] payload = Arrays.copyOfRange(ciphertext, IV_LENGTH_BYTES, ciphertext.length);
+        return doCipher(Cipher.DECRYPT_MODE, iv, payload);
+    }
+
+    @Override
+    public String dekId() {
+        return dekId;
+    }
+
+    private byte[] doCipher(int mode, byte[] iv, byte[] input) {
+        try {
+            Cipher cipher = Cipher.getInstance(TRANSFORMATION);
+            cipher.init(mode, secretKey, new GCMParameterSpec(TAG_LENGTH_BITS, iv));
+            return cipher.doFinal(input);
+        } catch (GeneralSecurityException e) {
+            throw new IllegalStateException("Failed to process message encryption.", e);
+        }
+    }
+
+    private static byte[] decodeKey(String encodedKey) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(encodedKey);
+            if (decoded.length != 32) {
+                throw new IllegalStateException("APP_ENCRYPTION_KEY must decode to 32 bytes.");
+            }
+            return decoded;
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("APP_ENCRYPTION_KEY must be a valid base64 string.", e);
+        }
+    }
+}

--- a/src/main/java/com/mio/common/crypto/MessageEncryptor.java
+++ b/src/main/java/com/mio/common/crypto/MessageEncryptor.java
@@ -1,0 +1,10 @@
+package com.mio.common.crypto;
+
+public interface MessageEncryptor {
+
+    byte[] encrypt(byte[] plaintext);
+
+    byte[] decrypt(byte[] ciphertext);
+
+    String dekId();
+}

--- a/src/main/java/com/mio/common/crypto/StubMessageEncryptor.java
+++ b/src/main/java/com/mio/common/crypto/StubMessageEncryptor.java
@@ -1,0 +1,27 @@
+package com.mio.common.crypto;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+/** 로컬 개발용 pass-through 암호화기. 다음 스프린트에 AES-256 DEK 구현으로 교체 */
+@Component
+@Profile({"local", "test"})
+public class StubMessageEncryptor implements MessageEncryptor {
+
+    private static final String STUB_DEK_ID = "stub-dek-v1";
+
+    @Override
+    public byte[] encrypt(byte[] plaintext) {
+        return plaintext;
+    }
+
+    @Override
+    public byte[] decrypt(byte[] ciphertext) {
+        return ciphertext;
+    }
+
+    @Override
+    public String dekId() {
+        return STUB_DEK_ID;
+    }
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -36,6 +36,7 @@ public enum ErrorCode {
 
     // Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
+    SESSION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "SESSION_ALREADY_ACTIVE", "이미 진행 중인 활성 세션이 있습니다."),
     SESSION_ALREADY_ENDED(HttpStatus.GONE, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode {
 
     // Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
-    SESSION_ALREADY_ENDED(HttpStatus.CONFLICT, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
+    SESSION_ALREADY_ENDED(HttpStatus.GONE, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
+    LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다.");

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -18,7 +18,6 @@ public class SecurityConfig {
             "/actuator/health",
             "/v1/auth/**",
             "/v1/onboarding/**",
-            "/v1/sessions/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -18,6 +18,7 @@ public class SecurityConfig {
             "/actuator/health",
             "/v1/auth/**",
             "/v1/onboarding/**",
+            "/v1/sessions/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -37,7 +38,7 @@ public class SessionController {
     public SseEmitter sendMessage(
             @RequestHeader("X-User-Id") UUID userId,
             @PathVariable UUID sessionId,
-            @RequestBody SendMessageRequest request) {
+            @Valid @RequestBody SendMessageRequest request) {
         SseEmitter emitter = new SseEmitter(60_000L);
         Thread.ofVirtual().start(() -> sessionService.streamMessage(userId, sessionId, request, emitter));
         return emitter;

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -23,13 +23,13 @@ public class SessionController {
     @GetMapping("/active")
     public ResponseEntity<ApiResponse<ActiveSessionResponse>> getActiveSession(
             @RequestHeader("X-User-Id") UUID userId) {
-        return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId)));
+        return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId).orElse(null)));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<SessionResponse>> createSession(
             @RequestHeader("X-User-Id") UUID userId,
-            @RequestBody CreateSessionRequest request) {
+            @Valid @RequestBody CreateSessionRequest request) {
         SessionResponse response = sessionService.createSession(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
     }
@@ -40,6 +40,8 @@ public class SessionController {
             @PathVariable UUID sessionId,
             @Valid @RequestBody SendMessageRequest request) {
         SseEmitter emitter = new SseEmitter(60_000L);
+        emitter.onTimeout(emitter::complete);
+        emitter.onError(error -> emitter.complete());
         Thread.ofVirtual().start(() -> sessionService.streamMessage(userId, sessionId, request, emitter));
         return emitter;
     }

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -11,7 +11,10 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.security.Principal;
 import java.util.UUID;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
 
 @RestController
 @RequestMapping("/v1/sessions")
@@ -22,23 +25,26 @@ public class SessionController {
 
     @GetMapping("/active")
     public ResponseEntity<ApiResponse<ActiveSessionResponse>> getActiveSession(
-            @RequestHeader("X-User-Id") UUID userId) {
+            Principal principal) {
+        UUID userId = resolveUserId(principal);
         return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId).orElse(null)));
     }
 
     @PostMapping
     public ResponseEntity<ApiResponse<SessionResponse>> createSession(
-            @RequestHeader("X-User-Id") UUID userId,
+            Principal principal,
             @Valid @RequestBody CreateSessionRequest request) {
+        UUID userId = resolveUserId(principal);
         SessionResponse response = sessionService.createSession(userId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
     }
 
     @PostMapping(value = "/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter sendMessage(
-            @RequestHeader("X-User-Id") UUID userId,
+            Principal principal,
             @PathVariable UUID sessionId,
             @Valid @RequestBody SendMessageRequest request) {
+        UUID userId = resolveUserId(principal);
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(error -> emitter.complete());
@@ -48,9 +54,21 @@ public class SessionController {
 
     @PostMapping("/{sessionId}/end")
     public ResponseEntity<ApiResponse<EndSessionResponse>> endSession(
-            @RequestHeader("X-User-Id") UUID userId,
+            Principal principal,
             @PathVariable UUID sessionId) {
+        UUID userId = resolveUserId(principal);
         EndSessionResponse response = sessionService.endSession(userId, sessionId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    private UUID resolveUserId(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        try {
+            return UUID.fromString(principal.getName());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "유효한 사용자 식별자가 필요합니다.");
+        }
     }
 }

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -1,0 +1,53 @@
+package com.mio.session.controller;
+
+import com.mio.common.response.ApiResponse;
+import com.mio.session.dto.*;
+import com.mio.session.service.SessionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/sessions")
+@RequiredArgsConstructor
+public class SessionController {
+
+    private final SessionService sessionService;
+
+    @GetMapping("/active")
+    public ResponseEntity<ApiResponse<ActiveSessionResponse>> getActiveSession(
+            @RequestHeader("X-User-Id") UUID userId) {
+        return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId)));
+    }
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<SessionResponse>> createSession(
+            @RequestHeader("X-User-Id") UUID userId,
+            @RequestBody CreateSessionRequest request) {
+        SessionResponse response = sessionService.createSession(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(response));
+    }
+
+    @PostMapping(value = "/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter sendMessage(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID sessionId,
+            @RequestBody SendMessageRequest request) {
+        SseEmitter emitter = new SseEmitter(60_000L);
+        Thread.ofVirtual().start(() -> sessionService.streamMessage(userId, sessionId, request, emitter));
+        return emitter;
+    }
+
+    @PostMapping("/{sessionId}/end")
+    public ResponseEntity<ApiResponse<EndSessionResponse>> endSession(
+            @RequestHeader("X-User-Id") UUID userId,
+            @PathVariable UUID sessionId) {
+        EndSessionResponse response = sessionService.endSession(userId, sessionId);
+        return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/com/mio/session/domain/Message.java
+++ b/src/main/java/com/mio/session/domain/Message.java
@@ -30,7 +30,7 @@ public class Message {
 
     /** user / assistant */
     @Column(name = "role", nullable = false)
-    private String role;
+    private MessageRole role;
 
     @Getter(AccessLevel.NONE)
     @Column(name = "content_ciphertext", nullable = false)

--- a/src/main/java/com/mio/session/domain/MessageRole.java
+++ b/src/main/java/com/mio/session/domain/MessageRole.java
@@ -1,0 +1,25 @@
+package com.mio.session.domain;
+
+import java.util.Arrays;
+
+public enum MessageRole {
+    USER("user"),
+    ASSISTANT("assistant");
+
+    private final String value;
+
+    MessageRole(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static MessageRole fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(role -> role.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown message role: " + value));
+    }
+}

--- a/src/main/java/com/mio/session/domain/MessageRoleConverter.java
+++ b/src/main/java/com/mio/session/domain/MessageRoleConverter.java
@@ -1,0 +1,18 @@
+package com.mio.session.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MessageRoleConverter implements AttributeConverter<MessageRole, String> {
+
+    @Override
+    public String convertToDatabaseColumn(MessageRole attribute) {
+        return attribute == null ? null : attribute.value();
+    }
+
+    @Override
+    public MessageRole convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : MessageRole.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -73,7 +73,7 @@ public class Session {
     }
 
     public void updateAvgEmotionScore(int newScore) {
-        if (this.avgEmotionScore == null) {
+        if (this.avgEmotionScore == null || this.messageCount == 0) {
             this.avgEmotionScore = newScore;
         } else {
             this.avgEmotionScore = (this.avgEmotionScore * (this.messageCount - 1) + newScore) / this.messageCount;

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -50,8 +50,38 @@ public class Session {
     @Builder.Default
     private String embeddingStatus = "pending";
 
+    @Column(name = "last_message_at")
+    private OffsetDateTime lastMessageAt;
+
     @PrePersist
     protected void onCreate() {
         startedAt = OffsetDateTime.now();
+    }
+
+    public void end() {
+        if ("ended".equals(this.status)) {
+            throw new com.mio.common.error.BusinessException(
+                    com.mio.common.error.ErrorCode.SESSION_ALREADY_ENDED);
+        }
+        this.status = "ended";
+        this.endedAt = OffsetDateTime.now();
+    }
+
+    public void incrementMessageCount() {
+        this.messageCount += 1;
+        this.lastMessageAt = OffsetDateTime.now();
+    }
+
+    public void updateAvgEmotionScore(int newScore) {
+        if (this.avgEmotionScore == null) {
+            this.avgEmotionScore = newScore;
+        } else {
+            this.avgEmotionScore = (this.avgEmotionScore * (this.messageCount - 1) + newScore) / this.messageCount;
+        }
+    }
+
+    public long durationSeconds() {
+        if (startedAt == null || endedAt == null) return 0;
+        return java.time.temporal.ChronoUnit.SECONDS.between(startedAt, endedAt);
     }
 }

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -5,6 +5,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
@@ -29,7 +31,7 @@ public class Session {
     /** active / ended  (5차 회의: idle 제거) */
     @Column(name = "status", nullable = false)
     @Builder.Default
-    private String status = "active";
+    private SessionStatus status = SessionStatus.ACTIVE;
 
     @Column(name = "started_at", nullable = false)
     private OffsetDateTime startedAt;
@@ -59,12 +61,20 @@ public class Session {
     }
 
     public void end() {
-        if ("ended".equals(this.status)) {
+        if (isEnded()) {
             throw new com.mio.common.error.BusinessException(
                     com.mio.common.error.ErrorCode.SESSION_ALREADY_ENDED);
         }
-        this.status = "ended";
+        this.status = SessionStatus.ENDED;
         this.endedAt = OffsetDateTime.now();
+    }
+
+    public boolean isEnded() {
+        return this.status == SessionStatus.ENDED;
+    }
+
+    public boolean belongsTo(UUID userId) {
+        return Objects.equals(this.user.getId(), userId);
     }
 
     public void incrementMessageCount() {
@@ -82,6 +92,6 @@ public class Session {
 
     public long durationSeconds() {
         if (startedAt == null || endedAt == null) return 0;
-        return java.time.temporal.ChronoUnit.SECONDS.between(startedAt, endedAt);
+        return ChronoUnit.SECONDS.between(startedAt, endedAt);
     }
 }

--- a/src/main/java/com/mio/session/domain/SessionStatus.java
+++ b/src/main/java/com/mio/session/domain/SessionStatus.java
@@ -1,0 +1,25 @@
+package com.mio.session.domain;
+
+import java.util.Arrays;
+
+public enum SessionStatus {
+    ACTIVE("active"),
+    ENDED("ended");
+
+    private final String value;
+
+    SessionStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static SessionStatus fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(status -> status.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown session status: " + value));
+    }
+}

--- a/src/main/java/com/mio/session/domain/SessionStatusConverter.java
+++ b/src/main/java/com/mio/session/domain/SessionStatusConverter.java
@@ -1,0 +1,18 @@
+package com.mio.session.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class SessionStatusConverter implements AttributeConverter<SessionStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SessionStatus attribute) {
+        return attribute == null ? null : attribute.value();
+    }
+
+    @Override
+    public SessionStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : SessionStatus.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -18,7 +18,7 @@ public record ActiveSessionResponse(
         return new ActiveSessionResponse(
                 session.getId(),
                 session.getCharacterId(),
-                session.getStatus(),
+                session.getStatus().value(),
                 session.getStartedAt(),
                 session.getLastMessageAt(),
                 session.getMessageCount()

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -1,0 +1,27 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Session;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record ActiveSessionResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("character_id") String characterId,
+        String status,
+        @JsonProperty("started_at") OffsetDateTime startedAt,
+        @JsonProperty("last_message_at") OffsetDateTime lastMessageAt,
+        @JsonProperty("message_count") int messageCount
+) {
+    public static ActiveSessionResponse from(Session session) {
+        return new ActiveSessionResponse(
+                session.getId(),
+                session.getCharacterId(),
+                session.getStatus(),
+                session.getStartedAt(),
+                session.getLastMessageAt(),
+                session.getMessageCount()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/CreateSessionRequest.java
+++ b/src/main/java/com/mio/session/dto/CreateSessionRequest.java
@@ -1,0 +1,8 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreateSessionRequest(
+        @JsonProperty("character_id") String characterId
+) {
+}

--- a/src/main/java/com/mio/session/dto/CreateSessionRequest.java
+++ b/src/main/java/com/mio/session/dto/CreateSessionRequest.java
@@ -1,8 +1,10 @@
 package com.mio.session.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
 
 public record CreateSessionRequest(
+        @Size(max = 50, message = "character_id는 50자를 초과할 수 없습니다.")
         @JsonProperty("character_id") String characterId
 ) {
 }

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -20,7 +20,7 @@ public record EndSessionResponse(
         }
         return new EndSessionResponse(
                 session.getId(),
-                session.getStatus(),
+                session.getStatus().value(),
                 session.getEndedAt(),
                 session.getMessageCount(),
                 session.durationSeconds(),

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -15,6 +15,9 @@ public record EndSessionResponse(
         @JsonProperty("summary_status") String summaryStatus
 ) {
     public static EndSessionResponse from(Session session) {
+        if (session.getEndedAt() == null) {
+            throw new IllegalStateException("종료되지 않은 세션으로 EndSessionResponse를 생성할 수 없습니다.");
+        }
         return new EndSessionResponse(
                 session.getId(),
                 session.getStatus(),

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -1,0 +1,27 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Session;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record EndSessionResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        String status,
+        @JsonProperty("ended_at") OffsetDateTime endedAt,
+        @JsonProperty("message_count") int messageCount,
+        @JsonProperty("duration_seconds") long durationSeconds,
+        @JsonProperty("summary_status") String summaryStatus
+) {
+    public static EndSessionResponse from(Session session) {
+        return new EndSessionResponse(
+                session.getId(),
+                session.getStatus(),
+                session.getEndedAt(),
+                session.getMessageCount(),
+                session.durationSeconds(),
+                "pending"
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/SendMessageRequest.java
+++ b/src/main/java/com/mio/session/dto/SendMessageRequest.java
@@ -1,0 +1,4 @@
+package com.mio.session.dto;
+
+public record SendMessageRequest(String content) {
+}

--- a/src/main/java/com/mio/session/dto/SendMessageRequest.java
+++ b/src/main/java/com/mio/session/dto/SendMessageRequest.java
@@ -1,4 +1,11 @@
 package com.mio.session.dto;
 
-public record SendMessageRequest(String content) {
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SendMessageRequest(
+        @NotBlank(message = "메시지 내용은 비워둘 수 없습니다.")
+        @Size(max = 4000, message = "메시지는 4000자를 초과할 수 없습니다.")
+        String content
+) {
 }

--- a/src/main/java/com/mio/session/dto/SessionResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionResponse.java
@@ -16,7 +16,7 @@ public record SessionResponse(
         return new SessionResponse(
                 session.getId(),
                 session.getCharacterId(),
-                session.getStatus(),
+                session.getStatus().value(),
                 session.getStartedAt()
         );
     }

--- a/src/main/java/com/mio/session/dto/SessionResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionResponse.java
@@ -1,0 +1,23 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Session;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record SessionResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("character_id") String characterId,
+        String status,
+        @JsonProperty("started_at") OffsetDateTime startedAt
+) {
+    public static SessionResponse from(Session session) {
+        return new SessionResponse(
+                session.getId(),
+                session.getCharacterId(),
+                session.getStatus(),
+                session.getStartedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -1,0 +1,49 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+public sealed interface SseEventDto
+        permits SseEventDto.SessionMetaEvent,
+                SseEventDto.DeltaEvent,
+                SseEventDto.CrisisEvent,
+                SseEventDto.DoneEvent {
+
+    String eventName();
+
+    record SessionMetaEvent(
+            @JsonProperty("message_id") String messageId,
+            @JsonProperty("received_at") OffsetDateTime receivedAt
+    ) implements SseEventDto {
+        @Override public String eventName() { return "session_meta"; }
+    }
+
+    record DeltaEvent(
+            String chunk,
+            @JsonProperty("msg_id") String msgId
+    ) implements SseEventDto {
+        @Override public String eventName() { return "delta"; }
+    }
+
+    record CrisisEvent(
+            int severity,
+            @JsonProperty("fixed_response") String fixedResponse,
+            Resources resources
+    ) implements SseEventDto {
+        @Override public String eventName() { return "crisis"; }
+
+        public record Resources(List<Hotline> hotlines) {}
+        public record Hotline(String name, String number, String hours) {}
+    }
+
+    record DoneEvent(
+            @JsonProperty("msg_id") String msgId,
+            @JsonProperty("emotion_score") Integer emotionScore,
+            @JsonProperty("is_crisis_flagged") boolean isCrisisFlagged,
+            @JsonProperty("finished_reason") String finishedReason
+    ) implements SseEventDto {
+        @Override public String eventName() { return "done"; }
+    }
+}

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -14,7 +14,7 @@ public sealed interface SseEventDto
     String eventName();
 
     record SessionMetaEvent(
-            @JsonProperty("message_id") String messageId,
+            @JsonProperty("msg_id") String msgId,
             @JsonProperty("received_at") OffsetDateTime receivedAt
     ) implements SseEventDto {
         @Override public String eventName() { return "session_meta"; }

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -1,0 +1,9 @@
+package com.mio.session.repository;
+
+import com.mio.session.domain.Message;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MessageRepository extends JpaRepository<Message, UUID> {
+}

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -1,6 +1,7 @@
 package com.mio.session.repository;
 
 import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -8,5 +9,7 @@ import java.util.UUID;
 
 public interface SessionRepository extends JpaRepository<Session, UUID> {
 
-    Optional<Session> findByUser_IdAndStatus(UUID userId, String status);
+    Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);
+
+    boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);
 }

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -2,8 +2,12 @@ package com.mio.session.repository;
 
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -12,4 +16,17 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
     Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);
 
     boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Session s
+            set s.messageCount = s.messageCount + :increment,
+                s.lastMessageAt = :lastMessageAt
+            where s.id = :sessionId
+            """)
+    int incrementMessageCountAndSetLastMessageAt(
+            @Param("sessionId") UUID sessionId,
+            @Param("increment") int increment,
+            @Param("lastMessageAt") OffsetDateTime lastMessageAt
+    );
 }

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -1,0 +1,12 @@
+package com.mio.session.repository;
+
+import com.mio.session.domain.Session;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SessionRepository extends JpaRepository<Session, UUID> {
+
+    Optional<Session> findByUser_IdAndStatus(UUID userId, String status);
+}

--- a/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
+++ b/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @Service
@@ -42,6 +43,7 @@ public class SessionMessagePersistenceService {
 
         saveMessage(session, user, MessageRole.USER, userContent);
         saveMessage(session, user, MessageRole.ASSISTANT, assistantContent);
+        sessionRepository.incrementMessageCountAndSetLastMessageAt(session.getId(), 2, OffsetDateTime.now());
     }
 
     private void saveMessage(Session session, User user, MessageRole role, String content) {
@@ -55,7 +57,5 @@ public class SessionMessagePersistenceService {
                 .isCrisisFlagged(false)
                 .build();
         messageRepository.save(message);
-        session.incrementMessageCount();
-        sessionRepository.save(session);
     }
 }

--- a/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
+++ b/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
@@ -1,0 +1,61 @@
+package com.mio.session.service;
+
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageRole;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SessionMessagePersistenceService {
+
+    private final SessionRepository sessionRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final MessageEncryptor messageEncryptor;
+
+    @Transactional
+    public void saveConversation(UUID sessionId, UUID userId, String userContent, String assistantContent) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!session.belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        if (session.isEnded()) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
+        }
+
+        saveMessage(session, user, MessageRole.USER, userContent);
+        saveMessage(session, user, MessageRole.ASSISTANT, assistantContent);
+    }
+
+    private void saveMessage(Session session, User user, MessageRole role, String content) {
+        byte[] ciphertext = messageEncryptor.encrypt(content.getBytes(StandardCharsets.UTF_8));
+        Message message = Message.builder()
+                .session(session)
+                .user(user)
+                .role(role)
+                .contentCiphertext(ciphertext)
+                .contentDekId(messageEncryptor.dekId())
+                .isCrisisFlagged(false)
+                .build();
+        messageRepository.save(message);
+        session.incrementMessageCount();
+        sessionRepository.save(session);
+    }
+}

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -1,0 +1,157 @@
+package com.mio.session.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.*;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class SessionService {
+
+    private final SessionRepository sessionRepository;
+    private final MessageRepository messageRepository;
+    private final UserRepository userRepository;
+    private final MessageEncryptor messageEncryptor;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    public SessionResponse createSession(UUID userId, CreateSessionRequest request) {
+        User user = findUser(userId);
+
+        if (!"ONBOARDING_COMPLETED".equals(user.getSignupStep())
+                && !"COMPLETED".equals(user.getSignupStep())) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
+
+        String characterId = (request.characterId() != null && !request.characterId().isBlank())
+                ? request.characterId()
+                : user.getPreferredCharacterId();
+
+        Session session = Session.builder()
+                .user(user)
+                .characterId(characterId)
+                .build();
+
+        return SessionResponse.from(sessionRepository.save(session));
+    }
+
+    @Transactional(readOnly = true)
+    public ActiveSessionResponse getActiveSession(UUID userId) {
+        return sessionRepository.findByUser_IdAndStatus(userId, "active")
+                .map(ActiveSessionResponse::from)
+                .orElse(null);
+    }
+
+    @Transactional
+    public EndSessionResponse endSession(UUID userId, UUID sessionId) {
+        Session session = findSession(sessionId);
+        if ("ended".equals(session.getStatus())) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
+        }
+        if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        session.end();
+        return EndSessionResponse.from(sessionRepository.save(session));
+    }
+
+    public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request, SseEmitter emitter) {
+        try {
+            Session session = findSessionTransactional(sessionId);
+            validateSessionOwner(session, userId);
+
+            String inboundMsgId = "msg_in_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            String outboundMsgId = "msg_out_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+            // session_meta 이벤트
+            sendEvent(emitter, new SseEventDto.SessionMetaEvent(inboundMsgId, OffsetDateTime.now()));
+
+            // 사용자 메시지 저장
+            saveMessage(session, findUser(userId), "user", request.content());
+
+            // stub: delta 이벤트 1개
+            sendEvent(emitter, new SseEventDto.DeltaEvent("안녕하세요! 오늘 어떤 이야기를 나눠볼까요?", outboundMsgId));
+
+            // stub: 어시스턴트 메시지 저장
+            saveMessage(session, findUser(userId), "assistant", "안녕하세요! 오늘 어떤 이야기를 나눠볼까요?");
+
+            // done 이벤트
+            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+
+            emitter.complete();
+        } catch (Exception e) {
+            emitter.completeWithError(e);
+        }
+    }
+
+    private void saveMessage(Session session, User user, String role, String content) {
+        byte[] ciphertext = messageEncryptor.encrypt(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        Message message = Message.builder()
+                .session(session)
+                .user(user)
+                .role(role)
+                .contentCiphertext(ciphertext)
+                .contentDekId(messageEncryptor.dekId())
+                .isCrisisFlagged(false)
+                .build();
+        messageRepository.save(message);
+
+        // 세션 카운터 갱신은 별도 트랜잭션에서 처리 (SSE는 비동기 컨텍스트)
+    }
+
+    private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {
+        String json = toJson(event);
+        emitter.send(SseEmitter.event()
+                .name(event.eventName())
+                .data(json));
+    }
+
+    private String toJson(Object value) {
+        try {
+            return objectMapper.writeValueAsString(value);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private Session findSession(UUID sessionId) {
+        return sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    private Session findSessionTransactional(UUID sessionId) {
+        return sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    private void validateSessionOwner(Session session, UUID userId) {
+        if ("ended".equals(session.getStatus())) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
+        }
+        if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+    }
+}

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -62,11 +62,11 @@ public class SessionService {
     @Transactional
     public EndSessionResponse endSession(UUID userId, UUID sessionId) {
         Session session = findSession(sessionId);
-        if ("ended".equals(session.getStatus())) {
-            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
-        }
         if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        if ("ended".equals(session.getStatus())) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
         session.end();
         return EndSessionResponse.from(sessionRepository.save(session));
@@ -74,7 +74,7 @@ public class SessionService {
 
     public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request, SseEmitter emitter) {
         try {
-            Session session = findSessionTransactional(sessionId);
+            Session session = findSession(sessionId);
             validateSessionOwner(session, userId);
 
             String inboundMsgId = "msg_in_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
@@ -112,8 +112,8 @@ public class SessionService {
                 .isCrisisFlagged(false)
                 .build();
         messageRepository.save(message);
-
-        // 세션 카운터 갱신은 별도 트랜잭션에서 처리 (SSE는 비동기 컨텍스트)
+        session.incrementMessageCount();
+        sessionRepository.save(session);
     }
 
     private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {
@@ -141,17 +141,12 @@ public class SessionService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
     }
 
-    private Session findSessionTransactional(UUID sessionId) {
-        return sessionRepository.findById(sessionId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-    }
-
     private void validateSessionOwner(Session session, UUID userId) {
-        if ("ended".equals(session.getStatus())) {
-            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
-        }
         if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        if ("ended".equals(session.getStatus())) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
     }
 }

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -13,6 +13,7 @@ import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -56,7 +57,10 @@ public class SessionService {
         try {
             return SessionResponse.from(sessionRepository.save(session));
         } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);
+            if (isActiveSessionUniqueViolation(e)) {
+                throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);
+            }
+            throw e;
         }
     }
 
@@ -139,5 +143,12 @@ public class SessionService {
         if (session.isEnded()) {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
+    }
+
+    private boolean isActiveSessionUniqueViolation(DataIntegrityViolationException e) {
+        Throwable mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e);
+        return mostSpecificCause != null
+                && mostSpecificCause.getMessage() != null
+                && mostSpecificCause.getMessage().contains("uq_sessions_one_active_per_user");
     }
 }

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -2,23 +2,24 @@ package com.mio.session.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mio.common.crypto.MessageEncryptor;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
-import com.mio.session.domain.Message;
 import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionStatus;
 import com.mio.session.dto.*;
-import com.mio.session.repository.MessageRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
 import java.time.OffsetDateTime;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -26,9 +27,8 @@ import java.util.UUID;
 public class SessionService {
 
     private final SessionRepository sessionRepository;
-    private final MessageRepository messageRepository;
     private final UserRepository userRepository;
-    private final MessageEncryptor messageEncryptor;
+    private final SessionMessagePersistenceService sessionMessagePersistenceService;
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -44,28 +44,35 @@ public class SessionService {
                 ? request.characterId()
                 : user.getPreferredCharacterId();
 
+        if (sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);
+        }
+
         Session session = Session.builder()
                 .user(user)
                 .characterId(characterId)
                 .build();
 
-        return SessionResponse.from(sessionRepository.save(session));
+        try {
+            return SessionResponse.from(sessionRepository.save(session));
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);
+        }
     }
 
     @Transactional(readOnly = true)
-    public ActiveSessionResponse getActiveSession(UUID userId) {
-        return sessionRepository.findByUser_IdAndStatus(userId, "active")
-                .map(ActiveSessionResponse::from)
-                .orElse(null);
+    public Optional<ActiveSessionResponse> getActiveSession(UUID userId) {
+        return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)
+                .map(ActiveSessionResponse::from);
     }
 
     @Transactional
     public EndSessionResponse endSession(UUID userId, UUID sessionId) {
         Session session = findSession(sessionId);
-        if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
+        if (!session.belongsTo(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        if ("ended".equals(session.getStatus())) {
+        if (session.isEnded()) {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
         session.end();
@@ -76,21 +83,20 @@ public class SessionService {
         try {
             Session session = findSession(sessionId);
             validateSessionOwner(session, userId);
+            User user = findUser(userId);
 
             String inboundMsgId = "msg_in_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
             String outboundMsgId = "msg_out_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+            String assistantReply = "안녕하세요! 오늘 어떤 이야기를 나눠볼까요?";
 
             // session_meta 이벤트
             sendEvent(emitter, new SseEventDto.SessionMetaEvent(inboundMsgId, OffsetDateTime.now()));
 
-            // 사용자 메시지 저장
-            saveMessage(session, findUser(userId), "user", request.content());
+            // 사용자/어시스턴트 메시지를 한 트랜잭션으로 저장
+            sessionMessagePersistenceService.saveConversation(session.getId(), user.getId(), request.content(), assistantReply);
 
             // stub: delta 이벤트 1개
-            sendEvent(emitter, new SseEventDto.DeltaEvent("안녕하세요! 오늘 어떤 이야기를 나눠볼까요?", outboundMsgId));
-
-            // stub: 어시스턴트 메시지 저장
-            saveMessage(session, findUser(userId), "assistant", "안녕하세요! 오늘 어떤 이야기를 나눠볼까요?");
+            sendEvent(emitter, new SseEventDto.DeltaEvent(assistantReply, outboundMsgId));
 
             // done 이벤트
             sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
@@ -99,21 +105,6 @@ public class SessionService {
         } catch (Exception e) {
             emitter.completeWithError(e);
         }
-    }
-
-    private void saveMessage(Session session, User user, String role, String content) {
-        byte[] ciphertext = messageEncryptor.encrypt(content.getBytes(java.nio.charset.StandardCharsets.UTF_8));
-        Message message = Message.builder()
-                .session(session)
-                .user(user)
-                .role(role)
-                .contentCiphertext(ciphertext)
-                .contentDekId(messageEncryptor.dekId())
-                .isCrisisFlagged(false)
-                .build();
-        messageRepository.save(message);
-        session.incrementMessageCount();
-        sessionRepository.save(session);
     }
 
     private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {
@@ -142,10 +133,10 @@ public class SessionService {
     }
 
     private void validateSessionOwner(Session session, UUID userId) {
-        if (!java.util.Objects.equals(session.getUser().getId(), userId)) {
+        if (!Objects.equals(session.getUser().getId(), userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        if ("ended".equals(session.getStatus())) {
+        if (session.isEnded()) {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
     }

--- a/src/main/resources/db/migration/V10__alter_sessions_add_last_message_at.sql
+++ b/src/main/resources/db/migration/V10__alter_sessions_add_last_message_at.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;

--- a/src/main/resources/db/migration/V11__enforce_single_active_session.sql
+++ b/src/main/resources/db/migration/V11__enforce_single_active_session.sql
@@ -1,0 +1,16 @@
+WITH ranked_active_sessions AS (
+    SELECT id,
+           ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY started_at DESC, id DESC) AS row_num
+    FROM sessions
+    WHERE status = 'active'
+)
+UPDATE sessions s
+SET status = 'ended',
+    ended_at = COALESCE(s.ended_at, now())
+FROM ranked_active_sessions r
+WHERE s.id = r.id
+  AND r.row_num > 1;
+
+CREATE UNIQUE INDEX uq_sessions_one_active_per_user
+    ON sessions (user_id)
+    WHERE status = 'active';

--- a/src/test/java/com/mio/common/crypto/AesGcmMessageEncryptorTest.java
+++ b/src/test/java/com/mio/common/crypto/AesGcmMessageEncryptorTest.java
@@ -1,0 +1,41 @@
+package com.mio.common.crypto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AesGcmMessageEncryptorTest {
+
+    @Test
+    @DisplayName("AES-GCM 암호화기는 평문을 복호화 가능해야 한다")
+    void encryptDecrypt_roundTrip() {
+        byte[] key = new byte[32];
+        for (int i = 0; i < key.length; i++) {
+            key[i] = (byte) (i + 1);
+        }
+        String encodedKey = Base64.getEncoder().encodeToString(key);
+        AesGcmMessageEncryptor encryptor = new AesGcmMessageEncryptor(encodedKey, "test-dek");
+
+        byte[] ciphertext = encryptor.encrypt("hello mio".getBytes(StandardCharsets.UTF_8));
+        byte[] plaintext = encryptor.decrypt(ciphertext);
+
+        assertThat(ciphertext).isNotEqualTo("hello mio".getBytes(StandardCharsets.UTF_8));
+        assertThat(new String(plaintext, StandardCharsets.UTF_8)).isEqualTo("hello mio");
+        assertThat(encryptor.dekId()).isEqualTo("test-dek");
+    }
+
+    @Test
+    @DisplayName("APP_ENCRYPTION_KEY가 32바이트가 아니면 예외가 발생한다")
+    void invalidKeyLength_throws() {
+        String encodedKey = Base64.getEncoder().encodeToString(new byte[16]);
+
+        assertThatThrownBy(() -> new AesGcmMessageEncryptor(encodedKey, "test-dek"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("32 bytes");
+    }
+}

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -1,0 +1,125 @@
+package com.mio.session.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.session.dto.*;
+import com.mio.session.service.SessionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = SessionController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(GlobalExceptionHandler.class)
+class SessionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private SessionService sessionService;
+
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
+    private static final UUID TEST_SESSION_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("GET /v1/sessions/active - 활성 세션 없으면 data: null 반환")
+    void getActiveSession_noSession_returnsNullData() throws Exception {
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(null);
+
+        mockMvc.perform(get("/v1/sessions/active")
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/active - 활성 세션 있으면 세션 정보 반환")
+    void getActiveSession_hasSession_returnsSession() throws Exception {
+        ActiveSessionResponse response = new ActiveSessionResponse(
+                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 0
+        );
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/sessions/active")
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
+                .andExpect(jsonPath("$.data.character_id").value("mio"))
+                .andExpect(jsonPath("$.data.status").value("active"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions - 세션 생성 성공 시 201 반환")
+    void createSession_success_returns201() throws Exception {
+        SessionResponse response = new SessionResponse(TEST_SESSION_ID, "mio", "active", OffsetDateTime.now());
+        when(sessionService.createSession(eq(TEST_USER_ID), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/sessions")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"character_id\":\"mio\"}"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
+                .andExpect(jsonPath("$.data.status").value("active"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions - 온보딩 미완료 시 403 반환")
+    void createSession_onboardingRequired_returns403() throws Exception {
+        when(sessionService.createSession(eq(TEST_USER_ID), any()))
+                .thenThrow(new BusinessException(ErrorCode.ONBOARDING_REQUIRED));
+
+        mockMvc.perform(post("/v1/sessions")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"character_id\":\"mio\"}"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ONBOARDING_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions/{id}/end - 세션 종료 성공 시 200 반환")
+    void endSession_success_returns200() throws Exception {
+        EndSessionResponse response = new EndSessionResponse(
+                TEST_SESSION_ID, "ended", OffsetDateTime.now(), 5, 300L, "pending"
+        );
+        when(sessionService.endSession(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
+
+        mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("ended"))
+                .andExpect(jsonPath("$.data.summary_status").value("pending"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions/{id}/end - 이미 종료된 세션은 410 반환")
+    void endSession_alreadyEnded_returns410() throws Exception {
+        when(sessionService.endSession(eq(TEST_USER_ID), eq(TEST_SESSION_ID)))
+                .thenThrow(new BusinessException(ErrorCode.SESSION_ALREADY_ENDED));
+
+        mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.error.code").value("SESSION_ALREADY_ENDED"));
+    }
+}

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -47,7 +47,7 @@ class SessionControllerTest {
         when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/v1/sessions/active")
-                        .header("X-User-Id", TEST_USER_ID.toString()))
+                        .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
@@ -61,7 +61,7 @@ class SessionControllerTest {
         when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.of(response));
 
         mockMvc.perform(get("/v1/sessions/active")
-                        .header("X-User-Id", TEST_USER_ID.toString()))
+                        .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
                 .andExpect(jsonPath("$.data.character_id").value("mio"))
@@ -75,7 +75,7 @@ class SessionControllerTest {
         when(sessionService.createSession(eq(TEST_USER_ID), any())).thenReturn(response);
 
         mockMvc.perform(post("/v1/sessions")
-                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .principal(() -> TEST_USER_ID.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"character_id\":\"mio\"}"))
                 .andExpect(status().isCreated())
@@ -89,7 +89,7 @@ class SessionControllerTest {
         String invalidCharacterId = "x".repeat(51);
 
         mockMvc.perform(post("/v1/sessions")
-                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .principal(() -> TEST_USER_ID.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"character_id\":\"" + invalidCharacterId + "\"}"))
                 .andExpect(status().isBadRequest())
@@ -103,11 +103,21 @@ class SessionControllerTest {
                 .thenThrow(new BusinessException(ErrorCode.ONBOARDING_REQUIRED));
 
         mockMvc.perform(post("/v1/sessions")
-                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .principal(() -> TEST_USER_ID.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"character_id\":\"mio\"}"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.error.code").value("ONBOARDING_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions - 인증 principal이 없으면 401 반환")
+    void createSession_missingPrincipal_returns401() throws Exception {
+        mockMvc.perform(post("/v1/sessions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"character_id\":\"mio\"}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
     }
 
     @Test
@@ -119,7 +129,7 @@ class SessionControllerTest {
         when(sessionService.endSession(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 
         mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
-                        .header("X-User-Id", TEST_USER_ID.toString()))
+                        .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.status").value("ended"))
                 .andExpect(jsonPath("$.data.summary_status").value("pending"));
@@ -132,7 +142,7 @@ class SessionControllerTest {
                 .thenThrow(new BusinessException(ErrorCode.SESSION_ALREADY_ENDED));
 
         mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
-                        .header("X-User-Id", TEST_USER_ID.toString()))
+                        .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isGone())
                 .andExpect(jsonPath("$.error.code").value("SESSION_ALREADY_ENDED"));
     }

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -43,7 +44,7 @@ class SessionControllerTest {
     @Test
     @DisplayName("GET /v1/sessions/active - 활성 세션 없으면 data: null 반환")
     void getActiveSession_noSession_returnsNullData() throws Exception {
-        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(null);
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.empty());
 
         mockMvc.perform(get("/v1/sessions/active")
                         .header("X-User-Id", TEST_USER_ID.toString()))
@@ -57,7 +58,7 @@ class SessionControllerTest {
         ActiveSessionResponse response = new ActiveSessionResponse(
                 TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 0
         );
-        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.of(response));
 
         mockMvc.perform(get("/v1/sessions/active")
                         .header("X-User-Id", TEST_USER_ID.toString()))
@@ -80,6 +81,19 @@ class SessionControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
                 .andExpect(jsonPath("$.data.status").value("active"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/sessions - 잘못된 입력이면 400 반환")
+    void createSession_invalidRequest_returns400() throws Exception {
+        String invalidCharacterId = "x".repeat(51);
+
+        mockMvc.perform(post("/v1/sessions")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"character_id\":\"" + invalidCharacterId + "\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 
     @Test

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -1,12 +1,14 @@
 package com.mio.session.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mio.common.crypto.MessageEncryptor;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
-import com.mio.session.dto.*;
-import com.mio.session.repository.MessageRepository;
+import com.mio.session.domain.SessionStatus;
+import com.mio.session.dto.ActiveSessionResponse;
+import com.mio.session.dto.CreateSessionRequest;
+import com.mio.session.dto.SendMessageRequest;
+import com.mio.session.dto.SessionResponse;
 import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -17,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -24,15 +27,18 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SessionServiceTest {
 
     @Mock private SessionRepository sessionRepository;
-    @Mock private MessageRepository messageRepository;
     @Mock private UserRepository userRepository;
-    @Mock private MessageEncryptor messageEncryptor;
+    @Mock private SessionMessagePersistenceService sessionMessagePersistenceService;
 
     private SessionService sessionService;
     private UUID userId;
@@ -41,7 +47,7 @@ class SessionServiceTest {
     @BeforeEach
     void setUp() {
         sessionService = new SessionService(
-                sessionRepository, messageRepository, userRepository, messageEncryptor, new ObjectMapper()
+                sessionRepository, userRepository, sessionMessagePersistenceService, new ObjectMapper().findAndRegisterModules()
         );
         userId = UUID.randomUUID();
         mockUser = User.builder()
@@ -57,6 +63,7 @@ class SessionServiceTest {
     @DisplayName("세션 생성 성공 시 SessionResponse를 반환한다")
     void createSession_success_returnsSessionResponse() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
         Session session = Session.builder()
                 .user(mockUser)
                 .characterId("mio")
@@ -73,6 +80,7 @@ class SessionServiceTest {
     @DisplayName("character_id 생략 시 preferred_character_id를 사용한다")
     void createSession_noCharacterId_usesPreferred() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
         Session session = Session.builder()
                 .user(mockUser)
                 .characterId("mio")
@@ -101,13 +109,25 @@ class SessionServiceTest {
     }
 
     @Test
-    @DisplayName("활성 세션이 없으면 getActiveSession은 null을 반환한다")
+    @DisplayName("이미 활성 세션이 있으면 SESSION_ALREADY_ACTIVE 예외가 발생한다")
+    void createSession_activeSessionExists_throws() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(true);
+
+        assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_ALREADY_ACTIVE));
+    }
+
+    @Test
+    @DisplayName("활성 세션이 없으면 getActiveSession은 Optional.empty를 반환한다")
     void getActiveSession_noSession_returnsNull() {
-        when(sessionRepository.findByUser_IdAndStatus(userId, "active")).thenReturn(Optional.empty());
+        when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(Optional.empty());
 
-        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+        Optional<ActiveSessionResponse> response = sessionService.getActiveSession(userId);
 
-        assertThat(response).isNull();
+        assertThat(response).isEmpty();
     }
 
     @Test
@@ -117,13 +137,13 @@ class SessionServiceTest {
                 .user(mockUser)
                 .characterId("mio")
                 .build();
-        when(sessionRepository.findByUser_IdAndStatus(userId, "active")).thenReturn(Optional.of(session));
+        when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(Optional.of(session));
 
-        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+        Optional<ActiveSessionResponse> response = sessionService.getActiveSession(userId);
 
-        assertThat(response).isNotNull();
-        assertThat(response.characterId()).isEqualTo("mio");
-        assertThat(response.status()).isEqualTo("active");
+        assertThat(response).isPresent();
+        assertThat(response.orElseThrow().characterId()).isEqualTo("mio");
+        assertThat(response.orElseThrow().status()).isEqualTo("active");
     }
 
     @Test
@@ -153,5 +173,30 @@ class SessionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("streamMessage는 사용자/어시스턴트 메시지를 한 번에 저장한다")
+    void streamMessage_success_persistsConversationAtomically() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder()
+                .user(mockUser)
+                .characterId("mio")
+                .build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        SseEmitter emitter = mock(SseEmitter.class);
+        doNothing().when(emitter).send(any(SseEmitter.SseEventBuilder.class));
+
+        sessionService.streamMessage(userId, sessionId, new SendMessageRequest("안녕"), emitter);
+
+        verify(sessionMessagePersistenceService).saveConversation(
+                eq(sessionId),
+                eq(userId),
+                eq("안녕"),
+                eq("안녕하세요! 오늘 어떤 이야기를 나눠볼까요?")
+        );
+        verify(emitter).complete();
     }
 }

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -1,0 +1,155 @@
+package com.mio.session.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.*;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SessionServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MessageEncryptor messageEncryptor;
+
+    private SessionService sessionService;
+    private UUID userId;
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        sessionService = new SessionService(
+                sessionRepository, messageRepository, userRepository, messageEncryptor, new ObjectMapper()
+        );
+        userId = UUID.randomUUID();
+        mockUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-id")
+                .privacyConsent(true)
+                .build();
+        mockUser.completeOnboarding("mio");
+    }
+
+    @Test
+    @DisplayName("세션 생성 성공 시 SessionResponse를 반환한다")
+    void createSession_success_returnsSessionResponse() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        Session session = Session.builder()
+                .user(mockUser)
+                .characterId("mio")
+                .build();
+        when(sessionRepository.save(any())).thenReturn(session);
+
+        SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest("mio"));
+
+        assertThat(response.characterId()).isEqualTo("mio");
+        assertThat(response.status()).isEqualTo("active");
+    }
+
+    @Test
+    @DisplayName("character_id 생략 시 preferred_character_id를 사용한다")
+    void createSession_noCharacterId_usesPreferred() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        Session session = Session.builder()
+                .user(mockUser)
+                .characterId("mio")
+                .build();
+        when(sessionRepository.save(any())).thenReturn(session);
+
+        SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest(null));
+
+        assertThat(response.characterId()).isEqualTo("mio");
+    }
+
+    @Test
+    @DisplayName("온보딩 미완료 사용자는 ONBOARDING_REQUIRED 예외가 발생한다")
+    void createSession_onboardingIncomplete_throws() {
+        User incompleteUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-id")
+                .privacyConsent(true)
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(incompleteUser));
+
+        assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("활성 세션이 없으면 getActiveSession은 null을 반환한다")
+    void getActiveSession_noSession_returnsNull() {
+        when(sessionRepository.findByUser_IdAndStatus(userId, "active")).thenReturn(Optional.empty());
+
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+
+        assertThat(response).isNull();
+    }
+
+    @Test
+    @DisplayName("활성 세션이 있으면 getActiveSession은 세션 정보를 반환한다")
+    void getActiveSession_hasSession_returnsSession() {
+        Session session = Session.builder()
+                .user(mockUser)
+                .characterId("mio")
+                .build();
+        when(sessionRepository.findByUser_IdAndStatus(userId, "active")).thenReturn(Optional.of(session));
+
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+
+        assertThat(response).isNotNull();
+        assertThat(response.characterId()).isEqualTo("mio");
+        assertThat(response.status()).isEqualTo("active");
+    }
+
+    @Test
+    @DisplayName("이미 종료된 세션을 종료하면 SESSION_ALREADY_ENDED 예외가 발생한다")
+    void endSession_alreadyEnded_throws() {
+        UUID sessionId = UUID.randomUUID();
+        Session endedSession = Session.builder()
+                .user(mockUser)
+                .characterId("mio")
+                .build();
+        endedSession.end();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(endedSession));
+
+        assertThatThrownBy(() -> sessionService.endSession(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_ALREADY_ENDED));
+    }
+
+    @Test
+    @DisplayName("세션이 존재하지 않으면 SESSION_NOT_FOUND 예외가 발생한다")
+    void endSession_notFound_throws() {
+        UUID sessionId = UUID.randomUUID();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> sessionService.endSession(userId, sessionId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -118,6 +119,32 @@ class SessionServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.SESSION_ALREADY_ACTIVE));
+    }
+
+    @Test
+    @DisplayName("활성 세션 unique 제약 위반이면 SESSION_ALREADY_ACTIVE 예외로 변환한다")
+    void createSession_uniqueViolation_throwsBusinessException() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
+        when(sessionRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException("save failed", new RuntimeException("uq_sessions_one_active_per_user")));
+
+        assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_ALREADY_ACTIVE));
+    }
+
+    @Test
+    @DisplayName("다른 DB 무결성 예외는 그대로 전파한다")
+    void createSession_otherIntegrityViolation_propagates() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
+        when(sessionRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException("save failed", new RuntimeException("other_constraint")));
+
+        assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     @Test

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -49,6 +50,7 @@ class SessionServiceTest {
                 .privacyConsent(true)
                 .build();
         mockUser.completeOnboarding("mio");
+        ReflectionTestUtils.setField(mockUser, "id", userId);
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Session 엔티티 비즈니스 메서드 추가 (`end`, `incrementMessageCount`, `durationSeconds`)
- SSE 스트리밍 엔드포인트 `POST /v1/sessions/{id}/messages` (stub 응답, 가상 스레드 실행)
- `MessageEncryptor` 인터페이스 + `StubMessageEncryptor` (local/test 프로파일) — 2차 스프린트에서 AES-256 DEK로 교체 예정
- `SESSION_ALREADY_ENDED` 상태 코드 409 → 410(GONE) 수정
- `LOCKED_BY_SAFETY` 에러 코드 추가
- V10 마이그레이션: `sessions.last_message_at` 컬럼 추가
- SessionServiceTest (6개) + SessionControllerTest (5개)

## 이번 스프린트 범위 (stub)

- SSE delta 이벤트는 고정 문자열 반환 (실제 LLM 미연동)
- 암호화는 평문 pass-through (StubMessageEncryptor)
- 세션 자동 만료(30분) 미구현

## 다음 스프린트 예정

- LlmClient 연동 및 실제 스트리밍 응답
- AES-256 실제 암호화 (`AesMessageEncryptor`)
- Redis 세션 상태 pre-warming
- 감정/편향 점수 가중치 설계
- 30분 자동 만료 스케줄러

## Test plan

- [ ] `./gradlew test --tests "com.mio.session.*"` 전체 통과 확인
- [ ] `POST /v1/sessions` — 온보딩 완료 유저로 세션 생성 201
- [ ] `GET /v1/sessions/active` — 활성 세션 없을 때 data 필드 부재 확인
- [ ] `POST /v1/sessions/{id}/messages` — SSE 스트림 `session_meta → delta → done` 순서 확인
- [ ] `POST /v1/sessions/{id}/end` — 이미 종료된 세션 재종료 시 410 반환 확인

Closes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added session management API: create sessions, retrieve active sessions, and end sessions with full REST endpoints
  * Implemented Server-Sent Events (SSE) streaming for real-time message delivery during sessions
  * Added message encryption functionality for enhanced data security

* **Bug Fixes**
  * Updated session error handling: improved HTTP status codes for session termination scenarios

* **Tests**
  * Added comprehensive test coverage for session management and encryption components

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->