### PR TITLE
Feat/#6 signup flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,22 +8,17 @@ DB_PASSWORD=mio
 # Redis
 REDIS_HOST=localhost
 REDIS_PORT=6379
+REDIS_PASSWORD=your-redis-password
 
-# JWT
-JWT_SECRET=your-256-bit-secret-key-here-change-in-production
-JWT_ACCESS_TOKEN_EXPIRE_MS=900000
-JWT_REFRESH_TOKEN_EXPIRE_MS=2592000000
+# JWT — 반드시 32자 이상
+JWT_SECRET=SI1qAT3I3yVj5jbHN18ZCyobyySXSsJqnTXFZK4tfQZ
 
-# Kakao OAuth
-KAKAO_CLIENT_ID=your-kakao-rest-api-key
-KAKAO_CLIENT_SECRET=your-kakao-client-secret
+# Kakao (기본값 사용 시 생략 가능)
+KAKAO_API_URL=https://kapi.kakao.com
 
-# Apple Sign In
-APPLE_CLIENT_ID=com.example.mio
-APPLE_TEAM_ID=YOUR_TEAM_ID
-APPLE_KEY_ID=YOUR_KEY_ID
-# base64로 인코딩된 .p8 파일 내용
-APPLE_PRIVATE_KEY=
+# Apple — Apple Developer에서 번들 ID 확인
+APPLE_APP_ID=com.example.mio
+APPLE_JWKS_URL=https://appleid.apple.com/auth/keys
 
 # OpenAI (2차 개발)
 OPENAI_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,5 @@ FCM_CREDENTIALS_JSON=
 # AES-256 암호화 키 (32 bytes base64)
 APP_ENCRYPTION_KEY=your-32-byte-base64-encoded-encryption-key
 
-# 탈퇴 사용자 social_id 익명화 HMAC 키 — jwt.secret과 독립적으로 관리 (32자 이상, 로테이션 시 기존 탈퇴 데이터 재해시 필요)
-WITHDRAWAL_ANONYMIZATION_SECRET=your-withdrawal-anonymization-secret-32chars
-
 # HIRA API
 HIRA_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -30,5 +30,8 @@ FCM_CREDENTIALS_JSON=
 # AES-256 암호화 키 (32 bytes base64)
 APP_ENCRYPTION_KEY=your-32-byte-base64-encoded-encryption-key
 
+# 탈퇴 사용자 social_id 익명화 HMAC 키 — jwt.secret과 독립적으로 관리 (32자 이상, 로테이션 시 기존 탈퇴 데이터 재해시 필요)
+WITHDRAWAL_ANONYMIZATION_SECRET=your-withdrawal-anonymization-secret-32chars
+
 # HIRA API
 HIRA_API_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
           JWT_ACCESS_TOKEN_EXPIRE_MS: 900000
           JWT_REFRESH_TOKEN_EXPIRE_MS: 2592000000
           APP_ENCRYPTION_KEY: Y2l0ZXN0a2V5MzJieXRlc2xvbmdrZXlmb3JhZXM=
+          REDIS_PASSWORD: ""
+          APPLE_APP_ID: com.example.mio
+          APPLE_JWKS_URL: https://appleid.apple.com/auth/keys
+          REDIS_PASSWORD: ""
+          APPLE_APP_ID: com.example.mio
+          APPLE_JWKS_URL: https://appleid.apple.com/auth/keys
+          WITHDRAWAL_ANONYMIZATION_SECRET: ci-test-withdrawal-secret-key-32chars!!
 
       - name: Upload test report
         if: failure()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("it.ozimov:embedded-redis:0.7.3")  // 테스트용 Embedded Redis 추가
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -21,7 +21,9 @@ services:
     container_name: mio-redis
     ports:
       - "6379:6379"
-    command: redis-server --save 20 1 --loglevel warning
+    command: redis-server 
+      --requirepass ${REDIS_PASSWORD} # 비밀번호 인증 활성화
+      --save 20 1 --loglevel warning
     volumes:
       - redis_data:/data
     healthcheck:

