### PR TITLE
feat: Daily Test 데일리 테스트 API 구현 (#10)

### DIFF
--- a/src/main/java/com/mio/common/AppConstants.java
+++ b/src/main/java/com/mio/common/AppConstants.java
@@ -1,0 +1,10 @@
+package com.mio.common;
+
+import java.time.ZoneId;
+
+public final class AppConstants {
+
+    public static final ZoneId ZONE = ZoneId.of("Asia/Seoul");
+
+    private AppConstants() {}
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -40,6 +40,10 @@ public enum ErrorCode {
     SESSION_ALREADY_ENDED(HttpStatus.GONE, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 
+    // Daily Test
+    DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),
+    DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
+
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다.");
 

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,7 +18,6 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/health",
             "/v1/auth/**",
-            "/v1/onboarding/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"
@@ -29,6 +29,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new XUserIdAuthFilter(), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated());

--- a/src/main/java/com/mio/config/XUserIdAuthFilter.java
+++ b/src/main/java/com/mio/config/XUserIdAuthFilter.java
@@ -1,0 +1,30 @@
+package com.mio.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+public class XUserIdAuthFilter extends OncePerRequestFilter {
+
+    static final String HEADER = "X-User-Id";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String userId = request.getHeader(HEADER);
+        if (userId != null && !userId.isBlank()
+                && SecurityContextHolder.getContext().getAuthentication() == null) {
+            var auth = new UsernamePasswordAuthenticationToken(userId, null, List.of());
+            SecurityContextHolder.getContext().setAuthentication(auth);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/mio/config/XUserIdAuthFilter.java
+++ b/src/main/java/com/mio/config/XUserIdAuthFilter.java
@@ -10,6 +10,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.UUID;
 
 public class XUserIdAuthFilter extends OncePerRequestFilter {
 
@@ -22,8 +23,13 @@ public class XUserIdAuthFilter extends OncePerRequestFilter {
         String userId = request.getHeader(HEADER);
         if (userId != null && !userId.isBlank()
                 && SecurityContextHolder.getContext().getAuthentication() == null) {
-            var auth = new UsernamePasswordAuthenticationToken(userId, null, List.of());
-            SecurityContextHolder.getContext().setAuthentication(auth);
+            try {
+                UUID parsedId = UUID.fromString(userId);
+                var auth = new UsernamePasswordAuthenticationToken(parsedId, null, List.of());
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            } catch (IllegalArgumentException ignored) {
+                // leave unauthenticated; 401 returned downstream by anyRequest().authenticated()
+            }
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/mio/dailytest/controller/DailyTestController.java
+++ b/src/main/java/com/mio/dailytest/controller/DailyTestController.java
@@ -1,0 +1,49 @@
+package com.mio.dailytest.controller;
+
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import com.mio.dailytest.dto.AnswerSubmitRequest;
+import com.mio.dailytest.dto.DailyTestResultResponse;
+import com.mio.dailytest.dto.DailyTestTodayResponse;
+import com.mio.dailytest.service.DailyTestService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/daily-test")
+@RequiredArgsConstructor
+public class DailyTestController {
+
+    private final DailyTestService dailyTestService;
+
+    @GetMapping("/today")
+    public ResponseEntity<ApiResponse<DailyTestTodayResponse>> getTodayTest(
+            @RequestHeader("X-User-Id") String userIdStr) {
+        UUID userId = parseUserId(userIdStr);
+        return ResponseEntity.ok(ApiResponse.ok(dailyTestService.getTodayTest(userId)));
+    }
+
+    @PostMapping("/{testId}/answer")
+    public ResponseEntity<ApiResponse<DailyTestResultResponse>> submitAnswer(
+            @RequestHeader("X-User-Id") String userIdStr,
+            @PathVariable UUID testId,
+            @Valid @RequestBody AnswerSubmitRequest request) {
+        UUID userId = parseUserId(userIdStr);
+        DailyTestResultResponse result = dailyTestService.submitAnswer(userId, testId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
+    }
+
+    private UUID parseUserId(String userIdStr) {
+        try {
+            return UUID.fromString(userIdStr);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/mio/dailytest/controller/DailyTestController.java
+++ b/src/main/java/com/mio/dailytest/controller/DailyTestController.java
@@ -1,7 +1,5 @@
 package com.mio.dailytest.controller;
 
-import com.mio.common.error.BusinessException;
-import com.mio.common.error.ErrorCode;
 import com.mio.common.response.ApiResponse;
 import com.mio.dailytest.dto.AnswerSubmitRequest;
 import com.mio.dailytest.dto.DailyTestResultResponse;
@@ -24,26 +22,16 @@ public class DailyTestController {
 
     @GetMapping("/today")
     public ResponseEntity<ApiResponse<DailyTestTodayResponse>> getTodayTest(
-            @RequestHeader("X-User-Id") String userIdStr) {
-        UUID userId = parseUserId(userIdStr);
+            @RequestHeader("X-User-Id") UUID userId) {
         return ResponseEntity.ok(ApiResponse.ok(dailyTestService.getTodayTest(userId)));
     }
 
     @PostMapping("/{testId}/answer")
     public ResponseEntity<ApiResponse<DailyTestResultResponse>> submitAnswer(
-            @RequestHeader("X-User-Id") String userIdStr,
+            @RequestHeader("X-User-Id") UUID userId,
             @PathVariable UUID testId,
             @Valid @RequestBody AnswerSubmitRequest request) {
-        UUID userId = parseUserId(userIdStr);
         DailyTestResultResponse result = dailyTestService.submitAnswer(userId, testId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(result));
-    }
-
-    private UUID parseUserId(String userIdStr) {
-        try {
-            return UUID.fromString(userIdStr);
-        } catch (IllegalArgumentException e) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
-        }
     }
 }

--- a/src/main/java/com/mio/dailytest/dto/AnswerSubmitRequest.java
+++ b/src/main/java/com/mio/dailytest/dto/AnswerSubmitRequest.java
@@ -1,9 +1,10 @@
 package com.mio.dailytest.dto;
 
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotBlank;
 
 import java.util.Map;
 
 public record AnswerSubmitRequest(
-        @NotEmpty Map<String, String> answers
+        @NotEmpty Map<@NotBlank String, @NotBlank String> answers
 ) {}

--- a/src/main/java/com/mio/dailytest/dto/AnswerSubmitRequest.java
+++ b/src/main/java/com/mio/dailytest/dto/AnswerSubmitRequest.java
@@ -1,0 +1,9 @@
+package com.mio.dailytest.dto;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.Map;
+
+public record AnswerSubmitRequest(
+        @NotEmpty Map<String, String> answers
+) {}

--- a/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
@@ -1,0 +1,10 @@
+package com.mio.dailytest.dto;
+
+import java.util.List;
+
+public record DailyTestContent(List<Question> questions) {
+
+    public record Question(String id, int order, String text, List<Option> options) {}
+
+    public record Option(String id, String text, int score, List<String> tags) {}
+}

--- a/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
@@ -1,0 +1,9 @@
+package com.mio.dailytest.dto;
+
+import java.util.UUID;
+
+public record DailyTestResultResponse(
+        UUID responseId,
+        UUID testId,
+        String resultSummary
+) {}

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,5 +1,7 @@
 package com.mio.dailytest.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -7,6 +9,7 @@ import java.util.UUID;
  * status=pending: testId, title, description, questions 포함
  * status=completed: testId, resultSummary 포함, questions null
  */
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public record DailyTestTodayResponse(
         String status,
         UUID testId,

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,0 +1,30 @@
+package com.mio.dailytest.dto;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * status=pending: testId, title, description, questions 포함
+ * status=completed: testId, resultSummary 포함, questions null
+ */
+public record DailyTestTodayResponse(
+        String status,
+        UUID testId,
+        String title,
+        String description,
+        List<QuestionDto> questions,
+        String resultSummary
+) {
+    public record QuestionDto(String id, int order, String text, List<OptionDto> options) {}
+
+    public record OptionDto(String id, String text) {}
+
+    public static DailyTestTodayResponse pending(UUID testId, String title, String description,
+                                                  List<QuestionDto> questions) {
+        return new DailyTestTodayResponse("pending", testId, title, description, questions, null);
+    }
+
+    public static DailyTestTodayResponse completed(UUID testId, String resultSummary) {
+        return new DailyTestTodayResponse("completed", testId, null, null, null, resultSummary);
+    }
+}

--- a/src/main/java/com/mio/dailytest/repository/DailyTestRepository.java
+++ b/src/main/java/com/mio/dailytest/repository/DailyTestRepository.java
@@ -1,0 +1,13 @@
+package com.mio.dailytest.repository;
+
+import com.mio.dailytest.domain.DailyTest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DailyTestRepository extends JpaRepository<DailyTest, UUID> {
+
+    Optional<DailyTest> findByActiveDate(LocalDate date);
+}

--- a/src/main/java/com/mio/dailytest/repository/DailyTestResponseRepository.java
+++ b/src/main/java/com/mio/dailytest/repository/DailyTestResponseRepository.java
@@ -1,0 +1,12 @@
+package com.mio.dailytest.repository;
+
+import com.mio.dailytest.domain.DailyTestResponse;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface DailyTestResponseRepository extends JpaRepository<DailyTestResponse, UUID> {
+
+    Optional<DailyTestResponse> findByUser_IdAndDailyTest_Id(UUID userId, UUID dailyTestId);
+}

--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -1,0 +1,40 @@
+package com.mio.dailytest.service;
+
+import com.mio.dailytest.dto.DailyTestContent;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+public class DailyTestResultEngine {
+
+    private static final int THRESHOLD_LOW = 4;
+    private static final int THRESHOLD_HIGH = 8;
+
+    private static final String RESULT_STABLE = "오늘은 비교적 안정된 하루였네요.";
+    private static final String RESULT_MODERATE = "감정의 기복이 있었던 하루군요.";
+    private static final String RESULT_HARD = "힘든 하루를 보냈군요. 충분히 쉬어요.";
+
+    /**
+     * @param content 테스트 문항 구조 (JSONB 역직렬화 결과)
+     * @param answers questionId → optionId 매핑
+     * @return result summary 문자열
+     */
+    public String calculate(DailyTestContent content, Map<String, String> answers) {
+        int totalScore = content.questions().stream()
+                .mapToInt(question -> {
+                    String selectedOptionId = answers.get(question.id());
+                    if (selectedOptionId == null) return 0;
+                    return question.options().stream()
+                            .filter(opt -> opt.id().equals(selectedOptionId))
+                            .mapToInt(DailyTestContent.Option::score)
+                            .findFirst()
+                            .orElse(0);
+                })
+                .sum();
+
+        if (totalScore < THRESHOLD_LOW) return RESULT_STABLE;
+        if (totalScore < THRESHOLD_HIGH) return RESULT_MODERATE;
+        return RESULT_HARD;
+    }
+}

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -2,6 +2,7 @@ package com.mio.dailytest.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.dailytest.domain.DailyTest;
@@ -12,6 +13,7 @@ import com.mio.dailytest.repository.DailyTestResponseRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,7 +36,7 @@ public class DailyTestService {
         User user = findUser(userId);
         checkOnboarding(user);
 
-        DailyTest test = dailyTestRepository.findByActiveDate(LocalDate.now())
+        DailyTest test = dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))
                 .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
 
         return dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, test.getId())
@@ -55,6 +57,10 @@ public class DailyTestService {
         DailyTest test = dailyTestRepository.findById(testId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
 
+        if (!LocalDate.now(AppConstants.ZONE).equals(test.getActiveDate())) {
+            throw new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND);
+        }
+
         if (dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId).isPresent()) {
             throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
         }
@@ -70,8 +76,12 @@ public class DailyTestService {
                 .resultSummary(resultSummary)
                 .build();
 
-        DailyTestResponse saved = dailyTestResponseRepository.save(response);
-        return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
+        try {
+            DailyTestResponse saved = dailyTestResponseRepository.save(response);
+            return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
+        } catch (DataIntegrityViolationException e) {
+            throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+        }
     }
 
     private User findUser(UUID userId) {

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -13,6 +13,7 @@ import com.mio.dailytest.repository.DailyTestResponseRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.postgresql.util.PSQLException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -80,7 +81,10 @@ public class DailyTestService {
             DailyTestResponse saved = dailyTestResponseRepository.save(response);
             return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
         } catch (DataIntegrityViolationException e) {
-            throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+            if (e.getCause() instanceof PSQLException psql && "23505".equals(psql.getSQLState())) {
+                throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+            }
+            throw e;
         }
     }
 

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -1,0 +1,118 @@
+package com.mio.dailytest.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.dailytest.domain.DailyTest;
+import com.mio.dailytest.domain.DailyTestResponse;
+import com.mio.dailytest.dto.*;
+import com.mio.dailytest.repository.DailyTestRepository;
+import com.mio.dailytest.repository.DailyTestResponseRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DailyTestService {
+
+    private final DailyTestRepository dailyTestRepository;
+    private final DailyTestResponseRepository dailyTestResponseRepository;
+    private final UserRepository userRepository;
+    private final DailyTestResultEngine resultEngine;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public DailyTestTodayResponse getTodayTest(UUID userId) {
+        User user = findUser(userId);
+        checkOnboarding(user);
+
+        DailyTest test = dailyTestRepository.findByActiveDate(LocalDate.now())
+                .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
+
+        return dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, test.getId())
+                .map(resp -> DailyTestTodayResponse.completed(test.getId(), resp.getResultSummary()))
+                .orElseGet(() -> DailyTestTodayResponse.pending(
+                        test.getId(),
+                        test.getTitle(),
+                        test.getDescription(),
+                        mapToQuestionDtos(parseContent(test.getContent()))
+                ));
+    }
+
+    @Transactional
+    public DailyTestResultResponse submitAnswer(UUID userId, UUID testId, AnswerSubmitRequest request) {
+        User user = findUser(userId);
+        checkOnboarding(user);
+
+        DailyTest test = dailyTestRepository.findById(testId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
+
+        if (dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId).isPresent()) {
+            throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+        }
+
+        DailyTestContent content = parseContent(test.getContent());
+        String resultSummary = resultEngine.calculate(content, request.answers());
+        String answersJson = serializeAnswers(request.answers());
+
+        DailyTestResponse response = DailyTestResponse.builder()
+                .user(user)
+                .dailyTest(test)
+                .answers(answersJson)
+                .resultSummary(resultSummary)
+                .build();
+
+        DailyTestResponse saved = dailyTestResponseRepository.save(response);
+        return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void checkOnboarding(User user) {
+        String step = user.getSignupStep();
+        if (!"ONBOARDING_COMPLETED".equals(step) && !"COMPLETED".equals(step)) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
+    }
+
+    private DailyTestContent parseContent(String contentJson) {
+        try {
+            return objectMapper.readValue(contentJson, DailyTestContent.class);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private String serializeAnswers(Object answers) {
+        try {
+            return objectMapper.writeValueAsString(answers);
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    private List<DailyTestTodayResponse.QuestionDto> mapToQuestionDtos(DailyTestContent content) {
+        return content.questions().stream()
+                .sorted((a, b) -> Integer.compare(a.order(), b.order()))
+                .map(q -> new DailyTestTodayResponse.QuestionDto(
+                        q.id(),
+                        q.order(),
+                        q.text(),
+                        q.options().stream()
+                                .map(o -> new DailyTestTodayResponse.OptionDto(o.id(), o.text()))
+                                .toList()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -13,18 +13,22 @@ import com.mio.dailytest.repository.DailyTestResponseRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.postgresql.util.PSQLException;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class DailyTestService {
+
+    private static final String DUPLICATE_RESPONSE_CONSTRAINT =
+            "daily_test_responses_user_id_daily_test_id_key";
 
     private final DailyTestRepository dailyTestRepository;
     private final DailyTestResponseRepository dailyTestResponseRepository;
@@ -81,7 +85,7 @@ public class DailyTestService {
             DailyTestResponse saved = dailyTestResponseRepository.save(response);
             return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
         } catch (DataIntegrityViolationException e) {
-            if (e.getCause() instanceof PSQLException psql && "23505".equals(psql.getSQLState())) {
+            if (isDuplicateResponseViolation(e)) {
                 throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
             }
             throw e;
@@ -116,9 +120,16 @@ public class DailyTestService {
         }
     }
 
+    private boolean isDuplicateResponseViolation(DataIntegrityViolationException e) {
+        Throwable mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e);
+        return mostSpecificCause != null
+                && mostSpecificCause.getMessage() != null
+                && mostSpecificCause.getMessage().contains(DUPLICATE_RESPONSE_CONSTRAINT);
+    }
+
     private List<DailyTestTodayResponse.QuestionDto> mapToQuestionDtos(DailyTestContent content) {
         return content.questions().stream()
-                .sorted((a, b) -> Integer.compare(a.order(), b.order()))
+                .sorted(Comparator.comparingInt(DailyTestContent.Question::order))
                 .map(q -> new DailyTestTodayResponse.QuestionDto(
                         q.id(),
                         q.order(),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,13 @@ spring:
       port: ${REDIS_PORT:6379}
       timeout: 2000ms
 
+  jackson:
+    time-zone: Asia/Seoul
+    serialization:
+      write-dates-as-timestamps: false
+    deserialization:
+      fail-on-unknown-properties: false
+
   threads:
     virtual:
       enabled: true

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -145,4 +145,34 @@ class DailyTestControllerTest {
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest());
     }
+
+    @Test
+    @DisplayName("POST /v1/daily-test/{testId}/answer - answers null이면 400")
+    void submitAnswer_nullAnswers_returns400() throws Exception {
+        mockMvc.perform(post("/v1/daily-test/{testId}/answer", TEST_ID)
+                        .header("X-User-Id", USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "answers": null
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /v1/daily-test/{testId}/answer - answers value가 blank면 400")
+    void submitAnswer_blankAnswerValue_returns400() throws Exception {
+        mockMvc.perform(post("/v1/daily-test/{testId}/answer", TEST_ID)
+                        .header("X-User-Id", USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "answers": {
+                                    "q1": " "
+                                  }
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -143,7 +143,8 @@ class DailyTestControllerTest {
                         .header("X-User-Id", USER_ID.toString())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 
     @Test
@@ -157,7 +158,8 @@ class DailyTestControllerTest {
                                   "answers": null
                                 }
                                 """))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 
     @Test
@@ -173,6 +175,7 @@ class DailyTestControllerTest {
                                   }
                                 }
                                 """))
-                .andExpect(status().isBadRequest());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 }

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -1,0 +1,148 @@
+package com.mio.dailytest.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.dailytest.dto.AnswerSubmitRequest;
+import com.mio.dailytest.dto.DailyTestResultResponse;
+import com.mio.dailytest.dto.DailyTestTodayResponse;
+import com.mio.dailytest.service.DailyTestService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = DailyTestController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(GlobalExceptionHandler.class)
+class DailyTestControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private DailyTestService dailyTestService;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final UUID TEST_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("GET /v1/daily-test/today - pending 상태 반환")
+    void getTodayTest_pending_returns200() throws Exception {
+        DailyTestTodayResponse response = DailyTestTodayResponse.pending(
+                TEST_ID, "오늘의 테스트", "설명",
+                List.of(new DailyTestTodayResponse.QuestionDto("q1", 1, "질문1", List.of(
+                        new DailyTestTodayResponse.OptionDto("q1_a", "옵션A")
+                )))
+        );
+        when(dailyTestService.getTodayTest(USER_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/daily-test/today")
+                        .header("X-User-Id", USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("pending"))
+                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
+                .andExpect(jsonPath("$.data.questions").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /v1/daily-test/today - completed 상태 반환")
+    void getTodayTest_completed_returns200() throws Exception {
+        DailyTestTodayResponse response = DailyTestTodayResponse.completed(TEST_ID, "안정된 하루였네요.");
+        when(dailyTestService.getTodayTest(USER_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/daily-test/today")
+                        .header("X-User-Id", USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("completed"))
+                .andExpect(jsonPath("$.data.resultSummary").value("안정된 하루였네요."));
+    }
+
+    @Test
+    @DisplayName("GET /v1/daily-test/today - 온보딩 미완료 시 403")
+    void getTodayTest_onboardingRequired_returns403() throws Exception {
+        when(dailyTestService.getTodayTest(any()))
+                .thenThrow(new BusinessException(ErrorCode.ONBOARDING_REQUIRED));
+
+        mockMvc.perform(get("/v1/daily-test/today")
+                        .header("X-User-Id", USER_ID.toString()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ONBOARDING_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/daily-test/today - 오늘 테스트 없으면 404")
+    void getTodayTest_notFound_returns404() throws Exception {
+        when(dailyTestService.getTodayTest(any()))
+                .thenThrow(new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
+
+        mockMvc.perform(get("/v1/daily-test/today")
+                        .header("X-User-Id", USER_ID.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("DAILY_TEST_NOT_FOUND"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/daily-test/{testId}/answer - 정상 제출 시 201")
+    void submitAnswer_valid_returns201() throws Exception {
+        DailyTestResultResponse result = new DailyTestResultResponse(
+                UUID.randomUUID(), TEST_ID, "오늘은 비교적 안정된 하루였네요."
+        );
+        when(dailyTestService.submitAnswer(eq(USER_ID), eq(TEST_ID), any())).thenReturn(result);
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        mockMvc.perform(post("/v1/daily-test/{testId}/answer", TEST_ID)
+                        .header("X-User-Id", USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
+                .andExpect(jsonPath("$.data.resultSummary").isString());
+    }
+
+    @Test
+    @DisplayName("POST /v1/daily-test/{testId}/answer - 중복 제출 시 409")
+    void submitAnswer_duplicate_returns409() throws Exception {
+        when(dailyTestService.submitAnswer(any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED));
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        mockMvc.perform(post("/v1/daily-test/{testId}/answer", TEST_ID)
+                        .header("X-User-Id", USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("DAILY_TEST_ALREADY_COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/daily-test/{testId}/answer - answers 비어있으면 400")
+    void submitAnswer_emptyAnswers_returns400() throws Exception {
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of());
+
+        mockMvc.perform(post("/v1/daily-test/{testId}/answer", TEST_ID)
+                        .header("X-User-Id", USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -1,0 +1,68 @@
+package com.mio.dailytest.service;
+
+import com.mio.dailytest.dto.DailyTestContent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DailyTestResultEngineTest {
+
+    private final DailyTestResultEngine engine = new DailyTestResultEngine();
+
+    private static final DailyTestContent CONTENT = new DailyTestContent(List.of(
+            new DailyTestContent.Question("q1", 1, "질문1", List.of(
+                    new DailyTestContent.Option("q1_a", "낮음", 0, List.of("neutral")),
+                    new DailyTestContent.Option("q1_b", "중간", 2, List.of("moderate")),
+                    new DailyTestContent.Option("q1_c", "높음", 4, List.of("high"))
+            )),
+            new DailyTestContent.Question("q2", 2, "질문2", List.of(
+                    new DailyTestContent.Option("q2_a", "낮음", 0, List.of("neutral")),
+                    new DailyTestContent.Option("q2_b", "중간", 3, List.of("moderate")),
+                    new DailyTestContent.Option("q2_c", "높음", 5, List.of("high"))
+            ))
+    ));
+
+    @Test
+    @DisplayName("총점 0~3 → 안정 메시지 반환")
+    void calculate_lowScore_returnsStableMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_a"); // 0+0=0
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+
+    @Test
+    @DisplayName("총점 4~7 → 중간 메시지 반환")
+    void calculate_moderateScore_returnsModerateMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_b", "q2", "q2_b"); // 2+3=5
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+    }
+
+    @Test
+    @DisplayName("총점 8 이상 → 힘든 하루 메시지 반환")
+    void calculate_highScore_returnsHardMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_c"); // 4+5=9
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+    }
+
+    @Test
+    @DisplayName("답변 없는 문항은 0점 처리")
+    void calculate_missingAnswer_treatedAsZero() {
+        Map<String, String> answers = Map.of("q1", "q1_a"); // q2 없음 → 0+0=0
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 optionId는 0점 처리")
+    void calculate_unknownOptionId_treatedAsZero() {
+        Map<String, String> answers = Map.of("q1", "q1_z", "q2", "q2_a"); // 0+0=0
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+}

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -65,4 +65,28 @@ class DailyTestResultEngineTest {
         String result = engine.calculate(CONTENT, answers);
         assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
     }
+
+    @Test
+    @DisplayName("경계값 3점 → 안정 (stable 상한)")
+    void calculate_boundary3_returnsStableMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_b"); // 0+3=3
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+
+    @Test
+    @DisplayName("경계값 4점 → 중간 (moderate 하한)")
+    void calculate_boundary4_returnsModerateMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_a"); // 4+0=4
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+    }
+
+    @Test
+    @DisplayName("경계값 7점 → 중간 (moderate 상한)")
+    void calculate_boundary7_returnsModerateMessage() {
+        Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_b"); // 4+3=7
+        String result = engine.calculate(CONTENT, answers);
+        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+    }
 }

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -89,4 +89,17 @@ class DailyTestResultEngineTest {
         String result = engine.calculate(CONTENT, answers);
         assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
     }
+
+    @Test
+    @DisplayName("경계값 8점 → 힘든 하루 (hard 하한)")
+    void calculate_boundary8_returnsHardMessage() {
+        DailyTestContent thresholdContent = new DailyTestContent(List.of(
+                new DailyTestContent.Question("q1", 1, "질문1", List.of(
+                        new DailyTestContent.Option("q1_hard", "매우 높음", 8, List.of("high"))
+                ))
+        ));
+        Map<String, String> answers = Map.of("q1", "q1_hard");
+        String result = engine.calculate(thresholdContent, answers);
+        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+    }
 }

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -1,0 +1,192 @@
+package com.mio.dailytest.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.dailytest.domain.DailyTest;
+import com.mio.dailytest.domain.DailyTestResponse;
+import com.mio.dailytest.dto.AnswerSubmitRequest;
+import com.mio.dailytest.dto.DailyTestResultResponse;
+import com.mio.dailytest.dto.DailyTestTodayResponse;
+import com.mio.dailytest.repository.DailyTestRepository;
+import com.mio.dailytest.repository.DailyTestResponseRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DailyTestServiceTest {
+
+    @Mock private DailyTestRepository dailyTestRepository;
+    @Mock private DailyTestResponseRepository dailyTestResponseRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private DailyTestResultEngine resultEngine;
+
+    private DailyTestService service;
+    private UUID userId;
+    private UUID testId;
+    private User onboardedUser;
+    private User pendingUser;
+
+    private static final String CONTENT_JSON = """
+            {
+              "questions": [
+                {
+                  "id": "q1", "order": 1, "text": "질문1",
+                  "options": [
+                    {"id": "q1_a", "text": "옵션A", "score": 0, "tags": ["neutral"]},
+                    {"id": "q1_b", "text": "옵션B", "score": 3, "tags": ["moderate"]}
+                  ]
+                }
+              ]
+            }
+            """;
+
+    @BeforeEach
+    void setUp() {
+        service = new DailyTestService(
+                dailyTestRepository, dailyTestResponseRepository, userRepository,
+                resultEngine, new ObjectMapper()
+        );
+        userId = UUID.randomUUID();
+        testId = UUID.randomUUID();
+
+        onboardedUser = User.builder().socialProvider("kakao").socialId("sid").privacyConsent(true).build();
+        onboardedUser.completeOnboarding("mio");
+        ReflectionTestUtils.setField(onboardedUser, "id", userId);
+
+        pendingUser = User.builder().socialProvider("kakao").socialId("sid2").privacyConsent(true).build();
+        ReflectionTestUtils.setField(pendingUser, "id", UUID.randomUUID());
+    }
+
+    @Test
+    @DisplayName("getTodayTest - 온보딩 미완료 유저는 ONBOARDING_REQUIRED")
+    void getTodayTest_notOnboarded_throwsOnboardingRequired() {
+        when(userRepository.findById(any())).thenReturn(Optional.of(pendingUser));
+
+        assertThatThrownBy(() -> service.getTodayTest(pendingUser.getId()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ONBOARDING_REQUIRED);
+    }
+
+    @Test
+    @DisplayName("getTodayTest - 오늘 테스트 없으면 DAILY_TEST_NOT_FOUND")
+    void getTodayTest_noTodayTest_throwsNotFound() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getTodayTest(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DAILY_TEST_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("getTodayTest - 미완료 상태면 pending 응답 반환")
+    void getTodayTest_notCompleted_returnsPending() {
+        DailyTest test = buildDailyTest();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.empty());
+
+        DailyTestTodayResponse response = service.getTodayTest(userId);
+
+        assertThat(response.status()).isEqualTo("pending");
+        assertThat(response.testId()).isEqualTo(testId);
+        assertThat(response.questions()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("getTodayTest - 완료 상태면 completed 응답 반환")
+    void getTodayTest_alreadyCompleted_returnsCompleted() {
+        DailyTest test = buildDailyTest();
+        DailyTestResponse existingResponse = buildDailyTestResponse(test, "안정된 하루");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.of(existingResponse));
+
+        DailyTestTodayResponse response = service.getTodayTest(userId);
+
+        assertThat(response.status()).isEqualTo("completed");
+        assertThat(response.resultSummary()).isEqualTo("안정된 하루");
+    }
+
+    @Test
+    @DisplayName("submitAnswer - 이미 완료한 경우 DAILY_TEST_ALREADY_COMPLETED")
+    void submitAnswer_alreadyCompleted_throwsConflict() {
+        DailyTest test = buildDailyTest();
+        DailyTestResponse existingResponse = buildDailyTestResponse(test, "이미 완료");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.of(existingResponse));
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        assertThatThrownBy(() -> service.submitAnswer(userId, testId, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("submitAnswer - 정상 제출 시 결과 반환")
+    void submitAnswer_valid_returnsResult() {
+        DailyTest test = buildDailyTest();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.empty());
+        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+
+        DailyTestResponse savedResponse = buildDailyTestResponse(test, "오늘은 비교적 안정된 하루였네요.");
+        when(dailyTestResponseRepository.save(any())).thenReturn(savedResponse);
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+        DailyTestResultResponse result = service.submitAnswer(userId, testId, request);
+
+        assertThat(result.testId()).isEqualTo(testId);
+        assertThat(result.resultSummary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+
+    private DailyTest buildDailyTest() {
+        DailyTest test = DailyTest.builder()
+                .title("오늘의 테스트")
+                .description("설명")
+                .content(CONTENT_JSON)
+                .activeDate(LocalDate.now())
+                .build();
+        ReflectionTestUtils.setField(test, "id", testId);
+        return test;
+    }
+
+    private DailyTestResponse buildDailyTestResponse(DailyTest test, String summary) {
+        DailyTestResponse resp = DailyTestResponse.builder()
+                .user(onboardedUser)
+                .dailyTest(test)
+                .answers("{}")
+                .resultSummary(summary)
+                .build();
+        ReflectionTestUtils.setField(resp, "id", UUID.randomUUID());
+        return resp;
+    }
+}

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
@@ -182,6 +183,50 @@ class DailyTestServiceTest {
 
         assertThat(result.testId()).isEqualTo(testId);
         assertThat(result.resultSummary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+    }
+
+    @Test
+    @DisplayName("submitAnswer - unique 제약 위반이면 DAILY_TEST_ALREADY_COMPLETED")
+    void submitAnswer_duplicateConstraint_throwsAlreadyCompleted() {
+        DailyTest test = buildDailyTest();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.empty());
+        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(dailyTestResponseRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "save failed",
+                        new RuntimeException("daily_test_responses_user_id_daily_test_id_key")
+                ));
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        assertThatThrownBy(() -> service.submitAnswer(userId, testId, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
+    }
+
+    @Test
+    @DisplayName("submitAnswer - 다른 DB 무결성 예외는 그대로 전파")
+    void submitAnswer_otherIntegrityViolation_propagates() {
+        DailyTest test = buildDailyTest();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.empty());
+        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(dailyTestResponseRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "save failed",
+                        new RuntimeException("other_constraint")
+                ));
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        assertThatThrownBy(() -> service.submitAnswer(userId, testId, request))
+                .isInstanceOf(DataIntegrityViolationException.class);
     }
 
     private DailyTest buildDailyTest() {

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -1,6 +1,7 @@
 package com.mio.dailytest.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.dailytest.domain.DailyTest;
@@ -90,7 +91,7 @@ class DailyTestServiceTest {
     @DisplayName("getTodayTest - 오늘 테스트 없으면 DAILY_TEST_NOT_FOUND")
     void getTodayTest_noTodayTest_throwsNotFound() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
-        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.empty());
+        when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.getTodayTest(userId))
                 .isInstanceOf(BusinessException.class)
@@ -103,7 +104,7 @@ class DailyTestServiceTest {
     void getTodayTest_notCompleted_returnsPending() {
         DailyTest test = buildDailyTest();
         when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
-        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.of(test));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
 
@@ -120,7 +121,7 @@ class DailyTestServiceTest {
         DailyTest test = buildDailyTest();
         DailyTestResponse existingResponse = buildDailyTestResponse(test, "안정된 하루");
         when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
-        when(dailyTestRepository.findByActiveDate(LocalDate.now())).thenReturn(Optional.of(test));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.of(existingResponse));
 
@@ -128,6 +129,21 @@ class DailyTestServiceTest {
 
         assertThat(response.status()).isEqualTo("completed");
         assertThat(response.resultSummary()).isEqualTo("안정된 하루");
+    }
+
+    @Test
+    @DisplayName("submitAnswer - 오늘 날짜가 아닌 테스트는 DAILY_TEST_NOT_FOUND")
+    void submitAnswer_notTodayTest_throwsNotFound() {
+        DailyTest oldTest = buildDailyTest(LocalDate.now(AppConstants.ZONE).minusDays(1));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(oldTest));
+
+        AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
+
+        assertThatThrownBy(() -> service.submitAnswer(userId, testId, request))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DAILY_TEST_NOT_FOUND);
     }
 
     @Test
@@ -169,11 +185,15 @@ class DailyTestServiceTest {
     }
 
     private DailyTest buildDailyTest() {
+        return buildDailyTest(LocalDate.now(AppConstants.ZONE));
+    }
+
+    private DailyTest buildDailyTest(LocalDate date) {
         DailyTest test = DailyTest.builder()
                 .title("오늘의 테스트")
                 .description("설명")
                 .content(CONTENT_JSON)
-                .activeDate(LocalDate.now())
+                .activeDate(date)
                 .build();
         ReflectionTestUtils.setField(test, "id", testId);
         return test;


### PR DESCRIPTION
## Summary

- `GET /v1/daily-test/today` — 미완료(pending)/완료(completed) 분기 응답
- `POST /v1/daily-test/{testId}/answer` — 답변 제출 → 룰 기반 결과 생성 (201)
- `XUserIdAuthFilter` 추가로 `X-User-Id` 헤더 → SecurityContext 세팅 (임시 auth, 추후 JWT 필터로 교체)
- `/v1/onboarding/**` PUBLIC_ENDPOINTS 제거 — 필터 도입으로 통합 처리

## Changes

### 인증 레이어
- `XUserIdAuthFilter`: `X-User-Id` 헤더 값을 읽어 `UsernamePasswordAuthenticationToken` 생성 → `SecurityContextHolder` 세팅
- `SecurityConfig`: 필터 등록, `/v1/onboarding/**` PUBLIC에서 제거 (동일 필터로 통합)

### Daily Test 도메인
- `DailyTestRepository` / `DailyTestResponseRepository` (Spring Data JPA)
- `DailyTestResultEngine`: 선택지 score 합산 → 구간별 resultSummary 매핑 (0~3/4~7/8+)
- `DailyTestService`: 온보딩 가드, 오늘 테스트 조회, 중복 제출 방지, 결과 생성
- `DailyTestController`: `@RequestHeader("X-User-Id")` 기반 2개 엔드포인트
- `ErrorCode`: `DAILY_TEST_NOT_FOUND`, `DAILY_TEST_ALREADY_COMPLETED` 추가

### JSONB Content 구조
```json
{
  "questions": [
    {
      "id": "q1", "order": 1, "text": "질문",
      "options": [
        {"id": "q1_a", "text": "옵션A", "score": 0, "tags": ["neutral"]},
        {"id": "q1_b", "text": "옵션B", "score": 3, "tags": ["moderate"]}
      ]
    }
  ]
}
```

## Test plan

- [x] `DailyTestResultEngineTest` (5): 저점/중점/고점/미응답/unknown optionId 처리
- [x] `DailyTestServiceTest` (5): 온보딩 미완료 403, 테스트 없음 404, pending/completed 분기, 중복 제출 409, 정상 제출
- [x] `DailyTestControllerTest` (8): pending 200, completed 200, 403, 404, 201, 409, 빈 answers 400
- [x] 전체 18개 테스트 통과
- [ ] DB 연동 확인 (docker compose 기동 후 Swagger로 직접 검증)

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added daily test workflow: view today's test (pending or completed) and submit answers; immediate result summary returned. Endpoints require X-User-Id header.

* **Bug Fixes / API**
  * New error responses for "daily test not found" (404) and "daily test already completed" (409). Validation tightened for submitted answers.

* **Documentation**
  * API docs exposed via Swagger UI.

* **Configuration**
  * Default JSON timezone set to Asia/Seoul.

* **Tests**
  * Expanded unit and controller tests covering daily test flows and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/11?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->