--- a/redis.md
+++ b/redis.md
@@ -1,0 +1,983 @@
+# Auth 도메인 명세 — v1.2.0
+
+> 정책: MIO-User-001~017 | 기준 문서: Mio_Backend_Design_v2.3.md
+
+---
+
+## 1. 서비스 개요
+
+Firebase 없이 Kakao OAuth REST API와 Apple Sign In REST API를 백엔드에서 직접 검증한다.
+회원가입은 `signup_step` 상태 머신으로 단계별 관리하며, 이탈 후 재진입을 지원한다.
+Access Token은 JWT(15분), Refresh Token은 Opaque(30일) + Redis 저장 방식으로 운영한다.
+
+### 플랫폼별 지원 로그인
+| 플랫폼 | 지원 로그인 | 비고 |
+|---|---|---|
+| iOS | Apple Sign In (필수), Kakao (선택) | App Store 정책상 Apple 필수 (MIO-User-005) |
+| Android | Kakao | Kakao만 제공 (MIO-User-005) |
+
+---
+
+## 2. signup_step 상태 머신
+
+```
+SOCIAL_AUTHENTICATED
+      ↓ POST /v1/auth/signup/complete
+PROFILE_COMPLETED
+      ↓ POST /v1/onboarding/step/1~3 완료
+ONBOARDING_COMPLETED
+      ↓ POST /v1/onboarding/character
+COMPLETED
+```
+
+| signup_step | 설명 | 다음 화면 | 전환 조건 |
+|---|---|---|---|
+| `SOCIAL_AUTHENTICATED` | 소셜 로그인 완료, 약관 동의 전 | 닉네임·약관 동의 | 최초 소셜 로그인 성공 |
+| `PROFILE_COMPLETED` | 닉네임·약관 동의 완료 | 온보딩 | `POST /v1/auth/signup/complete` 성공 |
+| `ONBOARDING_COMPLETED` | 온보딩 + 캐릭터 선택 완료 | 홈 | `POST /v1/onboarding/character` 성공 |
+| `COMPLETED` | 가입 최종 완료 | 홈 | `ONBOARDING_COMPLETED` 전환 후 즉시 |
+
+> `ONBOARDING_COMPLETED` 와 `COMPLETED` 는 동시 처리.
+> `signup_step` 은 회원가입 단계, `onboarding_step` 은 온보딩 진행 단계. 두 값은 독립적으로 관리.
+> 이탈 후 재진입: `signup_step` 이 `SOCIAL_AUTHENTICATED` 가 아니면 `GET /v1/auth/signup/status` 호출 후 해당 단계 화면 구성.
+
+---
+
+## 3. 클래스 구조
+
+```
+auth/
+├── controller/
+│   └── AuthController.java
+├── service/
+│   ├── AuthService.java
+│   ├── JwtTokenService.java
+│   └── RefreshTokenService.java
+├── provider/
+│   ├── SocialAuthProvider.java      # interface: verify(token) → SocialUserInfo
+│   ├── KakaoAuthProvider.java       # Kakao User Info API 호출
+│   └── AppleAuthProvider.java       # Apple JWKS 서명 검증
+├── dto/
+│   ├── LoginRequest.java
+│   ├── LoginResponse.java
+│   ├── SignupCompleteRequest.java
+│   └── TokenRefreshResponse.java
+├── filter/
+│   └── JwtAuthenticationFilter.java
+└── redis/
+    ├── RefreshTokenRedisRepository.java
+    └── AppleJwksRedisRepository.java
+```
+
+---
+
+## 4. 연관 DB 테이블
+
+| 테이블 | 역할 | 주요 컬럼 |
+|---|---|---|
+| `users` | 사용자 계정 | `id`, `social_provider`, `social_id`, `nickname`, `signup_step`, `status`, `deleted_at` |
+| `user_devices` | 기기 등록 | `user_id`, `device_id`, `last_active_at` |
+| `user_consents` | 약관 동의 이력 | `user_id`, `type`, `version`, `agreed_at` |
+
+> `user_devices` 는 로그인 시 `device_id` 기준 UPSERT. `is_new_device` 판단 기준이며 탈퇴 시 하드 삭제 대상.
+
+---
+
+## 5. Redis 키 설계
+
+| 키 패턴 | 값 | TTL | 용도 |
+|---|---|---|---|
+| `refresh:{uuid}` | `{ user_id, device_id, social_provider, signup_step }` | 30일 | Refresh Token 본체 |
+| `refresh:user:{user_id}` | Hash `{ device_id → uuid }` | 30일 | 기기별 토큰 맵 |
+| `apple:jwks` | Apple 공개키 목록 | 24h | Apple ID Token 검증 캐시 |
+
+### 주요 연산
+```
+issueToken(userId, deviceId)   → SET + HSET
+validateToken(uuid)            → GET
+logoutDevice(userId, deviceId) → HGET → DEL + HDEL
+invalidateAll(userId)          → HGETALL → bulk DEL (탈퇴/재사용 공격 감지 시)
+isNewDevice(userId, deviceId)  → HEXISTS
+```
+
+> Redis 장애 시 전체 세션 만료. 운영 중 허용된 트레이드오프.
+
+---
+
+## 6. 소셜 로그인 내부 흐름
+
+### Apple Sign In (iOS)
+```
+[클라이언트]
+  ① Apple Sign In SDK로 로그인
+  ② Apple ID Token (JWT) 획득
+  ③ POST /v1/auth/login { provider: "apple", id_token: "eyJ..." }
+
+[백엔드]
+  ④ Redis apple:jwks 캐시 조회 (TTL 24h)
+     └─ kid 미매칭 시 캐시 무효화 후 재조회
+  ⑤ RSA 서명 검증 → iss, aud, exp 확인
+  ⑥ sub(= apple_user_id), email 추출
+  ⑦ social_provider="apple" + social_id=sub 로 사용자 조회
+  ⑧ 없으면 신규 생성 → 온보딩 플로우
+  ⑨ Access Token (JWT 15분) + Refresh Token (Opaque 30일) 발급
+```
+
+### Kakao OAuth (Android / iOS 선택)
+```
+[클라이언트]
+  ① Kakao SDK로 로그인
+  ② Kakao Access Token 획득
+  ③ POST /v1/auth/login { provider: "kakao", access_token: "..." }
+
+[백엔드]
+  ④ Kakao User Info API 호출: GET https://kapi.kakao.com/v2/user/me
+     → kakao_id, nickname 조회
+     → 실패 시 3회 retry → 503 UPSTREAM_UNAVAILABLE
+  ⑤ social_provider="kakao" + social_id=kakao_id 로 사용자 조회
+  ⑥ 없으면 신규 생성 → 온보딩 플로우
+  ⑦ Access Token + Refresh Token 발급
+```
+
+### 로그인 처리 메인 플로우
+```
+AuthService.login(request)
+  ├─ provider 분기 → SocialAuthProvider.verify() → SocialUserInfo
+  ├─ User 조회 (social_provider + social_id)
+  │   ├─ 신규: User INSERT (status=PENDING, signup_step=SOCIAL_AUTHENTICATED)
+  │   ├─ 기존 미완료: 현재 signup_step 그대로 반환
+  │   └─ 기존 완료: user 정보 포함 응답
+  ├─ 이메일 기반 PROVIDER_MISMATCH 검사 (동일 email + 다른 provider)
+  ├─ UserDevice UPSERT (device_id 기준)
+  ├─ JWT 발급 (sub=userId, deviceId claim 포함)
+  └─ Refresh Token 생성 → Redis 저장 (TTL 30일)
+```
+
+---
+
+## 7. JWT 구조
+
+```json
+{
+  "sub": "user_uuid",
+  "iat": 1746489600,
+  "exp": 1746490500,
+  "is_minor": false,
+  "device_id": "device_uuid",
+  "scope": ["user"]
+}
+```
+
+- 알고리즘: HS256
+- Signing Key: 환경변수 `JWT_SECRET`
+- 유효기간: 900초 (15분)
+- JWT에 민감 정보(이메일 등) 포함 금지
+
+---
+
+## 8. Refresh Token Rotation
+
+```
+1. 클라이언트 → POST /v1/auth/refresh (refresh_token)
+2. Redis refresh:{uuid} 조회
+   └─ 없음 → REFRESH_TOKEN_INVALID + 전체 세션 강제 로그아웃
+3. 새 Access Token 발급 (Refresh Token 유지, TTL 30일 만료까지 재사용)
+```
+
+> 재사용 공격 감지: 이미 삭제된 토큰으로 재시도 시 → 해당 userId 모든 Refresh Token 즉시 무효화
+
+---
+
+## 9. 인증 필터 (JwtAuthenticationFilter)
+
+```
+모든 요청 인터셉트
+  ├─ Authorization: Bearer {token} 헤더 추출
+  ├─ JWT 서명 검증 + 만료 확인
+  │   ├─ 만료 → 401 AUTH_TOKEN_EXPIRED
+  │   └─ 무효 → 401 AUTH_TOKEN_INVALID
+  ├─ SecurityContext에 Authentication 설정
+  └─ 화이트리스트 (인증 불필요 경로)
+         POST /v1/auth/login
+         POST /v1/auth/refresh
+         GET  /v1/health
+```
+
+---
+
+## 10. 권한 모델
+
+| Role | Scope | 접근 범위 |
+|---|---|---|
+| 일반 유저 | `user` | 본인 데이터만 접근 |
+| 프리미엄 유저 | `user`, `premium` | 모든 캐릭터 + 월간 리포트 (MVP 제외) |
+| 시스템 Worker | `system` | 내부 비동기 Job |
+| 관리자 | `admin` | 어드민 콘솔 (MIO-Ops-008) |
+
+---
+
+## 11. 필수 요청 헤더
+
+| 헤더 | 필수 | 설명 |
+|---|---|---|
+| `Authorization` | Y | `Bearer <access_token>` |
+| `X-Device-Id` | Y | UUID v4. 디바이스 식별 |
+| `X-App-Version` | Y | 클라이언트 빌드 버전 |
+| `X-Platform` | Y | `ios` / `android` |
+| `Idempotency-Key` | 선택 | UUID v4. 체크인·세션 종료 등 |
+
+---
+
+## 12. API 목록
+
+| Method | Endpoint | 인증 필요 | 설명 |
+|---|---|---|---|
+| `POST` | `/v1/auth/login` | X | 소셜 로그인 및 신규 가입 |
+| `GET` | `/v1/auth/signup/status` | O | 회원가입 상태 조회 |
+| `POST` | `/v1/auth/signup/complete` | O | 닉네임·약관 동의 완료 |
+| `GET` | `/v1/auth/nickname/duplicate-check` | O | 닉네임 중복 확인 |
+| `POST` | `/v1/auth/refresh` | X | Access Token 갱신 |
+| `POST` | `/v1/auth/logout` | O | 로그아웃 |
+| `DELETE` | `/v1/auth/withdraw` | O | 회원 탈퇴 |
+
+---
+
+## 13. API 상세 명세
+
+### POST /v1/auth/login
+
+#### Request Body
+```json
+{
+  "provider": "apple",
+  "id_token": "eyJhbGci...",
+  "access_token": null,
+  "device_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+| Field | Type | 필수 | 설명 |
+|---|---|---|---|
+| `provider` | String | Y | `apple` / `kakao` |
+| `id_token` | String | 조건부 | Apple 전용 |
+| `access_token` | String | 조건부 | Kakao 전용 |
+| `device_id` | String (UUID) | Y | 기기 고유 ID |
+
+#### Success Response `200 OK`
+
+신규 또는 가입 미완료 (`is_new_user: true`)
+```json
+{
+  "data": {
+    "access_token": "eyJhbGci...",
+    "refresh_token": "mio_refresh_...",
+    "expires_in": 900,
+    "is_new_user": true,
+    "is_new_device": true,
+    "signup_step": "SOCIAL_AUTHENTICATED",
+    "onboarding_step": 0
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+기존 회원 (`is_new_user: false`)
+```json
+{
+  "data": {
+    "access_token": "eyJhbGci...",
+    "refresh_token": "mio_refresh_...",
+    "expires_in": 900,
+    "is_new_user": false,
+    "is_new_device": false,
+    "signup_step": "COMPLETED",
+    "onboarding_step": 4,
+    "user": {
+      "id": "550e8400-...",
+      "nickname": "효찬",
+      "preferred_character_id": "mio",
+      "is_minor": false,
+      "is_premium": false,
+      "status": "ACTIVE"
+    }
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+> DB `users.status` 컬럼은 소문자(`active`, `suspended`, `withdrawn`) 저장 → API 응답은 대문자(`ACTIVE`, `SUSPENDED`, `DELETED`) 반환. 매핑 필수.
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | 필수 필드 누락 또는 형식 오류 |
+| 400 | `INVALID_PROVIDER` | 지원하지 않는 provider |
+| 401 | `OAUTH_VERIFICATION_FAILED` | 소셜 토큰 검증 실패 |
+| 403 | `ACCOUNT_SUSPENDED` | 정지된 계정 |
+| 409 | `PROVIDER_MISMATCH` | 동일 이메일 + 다른 provider |
+| 410 | `GONE` | 탈퇴 계정 (30일 유예 포함) |
+| 429 | `RATE_LIMITED` | 30 req/분/IP 초과 |
+| 503 | `UPSTREAM_UNAVAILABLE` | Kakao API / Apple JWKS 장애 |
+
+---
+
+### GET /v1/auth/signup/status
+
+가입 이탈 후 재진입 시 호출. 현재 `signup_step` 과 온보딩 단계 반환.
+
+#### Success Response `200 OK`
+```json
+{
+  "data": {
+    "signup_step": "PROFILE_COMPLETED",
+    "onboarding_step": 2
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
+| 401 | `AUTH_TOKEN_INVALID` | 토큰 검증 실패 |
+| 404 | `NOT_FOUND` | 사용자 정보 없음 |
+
+---
+
+### POST /v1/auth/signup/complete
+
+`signup_step: SOCIAL_AUTHENTICATED` 상태에서만 호출 가능.
+
+#### Request Body
+```json
+{
+  "nickname": "효찬",
+  "age_range": "20대",
+  "gender": "male",
+  "consents": [
+    { "type": "terms", "agreed": true, "version": "v1.0" },
+    { "type": "privacy", "agreed": true, "version": "v1.0" },
+    { "type": "marketing", "agreed": false, "version": "v1.0" }
+  ]
+}
+```
+
+| Field | Type | 필수 | 설명 |
+|---|---|---|---|
+| `nickname` | String | Y | 2~13자 |
+| `age_range` | String | N | `10대` / `20대` / `30대` / `40대` / `50대+` |
+| `gender` | String | N | `male` / `female` / `other` / `prefer_not_to_say` |
+| `consents` | Array | Y | `terms`, `privacy` 필수 / `marketing` 선택 |
+
+#### Success Response `200 OK`
+```json
+{
+  "data": {
+    "signup_step": "PROFILE_COMPLETED",
+    "onboarding_step": 0,
+    "nickname": "효찬"
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | 닉네임 길이 오류 (2~13자) |
+| 400 | `CONSENT_REQUIRED` | `terms` 또는 `privacy` 미동의 |
+| 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
+| 403 | `SIGNUP_STEP_INVALID` | `signup_step` 이 `SOCIAL_AUTHENTICATED` 가 아님 |
+| 409 | `CONFLICT` | 닉네임 중복 |
+| 422 | `AGE_RESTRICTION` | 만 14세 미만 가입 불가 |
+
+---
+
+### GET /v1/auth/nickname/duplicate-check
+
+#### Query Parameter
+| Parameter | Type | 필수 | 설명 |
+|---|---|---|---|
+| `nickname` | String | Y | 중복 확인할 닉네임 |
+
+#### Success Response `200 OK`
+```json
+{
+  "data": { "duplicate": false },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | `nickname` 파라미터 누락 |
+| 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
+
+---
+
+### POST /v1/auth/refresh
+
+#### Request Body
+```json
+{
+  "refresh_token": "mio_refresh_..."
+}
+```
+
+#### Success Response `200 OK`
+```json
+{
+  "data": {
+    "access_token": "eyJhbGci...",
+    "expires_in": 900
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | `refresh_token` 필드 누락 |
+| 401 | `REFRESH_TOKEN_INVALID` | 만료 또는 재사용 감지 → 전체 세션 로그아웃 |
+| 403 | `ACCOUNT_SUSPENDED` | 정지된 계정 |
+| 410 | `GONE` | 탈퇴한 계정 |
+
+---
+
+### POST /v1/auth/logout
+
+해당 `device_id` 의 Refresh Token만 삭제. 타 기기 세션 유지.
+
+#### Request Body
+```json
+{
+  "device_id": "550e8400-e29b-41d4-a716-446655440000"
+}
+```
+
+#### Success Response `200 OK`
+```json
+{
+  "data": { "success": true },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 400 | `VALIDATION_ERROR` | `device_id` 누락 |
+| 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
+| 401 | `AUTH_TOKEN_INVALID` | 토큰 검증 실패 |
+
+---
+
+### DELETE /v1/auth/withdraw
+
+#### 처리 흐름
+```
+1. 전체 기기 Refresh Token 일괄 삭제 (Redis)
+2. PII 비식별화
+   social_id → SHA256 hash
+   nickname  → "탈퇴한 사용자"
+   email     → null
+3. users 업데이트: status=DELETED, deleted_at=NOW()
+4. DataRetentionJob 등록 (매일 00:00, deleted_at+30일 기준 하드 삭제)
+   삭제 대상: users, user_devices, user_onboarding_answers
+   보존 대상: user_consents, crisis_events (법적 의무 3년)
+```
+
+> 탈퇴 후 30일 이내 동일 소셜 계정 재가입 시도 시 `410 GONE` 반환.
+
+#### Success Response `200 OK`
+```json
+{
+  "data": {
+    "success": true,
+    "withdrawn_at": "2026-05-17T09:00:00Z",
+    "hard_delete_scheduled_at": "2026-06-16T00:00:00Z"
+  },
+  "meta": { "trace_id": "01HVZABC123..." }
+}
+```
+
+#### Error Responses
+| HTTP | 코드 | 설명 |
+|---|---|---|
+| 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
+| 401 | `AUTH_TOKEN_INVALID` | 토큰 검증 실패 |
+| 409 | `CONFLICT` | 이미 탈퇴 처리된 계정 |
+
+---
+
+## 14. 에러 처리 정책
+
+| 에러코드 | HTTP | 발생 조건 | 처리 방식 |
+|---|---|---|---|
+| `OAUTH_VERIFICATION_FAILED` | 401 | 소셜 토큰 서명/만료 오류 | 로그 기록 후 반환 |
+| `PROVIDER_MISMATCH` | 409 | 동일 이메일 + 다른 provider | 이메일 필드 비교 |
+| `REFRESH_TOKEN_INVALID` | 401 | RT 없음/만료/재사용 감지 | 재사용 시 전체 세션 무효화 |
+| `ACCOUNT_SUSPENDED` | 403 | status = SUSPENDED | 관리자 복구 필요 |
+| `UPSTREAM_UNAVAILABLE` | 503 | 소셜 API 호출 실패 | Retry 3회 후 반환 |
+
+---
+
+## 15. 보안 고려사항
+
+- Apple JWKS 캐싱, kid 미매칭 시 캐시 무효화 후 재조회
+- device_id는 클라이언트 생성 UUID → 서버는 형식 검증만
+- JWT에 민감 정보(이메일 등) 포함 금지
+- Refresh Token 값은 `SecureRandom` 으로 생성 (cryptographically secure), `mio_refresh_` prefix
+- 미성년자(`is_minor=true`) 계정: 특정 기능 접근 제한 처리 예정
+
+---
+
+## 16. 공통 응답 포맷
+
+### 성공
+```json
+{ "data": { ... }, "meta": { "trace_id": "01HVZ..." } }
+```
+
+### 에러
+```json
+{
+  "error": {
+    "code": "AUTH_TOKEN_EXPIRED",
+    "message": "Access token has expired.",
+    "details": { "expired_at": "2026-05-06T01:23:45Z" },
+    "trace_id": "01HVZ..."
+  }
+}
+```
+
+### Rate Limit
+| 대상 | 한도 |
+|---|---|
+| `/v1/auth/*` | 30 req/분/IP |
+| 일반 API | 120 req/분/유저 |
+
+응답 헤더: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`
+
+---
+
+# §19. 데이터베이스 설계
+
+> 원본: `Mio_Backend_Design_v2.3.md` | 버전: v2.4
+변경 이력:
+>
+> - `[v2.4]` `notification_settings` 컬럼명 API 명세 기준 통일 (`checkin_reminder_on` → `checkin_enabled` 등)
+> - `[v2.4]` `proactive_care_logs.trigger_code` CHECK 제약 추가 (7종 enum)
+> - `[v2.4]` `sessions.ended_at` 주석 추가 — `total_minutes` 계산식 명시
+> - `[v2.4]` `checkins.emoji_score` 주석 보강 — API 명세 필드명 안내
+> - `[v2.4]` `weekly_reports.distortion_distribution` 주석 추가 — `distortion_top3` 변환 쿼리
+
+---
+
+## §19.1 스키마 구조 개요
+
+```
+PostgreSQL
+ ├─ 사용자:   users, user_consents, user_onboarding_answers
+ │            (Refresh Token은 Redis로 이관 — user_refresh_tokens 제거)
+ ├─ 세션:     sessions, messages, session_summaries
+ ├─ 체크인:   checkins
+ ├─ Daily Test: daily_tests, daily_test_responses
+ ├─ To-do:    behavior_tasks
+ ├─ 리포트:   weekly_reports
+ ├─ 위기:     crisis_events
+ ├─ 알림:     notification_settings, device_tokens, proactive_care_logs
+ │
+ ├─ CBT:      cbt_reconstructions (재구성 기록, CHAT-003/004)
+ │
+ ├─ AI Memory (2차 개발 완성)
+ │   ├─ user_memory_events
+ │   ├─ emotional_states
+ │   ├─ cbt_patterns
+ │   ├─ character_interactions
+ │   ├─ user_memory_preferences
+ │   ├─ safety_risk_daily
+ │   └─ ai_policy_decisions
+ │
+ ├─ memory_embeddings  (pgvector)
+ ├─ outbox_events      (비동기)
+ └─ audit_logs         (감사, INSERT ONLY)
+```
+
+---
+
+## §19.2 핵심 테이블 DDL
+
+### 사용자 도메인
+
+`users` / `user_onboarding_answers` / `user_consents`
+
+```sql
+-- 사용자
+CREATE TABLE users (
+  id                    UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  email                 TEXT,
+  social_provider       TEXT        NOT NULL CHECK (social_provider IN ('apple', 'kakao')),
+  social_id             TEXT        NOT NULL,
+  nickname              TEXT,
+  age_range             TEXT        CHECK (age_range IN ('10대','20대','30대','40대','50대+')),
+  gender                TEXT        CHECK (gender IN ('male','female','other','prefer_not_to_say')),
+  notification_agree    BOOLEAN     NOT NULL DEFAULT true,
+  privacy_consent       BOOLEAN     NOT NULL DEFAULT false,
+  signup_step           TEXT        NOT NULL DEFAULT 'SOCIAL_AUTHENTICATED'
+    CHECK (signup_step IN (
+      'SOCIAL_AUTHENTICATED','CONSENT_AGREED','PROFILE_COMPLETED',
+      'ONBOARDING_COMPLETED','COMPLETED'
+    )),
+  onboarding_step       INT         NOT NULL DEFAULT 0,
+  preferred_character_id TEXT       DEFAULT 'mio',
+  last_checkin_at       TIMESTAMPTZ,
+  is_premium            BOOLEAN     NOT NULL DEFAULT false,
+  is_minor              BOOLEAN     NOT NULL DEFAULT false,
+  status                TEXT        NOT NULL DEFAULT 'PENDING'
+    CHECK (status IN ('PENDING','ACTIVE','SUSPENDED','DELETED')),
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deleted_at            TIMESTAMPTZ,
+  UNIQUE(social_provider, social_id)
+);
+
+-- 온보딩 응답
+CREATE TABLE user_onboarding_answers (
+  id                        UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                   UUID        NOT NULL REFERENCES users(id) UNIQUE,
+  emotion_state             TEXT        CHECK (emotion_state IN (
+                              'happy','calm','anxious','sad','angry','ashamed','numb','tired','confused'
+                            )),
+  concern_types             JSONB       DEFAULT '[]',
+  preferred_style           TEXT        CHECK (preferred_style IN (
+                              'empathetic','analytical','solution','balanced'
+                            )),
+  character_recommendations JSONB       DEFAULT '[]',
+  responses                 JSONB       DEFAULT '[]',
+  submitted_at              TIMESTAMPTZ
+);
+
+-- 동의 이력
+CREATE TABLE user_consents (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID        NOT NULL REFERENCES users(id),
+  consent_type TEXT        NOT NULL CHECK (consent_type IN (
+                 'terms','privacy','push_notification','emotion_report'
+               )),
+  agreed       BOOLEAN     NOT NULL,
+  agreed_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  version      TEXT        NOT NULL
+);
+```
+
+---
+
+### 세션 도메인
+
+```sql
+CREATE TABLE sessions (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id          UUID        NOT NULL REFERENCES users(id),
+  character_id     TEXT        NOT NULL,
+  status           TEXT        NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active','ended')),
+  started_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ended_at         TIMESTAMPTZ,
+  message_count    INT         NOT NULL DEFAULT 0,
+  avg_emotion_score INT,
+  embedding_status TEXT        NOT NULL DEFAULT 'pending'
+    CHECK (embedding_status IN ('pending','done','failed'))
+);
+
+CREATE INDEX idx_sessions_user ON sessions(user_id, started_at DESC);
+
+CREATE TABLE messages (
+  id                 UUID    PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id         UUID    NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  user_id            UUID    NOT NULL REFERENCES users(id),
+  role               TEXT    NOT NULL CHECK (role IN ('user','assistant')),
+  content_ciphertext BYTEA   NOT NULL,
+  content_dek_id     TEXT    NOT NULL,
+  emotion_score      INT     CHECK (emotion_score BETWEEN 0 AND 100),
+  bias_type          TEXT    CHECK (bias_type IN (
+                       'overgeneralization','catastrophizing','mind_reading',
+                       'all_or_nothing','self_blame','emotional_reasoning'
+                     )),
+  is_crisis_flagged  BOOLEAN NOT NULL DEFAULT false,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_messages_session ON messages(session_id, created_at);
+
+CREATE TABLE session_summaries (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             UUID        NOT NULL REFERENCES users(id),
+  session_id          UUID        NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+  character_id        TEXT        NOT NULL,
+  summary_text        TEXT        NOT NULL,
+  summary_ciphertext  BYTEA,
+  summary_dek_id      TEXT,
+  dominant_emotion    TEXT,
+  bias_types_detected JSONB       DEFAULT '[]',
+  cbt_intervened      BOOLEAN     NOT NULL DEFAULT false,
+  embedding_status    TEXT        NOT NULL DEFAULT 'pending'
+    CHECK (embedding_status IN ('pending','done','failed')),
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(session_id)
+);
+
+CREATE INDEX idx_session_summaries_user ON session_summaries(user_id, created_at DESC);
+```
+
+---
+
+### 체크인 / Daily Test / To-do / 리포트 / 위기
+
+```sql
+CREATE TABLE checkins (
+  id                 UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id            UUID        NOT NULL REFERENCES users(id),
+  character_id       TEXT,
+  time_of_day        TEXT        NOT NULL CHECK (time_of_day IN ('morning','afternoon','evening')),
+  emotion_type       TEXT        NOT NULL CHECK (emotion_type IN (
+                       'happy','calm','anxious','sad','angry','ashamed','numb','tired','confused'
+                     )),
+  emoji_score        INT         NOT NULL CHECK (emoji_score BETWEEN 1 AND 5),
+  memo_ciphertext    BYTEA,
+  memo_dek_id        TEXT,
+  ai_response        TEXT,
+  created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, time_of_day, (created_at::DATE))
+);
+
+CREATE TABLE daily_tests (
+  id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  title       TEXT        NOT NULL,
+  description TEXT,
+  content     JSONB       NOT NULL,
+  active_date DATE        NOT NULL UNIQUE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE daily_test_responses (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        NOT NULL REFERENCES users(id),
+  daily_test_id UUID        NOT NULL REFERENCES daily_tests(id),
+  answers       JSONB       NOT NULL,
+  result_summary TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, daily_test_id)
+);
+
+CREATE TABLE behavior_tasks (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID        NOT NULL REFERENCES users(id),
+  source_session_id UUID        REFERENCES sessions(id),
+  source_checkin_id UUID        REFERENCES checkins(id),
+  generated_from    TEXT        NOT NULL CHECK (generated_from IN (
+                      'chat','checkin','pattern','character','template'
+                    )),
+  action_text       TEXT        NOT NULL,
+  category          TEXT        NOT NULL CHECK (category IN (
+                      '심리_안정','인지_재구성','행동_활성화'
+                    )),
+  difficulty        INT         CHECK (difficulty BETWEEN 1 AND 5),
+  estimated_minutes INT,
+  character_id      TEXT,
+  status            TEXT        NOT NULL DEFAULT 'suggested'
+    CHECK (status IN ('suggested','completed','skipped','expired')),
+  before_emotion    INT         CHECK (before_emotion BETWEEN 0 AND 100),
+  after_emotion     INT         CHECK (after_emotion BETWEEN 0 AND 100),
+  feedback          TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at      TIMESTAMPTZ
+);
+
+CREATE TABLE weekly_reports (
+  id                      UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                 UUID        NOT NULL REFERENCES users(id),
+  week_start              DATE        NOT NULL,
+  week_end                DATE        NOT NULL,
+  checkin_count           INT         NOT NULL DEFAULT 0,
+  avg_emotion_score       FLOAT,
+  emotion_scores          JSONB       DEFAULT '{}',
+  distortion_distribution JSONB       DEFAULT '{}',
+  narrative               TEXT,
+  coaching_direction      TEXT,
+  status                  TEXT        NOT NULL DEFAULT 'PENDING'
+    CHECK (status IN ('PENDING','GENERATED','INSUFFICIENT_DATA')),
+  is_partial              BOOLEAN     NOT NULL DEFAULT false,
+  generated_at            TIMESTAMPTZ,
+  UNIQUE(user_id, week_start)
+);
+
+CREATE TABLE crisis_events (
+  id                UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID        NOT NULL REFERENCES users(id),
+  session_id        UUID        REFERENCES sessions(id),
+  trigger_type      TEXT        NOT NULL CHECK (trigger_type IN (
+                      'keyword','moderation','pattern','user_sos'
+                    )),
+  severity          INT         NOT NULL CHECK (severity BETWEEN 1 AND 3),
+  category          TEXT,
+  resource_shown    TEXT,
+  operator_reviewed BOOLEAN     NOT NULL DEFAULT false,
+  operator_note     TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+---
+
+### 알림 도메인
+
+```sql
+CREATE TABLE notification_settings (
+  id                     UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                UUID        NOT NULL REFERENCES users(id) UNIQUE,
+  notification_agree     BOOLEAN     NOT NULL DEFAULT true,
+  checkin_enabled        BOOLEAN     NOT NULL DEFAULT true,
+  checkin_morning_time   TIME        NOT NULL DEFAULT '09:00',
+  checkin_afternoon_time TIME        NOT NULL DEFAULT '12:00',
+  checkin_evening_time   TIME        NOT NULL DEFAULT '22:00',
+  character_enabled      BOOLEAN     NOT NULL DEFAULT true,
+  report_enabled         BOOLEAN     NOT NULL DEFAULT true,
+  todo_reminder_on       BOOLEAN     NOT NULL DEFAULT true,
+  created_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at             TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE device_tokens (
+  id         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID        NOT NULL REFERENCES users(id),
+  device_id  TEXT        NOT NULL,
+  platform   TEXT        NOT NULL CHECK (platform IN ('ios', 'android')),
+  token      TEXT        NOT NULL,
+  is_valid   BOOLEAN     NOT NULL DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, device_id)
+);
+
+CREATE TABLE proactive_care_logs (
+  id                  UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             UUID        NOT NULL REFERENCES users(id),
+  trigger_code        TEXT        NOT NULL CHECK (trigger_code IN (
+                        'checkin_reminder_morning','checkin_reminder_afternoon',
+                        'checkin_reminder_evening','todo_incomplete',
+                        'negative_emotion_streak','crisis_detected','report_weekly'
+                      )),
+  sent_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  notification_status TEXT        NOT NULL DEFAULT 'SENT'
+    CHECK (notification_status IN ('SENT','DELIVERED','OPENED','FAILED')),
+  responded_at        TIMESTAMPTZ,
+  response_action     TEXT        CHECK (response_action IN ('tapped','dismissed'))
+);
+```
+
+---
+
+### CBT / pgvector / 인프라
+
+```sql
+CREATE TABLE cbt_reconstructions (
+  id                               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id                          UUID        NOT NULL REFERENCES users(id),
+  session_id                       UUID        NOT NULL REFERENCES sessions(id),
+  message_id                       UUID        REFERENCES messages(id),
+  bias_type                        TEXT        NOT NULL CHECK (bias_type IN (
+                                     'overgeneralization','catastrophizing','mind_reading',
+                                     'all_or_nothing','self_blame','emotional_reasoning'
+                                   )),
+  distorted_thought_ciphertext     BYTEA       NOT NULL,
+  distorted_thought_dek_id         TEXT        NOT NULL,
+  reconstructed_thought_ciphertext BYTEA,
+  reconstructed_thought_dek_id     TEXT,
+  emotion_score_before             INT         CHECK (emotion_score_before BETWEEN 0 AND 100),
+  emotion_score_after              INT         CHECK (emotion_score_after  BETWEEN 0 AND 100),
+  created_at                       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE memory_embeddings (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         UUID        NOT NULL REFERENCES users(id),
+  source_event_id UUID        NOT NULL,
+  content_summary TEXT        NOT NULL,
+  embedding       VECTOR(1536),
+  memory_type     TEXT        NOT NULL,
+  sensitivity     TEXT        NOT NULL DEFAULT 'normal'
+    CHECK (sensitivity IN ('normal','sensitive','restricted')),
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_memory_embeddings_cosine ON memory_embeddings
+  USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+CREATE TABLE outbox_events (
+  id           UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_type   TEXT        NOT NULL,
+  payload      JSONB       NOT NULL,
+  processed    BOOLEAN     NOT NULL DEFAULT false,
+  retry_count  INT         NOT NULL DEFAULT 0,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  processed_at TIMESTAMPTZ
+);
+
+CREATE TABLE audit_logs (
+  id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID        REFERENCES users(id) ON DELETE SET NULL,
+  action        TEXT        NOT NULL,
+  resource_type TEXT,
+  resource_id   TEXT,
+  details       JSONB       NOT NULL DEFAULT '{}',
+  ip_address    TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+---
+
+## §19.3 Redis 사용 패턴
+
+| Key 패턴 | 데이터 | TTL | 목적 |
+|---|---|---|---|
+| `refresh:{uuid}` | `{ user_id, device_id, social_provider, signup_step }` | 30일 | Refresh Token 본체 |
+| `refresh:user:{user_id}` | Hash `{ device_id → uuid }` | 30일 | 기기별 토큰 맵 |
+| `session:{id}:state` | 현재 세션 상태 | 1시간 | 세션 비활성 감지 |
+| `session:{id}:messages` | 최근 10턴 | 1시간 | Context 빠른 조회 |
+| `session:{id}:context_cache` | Pre-warmed 컨텍스트 | 5분 | 첫 메시지 응답 단축 |
+| `user:{id}:emotion:current` | 최근 감정 점수 | 24시간 | emotion_spike 감지 |
+| `ratelimit:user:{id}:{endpoint}` | 요청 횟수 | 1분 | Rate Limit |
+| `ratelimit:ip:{ip}:auth` | 인증 시도 횟수 | 1분 | Brute Force 방지 |
+| `idempotency:{key}` | 처리 결과 | 24시간 | 중복 요청 방지 |
+| `proactive:{userId}:daily_count` | 당일 알림 횟수 | 자정 만료 | 하루 최대 3회 제한 |
+| `apple:jwks` | Apple 공개키 | 24시간 | Apple ID Token 검증 캐시 |
+
+### Refresh Token Redis 연산
+
+```
+[issueToken]
+SET  refresh:{uuid}          {json}   EX 2592000
+HSET refresh:user:{user_id}  {device_id} {uuid}
+HEXISTS → false: isNewDevice=true
+
+[validateToken]
+GET refresh:{uuid} → null: 재사용 공격 → invalidateAll → 401
+                   → 있음: Rotation
+
+[logoutDevice]
+HGET  refresh:user:{user_id} {device_id} → uuid
+DEL   refresh:{uuid}
+HDEL  refresh:user:{user_id} {device_id}
+
+[invalidateAll]
+HGETALL refresh:user:{user_id} → 모든 uuid DEL (파이프라인)
+DEL     refresh:user:{user_id}
+```

--- a/src/main/java/com/mio/auth/controller/AuthController.java
+++ b/src/main/java/com/mio/auth/controller/AuthController.java
@@ -49,17 +49,16 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenRefreshResponse>> refresh(
-            @RequestBody Map<String, String> body) {
-        String refreshToken = body.get("refresh_token");
-        String newAccessToken = refreshTokenService.refresh(refreshToken);
+            @Valid @RequestBody TokenRefreshRequest request) {
+        String newAccessToken = refreshTokenService.refresh(request.refreshToken());
         return ResponseEntity.ok(ApiResponse.ok(new TokenRefreshResponse(newAccessToken, 900)));
     }
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> logout(
             @AuthenticationPrincipal String userId,
-            @RequestBody Map<String, String> body) {
-        authService.logout(UUID.fromString(userId), body.get("device_id"));
+            @Valid @RequestBody LogoutRequest request) {
+        authService.logout(UUID.fromString(userId), request.deviceId());
         return ResponseEntity.ok(ApiResponse.ok(Map.of("success", true)));
     }
 

--- a/src/main/java/com/mio/auth/controller/AuthController.java
+++ b/src/main/java/com/mio/auth/controller/AuthController.java
@@ -1,0 +1,71 @@
+package com.mio.auth.controller;
+
+import com.mio.auth.dto.*;
+import com.mio.auth.service.AuthService;
+import com.mio.auth.service.RefreshTokenService;
+import com.mio.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final RefreshTokenService refreshTokenService;
+
+    @PostMapping("/login")
+    public ResponseEntity<ApiResponse<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.login(request)));
+    }
+
+    @GetMapping("/signup/status")
+    public ResponseEntity<ApiResponse<SignupStatusResponse>> getSignupStatus(
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.getSignupStatus(UUID.fromString(userId))));
+    }
+
+    @PostMapping("/signup/complete")
+    public ResponseEntity<ApiResponse<SignupCompleteResponse>> completeSignup(
+            @AuthenticationPrincipal String userId,
+            @Valid @RequestBody SignupCompleteRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.completeSignup(UUID.fromString(userId), request)));
+    }
+
+    @GetMapping("/nickname/duplicate-check")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkNickname(
+            @RequestParam @NotBlank String nickname) {
+        boolean duplicate = authService.checkNicknameDuplicate(nickname);
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("duplicate", duplicate)));
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse<TokenRefreshResponse>> refresh(
+            @RequestBody Map<String, String> body) {
+        String refreshToken = body.get("refresh_token");
+        String newAccessToken = refreshTokenService.refresh(refreshToken);
+        return ResponseEntity.ok(ApiResponse.ok(new TokenRefreshResponse(newAccessToken, 900)));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> logout(
+            @AuthenticationPrincipal String userId,
+            @RequestBody Map<String, String> body) {
+        authService.logout(UUID.fromString(userId), body.get("device_id"));
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("success", true)));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<ApiResponse<WithdrawResponse>> withdraw(
+            @AuthenticationPrincipal String userId) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.withdraw(UUID.fromString(userId))));
+    }
+}

--- a/src/main/java/com/mio/auth/dto/LoginRequest.java
+++ b/src/main/java/com/mio/auth/dto/LoginRequest.java
@@ -1,0 +1,11 @@
+package com.mio.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank String provider,
+        String idToken,
+        String accessToken,
+        @NotBlank String deviceId
+) {
+}

--- a/src/main/java/com/mio/auth/dto/LoginResponse.java
+++ b/src/main/java/com/mio/auth/dto/LoginResponse.java
@@ -1,0 +1,27 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record LoginResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") int expiresIn,
+        @JsonProperty("is_new_user") boolean isNewUser,
+        @JsonProperty("is_new_device") boolean isNewDevice,
+        @JsonProperty("signup_step") String signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep,
+        UserInfo user
+) {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public record UserInfo(
+            String id,
+            String nickname,
+            @JsonProperty("preferred_character_id") String preferredCharacterId,
+            @JsonProperty("is_minor") boolean isMinor,
+            @JsonProperty("is_premium") boolean isPremium,
+            String status
+    ) {
+    }
+}

--- a/src/main/java/com/mio/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/mio/auth/dto/LogoutRequest.java
@@ -1,0 +1,9 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record LogoutRequest(
+        @JsonProperty("device_id") @NotBlank String deviceId
+) {
+}

--- a/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
@@ -1,0 +1,22 @@
+package com.mio.auth.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record SignupCompleteRequest(
+        @NotBlank @Size(min = 2, max = 13) String nickname,
+        String ageRange,
+        String gender,
+        @NotEmpty @Valid List<ConsentItem> consents
+) {
+    public record ConsentItem(
+            @NotBlank String type,
+            boolean agreed,
+            @NotBlank String version
+    ) {
+    }
+}

--- a/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
@@ -1,0 +1,10 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SignupCompleteResponse(
+        @JsonProperty("signup_step") String signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep,
+        String nickname
+) {
+}

--- a/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
@@ -1,0 +1,9 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record SignupStatusResponse(
+        @JsonProperty("signup_step") String signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep
+) {
+}

--- a/src/main/java/com/mio/auth/dto/SocialUserInfo.java
+++ b/src/main/java/com/mio/auth/dto/SocialUserInfo.java
@@ -1,0 +1,8 @@
+package com.mio.auth.dto;
+
+public record SocialUserInfo(
+        String socialId,
+        String email,
+        String provider
+) {
+}

--- a/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @JsonProperty("refresh_token") @NotBlank String refreshToken
+) {
+}

--- a/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
@@ -1,0 +1,9 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record TokenRefreshResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") int expiresIn
+) {
+}

--- a/src/main/java/com/mio/auth/dto/WithdrawResponse.java
+++ b/src/main/java/com/mio/auth/dto/WithdrawResponse.java
@@ -1,0 +1,15 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+
+public record WithdrawResponse(
+        boolean success,
+        @JsonProperty("withdrawn_at") OffsetDateTime withdrawnAt,
+        @JsonProperty("hard_delete_scheduled_at") OffsetDateTime hardDeleteScheduledAt
+) {
+    public WithdrawResponse(OffsetDateTime withdrawnAt) {
+        this(true, withdrawnAt, withdrawnAt != null ? withdrawnAt.plusDays(30) : null);
+    }
+}

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,94 @@
+package com.mio.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.auth.service.JwtTokenService;
+import com.mio.common.error.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    // "METHOD URI" 형식으로 정확히 일치해야 함 — query string은 getRequestURI()에 포함되지 않아 안전
+    private static final Set<String> WHITELIST = Set.of(
+            "POST /v1/auth/login",
+            "POST /v1/auth/refresh",
+            "GET /v1/health"
+    );
+
+    private final JwtTokenService jwtTokenService;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String key = request.getMethod() + " " + request.getRequestURI();
+        return WHITELIST.contains(key);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String header = request.getHeader("Authorization");
+
+        if (header == null || !header.startsWith(BEARER_PREFIX)) {
+            sendError(response, HttpStatus.UNAUTHORIZED, ErrorCode.UNAUTHORIZED);
+            return;
+        }
+
+        String token = header.substring(BEARER_PREFIX.length());
+
+        try {
+            Claims claims = jwtTokenService.parseToken(token);
+            String userId = claims.getSubject();
+            String deviceId = claims.get("device_id", String.class);
+
+            // principal=userId, credentials=deviceId — 컨트롤러에서 @AuthenticationPrincipal로 userId 접근
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId,
+                    deviceId,
+                    List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+
+        } catch (ExpiredJwtException e) {
+            sendError(response, HttpStatus.UNAUTHORIZED, ErrorCode.EXPIRED_TOKEN);
+        } catch (JwtException e) {
+            sendError(response, HttpStatus.UNAUTHORIZED, ErrorCode.INVALID_TOKEN);
+        }
+    }
+
+    // 필터에서 예외를 throw하면 ExceptionTranslationFilter에 도달하지 않으므로 응답을 직접 작성
+    private void sendError(HttpServletResponse response, HttpStatus status, ErrorCode errorCode) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        objectMapper.writeValue(response.getWriter(), Map.of(
+                "error", Map.of(
+                        "code", errorCode.getCode(),
+                        "message", errorCode.getMessage()
+                )
+        ));
+    }
+}

--- a/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
@@ -32,6 +32,7 @@ public class AppleAuthProvider implements SocialAuthProvider {
 
     private final AppleJwksRedisRepository jwksRepository;
     private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.create();
 
     @Override
     public String provider() {
@@ -101,7 +102,7 @@ public class AppleAuthProvider implements SocialAuthProvider {
 
     private String fetchAndCacheJwks() {
         try {
-            String jwks = RestClient.create()
+            String jwks = restClient
                     .get()
                     .uri(appleJwksUrl)
                     .retrieve()
@@ -129,7 +130,7 @@ public class AppleAuthProvider implements SocialAuthProvider {
         if (!"https://appleid.apple.com".equals(claims.getIssuer())) {
             throw new BusinessException(ErrorCode.OAUTH_FAILED);
         }
-        if (!appleAppId.equals(claims.getAudience().iterator().next())) {
+        if (!claims.getAudience().contains(appleAppId)) {
             throw new BusinessException(ErrorCode.OAUTH_FAILED);
         }
     }

--- a/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
@@ -1,0 +1,136 @@
+package com.mio.auth.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.auth.dto.SocialUserInfo;
+import com.mio.auth.redis.AppleJwksRedisRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyFactory;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+@Component
+@RequiredArgsConstructor
+public class AppleAuthProvider implements SocialAuthProvider {
+
+    @Value("${apple.jwks-url}")
+    private String appleJwksUrl;
+
+    @Value("${apple.app-id}")
+    private String appleAppId;
+
+    private final AppleJwksRedisRepository jwksRepository;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String provider() {
+        return "apple";
+    }
+
+    @Override
+    public SocialUserInfo verify(String idToken) {
+        String kid = extractKid(idToken);
+        RSAPublicKey publicKey = resolvePublicKey(kid, false);
+
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(publicKey)
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+
+            validateClaims(claims);
+
+            String socialId = claims.getSubject();
+            String email = claims.get("email", String.class);
+            return new SocialUserInfo(socialId, email, "apple");
+
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+    }
+
+    private String extractKid(String idToken) {
+        try {
+            String header = idToken.split("\\.")[0];
+            byte[] decoded = Base64.getUrlDecoder().decode(header);
+            JsonNode node = objectMapper.readTree(new String(decoded, StandardCharsets.UTF_8));
+            return node.path("kid").asText();
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+    }
+
+    private RSAPublicKey resolvePublicKey(String kid, boolean forceRefresh) {
+        if (forceRefresh) {
+            jwksRepository.invalidate();
+        }
+
+        String jwksJson = jwksRepository.get().orElseGet(this::fetchAndCacheJwks);
+
+        try {
+            JsonNode keys = objectMapper.readTree(jwksJson).path("keys");
+            for (JsonNode key : keys) {
+                if (kid.equals(key.path("kid").asText())) {
+                    return buildRsaKey(key.path("n").asText(), key.path("e").asText());
+                }
+            }
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.UPSTREAM_UNAVAILABLE);
+        }
+
+        // kid 미매칭 → Apple이 키를 교체했을 수 있으므로 캐시 무효화 후 1회만 재시도
+        if (!forceRefresh) {
+            return resolvePublicKey(kid, true);
+        }
+        throw new BusinessException(ErrorCode.OAUTH_FAILED);
+    }
+
+    private String fetchAndCacheJwks() {
+        try {
+            String jwks = RestClient.create()
+                    .get()
+                    .uri(appleJwksUrl)
+                    .retrieve()
+                    .body(String.class);
+            jwksRepository.save(jwks);
+            return jwks;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.UPSTREAM_UNAVAILABLE);
+        }
+    }
+
+    private RSAPublicKey buildRsaKey(String n, String e) {
+        try {
+            BigInteger modulus = new BigInteger(1, Base64.getUrlDecoder().decode(n));
+            BigInteger exponent = new BigInteger(1, Base64.getUrlDecoder().decode(e));
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(modulus, exponent);
+            return (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(spec);
+        } catch (Exception ex) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+    }
+
+    // iss·aud 미검증 시 타 앱 발급 Apple 토큰도 수락되므로 반드시 확인
+    private void validateClaims(Claims claims) {
+        if (!"https://appleid.apple.com".equals(claims.getIssuer())) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+        if (!appleAppId.equals(claims.getAudience().iterator().next())) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
@@ -1,0 +1,69 @@
+package com.mio.auth.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.auth.dto.SocialUserInfo;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoAuthProvider implements SocialAuthProvider {
+
+    private static final String USER_INFO_PATH = "/v2/user/me";
+    private static final int MAX_RETRY = 3;
+
+    @Value("${kakao.api-url}")
+    private String kakaoApiUrl;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String provider() {
+        return "kakao";
+    }
+
+    @Override
+    public SocialUserInfo verify(String accessToken) {
+        RestClient client = RestClient.create();
+        Exception lastException = null;
+
+        for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
+            try {
+                String body = client.get()
+                        .uri(kakaoApiUrl + USER_INFO_PATH)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .retrieve()
+                        .onStatus(HttpStatusCode::isError, (req, res) -> {
+                            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+                        })
+                        .body(String.class);
+
+                return parseUserInfo(body);
+            } catch (BusinessException e) {
+                throw e; // 인증 실패(401)는 재시도 불필요, 즉시 전파
+            } catch (Exception e) {
+                lastException = e;
+            }
+        }
+
+        throw new BusinessException(ErrorCode.UPSTREAM_UNAVAILABLE);
+    }
+
+    private SocialUserInfo parseUserInfo(String body) {
+        try {
+            JsonNode root = objectMapper.readTree(body);
+            String socialId = root.path("id").asText();
+            String email = root.path("kakao_account").path("email").asText(null);
+            return new SocialUserInfo(socialId, email, "kakao");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.OAUTH_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
@@ -60,8 +60,13 @@ public class KakaoAuthProvider implements SocialAuthProvider {
         try {
             JsonNode root = objectMapper.readTree(body);
             String socialId = root.path("id").asText();
+            if (socialId.isBlank()) {
+                throw new BusinessException(ErrorCode.OAUTH_FAILED);
+            }
             String email = root.path("kakao_account").path("email").asText(null);
             return new SocialUserInfo(socialId, email, "kakao");
+        } catch (BusinessException e) {
+            throw e;
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.OAUTH_FAILED);
         }

--- a/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/KakaoAuthProvider.java
@@ -23,6 +23,7 @@ public class KakaoAuthProvider implements SocialAuthProvider {
     private String kakaoApiUrl;
 
     private final ObjectMapper objectMapper;
+    private final RestClient restClient = RestClient.create();
 
     @Override
     public String provider() {
@@ -31,12 +32,11 @@ public class KakaoAuthProvider implements SocialAuthProvider {
 
     @Override
     public SocialUserInfo verify(String accessToken) {
-        RestClient client = RestClient.create();
         Exception lastException = null;
 
         for (int attempt = 0; attempt < MAX_RETRY; attempt++) {
             try {
-                String body = client.get()
+                String body = restClient.get()
                         .uri(kakaoApiUrl + USER_INFO_PATH)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
                         .retrieve()

--- a/src/main/java/com/mio/auth/provider/SocialAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/SocialAuthProvider.java
@@ -1,0 +1,8 @@
+package com.mio.auth.provider;
+
+import com.mio.auth.dto.SocialUserInfo;
+
+public interface SocialAuthProvider {
+    SocialUserInfo verify(String token);
+    String provider();
+}

--- a/src/main/java/com/mio/auth/redis/AppleJwksRedisRepository.java
+++ b/src/main/java/com/mio/auth/redis/AppleJwksRedisRepository.java
@@ -1,0 +1,30 @@
+package com.mio.auth.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AppleJwksRedisRepository {
+
+    private static final String KEY = "apple:jwks";
+    private static final Duration TTL = Duration.ofHours(24);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void save(String jwksJson) {
+        redisTemplate.opsForValue().set(KEY, jwksJson, TTL);
+    }
+
+    public Optional<String> get() {
+        return Optional.ofNullable(redisTemplate.opsForValue().get(KEY));
+    }
+
+    public void invalidate() {
+        redisTemplate.delete(KEY);
+    }
+}

--- a/src/main/java/com/mio/auth/redis/RefreshTokenInfo.java
+++ b/src/main/java/com/mio/auth/redis/RefreshTokenInfo.java
@@ -1,0 +1,10 @@
+package com.mio.auth.redis;
+
+// refresh:{uuid} 에 저장되는 값 — 토큰 갱신 시 DB 조회 없이 새 JWT를 발급하기 위한 최소 정보
+public record RefreshTokenInfo(
+        String userId,
+        String deviceId,
+        String socialProvider,
+        String signupStep  // JWT claim 재구성 및 가입 단계 복원에 사용
+) {
+}

--- a/src/main/java/com/mio/auth/redis/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/mio/auth/redis/RefreshTokenRedisRepository.java
@@ -1,0 +1,80 @@
+package com.mio.auth.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRedisRepository {
+
+    private static final String TOKEN_KEY = "refresh:%s";
+    private static final String USER_KEY = "refresh:user:%s";
+    private static final Duration TTL = Duration.ofDays(30);
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    public void issueToken(String userId, String deviceId, String tokenUuid, RefreshTokenInfo info) {
+        String tokenKey = TOKEN_KEY.formatted(tokenUuid);
+        String userKey = USER_KEY.formatted(userId);
+
+        try {
+            redisTemplate.opsForValue().set(tokenKey, objectMapper.writeValueAsString(info), TTL);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("RefreshTokenInfo 직렬화 실패", e);
+        }
+
+        redisTemplate.<String, String>opsForHash().put(userKey, deviceId, tokenUuid);
+        redisTemplate.expire(userKey, TTL);
+    }
+
+    public Optional<RefreshTokenInfo> validateToken(String tokenUuid) {
+        String json = redisTemplate.opsForValue().get(TOKEN_KEY.formatted(tokenUuid));
+        if (json == null) return Optional.empty();
+
+        try {
+            return Optional.of(objectMapper.readValue(json, RefreshTokenInfo.class));
+        } catch (JsonProcessingException e) {
+            return Optional.empty();
+        }
+    }
+
+    public void logoutDevice(String userId, String deviceId) {
+        String userKey = USER_KEY.formatted(userId);
+        String tokenUuid = redisTemplate.<String, String>opsForHash().get(userKey, deviceId);
+
+        if (tokenUuid != null) {
+            redisTemplate.delete(TOKEN_KEY.formatted(tokenUuid));
+        }
+        redisTemplate.opsForHash().delete(userKey, deviceId);
+    }
+
+    public void invalidateAll(String userId) {
+        String userKey = USER_KEY.formatted(userId);
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(userKey);
+
+        // 탈퇴·재사용 공격 감지 시 부분 삭제 방지를 위해 파이프라인으로 일괄 처리
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            entries.values().forEach(uuid ->
+                connection.keyCommands().del(TOKEN_KEY.formatted(uuid.toString()).getBytes())
+            );
+            connection.keyCommands().del(userKey.getBytes());
+            return null;
+        });
+    }
+
+    public boolean isNewDevice(String userId, String deviceId) {
+        // hasKey()는 Redis 장애 시 null을 반환할 수 있어 Boolean.TRUE.equals로 방어
+        return !Boolean.TRUE.equals(
+            redisTemplate.opsForHash().hasKey(USER_KEY.formatted(userId), deviceId)
+        );
+    }
+}

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -13,11 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import org.springframework.beans.factory.annotation.Value;
-
-import javax.crypto.Mac;
-import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
@@ -28,10 +26,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AuthService {
 
     private static final int JWT_EXPIRY_SECONDS = 900;
-
-    // jwt.secret과 분리 — JWT 키 로테이션 시 기존 탈퇴 데이터 해시값이 깨지지 않도록 독립 관리
-    @Value("${withdrawal.anonymization.secret}")
-    private String withdrawalAnonymizationSecret;
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;
@@ -52,7 +46,7 @@ public class AuthService {
         }
 
         // 탈퇴 유저 재가입 차단 — social_id가 SHA-256으로 익명화되므로 해시 값으로 조회
-        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), hmacSha256(socialUser.socialId()))
+        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
                 .filter(u -> "DELETED".equals(u.getStatus()))
                 .ifPresent(u -> { throw new BusinessException(ErrorCode.USER_WITHDRAWN); });
 
@@ -160,7 +154,7 @@ public class AuthService {
         refreshTokenService.invalidateAll(userId.toString());
 
         // PII 비식별화 정책 — social_id를 해시로 대체해 재가입 방지 키만 유지
-        String anonymizedSocialId = hmacSha256(user.getSocialId());
+        String anonymizedSocialId = sha256(user.getSocialId());
         user.softDelete(anonymizedSocialId);
 
         return new WithdrawResponse(user.getDeletedAt());
@@ -183,13 +177,12 @@ public class AuthService {
         if ("DELETED".equals(user.getStatus())) throw new BusinessException(ErrorCode.USER_WITHDRAWN);
     }
 
-    // 솔트 없는 SHA-256은 레인보우 테이블에 취약 — HMAC-SHA256으로 서버 시크릿을 솔트로 사용
-    private String hmacSha256(String input) {
+    private static String sha256(String input) {
         try {
-            Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(withdrawalAnonymizationSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
-            return HexFormat.of().formatHex(mac.doFinal(input.getBytes(StandardCharsets.UTF_8)));
-        } catch (Exception e) {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -18,11 +18,8 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -47,6 +44,11 @@ public class AuthService {
             userRepository.findByEmailAndSocialProviderNot(socialUser.email(), request.provider())
                     .ifPresent(u -> { throw new BusinessException(ErrorCode.PROVIDER_MISMATCH); });
         }
+
+        // 탈퇴 유저 재가입 차단 — social_id가 SHA-256으로 익명화되므로 해시 값으로 조회
+        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
+                .filter(u -> "DELETED".equals(u.getStatus()))
+                .ifPresent(u -> { throw new BusinessException(ErrorCode.USER_WITHDRAWN); });
 
         // lambda 내에서 변경이 필요하므로 AtomicBoolean 사용 (effectively final 제약 우회)
         AtomicBoolean isNewUser = new AtomicBoolean(false);
@@ -122,14 +124,15 @@ public class AuthService {
 
         user.completeProfile(request.nickname(), request.ageRange(), request.gender());
 
-        request.consents().forEach(item ->
-                userConsentRepository.save(UserConsent.builder()
+        List<UserConsent> consents = request.consents().stream()
+                .map(item -> UserConsent.builder()
                         .user(user)
                         .consentType(item.type())
                         .agreed(item.agreed())
                         .version(item.version())
                         .build())
-        );
+                .toList();
+        userConsentRepository.saveAll(consents);
 
         return new SignupCompleteResponse(user.getSignupStep(), user.getOnboardingStep(), user.getNickname());
     }

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -13,9 +13,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import org.springframework.beans.factory.annotation.Value;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
 import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.UUID;
@@ -26,6 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AuthService {
 
     private static final int JWT_EXPIRY_SECONDS = 900;
+
+    @Value("${jwt.secret}")
+    private String hashSalt;
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;
@@ -46,7 +51,7 @@ public class AuthService {
         }
 
         // 탈퇴 유저 재가입 차단 — social_id가 SHA-256으로 익명화되므로 해시 값으로 조회
-        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
+        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), hmacSha256(socialUser.socialId()))
                 .filter(u -> "DELETED".equals(u.getStatus()))
                 .ifPresent(u -> { throw new BusinessException(ErrorCode.USER_WITHDRAWN); });
 
@@ -154,7 +159,7 @@ public class AuthService {
         refreshTokenService.invalidateAll(userId.toString());
 
         // PII 비식별화 정책 — social_id를 해시로 대체해 재가입 방지 키만 유지
-        String anonymizedSocialId = sha256(user.getSocialId());
+        String anonymizedSocialId = hmacSha256(user.getSocialId());
         user.softDelete(anonymizedSocialId);
 
         return new WithdrawResponse(user.getDeletedAt());
@@ -177,12 +182,13 @@ public class AuthService {
         if ("DELETED".equals(user.getStatus())) throw new BusinessException(ErrorCode.USER_WITHDRAWN);
     }
 
-    private static String sha256(String input) {
+    // 솔트 없는 SHA-256은 레인보우 테이블에 취약 — HMAC-SHA256으로 서버 시크릿을 솔트로 사용
+    private String hmacSha256(String input) {
         try {
-            byte[] hash = MessageDigest.getInstance("SHA-256")
-                    .digest(input.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException e) {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(hashSalt.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return HexFormat.of().formatHex(mac.doFinal(input.getBytes(StandardCharsets.UTF_8)));
+        } catch (Exception e) {
             throw new IllegalStateException(e);
         }
     }

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -29,8 +29,9 @@ public class AuthService {
 
     private static final int JWT_EXPIRY_SECONDS = 900;
 
-    @Value("${jwt.secret}")
-    private String hashSalt;
+    // jwt.secret과 분리 — JWT 키 로테이션 시 기존 탈퇴 데이터 해시값이 깨지지 않도록 독립 관리
+    @Value("${withdrawal.anonymization.secret}")
+    private String withdrawalAnonymizationSecret;
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;
@@ -186,7 +187,7 @@ public class AuthService {
     private String hmacSha256(String input) {
         try {
             Mac mac = Mac.getInstance("HmacSHA256");
-            mac.init(new SecretKeySpec(hashSalt.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            mac.init(new SecretKeySpec(withdrawalAnonymizationSecret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
             return HexFormat.of().formatHex(mac.doFinal(input.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -1,0 +1,186 @@
+package com.mio.auth.service;
+
+import com.mio.auth.dto.*;
+import com.mio.auth.provider.SocialAuthProvider;
+import com.mio.auth.redis.RefreshTokenRedisRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.domain.UserConsent;
+import com.mio.user.repository.UserConsentRepository;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private static final int JWT_EXPIRY_SECONDS = 900;
+
+    private final List<SocialAuthProvider> socialAuthProviders;
+    private final UserRepository userRepository;
+    private final UserConsentRepository userConsentRepository;
+    private final JwtTokenService jwtTokenService;
+    private final RefreshTokenService refreshTokenService;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        SocialAuthProvider provider = getProvider(request.provider());
+        String token = "apple".equals(request.provider()) ? request.idToken() : request.accessToken();
+        SocialUserInfo socialUser = provider.verify(token);
+
+        if (socialUser.email() != null) {
+            userRepository.findByEmailAndSocialProviderNot(socialUser.email(), request.provider())
+                    .ifPresent(u -> { throw new BusinessException(ErrorCode.PROVIDER_MISMATCH); });
+        }
+
+        // lambda 내에서 변경이 필요하므로 AtomicBoolean 사용 (effectively final 제약 우회)
+        AtomicBoolean isNewUser = new AtomicBoolean(false);
+        User user = userRepository.findBySocialProviderAndSocialId(socialUser.provider(), socialUser.socialId())
+                .orElseGet(() -> {
+                    isNewUser.set(true);
+                    return userRepository.save(User.builder()
+                            .socialProvider(socialUser.provider())
+                            .socialId(socialUser.socialId())
+                            .email(socialUser.email())
+                            .privacyConsent(false)
+                            .build());
+                });
+
+        checkUserStatus(user);
+
+        // issueToken 이전에 체크해야 정확한 신규 기기 여부를 반환할 수 있음
+        boolean isNewDevice = refreshTokenRedisRepository.isNewDevice(
+                user.getId().toString(), request.deviceId());
+
+        String accessToken = jwtTokenService.generateAccessToken(
+                user.getId().toString(), request.deviceId(), user.isMinor());
+        String refreshToken = refreshTokenService.issue(
+                user.getId().toString(), request.deviceId(),
+                user.getSocialProvider(), user.getSignupStep());
+
+        LoginResponse.UserInfo userInfo = null;
+        if (!isNewUser.get() && "COMPLETED".equals(user.getSignupStep())) {
+            userInfo = new LoginResponse.UserInfo(
+                    user.getId().toString(),
+                    user.getNickname(),
+                    user.getPreferredCharacterId(),
+                    user.isMinor(),
+                    user.isPremium(),
+                    user.getStatus()
+            );
+        }
+
+        return new LoginResponse(
+                accessToken, refreshToken, JWT_EXPIRY_SECONDS,
+                isNewUser.get(), isNewDevice,
+                user.getSignupStep(), user.getOnboardingStep(),
+                userInfo
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public SignupStatusResponse getSignupStatus(UUID userId) {
+        User user = findUser(userId);
+        return new SignupStatusResponse(user.getSignupStep(), user.getOnboardingStep());
+    }
+
+    @Transactional
+    public SignupCompleteResponse completeSignup(UUID userId, SignupCompleteRequest request) {
+        User user = findUser(userId);
+
+        if (!"SOCIAL_AUTHENTICATED".equals(user.getSignupStep())) {
+            throw new BusinessException(ErrorCode.SIGNUP_STEP_INVALID);
+        }
+
+        boolean hasTerms = false, hasPrivacy = false;
+        for (SignupCompleteRequest.ConsentItem item : request.consents()) {
+            if ("terms".equals(item.type()) && item.agreed()) hasTerms = true;
+            if ("privacy".equals(item.type()) && item.agreed()) hasPrivacy = true;
+        }
+        if (!hasTerms || !hasPrivacy) {
+            throw new BusinessException(ErrorCode.CONSENT_REQUIRED);
+        }
+
+        if (userRepository.existsByNickname(request.nickname())) {
+            throw new BusinessException(ErrorCode.NICKNAME_DUPLICATE);
+        }
+
+        user.completeProfile(request.nickname(), request.ageRange(), request.gender());
+
+        request.consents().forEach(item ->
+                userConsentRepository.save(UserConsent.builder()
+                        .user(user)
+                        .consentType(item.type())
+                        .agreed(item.agreed())
+                        .version(item.version())
+                        .build())
+        );
+
+        return new SignupCompleteResponse(user.getSignupStep(), user.getOnboardingStep(), user.getNickname());
+    }
+
+    @Transactional(readOnly = true)
+    public boolean checkNicknameDuplicate(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Transactional
+    public void logout(UUID userId, String deviceId) {
+        refreshTokenService.logout(userId.toString(), deviceId);
+    }
+
+    @Transactional
+    public WithdrawResponse withdraw(UUID userId) {
+        User user = findUser(userId);
+
+        refreshTokenService.invalidateAll(userId.toString());
+
+        // PII 비식별화 정책 — social_id를 해시로 대체해 재가입 방지 키만 유지
+        String anonymizedSocialId = sha256(user.getSocialId());
+        user.softDelete(anonymizedSocialId);
+
+        return new WithdrawResponse(user.getDeletedAt());
+    }
+
+    private SocialAuthProvider getProvider(String providerName) {
+        return socialAuthProviders.stream()
+                .filter(p -> p.provider().equals(providerName))
+                .findFirst()
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_PROVIDER));
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void checkUserStatus(User user) {
+        if ("SUSPENDED".equals(user.getStatus())) throw new BusinessException(ErrorCode.USER_SUSPENDED);
+        if ("DELETED".equals(user.getStatus())) throw new BusinessException(ErrorCode.USER_WITHDRAWN);
+    }
+
+    private static String sha256(String input) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256")
+                    .digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/main/java/com/mio/auth/service/JwtTokenService.java
+++ b/src/main/java/com/mio/auth/service/JwtTokenService.java
@@ -1,0 +1,52 @@
+package com.mio.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+@Service
+public class JwtTokenService {
+
+    private final SecretKey signingKey;
+    private final long expirySeconds;
+
+    public JwtTokenService(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.expiry-seconds}") long expirySeconds
+    ) {
+        // 매 호출마다 키 생성 비용을 방지하기 위해 생성자에서 1회만 초기화
+        // HS256은 최소 256bit(32자) 이상의 시크릿 필요 — JWT_SECRET 길이 주의
+        this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.expirySeconds = expirySeconds;
+    }
+
+    public String generateAccessToken(String userId, String deviceId, boolean isMinor) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .subject(userId)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plusSeconds(expirySeconds)))
+                .claim("device_id", deviceId)
+                .claim("is_minor", isMinor)
+                .claim("scope", List.of("user"))
+                .signWith(signingKey)
+                .compact();
+    }
+
+    // ExpiredJwtException은 JwtException의 하위 클래스 — 호출부에서 expired를 먼저 catch해야 구분 가능
+    public Claims parseToken(String token) {
+        return Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/mio/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/mio/auth/service/RefreshTokenService.java
@@ -1,0 +1,69 @@
+package com.mio.auth.service;
+
+import com.mio.auth.redis.RefreshTokenInfo;
+import com.mio.auth.redis.RefreshTokenRedisRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class RefreshTokenService {
+
+    private static final String PREFIX = "mio_refresh_";
+
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+    private final JwtTokenService jwtTokenService;
+    private final UserRepository userRepository;
+
+    public String issue(String userId, String deviceId, String socialProvider, String signupStep) {
+        String uuid = UUID.randomUUID().toString();
+        RefreshTokenInfo info = new RefreshTokenInfo(userId, deviceId, socialProvider, signupStep);
+        refreshTokenRedisRepository.issueToken(userId, deviceId, uuid, info);
+        return PREFIX + uuid;
+    }
+
+    public String refresh(String refreshToken) {
+        String uuid = parseUuid(refreshToken);
+
+        // 만료와 재사용 공격 모두 INVALID 처리 — Redis에서 삭제된 토큰은 userId를 알 수 없어 구분 불가
+        RefreshTokenInfo info = refreshTokenRedisRepository.validateToken(uuid)
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID));
+
+        User user = userRepository.findById(UUID.fromString(info.userId()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        checkUserStatus(user);
+
+        return jwtTokenService.generateAccessToken(info.userId(), info.deviceId(), user.isMinor());
+    }
+
+    public void logout(String userId, String deviceId) {
+        refreshTokenRedisRepository.logoutDevice(userId, deviceId);
+    }
+
+    public void invalidateAll(String userId) {
+        refreshTokenRedisRepository.invalidateAll(userId);
+    }
+
+    private String parseUuid(String refreshToken) {
+        if (refreshToken == null || !refreshToken.startsWith(PREFIX)) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_INVALID);
+        }
+        return refreshToken.substring(PREFIX.length());
+    }
+
+    private void checkUserStatus(User user) {
+        if ("SUSPENDED".equals(user.getStatus())) {
+            throw new BusinessException(ErrorCode.USER_SUSPENDED);
+        }
+        if ("DELETED".equals(user.getStatus())) {
+            throw new BusinessException(ErrorCode.USER_WITHDRAWN);
+        }
+    }
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -17,9 +17,10 @@ public enum ErrorCode {
     // Auth
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "인증이 필요합니다."),
     FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "접근 권한이 없습니다."),
-    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "INVALID_TOKEN", "유효하지 않은 토큰입니다."),
-    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EXPIRED_TOKEN", "만료된 토큰입니다."),
-    OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "OAUTH_FAILED", "소셜 로그인에 실패했습니다."),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_INVALID", "유효하지 않은 토큰입니다."),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_TOKEN_EXPIRED", "만료된 토큰입니다."),
+    REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "REFRESH_TOKEN_INVALID", "유효하지 않은 Refresh Token입니다."),
+    OAUTH_FAILED(HttpStatus.UNAUTHORIZED, "OAUTH_VERIFICATION_FAILED", "소셜 로그인에 실패했습니다."),
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
@@ -39,7 +40,15 @@ public enum ErrorCode {
     SESSION_ALREADY_ENDED(HttpStatus.CONFLICT, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
 
     // Rate Limit
-    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다.");
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다."),
+
+    // External
+    UPSTREAM_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "UPSTREAM_UNAVAILABLE", "외부 서비스가 일시적으로 응답하지 않습니다."),
+    PROVIDER_MISMATCH(HttpStatus.CONFLICT, "PROVIDER_MISMATCH", "동일 이메일로 다른 소셜 계정이 이미 존재합니다."),
+    INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "INVALID_PROVIDER", "지원하지 않는 소셜 로그인 제공자입니다."),
+    SIGNUP_STEP_INVALID(HttpStatus.FORBIDDEN, "SIGNUP_STEP_INVALID", "현재 가입 단계에서 허용되지 않는 요청입니다."),
+    NICKNAME_DUPLICATE(HttpStatus.CONFLICT, "CONFLICT", "이미 사용 중인 닉네임입니다."),
+    CONSENT_REQUIRED(HttpStatus.BAD_REQUEST, "CONSENT_REQUIRED", "필수 약관에 동의해야 합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.mio.config;
 
+import com.mio.auth.filter.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -8,11 +10,15 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @EnableMethodSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/health",
@@ -31,7 +37,8 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
-                        .anyRequest().authenticated());
+                        .anyRequest().authenticated())
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -98,6 +98,25 @@ public class User {
         this.signupStep = "ONBOARDING_COMPLETED";
     }
 
+    public void completeProfile(String nickname, String ageRange, String gender) {
+        this.nickname = nickname;
+        this.ageRange = ageRange;
+        this.gender = gender;
+        this.signupStep = "PROFILE_COMPLETED";
+    }
+
+    public void activate() {
+        this.status = "ACTIVE";
+    }
+
+    public void softDelete(String anonymizedSocialId) {
+        this.socialId = anonymizedSocialId;
+        this.nickname = "탈퇴한 사용자";
+        this.email = null;
+        this.status = "DELETED";
+        this.deletedAt = OffsetDateTime.now();
+    }
+
     @PrePersist
     protected void onCreate() {
         createdAt = OffsetDateTime.now();

--- a/src/main/java/com/mio/user/repository/UserConsentRepository.java
+++ b/src/main/java/com/mio/user/repository/UserConsentRepository.java
@@ -1,0 +1,9 @@
+package com.mio.user.repository;
+
+import com.mio.user.domain.UserConsent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface UserConsentRepository extends JpaRepository<UserConsent, UUID> {
+}

--- a/src/main/java/com/mio/user/repository/UserRepository.java
+++ b/src/main/java/com/mio/user/repository/UserRepository.java
@@ -3,7 +3,14 @@ package com.mio.user.repository;
 import com.mio.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface UserRepository extends JpaRepository<User, UUID> {
+
+    Optional<User> findBySocialProviderAndSocialId(String socialProvider, String socialId);
+
+    Optional<User> findByEmailAndSocialProviderNot(String email, String socialProvider);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,10 +80,6 @@ apple:
   jwks-url: ${APPLE_JWKS_URL:https://appleid.apple.com/auth/keys}
   app-id: ${APPLE_APP_ID}
 
-withdrawal:
-  anonymization:
-    secret: ${WITHDRAWAL_ANONYMIZATION_SECRET}
-
 logging:
   level:
     com.mio: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,6 +80,10 @@ apple:
   jwks-url: ${APPLE_JWKS_URL:https://appleid.apple.com/auth/keys}
   app-id: ${APPLE_APP_ID}
 
+withdrawal:
+  anonymization:
+    secret: ${WITHDRAWAL_ANONYMIZATION_SECRET}
+
 logging:
   level:
     com.mio: INFO

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,10 +31,13 @@ spring:
     locations: classpath:db/migration
     baseline-on-migrate: false
 
+
+
   data:
     redis:
       host: ${REDIS_HOST:localhost}
       port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD}
       timeout: 2000ms
 
   threads:
@@ -65,6 +68,17 @@ management:
   endpoint:
     health:
       show-details: when-authorized
+
+jwt:
+  secret: ${JWT_SECRET}
+  expiry-seconds: 900
+
+kakao:
+  api-url: ${KAKAO_API_URL:https://kapi.kakao.com}
+
+apple:
+  jwks-url: ${APPLE_JWKS_URL:https://appleid.apple.com/auth/keys}
+  app-id: ${APPLE_APP_ID}
 
 logging:
   level:

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -42,6 +42,9 @@ class AuthServiceTest {
     @BeforeEach
     void setUp() {
         lenient().when(kakaoProvider.provider()).thenReturn("kakao");
+        // 탈퇴 유저 해시 체크(findBySocialProviderAndSocialId 1차 호출)에 대한 기본 응답
+        lenient().when(userRepository.findBySocialProviderAndSocialId(any(), any()))
+                .thenReturn(Optional.empty());
         authService = new AuthService(
                 List.of(kakaoProvider), userRepository, userConsentRepository,
                 jwtTokenService, refreshTokenService, refreshTokenRedisRepository
@@ -147,7 +150,6 @@ class AuthServiceTest {
         User user = buildUser(USER_ID, "kakao", "social-123", "SOCIAL_AUTHENTICATED", "PENDING");
         when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
         when(userRepository.existsByNickname("닉네임")).thenReturn(false);
-        when(userConsentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
         SignupCompleteRequest request = new SignupCompleteRequest(
                 "닉네임", "20대", "male",

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -1,0 +1,259 @@
+package com.mio.auth.service;
+
+import com.mio.auth.dto.*;
+import com.mio.auth.provider.SocialAuthProvider;
+import com.mio.auth.redis.RefreshTokenRedisRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserConsentRepository;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock private SocialAuthProvider kakaoProvider;
+    @Mock private UserRepository userRepository;
+    @Mock private UserConsentRepository userConsentRepository;
+    @Mock private JwtTokenService jwtTokenService;
+    @Mock private RefreshTokenService refreshTokenService;
+    @Mock private RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+    private AuthService authService;
+
+    private static final UUID USER_ID = UUID.randomUUID();
+    private static final String DEVICE_ID = "device-abc";
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(kakaoProvider.provider()).thenReturn("kakao");
+        authService = new AuthService(
+                List.of(kakaoProvider), userRepository, userConsentRepository,
+                jwtTokenService, refreshTokenService, refreshTokenRedisRepository
+        );
+    }
+
+    // ──────────────── login ────────────────
+
+    @Test
+    @DisplayName("신규 사용자 로그인 시 isNewUser=true를 반환한다")
+    void login_newUser_isNewUserTrue() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "user@test.com", "kakao");
+        User savedUser = buildUser(USER_ID, "kakao", "social-123", "SOCIAL_AUTHENTICATED", "PENDING");
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findByEmailAndSocialProviderNot(any(), any())).thenReturn(Optional.empty());
+        when(userRepository.findBySocialProviderAndSocialId("kakao", "social-123")).thenReturn(Optional.empty());
+        when(userRepository.save(any())).thenReturn(savedUser);
+        when(refreshTokenRedisRepository.isNewDevice(any(), any())).thenReturn(true);
+        when(jwtTokenService.generateAccessToken(any(), any(), anyBoolean())).thenReturn("access-token");
+        when(refreshTokenService.issue(any(), any(), any(), any())).thenReturn("mio_refresh_xxx");
+
+        LoginResponse response = authService.login(new LoginRequest("kakao", null, "kakao-token", DEVICE_ID));
+
+        assertThat(response.isNewUser()).isTrue();
+        assertThat(response.accessToken()).isEqualTo("access-token");
+    }
+
+    @Test
+    @DisplayName("기존 사용자 로그인 시 isNewUser=false이고 COMPLETED 단계면 userInfo를 반환한다")
+    void login_existingCompletedUser_returnsUserInfo() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", null, "kakao");
+        User existingUser = User.builder()
+                .id(USER_ID)
+                .socialProvider("kakao")
+                .socialId("social-123")
+                .privacyConsent(true)
+                .signupStep("COMPLETED")
+                .nickname("테스트닉네임")
+                .status("ACTIVE")
+                .build();
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findBySocialProviderAndSocialId("kakao", "social-123"))
+                .thenReturn(Optional.of(existingUser));
+        when(refreshTokenRedisRepository.isNewDevice(any(), any())).thenReturn(false);
+        when(jwtTokenService.generateAccessToken(any(), any(), anyBoolean())).thenReturn("access-token");
+        when(refreshTokenService.issue(any(), any(), any(), any())).thenReturn("mio_refresh_xxx");
+
+        LoginResponse response = authService.login(new LoginRequest("kakao", null, "kakao-token", DEVICE_ID));
+
+        assertThat(response.isNewUser()).isFalse();
+        assertThat(response.user()).isNotNull();
+        assertThat(response.user().nickname()).isEqualTo("테스트닉네임");
+    }
+
+    @Test
+    @DisplayName("동일 이메일로 다른 소셜 계정이 존재하면 PROVIDER_MISMATCH를 던진다")
+    void login_providerMismatch_throws() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "dup@test.com", "kakao");
+        User existingWithSameEmail = buildUser(UUID.randomUUID(), "apple", "apple-id", "COMPLETED", "ACTIVE");
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findByEmailAndSocialProviderNot("dup@test.com", "kakao"))
+                .thenReturn(Optional.of(existingWithSameEmail));
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("kakao", null, "kakao-token", DEVICE_ID)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.PROVIDER_MISMATCH));
+    }
+
+    @Test
+    @DisplayName("정지된 사용자 로그인 시 USER_SUSPENDED를 던진다")
+    void login_suspendedUser_throwsSuspended() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", null, "kakao");
+        User suspendedUser = buildUser(USER_ID, "kakao", "social-123", "COMPLETED", "SUSPENDED");
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findBySocialProviderAndSocialId("kakao", "social-123"))
+                .thenReturn(Optional.of(suspendedUser));
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("kakao", null, "kakao-token", DEVICE_ID)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_SUSPENDED));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 provider면 INVALID_PROVIDER를 던진다")
+    void login_unknownProvider_throwsInvalidProvider() {
+        assertThatThrownBy(() -> authService.login(new LoginRequest("naver", null, "token", DEVICE_ID)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_PROVIDER));
+    }
+
+    // ──────────────── completeSignup ────────────────
+
+    @Test
+    @DisplayName("유효한 동의 항목과 닉네임으로 회원가입을 완료한다")
+    void completeSignup_validRequest_returnsResponse() {
+        User user = buildUser(USER_ID, "kakao", "social-123", "SOCIAL_AUTHENTICATED", "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("닉네임")).thenReturn(false);
+        when(userConsentRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        SignupCompleteRequest request = new SignupCompleteRequest(
+                "닉네임", "20대", "male",
+                List.of(
+                        new SignupCompleteRequest.ConsentItem("terms", true, "v1"),
+                        new SignupCompleteRequest.ConsentItem("privacy", true, "v1")
+                )
+        );
+
+        SignupCompleteResponse response = authService.completeSignup(USER_ID, request);
+
+        assertThat(response.nickname()).isEqualTo("닉네임");
+        assertThat(user.getSignupStep()).isEqualTo("PROFILE_COMPLETED");
+    }
+
+    @Test
+    @DisplayName("SOCIAL_AUTHENTICATED 단계가 아니면 SIGNUP_STEP_INVALID를 던진다")
+    void completeSignup_wrongStep_throwsStepInvalid() {
+        User user = buildUser(USER_ID, "kakao", "social-123", "PROFILE_COMPLETED", "ACTIVE");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        assertThatThrownBy(() -> authService.completeSignup(USER_ID, buildCompleteRequest("닉네임")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SIGNUP_STEP_INVALID));
+    }
+
+    @Test
+    @DisplayName("terms 동의가 없으면 CONSENT_REQUIRED를 던진다")
+    void completeSignup_missingTermsConsent_throwsConsentRequired() {
+        User user = buildUser(USER_ID, "kakao", "social-123", "SOCIAL_AUTHENTICATED", "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        SignupCompleteRequest request = new SignupCompleteRequest(
+                "닉네임", "20대", "male",
+                List.of(new SignupCompleteRequest.ConsentItem("privacy", true, "v1"))
+        );
+
+        assertThatThrownBy(() -> authService.completeSignup(USER_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.CONSENT_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("이미 사용 중인 닉네임이면 NICKNAME_DUPLICATE를 던진다")
+    void completeSignup_duplicateNickname_throwsDuplicate() {
+        User user = buildUser(USER_ID, "kakao", "social-123", "SOCIAL_AUTHENTICATED", "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("중복닉네임")).thenReturn(true);
+
+        assertThatThrownBy(() -> authService.completeSignup(USER_ID, buildCompleteRequest("중복닉네임")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.NICKNAME_DUPLICATE));
+    }
+
+    // ──────────────── checkNicknameDuplicate ────────────────
+
+    @Test
+    @DisplayName("닉네임 중복 여부를 올바르게 반환한다")
+    void checkNicknameDuplicate_returnsRepoResult() {
+        when(userRepository.existsByNickname("사용중")).thenReturn(true);
+        when(userRepository.existsByNickname("사용가능")).thenReturn(false);
+
+        assertThat(authService.checkNicknameDuplicate("사용중")).isTrue();
+        assertThat(authService.checkNicknameDuplicate("사용가능")).isFalse();
+    }
+
+    // ──────────────── withdraw ────────────────
+
+    @Test
+    @DisplayName("회원탈퇴 시 social_id가 익명화되고 status가 DELETED가 된다")
+    void withdraw_anonymizesSocialIdAndSetsDeleted() {
+        User user = buildUser(USER_ID, "kakao", "original-social-id", "COMPLETED", "ACTIVE");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        authService.withdraw(USER_ID);
+
+        verify(refreshTokenService).invalidateAll(USER_ID.toString());
+        assertThat(user.getStatus()).isEqualTo("DELETED");
+        assertThat(user.getSocialId()).isNotEqualTo("original-social-id"); // SHA-256 해시로 대체
+        assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자");
+        assertThat(user.getEmail()).isNull();
+    }
+
+    // ──────────────── helpers ────────────────
+
+    private User buildUser(UUID id, String provider, String socialId, String signupStep, String status) {
+        return User.builder()
+                .id(id)
+                .socialProvider(provider)
+                .socialId(socialId)
+                .privacyConsent(true)
+                .signupStep(signupStep)
+                .status(status)
+                .build();
+    }
+
+    private SignupCompleteRequest buildCompleteRequest(String nickname) {
+        return new SignupCompleteRequest(
+                nickname, "20대", "male",
+                List.of(
+                        new SignupCompleteRequest.ConsentItem("terms", true, "v1"),
+                        new SignupCompleteRequest.ConsentItem("privacy", true, "v1")
+                )
+        );
+    }
+}

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -39,7 +38,6 @@ class AuthServiceTest {
 
     private static final UUID USER_ID = UUID.randomUUID();
     private static final String DEVICE_ID = "device-abc";
-    private static final String TEST_HASH_SALT = "test-jwt-secret-key-minimum-32-chars!!";
 
     @BeforeEach
     void setUp() {
@@ -51,7 +49,6 @@ class AuthServiceTest {
                 List.of(kakaoProvider), userRepository, userConsentRepository,
                 jwtTokenService, refreshTokenService, refreshTokenRedisRepository
         );
-        ReflectionTestUtils.setField(authService, "withdrawalAnonymizationSecret", TEST_HASH_SALT);
     }
 
     // ──────────────── login ────────────────

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
 import java.util.Optional;
@@ -38,6 +39,7 @@ class AuthServiceTest {
 
     private static final UUID USER_ID = UUID.randomUUID();
     private static final String DEVICE_ID = "device-abc";
+    private static final String TEST_HASH_SALT = "test-jwt-secret-key-minimum-32-chars!!";
 
     @BeforeEach
     void setUp() {
@@ -49,6 +51,7 @@ class AuthServiceTest {
                 List.of(kakaoProvider), userRepository, userConsentRepository,
                 jwtTokenService, refreshTokenService, refreshTokenRedisRepository
         );
+        ReflectionTestUtils.setField(authService, "hashSalt", TEST_HASH_SALT);
     }
 
     // ──────────────── login ────────────────

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -51,7 +51,7 @@ class AuthServiceTest {
                 List.of(kakaoProvider), userRepository, userConsentRepository,
                 jwtTokenService, refreshTokenService, refreshTokenRedisRepository
         );
-        ReflectionTestUtils.setField(authService, "hashSalt", TEST_HASH_SALT);
+        ReflectionTestUtils.setField(authService, "withdrawalAnonymizationSecret", TEST_HASH_SALT);
     }
 
     // ──────────────── login ────────────────

--- a/src/test/java/com/mio/auth/service/JwtTokenServiceTest.java
+++ b/src/test/java/com/mio/auth/service/JwtTokenServiceTest.java
@@ -1,0 +1,75 @@
+package com.mio.auth.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenServiceTest {
+
+    private static final String SECRET = "test-jwt-secret-key-minimum-32-chars!!";
+
+    private JwtTokenService jwtTokenService;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenService = new JwtTokenService(SECRET, 900);
+    }
+
+    @Test
+    @DisplayName("발급된 토큰에서 userId, deviceId, is_minor claim을 올바르게 추출한다")
+    void generateAndParse_returnsCorrectClaims() {
+        String token = jwtTokenService.generateAccessToken("user-123", "device-abc", false);
+
+        Claims claims = jwtTokenService.parseToken(token);
+
+        assertThat(claims.getSubject()).isEqualTo("user-123");
+        assertThat(claims.get("device_id", String.class)).isEqualTo("device-abc");
+        assertThat(claims.get("is_minor", Boolean.class)).isFalse();
+        assertThat(claims.get("scope", List.class)).containsExactly("user");
+    }
+
+    @Test
+    @DisplayName("미성년자 플래그가 true인 경우 is_minor claim이 true다")
+    void generateToken_minorUser_isMinorTrue() {
+        String token = jwtTokenService.generateAccessToken("user-minor", "device-1", true);
+
+        Claims claims = jwtTokenService.parseToken(token);
+
+        assertThat(claims.get("is_minor", Boolean.class)).isTrue();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰 파싱 시 ExpiredJwtException을 던진다")
+    void parseToken_expiredToken_throwsExpiredJwtException() {
+        JwtTokenService shortLived = new JwtTokenService(SECRET, -1);
+        String expiredToken = shortLived.generateAccessToken("user-123", "device-abc", false);
+
+        assertThatThrownBy(() -> jwtTokenService.parseToken(expiredToken))
+                .isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @Test
+    @DisplayName("서명이 다른 토큰 파싱 시 JwtException을 던진다")
+    void parseToken_wrongSignature_throwsJwtException() {
+        JwtTokenService otherService = new JwtTokenService("other-secret-key-minimum-32-chars!!", 900);
+        String foreignToken = otherService.generateAccessToken("user-123", "device-abc", false);
+
+        assertThatThrownBy(() -> jwtTokenService.parseToken(foreignToken))
+                .isInstanceOf(JwtException.class);
+    }
+
+    @Test
+    @DisplayName("완전히 잘못된 문자열 파싱 시 JwtException을 던진다")
+    void parseToken_malformedToken_throwsJwtException() {
+        assertThatThrownBy(() -> jwtTokenService.parseToken("not.a.jwt"))
+                .isInstanceOf(JwtException.class);
+    }
+}

--- a/src/test/java/com/mio/auth/service/RefreshTokenServiceTest.java
+++ b/src/test/java/com/mio/auth/service/RefreshTokenServiceTest.java
@@ -1,0 +1,159 @@
+package com.mio.auth.service;
+
+import com.mio.auth.redis.RefreshTokenInfo;
+import com.mio.auth.redis.RefreshTokenRedisRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock private RefreshTokenRedisRepository refreshTokenRedisRepository;
+    @Mock private JwtTokenService jwtTokenService;
+    @Mock private UserRepository userRepository;
+
+    private RefreshTokenService refreshTokenService;
+
+    @BeforeEach
+    void setUp() {
+        refreshTokenService = new RefreshTokenService(refreshTokenRedisRepository, jwtTokenService, userRepository);
+    }
+
+    @Test
+    @DisplayName("issue는 mio_refresh_ 접두사가 붙은 토큰을 반환하고 Redis에 저장한다")
+    void issue_storesInRedisAndReturnsPrefixedToken() {
+        String token = refreshTokenService.issue("user-1", "device-1", "kakao", "COMPLETED");
+
+        assertThat(token).startsWith("mio_refresh_");
+        verify(refreshTokenRedisRepository).issueToken(eq("user-1"), eq("device-1"), any(), any());
+    }
+
+    @Test
+    @DisplayName("유효한 refresh 토큰으로 새 access 토큰을 발급한다")
+    void refresh_validToken_returnsNewAccessToken() {
+        UUID userId = UUID.randomUUID();
+        RefreshTokenInfo info = new RefreshTokenInfo(userId.toString(), "device-1", "kakao", "COMPLETED");
+        User activeUser = User.builder()
+                .id(userId)
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .status("ACTIVE")
+                .build();
+
+        when(refreshTokenRedisRepository.validateToken(any())).thenReturn(Optional.of(info));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(activeUser));
+        when(jwtTokenService.generateAccessToken(any(), any(), eq(false))).thenReturn("new-access-token");
+
+        String result = refreshTokenService.refresh("mio_refresh_" + UUID.randomUUID());
+
+        assertThat(result).isEqualTo("new-access-token");
+    }
+
+    @Test
+    @DisplayName("접두사가 없는 토큰은 REFRESH_TOKEN_INVALID를 던진다")
+    void refresh_noPrefixToken_throwsInvalid() {
+        assertThatThrownBy(() -> refreshTokenService.refresh("plain-uuid-token"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.REFRESH_TOKEN_INVALID));
+    }
+
+    @Test
+    @DisplayName("null 토큰은 REFRESH_TOKEN_INVALID를 던진다")
+    void refresh_nullToken_throwsInvalid() {
+        assertThatThrownBy(() -> refreshTokenService.refresh(null))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.REFRESH_TOKEN_INVALID));
+    }
+
+    @Test
+    @DisplayName("Redis에 존재하지 않는 토큰은 REFRESH_TOKEN_INVALID를 던진다")
+    void refresh_notInRedis_throwsInvalid() {
+        when(refreshTokenRedisRepository.validateToken(any())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> refreshTokenService.refresh("mio_refresh_" + UUID.randomUUID()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.REFRESH_TOKEN_INVALID));
+    }
+
+    @Test
+    @DisplayName("정지된 사용자는 refresh 시 USER_SUSPENDED를 던진다")
+    void refresh_suspendedUser_throwsSuspended() {
+        UUID userId = UUID.randomUUID();
+        RefreshTokenInfo info = new RefreshTokenInfo(userId.toString(), "device-1", "kakao", "COMPLETED");
+        User suspendedUser = User.builder()
+                .id(userId)
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .status("SUSPENDED")
+                .build();
+
+        when(refreshTokenRedisRepository.validateToken(any())).thenReturn(Optional.of(info));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(suspendedUser));
+
+        assertThatThrownBy(() -> refreshTokenService.refresh("mio_refresh_" + UUID.randomUUID()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_SUSPENDED));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 사용자는 refresh 시 USER_WITHDRAWN을 던진다")
+    void refresh_deletedUser_throwsWithdrawn() {
+        UUID userId = UUID.randomUUID();
+        RefreshTokenInfo info = new RefreshTokenInfo(userId.toString(), "device-1", "kakao", "COMPLETED");
+        User deletedUser = User.builder()
+                .id(userId)
+                .socialProvider("kakao")
+                .socialId("anonymized-hash")
+                .privacyConsent(true)
+                .status("DELETED")
+                .build();
+
+        when(refreshTokenRedisRepository.validateToken(any())).thenReturn(Optional.of(info));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(deletedUser));
+
+        assertThatThrownBy(() -> refreshTokenService.refresh("mio_refresh_" + UUID.randomUUID()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_WITHDRAWN));
+    }
+
+    @Test
+    @DisplayName("logout은 해당 기기의 refresh 토큰을 삭제한다")
+    void logout_callsLogoutDevice() {
+        refreshTokenService.logout("user-1", "device-1");
+
+        verify(refreshTokenRedisRepository).logoutDevice("user-1", "device-1");
+    }
+
+    @Test
+    @DisplayName("invalidateAll은 사용자의 모든 refresh 토큰을 삭제한다")
+    void invalidateAll_callsInvalidateAll() {
+        refreshTokenService.invalidateAll("user-1");
+
+        verify(refreshTokenRedisRepository).invalidateAll("user-1");
+    }
+}

--- a/src/test/java/com/mio/config/EmbeddedRedisConfig.java
+++ b/src/test/java/com/mio/config/EmbeddedRedisConfig.java
@@ -1,0 +1,31 @@
+package com.mio.config;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import redis.embedded.RedisServer;
+
+import java.io.IOException;
+
+@Configuration
+@Profile("test")
+public class EmbeddedRedisConfig {
+
+    private static final int PORT = 6370;
+
+    private RedisServer redisServer;
+
+    @PostConstruct
+    public void startRedis() throws IOException {
+        redisServer = new RedisServer(PORT);
+        redisServer.start();
+    }
+
+    @PreDestroy
+    public void stopRedis() {
+        if (redisServer != null && redisServer.isActive()) {
+            redisServer.stop();
+        }
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    redis:
+      host: localhost
+      port: 6370
+      password: ""


### PR DESCRIPTION
제목: feat: 회원가입 플로우 API 구현 (#6)

  본문:
  ## Summary
                                                                                                                                                                                      
  - `GET /v1/auth/signup/status` — 현재 가입 단계 조회
  - `GET /v1/auth/nickname/duplicate-check` — 닉네임 중복 확인
  - `POST /v1/auth/signup/complete` — 회원가입 완료 (닉네임·동의·프로필 저장)

  > 본 PR의 구현은 #5 (소셜 로그인 및 JWT 인증 도메인)에서 함께 완료되었습니다.
  > 이슈 #6 요구사항 전체가 해당 브랜치에 포함되어 있음을 확인 후 PR로 등록합니다.

  ## 구현 내용

  | 요구사항 | 구현 위치 |
  |---|---|
  | signup_step 유효성 검사 | `AuthService.completeSignup()` |
  | 닉네임 중복 체크 + NICKNAME_DUPLICATE | `AuthService.completeSignup()` |
  | 동의 항목 검증 + CONSENT_REQUIRED | `AuthService.completeSignup()` |
  | user_consents 저장 (saveAll) | `AuthService.completeSignup()` |
  | PROFILE_COMPLETED 전환 | `User.completeProfile()` |
  | 재진입 복구 지원 | `GET /v1/auth/signup/status` |

  ## Test plan

  - [x] completeSignup 정상 흐름
  - [x] SIGNUP_STEP_INVALID
  - [x] CONSENT_REQUIRED
  - [x] NICKNAME_DUPLICATE
  - [x] checkNicknameDuplicate 반환값 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Social login via Apple and Kakao OAuth providers
  * JWT-based authentication with refresh token support
  * Device tracking and session management
  * User onboarding with profile completion and consent management
  * Account withdrawal with 30-day deletion grace period
  * Nickname availability checking

* **Documentation**
  * Added authentication and database design specifications

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->