### PR TITLE
feat: Todo(BehaviorTask) 도메인 REST API 구현 (#18)

### DIFF
--- a/src/main/java/com/mio/checkin/repository/CheckinRepository.java
+++ b/src/main/java/com/mio/checkin/repository/CheckinRepository.java
@@ -9,6 +9,8 @@ import java.util.UUID;
 
 public interface CheckinRepository extends JpaRepository<Checkin, UUID> {
 
+    Optional<Checkin> findByIdAndUser_Id(UUID id, UUID userId);
+
     Optional<Checkin> findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(UUID userId, LocalDate date);
 
     Optional<Checkin> findTopByUser_IdOrderByCreatedAtDesc(UUID userId);

--- a/src/main/java/com/mio/checkin/repository/CheckinRepository.java
+++ b/src/main/java/com/mio/checkin/repository/CheckinRepository.java
@@ -1,0 +1,15 @@
+package com.mio.checkin.repository;
+
+import com.mio.checkin.domain.Checkin;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CheckinRepository extends JpaRepository<Checkin, UUID> {
+
+    Optional<Checkin> findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(UUID userId, LocalDate date);
+
+    Optional<Checkin> findTopByUser_IdOrderByCreatedAtDesc(UUID userId);
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -44,6 +44,10 @@ public enum ErrorCode {
     DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),
     DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
 
+    // Todo
+    TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),
+    TODO_ALREADY_COMPLETED(HttpStatus.CONFLICT, "TODO_ALREADY_COMPLETED", "이미 완료 또는 처리된 할 일입니다."),
+
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다.");
 

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     // Todo
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),
     TODO_ALREADY_COMPLETED(HttpStatus.CONFLICT, "TODO_ALREADY_COMPLETED", "이미 완료 또는 처리된 할 일입니다."),
+    TODO_ALREADY_GENERATED(HttpStatus.CONFLICT, "TODO_ALREADY_GENERATED", "이미 생성된 오늘의 할 일입니다."),
+    TODO_EXPIRED(HttpStatus.UNPROCESSABLE_ENTITY, "TODO_EXPIRED", "만료된 할 일은 처리할 수 없습니다."),
 
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다.");

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -18,6 +18,8 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/health",
             "/v1/auth/**",
+            "/v1/onboarding/**",
+            "/v1/todos/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -13,6 +13,8 @@ import java.util.UUID;
 
 public interface SessionRepository extends JpaRepository<Session, UUID> {
 
+    Optional<Session> findByIdAndUser_Id(UUID id, UUID userId);
+
     Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);
 
     boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);

--- a/src/main/java/com/mio/todo/controller/TodoController.java
+++ b/src/main/java/com/mio/todo/controller/TodoController.java
@@ -1,0 +1,63 @@
+package com.mio.todo.controller;
+
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import com.mio.todo.dto.TodoCheckinRequest;
+import com.mio.todo.dto.TodoCheckinResponse;
+import com.mio.todo.dto.TodoGenerateRequest;
+import com.mio.todo.dto.TodoResponse;
+import com.mio.todo.service.TodoService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/todos")
+@RequiredArgsConstructor
+public class TodoController {
+
+    private final TodoService todoService;
+
+    @PostMapping("/generate")
+    public ResponseEntity<ApiResponse<List<TodoResponse>>> generate(
+            @RequestHeader("X-User-Id") String userIdStr,
+            @Valid @RequestBody TodoGenerateRequest request) {
+        UUID userId = resolveUserId(userIdStr);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(todoService.generate(userId, request)));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<TodoResponse>>> getTodos(
+            @RequestHeader("X-User-Id") String userIdStr,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(required = false) String status) {
+        UUID userId = resolveUserId(userIdStr);
+        return ResponseEntity.ok(ApiResponse.ok(todoService.getTodos(userId, date, status)));
+    }
+
+    @PostMapping("/{todoId}/checkin")
+    public ResponseEntity<ApiResponse<TodoCheckinResponse>> checkin(
+            @RequestHeader("X-User-Id") String userIdStr,
+            @PathVariable UUID todoId,
+            @Valid @RequestBody TodoCheckinRequest request) {
+        UUID userId = resolveUserId(userIdStr);
+        return ResponseEntity.ok(ApiResponse.ok(todoService.checkin(userId, todoId, request)));
+    }
+
+    private UUID resolveUserId(String userIdStr) {
+        try {
+            return UUID.fromString(userIdStr);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/mio/todo/domain/BehaviorTask.java
+++ b/src/main/java/com/mio/todo/domain/BehaviorTask.java
@@ -56,10 +56,9 @@ public class BehaviorTask {
     @Column(name = "character_id")
     private String characterId;
 
-    /** suggested / completed / skipped / expired */
     @Column(name = "status", nullable = false)
     @Builder.Default
-    private String status = "suggested";
+    private TaskStatus status = TaskStatus.SUGGESTED;
 
     /** CBT 측정용 0~100 */
     @Column(name = "before_emotion")
@@ -79,12 +78,12 @@ public class BehaviorTask {
     private OffsetDateTime completedAt;
 
     public void complete(Integer beforeEmotion, Integer afterEmotion, String feedback) {
-        if (!"suggested".equals(this.status)) {
+        if (TaskStatus.SUGGESTED != this.status) {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
         validateEmotionRange(beforeEmotion);
         validateEmotionRange(afterEmotion);
-        this.status = "completed";
+        this.status = TaskStatus.COMPLETED;
         this.beforeEmotion = beforeEmotion;
         this.afterEmotion = afterEmotion;
         this.feedback = feedback;
@@ -92,10 +91,10 @@ public class BehaviorTask {
     }
 
     public void skip() {
-        if (!"suggested".equals(this.status)) {
+        if (TaskStatus.SUGGESTED != this.status) {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
-        this.status = "skipped";
+        this.status = TaskStatus.SKIPPED;
         this.completedAt = OffsetDateTime.now(AppConstants.ZONE);
     }
 

--- a/src/main/java/com/mio/todo/domain/BehaviorTask.java
+++ b/src/main/java/com/mio/todo/domain/BehaviorTask.java
@@ -1,6 +1,8 @@
 package com.mio.todo.domain;
 
 import com.mio.checkin.domain.Checkin;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
 import com.mio.user.domain.User;
 import jakarta.persistence.*;
@@ -74,6 +76,25 @@ public class BehaviorTask {
 
     @Column(name = "completed_at")
     private OffsetDateTime completedAt;
+
+    public void complete(Integer beforeEmotion, Integer afterEmotion, String feedback) {
+        if (!"suggested".equals(this.status)) {
+            throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
+        }
+        this.status = "completed";
+        this.beforeEmotion = beforeEmotion;
+        this.afterEmotion = afterEmotion;
+        this.feedback = feedback;
+        this.completedAt = OffsetDateTime.now();
+    }
+
+    public void skip() {
+        if (!"suggested".equals(this.status)) {
+            throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
+        }
+        this.status = "skipped";
+        this.completedAt = OffsetDateTime.now();
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/mio/todo/domain/BehaviorTask.java
+++ b/src/main/java/com/mio/todo/domain/BehaviorTask.java
@@ -1,6 +1,7 @@
 package com.mio.todo.domain;
 
 import com.mio.checkin.domain.Checkin;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
@@ -81,11 +82,13 @@ public class BehaviorTask {
         if (!"suggested".equals(this.status)) {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
+        validateEmotionRange(beforeEmotion);
+        validateEmotionRange(afterEmotion);
         this.status = "completed";
         this.beforeEmotion = beforeEmotion;
         this.afterEmotion = afterEmotion;
         this.feedback = feedback;
-        this.completedAt = OffsetDateTime.now();
+        this.completedAt = OffsetDateTime.now(AppConstants.ZONE);
     }
 
     public void skip() {
@@ -93,11 +96,17 @@ public class BehaviorTask {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
         this.status = "skipped";
-        this.completedAt = OffsetDateTime.now();
+        this.completedAt = OffsetDateTime.now(AppConstants.ZONE);
     }
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(AppConstants.ZONE);
+    }
+
+    private void validateEmotionRange(Integer value) {
+        if (value != null && (value < 0 || value > 100)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
     }
 }

--- a/src/main/java/com/mio/todo/domain/TaskStatus.java
+++ b/src/main/java/com/mio/todo/domain/TaskStatus.java
@@ -1,0 +1,27 @@
+package com.mio.todo.domain;
+
+import java.util.Arrays;
+
+public enum TaskStatus {
+    SUGGESTED("suggested"),
+    COMPLETED("completed"),
+    SKIPPED("skipped"),
+    EXPIRED("expired");
+
+    private final String value;
+
+    TaskStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static TaskStatus fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(s -> s.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown task status: " + value));
+    }
+}

--- a/src/main/java/com/mio/todo/domain/TaskStatusConverter.java
+++ b/src/main/java/com/mio/todo/domain/TaskStatusConverter.java
@@ -1,0 +1,18 @@
+package com.mio.todo.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class TaskStatusConverter implements AttributeConverter<TaskStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(TaskStatus attribute) {
+        return attribute == null ? null : attribute.value();
+    }
+
+    @Override
+    public TaskStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : TaskStatus.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
@@ -2,9 +2,11 @@ package com.mio.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 public record TodoCheckinRequest(
         @NotBlank
+        @Pattern(regexp = "completed|skipped", message = "status는 completed 또는 skipped 이어야 합니다.")
         String status,
 
         @JsonProperty("before_emotion")

--- a/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
@@ -1,0 +1,17 @@
+package com.mio.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+public record TodoCheckinRequest(
+        @NotBlank
+        String status,
+
+        @JsonProperty("before_emotion")
+        Integer beforeEmotion,
+
+        @JsonProperty("after_emotion")
+        Integer afterEmotion,
+
+        String feedback
+) {}

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -26,7 +26,7 @@ public record TodoCheckinResponse(
     public static TodoCheckinResponse from(BehaviorTask task) {
         return new TodoCheckinResponse(
                 task.getId(),
-                task.getStatus(),
+                task.getStatus().value(),
                 task.getBeforeEmotion(),
                 task.getAfterEmotion(),
                 task.getFeedback(),

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -1,0 +1,36 @@
+package com.mio.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.todo.domain.BehaviorTask;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record TodoCheckinResponse(
+        @JsonProperty("todo_id")
+        UUID todoId,
+
+        String status,
+
+        @JsonProperty("before_emotion")
+        Integer beforeEmotion,
+
+        @JsonProperty("after_emotion")
+        Integer afterEmotion,
+
+        String feedback,
+
+        @JsonProperty("completed_at")
+        OffsetDateTime completedAt
+) {
+    public static TodoCheckinResponse from(BehaviorTask task) {
+        return new TodoCheckinResponse(
+                task.getId(),
+                task.getStatus(),
+                task.getBeforeEmotion(),
+                task.getAfterEmotion(),
+                task.getFeedback(),
+                task.getCompletedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
@@ -1,0 +1,14 @@
+package com.mio.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.UUID;
+
+public record TodoGenerateRequest(
+        @NotBlank
+        String source,
+
+        @JsonProperty("source_id")
+        UUID sourceId
+) {}

--- a/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
@@ -2,11 +2,13 @@ package com.mio.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 
 import java.util.UUID;
 
 public record TodoGenerateRequest(
         @NotBlank
+        @Pattern(regexp = "checkin|chat", message = "source는 checkin 또는 chat 이어야 합니다.")
         String source,
 
         @JsonProperty("source_id")

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -31,7 +31,7 @@ public record TodoResponse(
                 task.getCategory(),
                 task.getDifficulty(),
                 task.getEstimatedMinutes(),
-                task.getStatus(),
+                task.getStatus().value(),
                 task.getCreatedAt()
         );
     }

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -2,6 +2,7 @@ package com.mio.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.domain.TaskStatus;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
@@ -36,14 +37,14 @@ public record TodoResponse(
         );
     }
 
-    public static TodoResponse fromWithStatus(BehaviorTask task, String overrideStatus) {
+    public static TodoResponse fromWithStatus(BehaviorTask task, TaskStatus overrideStatus) {
         return new TodoResponse(
                 task.getId(),
                 task.getActionText(),
                 task.getCategory(),
                 task.getDifficulty(),
                 task.getEstimatedMinutes(),
-                overrideStatus,
+                overrideStatus.value(),
                 task.getCreatedAt()
         );
     }

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -1,0 +1,50 @@
+package com.mio.todo.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.todo.domain.BehaviorTask;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record TodoResponse(
+        @JsonProperty("todo_id")
+        UUID todoId,
+
+        @JsonProperty("action_text")
+        String actionText,
+
+        String category,
+        Integer difficulty,
+
+        @JsonProperty("estimated_minutes")
+        Integer estimatedMinutes,
+
+        String status,
+
+        @JsonProperty("created_at")
+        OffsetDateTime createdAt
+) {
+    public static TodoResponse from(BehaviorTask task) {
+        return new TodoResponse(
+                task.getId(),
+                task.getActionText(),
+                task.getCategory(),
+                task.getDifficulty(),
+                task.getEstimatedMinutes(),
+                task.getStatus(),
+                task.getCreatedAt()
+        );
+    }
+
+    public static TodoResponse fromWithStatus(BehaviorTask task, String overrideStatus) {
+        return new TodoResponse(
+                task.getId(),
+                task.getActionText(),
+                task.getCategory(),
+                task.getDifficulty(),
+                task.getEstimatedMinutes(),
+                overrideStatus,
+                task.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
+++ b/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
@@ -17,4 +17,30 @@ public interface BehaviorTaskRepository extends JpaRepository<BehaviorTask, UUID
     List<BehaviorTask> findByUser_IdAndStatusAndCreatedAtBetween(
             UUID userId, TaskStatus status, OffsetDateTime from, OffsetDateTime to
     );
+
+    boolean existsByUser_IdAndGeneratedFromAndSourceCheckin_IdAndStatusAndCreatedAtBetween(
+            UUID userId,
+            String generatedFrom,
+            UUID sourceCheckinId,
+            TaskStatus status,
+            OffsetDateTime from,
+            OffsetDateTime to
+    );
+
+    boolean existsByUser_IdAndGeneratedFromAndSourceSession_IdAndStatusAndCreatedAtBetween(
+            UUID userId,
+            String generatedFrom,
+            UUID sourceSessionId,
+            TaskStatus status,
+            OffsetDateTime from,
+            OffsetDateTime to
+    );
+
+    boolean existsByUser_IdAndGeneratedFromAndSourceCheckinIsNullAndSourceSessionIsNullAndStatusAndCreatedAtBetween(
+            UUID userId,
+            String generatedFrom,
+            TaskStatus status,
+            OffsetDateTime from,
+            OffsetDateTime to
+    );
 }

--- a/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
+++ b/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
@@ -1,0 +1,19 @@
+package com.mio.todo.repository;
+
+import com.mio.todo.domain.BehaviorTask;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface BehaviorTaskRepository extends JpaRepository<BehaviorTask, UUID> {
+
+    List<BehaviorTask> findByUser_IdAndCreatedAtBetween(
+            UUID userId, OffsetDateTime from, OffsetDateTime to
+    );
+
+    List<BehaviorTask> findByUser_IdAndStatusAndCreatedAtBetween(
+            UUID userId, String status, OffsetDateTime from, OffsetDateTime to
+    );
+}

--- a/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
+++ b/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
@@ -1,6 +1,7 @@
 package com.mio.todo.repository;
 
 import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.domain.TaskStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
@@ -14,6 +15,6 @@ public interface BehaviorTaskRepository extends JpaRepository<BehaviorTask, UUID
     );
 
     List<BehaviorTask> findByUser_IdAndStatusAndCreatedAtBetween(
-            UUID userId, String status, OffsetDateTime from, OffsetDateTime to
+            UUID userId, TaskStatus status, OffsetDateTime from, OffsetDateTime to
     );
 }

--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -2,6 +2,7 @@ package com.mio.todo.service;
 
 import com.mio.checkin.domain.Checkin;
 import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
@@ -21,7 +22,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -49,9 +49,9 @@ public class TodoService {
         User user = findUser(userId);
         requireOnboardingComplete(user);
 
-        String emotionType = resolveEmotionType(userId, request);
-        List<TodoTemplateProvider.TaskTemplate> templates = templateProvider.getTemplates(emotionType);
         Checkin checkin = resolveCheckin(userId, request);
+        String emotionType = checkin != null ? checkin.getEmotionType() : "default";
+        List<TodoTemplateProvider.TaskTemplate> templates = templateProvider.getTemplates(emotionType);
         Session session = resolveSession(userId, request);
 
         List<BehaviorTask> tasks = templates.stream()
@@ -77,10 +77,10 @@ public class TodoService {
         User user = findUser(userId);
         requireOnboardingComplete(user);
 
-        LocalDate targetDate = date != null ? date : LocalDate.now(ZoneOffset.UTC);
-        OffsetDateTime from = targetDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
-        OffsetDateTime to = targetDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
-        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LocalDate targetDate = date != null ? date : LocalDate.now(AppConstants.ZONE);
+        OffsetDateTime from = targetDate.atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = targetDate.plusDays(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
 
         List<BehaviorTask> tasks;
         if (status != null) {
@@ -107,7 +107,7 @@ public class TodoService {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
 
-        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
         if (isExpired(task, today)) {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
@@ -126,34 +126,16 @@ public class TodoService {
                 && task.getCreatedAt().toLocalDate().isBefore(today);
     }
 
-    private String resolveEmotionType(UUID userId, TodoGenerateRequest request) {
-        if ("checkin".equals(request.source())) {
-            return resolveCheckinEmotion(userId, request.sourceId());
-        }
-        return "default";
-    }
-
-    private String resolveCheckinEmotion(UUID userId, UUID sourceId) {
-        Checkin checkin;
-        if (sourceId != null) {
-            checkin = checkinRepository.findById(sourceId).orElse(null);
-        } else {
-            checkin = checkinRepository
-                    .findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(userId, LocalDate.now(ZoneOffset.UTC))
-                    .orElse(null);
-        }
-        return checkin != null ? checkin.getEmotionType() : "default";
-    }
-
     private Checkin resolveCheckin(UUID userId, TodoGenerateRequest request) {
         if (!"checkin".equals(request.source())) {
             return null;
         }
         if (request.sourceId() != null) {
-            return checkinRepository.findById(request.sourceId()).orElse(null);
+            return checkinRepository.findByIdAndUser_Id(request.sourceId(), userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN));
         }
         return checkinRepository
-                .findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(userId, LocalDate.now(ZoneOffset.UTC))
+                .findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(userId, LocalDate.now(AppConstants.ZONE))
                 .orElse(null);
     }
 
@@ -162,7 +144,8 @@ public class TodoService {
             return null;
         }
         if (request.sourceId() != null) {
-            return sessionRepository.findById(request.sourceId()).orElse(null);
+            return sessionRepository.findByIdAndUser_Id(request.sourceId(), userId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN));
         }
         return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE).orElse(null);
     }

--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -1,0 +1,180 @@
+package com.mio.todo.service;
+
+import com.mio.checkin.domain.Checkin;
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionStatus;
+import com.mio.session.repository.SessionRepository;
+import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.dto.TodoCheckinRequest;
+import com.mio.todo.dto.TodoCheckinResponse;
+import com.mio.todo.dto.TodoGenerateRequest;
+import com.mio.todo.dto.TodoResponse;
+import com.mio.todo.repository.BehaviorTaskRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TodoService {
+
+    private static final Set<String> ONBOARDING_COMPLETE_STEPS = Set.of("ONBOARDING_COMPLETED", "COMPLETED");
+    private static final Set<String> VALID_SOURCES = Set.of("checkin", "chat");
+    private static final Set<String> VALID_CHECKIN_STATUSES = Set.of("completed", "skipped");
+
+    private final UserRepository userRepository;
+    private final BehaviorTaskRepository behaviorTaskRepository;
+    private final CheckinRepository checkinRepository;
+    private final SessionRepository sessionRepository;
+    private final TodoTemplateProvider templateProvider;
+
+    @Transactional
+    public List<TodoResponse> generate(UUID userId, TodoGenerateRequest request) {
+        if (!VALID_SOURCES.contains(request.source())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        User user = findUser(userId);
+        requireOnboardingComplete(user);
+
+        String emotionType = resolveEmotionType(userId, request);
+        List<TodoTemplateProvider.TaskTemplate> templates = templateProvider.getTemplates(emotionType);
+        Checkin checkin = resolveCheckin(userId, request);
+        Session session = resolveSession(userId, request);
+
+        List<BehaviorTask> tasks = templates.stream()
+                .map(t -> BehaviorTask.builder()
+                        .user(user)
+                        .generatedFrom(request.source())
+                        .actionText(t.actionText())
+                        .category(t.category())
+                        .difficulty(t.difficulty())
+                        .estimatedMinutes(t.estimatedMinutes())
+                        .sourceCheckin(checkin)
+                        .sourceSession(session)
+                        .build())
+                .toList();
+
+        return behaviorTaskRepository.saveAll(tasks).stream()
+                .map(TodoResponse::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TodoResponse> getTodos(UUID userId, LocalDate date, String status) {
+        User user = findUser(userId);
+        requireOnboardingComplete(user);
+
+        LocalDate targetDate = date != null ? date : LocalDate.now(ZoneOffset.UTC);
+        OffsetDateTime from = targetDate.atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
+        OffsetDateTime to = targetDate.plusDays(1).atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+
+        List<BehaviorTask> tasks;
+        if (status != null) {
+            tasks = behaviorTaskRepository.findByUser_IdAndStatusAndCreatedAtBetween(userId, status, from, to);
+        } else {
+            tasks = behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(userId, from, to);
+        }
+
+        return tasks.stream()
+                .map(t -> isExpired(t, today) ? TodoResponse.fromWithStatus(t, "expired") : TodoResponse.from(t))
+                .toList();
+    }
+
+    @Transactional
+    public TodoCheckinResponse checkin(UUID userId, UUID todoId, TodoCheckinRequest request) {
+        if (!VALID_CHECKIN_STATUSES.contains(request.status())) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        BehaviorTask task = behaviorTaskRepository.findById(todoId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.TODO_NOT_FOUND));
+
+        if (!task.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        LocalDate today = LocalDate.now(ZoneOffset.UTC);
+        if (isExpired(task, today)) {
+            throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
+        }
+
+        if ("completed".equals(request.status())) {
+            task.complete(request.beforeEmotion(), request.afterEmotion(), request.feedback());
+        } else {
+            task.skip();
+        }
+
+        return TodoCheckinResponse.from(task);
+    }
+
+    private boolean isExpired(BehaviorTask task, LocalDate today) {
+        return "suggested".equals(task.getStatus())
+                && task.getCreatedAt().toLocalDate().isBefore(today);
+    }
+
+    private String resolveEmotionType(UUID userId, TodoGenerateRequest request) {
+        if ("checkin".equals(request.source())) {
+            return resolveCheckinEmotion(userId, request.sourceId());
+        }
+        return "default";
+    }
+
+    private String resolveCheckinEmotion(UUID userId, UUID sourceId) {
+        Checkin checkin;
+        if (sourceId != null) {
+            checkin = checkinRepository.findById(sourceId).orElse(null);
+        } else {
+            checkin = checkinRepository
+                    .findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(userId, LocalDate.now(ZoneOffset.UTC))
+                    .orElse(null);
+        }
+        return checkin != null ? checkin.getEmotionType() : "default";
+    }
+
+    private Checkin resolveCheckin(UUID userId, TodoGenerateRequest request) {
+        if (!"checkin".equals(request.source())) {
+            return null;
+        }
+        if (request.sourceId() != null) {
+            return checkinRepository.findById(request.sourceId()).orElse(null);
+        }
+        return checkinRepository
+                .findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(userId, LocalDate.now(ZoneOffset.UTC))
+                .orElse(null);
+    }
+
+    private Session resolveSession(UUID userId, TodoGenerateRequest request) {
+        if (!"chat".equals(request.source())) {
+            return null;
+        }
+        if (request.sourceId() != null) {
+            return sessionRepository.findById(request.sourceId()).orElse(null);
+        }
+        return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE).orElse(null);
+    }
+
+    private User findUser(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private void requireOnboardingComplete(User user) {
+        if (!ONBOARDING_COMPLETE_STEPS.contains(user.getSignupStep())) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
+    }
+}

--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -18,6 +18,8 @@ import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.core.NestedExceptionUtils;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -54,6 +56,7 @@ public class TodoService {
         String emotionType = checkin != null ? checkin.getEmotionType() : "default";
         List<TodoTemplateProvider.TaskTemplate> templates = templateProvider.getTemplates(emotionType);
         Session session = resolveSession(userId, request);
+        ensureNoSuggestedTodosForToday(userId, request.source(), checkin, session);
 
         List<BehaviorTask> tasks = templates.stream()
                 .map(t -> BehaviorTask.builder()
@@ -68,9 +71,16 @@ public class TodoService {
                         .build())
                 .toList();
 
-        return behaviorTaskRepository.saveAll(tasks).stream()
-                .map(TodoResponse::from)
-                .toList();
+        try {
+            return behaviorTaskRepository.saveAll(tasks).stream()
+                    .map(TodoResponse::from)
+                    .toList();
+        } catch (DataIntegrityViolationException e) {
+            if (isSuggestedTodoDuplicateViolation(e)) {
+                throw new BusinessException(ErrorCode.TODO_ALREADY_GENERATED);
+            }
+            throw e;
+        }
     }
 
     @Transactional(readOnly = true)
@@ -82,22 +92,12 @@ public class TodoService {
         OffsetDateTime from = targetDate.atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
         OffsetDateTime to = targetDate.plusDays(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
         LocalDate today = LocalDate.now(AppConstants.ZONE);
+        TaskStatus requestedStatus = parseStatus(status);
 
-        List<BehaviorTask> tasks;
-        if (status != null) {
-            TaskStatus taskStatus;
-            try {
-                taskStatus = TaskStatus.fromValue(status);
-            } catch (IllegalArgumentException e) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT);
-            }
-            tasks = behaviorTaskRepository.findByUser_IdAndStatusAndCreatedAtBetween(userId, taskStatus, from, to);
-        } else {
-            tasks = behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(userId, from, to);
-        }
-
-        return tasks.stream()
-                .map(t -> isExpired(t, today) ? TodoResponse.fromWithStatus(t, "expired") : TodoResponse.from(t))
+        return behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(userId, from, to).stream()
+                .map(task -> new TaskWithEffectiveStatus(task, effectiveStatus(task, today)))
+                .filter(task -> requestedStatus == null || task.status() == requestedStatus)
+                .map(task -> TodoResponse.fromWithStatus(task.task(), task.status()))
                 .toList();
     }
 
@@ -116,7 +116,7 @@ public class TodoService {
 
         LocalDate today = LocalDate.now(AppConstants.ZONE);
         if (isExpired(task, today)) {
-            throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
+            throw new BusinessException(ErrorCode.TODO_EXPIRED);
         }
 
         if ("completed".equals(request.status())) {
@@ -131,6 +131,47 @@ public class TodoService {
     private boolean isExpired(BehaviorTask task, LocalDate today) {
         return TaskStatus.SUGGESTED == task.getStatus()
                 && task.getCreatedAt().toLocalDate().isBefore(today);
+    }
+
+    private TaskStatus effectiveStatus(BehaviorTask task, LocalDate today) {
+        return isExpired(task, today) ? TaskStatus.EXPIRED : task.getStatus();
+    }
+
+    private TaskStatus parseStatus(String status) {
+        if (status == null) {
+            return null;
+        }
+        try {
+            return TaskStatus.fromValue(status);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void ensureNoSuggestedTodosForToday(UUID userId, String source, Checkin checkin, Session session) {
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
+        OffsetDateTime from = today.atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = today.plusDays(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+
+        boolean exists;
+        if (checkin != null) {
+            exists = behaviorTaskRepository.existsByUser_IdAndGeneratedFromAndSourceCheckin_IdAndStatusAndCreatedAtBetween(
+                    userId, source, checkin.getId(), TaskStatus.SUGGESTED, from, to
+            );
+        } else if (session != null) {
+            exists = behaviorTaskRepository.existsByUser_IdAndGeneratedFromAndSourceSession_IdAndStatusAndCreatedAtBetween(
+                    userId, source, session.getId(), TaskStatus.SUGGESTED, from, to
+            );
+        } else {
+            exists = behaviorTaskRepository
+                    .existsByUser_IdAndGeneratedFromAndSourceCheckinIsNullAndSourceSessionIsNullAndStatusAndCreatedAtBetween(
+                            userId, source, TaskStatus.SUGGESTED, from, to
+                    );
+        }
+
+        if (exists) {
+            throw new BusinessException(ErrorCode.TODO_ALREADY_GENERATED);
+        }
     }
 
     private Checkin resolveCheckin(UUID userId, TodoGenerateRequest request) {
@@ -167,4 +208,13 @@ public class TodoService {
             throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
         }
     }
+
+    private boolean isSuggestedTodoDuplicateViolation(DataIntegrityViolationException e) {
+        Throwable mostSpecificCause = NestedExceptionUtils.getMostSpecificCause(e);
+        return mostSpecificCause != null
+                && mostSpecificCause.getMessage() != null
+                && mostSpecificCause.getMessage().contains("uq_behavior_tasks_suggested_");
+    }
+
+    private record TaskWithEffectiveStatus(BehaviorTask task, TaskStatus status) {}
 }

--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -9,6 +9,7 @@ import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
 import com.mio.session.repository.SessionRepository;
 import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.dto.TodoCheckinRequest;
 import com.mio.todo.dto.TodoCheckinResponse;
 import com.mio.todo.dto.TodoGenerateRequest;
@@ -84,7 +85,13 @@ public class TodoService {
 
         List<BehaviorTask> tasks;
         if (status != null) {
-            tasks = behaviorTaskRepository.findByUser_IdAndStatusAndCreatedAtBetween(userId, status, from, to);
+            TaskStatus taskStatus;
+            try {
+                taskStatus = TaskStatus.fromValue(status);
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+            tasks = behaviorTaskRepository.findByUser_IdAndStatusAndCreatedAtBetween(userId, taskStatus, from, to);
         } else {
             tasks = behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(userId, from, to);
         }
@@ -122,7 +129,7 @@ public class TodoService {
     }
 
     private boolean isExpired(BehaviorTask task, LocalDate today) {
-        return "suggested".equals(task.getStatus())
+        return TaskStatus.SUGGESTED == task.getStatus()
                 && task.getCreatedAt().toLocalDate().isBefore(today);
     }
 

--- a/src/main/java/com/mio/todo/service/TodoTemplateProvider.java
+++ b/src/main/java/com/mio/todo/service/TodoTemplateProvider.java
@@ -1,0 +1,45 @@
+package com.mio.todo.service;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class TodoTemplateProvider {
+
+    public record TaskTemplate(String actionText, String category, int difficulty, int estimatedMinutes) {}
+
+    private static final Map<String, List<TaskTemplate>> TEMPLATES = Map.of(
+            "anxious", List.of(
+                    new TaskTemplate("5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5),
+                    new TaskTemplate("걱정 목록 작성 후 통제 가능/불가능 분류하기", "인지_재구성", 2, 10)
+            ),
+            "sad", List.of(
+                    new TaskTemplate("오늘 감사한 일 3가지 적기", "심리_안정", 1, 5),
+                    new TaskTemplate("10분 가벼운 산책하기", "행동_활성화", 1, 10)
+            ),
+            "angry", List.of(
+                    new TaskTemplate("감정 일기에 지금 느끼는 것 자유롭게 쓰기", "심리_안정", 1, 10),
+                    new TaskTemplate("분노를 유발한 상황을 다른 시각으로 바라보기", "인지_재구성", 3, 15)
+            ),
+            "tired", List.of(
+                    new TaskTemplate("15분 낮잠 또는 눈 감고 휴식", "심리_안정", 1, 15),
+                    new TaskTemplate("오늘 에너지를 소모시킨 것 하나 줄이기", "행동_활성화", 2, 10)
+            ),
+            "happy", List.of(
+                    new TaskTemplate("이 좋은 감정을 이끈 행동 하나 더 하기", "행동_활성화", 2, 20)
+            ),
+            "calm", List.of(
+                    new TaskTemplate("명상 또는 마음챙김 5분 실천", "심리_안정", 1, 5)
+            )
+    );
+
+    private static final List<TaskTemplate> DEFAULT_TEMPLATES = List.of(
+            new TaskTemplate("오늘 자신을 위한 작은 일 한 가지 해보기", "행동_활성화", 1, 10)
+    );
+
+    public List<TaskTemplate> getTemplates(String emotionType) {
+        return TEMPLATES.getOrDefault(emotionType, DEFAULT_TEMPLATES);
+    }
+}

--- a/src/main/resources/db/migration/V12__prevent_duplicate_suggested_todos.sql
+++ b/src/main/resources/db/migration/V12__prevent_duplicate_suggested_todos.sql
@@ -1,0 +1,30 @@
+CREATE UNIQUE INDEX uq_behavior_tasks_suggested_checkin_per_day
+    ON behavior_tasks (
+        user_id,
+        generated_from,
+        source_checkin_id,
+        action_text,
+        ((created_at AT TIME ZONE 'Asia/Seoul')::date)
+    )
+    WHERE status = 'suggested' AND source_checkin_id IS NOT NULL;
+
+CREATE UNIQUE INDEX uq_behavior_tasks_suggested_session_per_day
+    ON behavior_tasks (
+        user_id,
+        generated_from,
+        source_session_id,
+        action_text,
+        ((created_at AT TIME ZONE 'Asia/Seoul')::date)
+    )
+    WHERE status = 'suggested' AND source_session_id IS NOT NULL;
+
+CREATE UNIQUE INDEX uq_behavior_tasks_suggested_default_per_day
+    ON behavior_tasks (
+        user_id,
+        generated_from,
+        action_text,
+        ((created_at AT TIME ZONE 'Asia/Seoul')::date)
+    )
+    WHERE status = 'suggested'
+      AND source_checkin_id IS NULL
+      AND source_session_id IS NULL;

--- a/src/test/java/com/mio/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/mio/todo/controller/TodoControllerTest.java
@@ -81,6 +81,19 @@ class TodoControllerTest {
     }
 
     @Test
+    @DisplayName("POST /v1/todos/generate - 지원하지 않는 source면 400 반환")
+    void generate_invalidSource_returns400() throws Exception {
+        mockMvc.perform(post("/v1/todos/generate")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoGenerateRequest("pattern", null)
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+    }
+
+    @Test
     @DisplayName("GET /v1/todos - 성공 시 200 반환")
     void getTodos_success_returns200() throws Exception {
         List<TodoResponse> responses = List.of(
@@ -131,6 +144,38 @@ class TodoControllerTest {
                         )))
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("TODO_ALREADY_COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/{todoId}/checkin - 만료된 Todo 처리 시 422 반환")
+    void checkin_expired_returns422() throws Exception {
+        UUID todoId = UUID.randomUUID();
+        when(todoService.checkin(eq(TEST_USER_ID), eq(todoId), any()))
+                .thenThrow(new BusinessException(ErrorCode.TODO_EXPIRED));
+
+        mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoCheckinRequest("completed", 60, 30, "늦었어요")
+                        )))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code").value("TODO_EXPIRED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/{todoId}/checkin - 지원하지 않는 status면 400 반환")
+    void checkin_invalidStatus_returns400() throws Exception {
+        UUID todoId = UUID.randomUUID();
+
+        mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoCheckinRequest("done", 60, 30, "...")
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
     }
 
     @Test

--- a/src/test/java/com/mio/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/mio/todo/controller/TodoControllerTest.java
@@ -1,0 +1,152 @@
+package com.mio.todo.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.todo.dto.TodoCheckinRequest;
+import com.mio.todo.dto.TodoCheckinResponse;
+import com.mio.todo.dto.TodoGenerateRequest;
+import com.mio.todo.dto.TodoResponse;
+import com.mio.todo.service.TodoService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = TodoController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class}
+)
+@Import(GlobalExceptionHandler.class)
+class TodoControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private TodoService todoService;
+
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("POST /v1/todos/generate - 성공 시 201 반환")
+    void generate_success_returns201() throws Exception {
+        List<TodoResponse> responses = List.of(
+                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now()),
+                new TodoResponse(UUID.randomUUID(), "걱정 목록 작성 후 통제 가능/불가능 분류하기", "인지_재구성", 2, 10, "suggested", OffsetDateTime.now())
+        );
+        when(todoService.generate(eq(TEST_USER_ID), any())).thenReturn(responses);
+
+        mockMvc.perform(post("/v1/todos/generate")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoGenerateRequest("checkin", null)
+                        )))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2));
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/generate - 온보딩 미완료 시 403 반환")
+    void generate_onboardingRequired_returns403() throws Exception {
+        when(todoService.generate(eq(TEST_USER_ID), any()))
+                .thenThrow(new BusinessException(ErrorCode.ONBOARDING_REQUIRED));
+
+        mockMvc.perform(post("/v1/todos/generate")
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoGenerateRequest("checkin", null)
+                        )))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ONBOARDING_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/todos - 성공 시 200 반환")
+    void getTodos_success_returns200() throws Exception {
+        List<TodoResponse> responses = List.of(
+                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now())
+        );
+        when(todoService.getTodos(eq(TEST_USER_ID), any(), any())).thenReturn(responses);
+
+        mockMvc.perform(get("/v1/todos")
+                        .header("X-User-Id", TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(1));
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/{todoId}/checkin - completed 처리 시 200 반환")
+    void checkin_completed_returns200() throws Exception {
+        UUID todoId = UUID.randomUUID();
+        TodoCheckinResponse response = new TodoCheckinResponse(todoId, "completed", 70, 40, "괜찮았어요", OffsetDateTime.now());
+        when(todoService.checkin(eq(TEST_USER_ID), eq(todoId), any())).thenReturn(response);
+
+        mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoCheckinRequest("completed", 70, 40, "괜찮았어요")
+                        )))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("completed"))
+                .andExpect(jsonPath("$.data.before_emotion").value(70))
+                .andExpect(jsonPath("$.data.after_emotion").value(40))
+                .andExpect(jsonPath("$.data.completed_at").isNotEmpty());
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/{todoId}/checkin - 이미 완료된 Todo 재요청 시 409 반환")
+    void checkin_alreadyCompleted_returns409() throws Exception {
+        UUID todoId = UUID.randomUUID();
+        when(todoService.checkin(eq(TEST_USER_ID), eq(todoId), any()))
+                .thenThrow(new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED));
+
+        mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoCheckinRequest("completed", 60, 30, "또 해봤어요")
+                        )))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("TODO_ALREADY_COMPLETED"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/todos/{todoId}/checkin - 다른 유저 Todo 접근 시 403 반환")
+    void checkin_forbidden_returns403() throws Exception {
+        UUID todoId = UUID.randomUUID();
+        when(todoService.checkin(eq(TEST_USER_ID), eq(todoId), any()))
+                .thenThrow(new BusinessException(ErrorCode.FORBIDDEN));
+
+        mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
+                        .header("X-User-Id", TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new TodoCheckinRequest("completed", 70, 40, "...")
+                        )))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("FORBIDDEN"));
+    }
+}

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -6,6 +6,7 @@ import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.repository.SessionRepository;
 import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.dto.TodoCheckinRequest;
 import com.mio.todo.dto.TodoCheckinResponse;
 import com.mio.todo.dto.TodoGenerateRequest;
@@ -19,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import com.mio.common.AppConstants;
 
@@ -122,6 +124,37 @@ class TodoServiceTest {
     }
 
     @Test
+    @DisplayName("status=expired 조회 시 과거 suggested Todo를 반환한다")
+    void getTodos_statusExpired_returnsExpiredTasks() {
+        OffsetDateTime yesterday = OffsetDateTime.now(AppConstants.ZONE).minusDays(1);
+        BehaviorTask task = buildTaskWithCreatedAt(yesterday);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of(task));
+
+        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(AppConstants.ZONE).minusDays(1), "expired");
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).status()).isEqualTo("expired");
+    }
+
+    @Test
+    @DisplayName("status=suggested 조회 시 과거 suggested Todo는 제외된다")
+    void getTodos_statusSuggested_excludesExpiredTasks() {
+        OffsetDateTime yesterday = OffsetDateTime.now(AppConstants.ZONE).minusDays(1);
+        BehaviorTask task = buildTaskWithCreatedAt(yesterday);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of(task));
+
+        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(AppConstants.ZONE).minusDays(1), "suggested");
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
     @DisplayName("completed 처리 후 status와 completedAt이 변경된다")
     void checkin_complete_updatesStatus() {
         UUID todoId = UUID.randomUUID();
@@ -213,6 +246,42 @@ class TodoServiceTest {
     }
 
     @Test
+    @DisplayName("같은 source 컨텍스트의 suggested Todo가 있으면 중복 생성이 차단된다")
+    void generate_duplicateSuggestedTodo_throwsConflict() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(checkinRepository.findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(eq(userId), any()))
+                .thenReturn(Optional.empty());
+        when(behaviorTaskRepository
+                .existsByUser_IdAndGeneratedFromAndSourceCheckinIsNullAndSourceSessionIsNullAndStatusAndCreatedAtBetween(
+                        eq(userId), eq("checkin"), eq(TaskStatus.SUGGESTED), any(), any()
+                ))
+                .thenReturn(true);
+
+        assertThatThrownBy(() -> todoService.generate(userId, new TodoGenerateRequest("checkin", null)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.TODO_ALREADY_GENERATED));
+    }
+
+    @Test
+    @DisplayName("중복 생성 유니크 제약 위반이면 TODO_ALREADY_GENERATED 예외로 변환한다")
+    void generate_duplicateUniqueViolation_throwsConflict() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(checkinRepository.findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(eq(userId), any()))
+                .thenReturn(Optional.empty());
+        when(behaviorTaskRepository.saveAll(any()))
+                .thenThrow(new DataIntegrityViolationException(
+                        "save failed",
+                        new RuntimeException("uq_behavior_tasks_suggested_default_per_day")
+                ));
+
+        assertThatThrownBy(() -> todoService.generate(userId, new TodoGenerateRequest("checkin", null)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.TODO_ALREADY_GENERATED));
+    }
+
+    @Test
     @DisplayName("오늘 체크인이 없으면 default 템플릿 1개를 생성한다")
     void generate_noCheckin_usesDefaultTemplate() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
@@ -272,6 +341,24 @@ class TodoServiceTest {
         List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(AppConstants.ZONE).minusDays(1), null);
 
         assertThat(result.get(0).status()).isEqualTo("expired");
+    }
+
+    @Test
+    @DisplayName("만료된 Todo 체크인 시 TODO_EXPIRED 예외를 발생시킨다")
+    void checkin_expiredTask_throwsTodoExpired() {
+        UUID todoId = UUID.randomUUID();
+        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(AppConstants.ZONE).minusDays(1));
+
+        setUserId(completedUser, userId);
+        when(behaviorTaskRepository.findById(todoId)).thenReturn(Optional.of(task));
+
+        assertThatThrownBy(() -> todoService.checkin(
+                userId, todoId,
+                new TodoCheckinRequest("completed", 70, 40, "늦었어요")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.TODO_EXPIRED));
     }
 
     private void setUserId(User user, UUID id) {

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -1,0 +1,270 @@
+package com.mio.todo.service;
+
+import com.mio.checkin.domain.Checkin;
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.repository.SessionRepository;
+import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.dto.TodoCheckinRequest;
+import com.mio.todo.dto.TodoCheckinResponse;
+import com.mio.todo.dto.TodoGenerateRequest;
+import com.mio.todo.dto.TodoResponse;
+import com.mio.todo.repository.BehaviorTaskRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TodoServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private BehaviorTaskRepository behaviorTaskRepository;
+    @Mock private CheckinRepository checkinRepository;
+    @Mock private SessionRepository sessionRepository;
+
+    private TodoService todoService;
+    private UUID userId;
+    private User completedUser;
+    private User incompleteUser;
+
+    @BeforeEach
+    void setUp() {
+        todoService = new TodoService(
+                userRepository, behaviorTaskRepository,
+                checkinRepository, sessionRepository,
+                new TodoTemplateProvider()
+        );
+        userId = UUID.randomUUID();
+
+        completedUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-social-id")
+                .privacyConsent(true)
+                .build();
+        completedUser.completeOnboarding("mio");
+
+        incompleteUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-social-id-2")
+                .privacyConsent(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("온보딩 미완료 사용자는 generate 시 ONBOARDING_REQUIRED 예외를 발생시킨다")
+    void generate_onboardingNotComplete_throwsForbidden() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(incompleteUser));
+
+        assertThatThrownBy(() -> todoService.generate(
+                userId, new TodoGenerateRequest("checkin", null)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_REQUIRED));
+    }
+
+    @Test
+    @DisplayName("checkin source로 anxious 감정 전달 시 2개 태스크를 생성한다")
+    void generate_checkinSource_createsTasks() {
+        Checkin checkin = Checkin.builder()
+                .user(completedUser)
+                .timeOfDay("morning")
+                .emotionType("anxious")
+                .emojiScore(3)
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(checkinRepository.findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(eq(userId), any()))
+                .thenReturn(Optional.of(checkin));
+        when(behaviorTaskRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        List<TodoResponse> result = todoService.generate(userId, new TodoGenerateRequest("checkin", null));
+
+        assertThat(result).hasSize(2);
+        verify(behaviorTaskRepository).saveAll(argThat(tasks -> {
+            List<BehaviorTask> list = (List<BehaviorTask>) tasks;
+            return list.size() == 2;
+        }));
+    }
+
+    @Test
+    @DisplayName("오늘 날짜 필터링으로 getTodos 정상 동작한다")
+    void getTodos_today_returnsFilteredList() {
+        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of(task));
+
+        List<TodoResponse> result = todoService.getTodos(userId, null, null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).actionText()).isEqualTo("5분 복식 호흡");
+    }
+
+    @Test
+    @DisplayName("completed 처리 후 status와 completedAt이 변경된다")
+    void checkin_complete_updatesStatus() {
+        UUID todoId = UUID.randomUUID();
+        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+
+        setUserId(completedUser, userId);
+        when(behaviorTaskRepository.findById(todoId)).thenReturn(Optional.of(task));
+
+        TodoCheckinResponse response = todoService.checkin(
+                userId, todoId,
+                new TodoCheckinRequest("completed", 70, 40, "괜찮았어요")
+        );
+
+        assertThat(response.status()).isEqualTo("completed");
+        assertThat(response.beforeEmotion()).isEqualTo(70);
+        assertThat(response.afterEmotion()).isEqualTo(40);
+        assertThat(response.completedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 completed인 Todo에 재요청 시 TODO_ALREADY_COMPLETED 예외를 발생시킨다")
+    void checkin_alreadyCompleted_throwsConflict() {
+        UUID todoId = UUID.randomUUID();
+        BehaviorTask task = BehaviorTask.builder()
+                .user(completedUser)
+                .generatedFrom("checkin")
+                .actionText("5분 복식 호흡")
+                .category("심리_안정")
+                .difficulty(1)
+                .estimatedMinutes(5)
+                .build();
+
+        setUserId(completedUser, userId);
+        task.complete(70, 40, "괜찮았어요");
+
+        when(behaviorTaskRepository.findById(todoId)).thenReturn(Optional.of(task));
+
+        assertThatThrownBy(() -> todoService.checkin(
+                userId, todoId,
+                new TodoCheckinRequest("completed", 60, 30, "또 해봤어요")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.TODO_ALREADY_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("다른 유저의 Todo 접근 시 FORBIDDEN 예외를 발생시킨다")
+    void checkin_otherUserTodo_throwsForbidden() {
+        UUID todoId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        User otherUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("other-social-id")
+                .privacyConsent(true)
+                .build();
+        otherUser.completeOnboarding("mio");
+        setUserId(otherUser, otherUserId);
+
+        BehaviorTask task = BehaviorTask.builder()
+                .user(otherUser)
+                .generatedFrom("checkin")
+                .actionText("5분 복식 호흡")
+                .category("심리_안정")
+                .difficulty(1)
+                .estimatedMinutes(5)
+                .build();
+
+        when(behaviorTaskRepository.findById(todoId)).thenReturn(Optional.of(task));
+
+        assertThatThrownBy(() -> todoService.checkin(
+                userId, todoId,
+                new TodoCheckinRequest("completed", 70, 40, "...")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 source(pattern)는 INVALID_INPUT 예외를 발생시킨다")
+    void generate_invalidSource_throwsInvalidInput() {
+        assertThatThrownBy(() -> todoService.generate(
+                userId, new TodoGenerateRequest("pattern", null)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+
+    @Test
+    @DisplayName("오늘 체크인이 없으면 default 템플릿 1개를 생성한다")
+    void generate_noCheckin_usesDefaultTemplate() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(checkinRepository.findTopByUser_IdAndCheckinDateOrderByCreatedAtDesc(eq(userId), any()))
+                .thenReturn(Optional.empty());
+        when(behaviorTaskRepository.saveAll(any())).thenAnswer(i -> i.getArgument(0));
+
+        List<TodoResponse> result = todoService.generate(userId, new TodoGenerateRequest("checkin", null));
+
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("suggested 상태이고 어제 날짜인 Todo는 expired로 응답한다")
+    void getTodos_expiredSuggestedTask_returnsExpiredStatus() {
+        OffsetDateTime yesterday = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+        BehaviorTask task = buildTaskWithCreatedAt(yesterday);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of(task));
+
+        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(ZoneOffset.UTC).minusDays(1), null);
+
+        assertThat(result.get(0).status()).isEqualTo("expired");
+    }
+
+    private void setUserId(User user, UUID id) {
+        try {
+            var field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(user, id);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private BehaviorTask buildTaskWithCreatedAt(OffsetDateTime createdAt) {
+        try {
+            BehaviorTask task = BehaviorTask.builder()
+                    .user(completedUser)
+                    .generatedFrom("checkin")
+                    .actionText("5분 복식 호흡")
+                    .category("심리_안정")
+                    .difficulty(1)
+                    .estimatedMinutes(5)
+                    .build();
+            var field = BehaviorTask.class.getDeclaredField("createdAt");
+            field.setAccessible(true);
+            field.set(task, createdAt);
+            return task;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -20,9 +20,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.mio.common.AppConstants;
+
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -108,7 +109,7 @@ class TodoServiceTest {
     @Test
     @DisplayName("오늘 날짜 필터링으로 getTodos 정상 동작한다")
     void getTodos_today_returnsFilteredList() {
-        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(AppConstants.ZONE));
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
         when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
@@ -124,7 +125,7 @@ class TodoServiceTest {
     @DisplayName("completed 처리 후 status와 completedAt이 변경된다")
     void checkin_complete_updatesStatus() {
         UUID todoId = UUID.randomUUID();
-        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(ZoneOffset.UTC));
+        BehaviorTask task = buildTaskWithCreatedAt(OffsetDateTime.now(AppConstants.ZONE));
 
         setUserId(completedUser, userId);
         when(behaviorTaskRepository.findById(todoId)).thenReturn(Optional.of(task));
@@ -227,14 +228,14 @@ class TodoServiceTest {
     @Test
     @DisplayName("suggested 상태이고 어제 날짜인 Todo는 expired로 응답한다")
     void getTodos_expiredSuggestedTask_returnsExpiredStatus() {
-        OffsetDateTime yesterday = OffsetDateTime.now(ZoneOffset.UTC).minusDays(1);
+        OffsetDateTime yesterday = OffsetDateTime.now(AppConstants.ZONE).minusDays(1);
         BehaviorTask task = buildTaskWithCreatedAt(yesterday);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
         when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
                 .thenReturn(List.of(task));
 
-        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(ZoneOffset.UTC).minusDays(1), null);
+        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(AppConstants.ZONE).minusDays(1), null);
 
         assertThat(result.get(0).status()).isEqualTo("expired");
     }

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -226,6 +226,40 @@ class TodoServiceTest {
     }
 
     @Test
+    @DisplayName("타 유저 체크인 sourceId로 generate 시 FORBIDDEN 예외를 발생시킨다")
+    void generate_checkinSourceId_otherUser_throwsForbidden() {
+        UUID otherCheckinId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(checkinRepository.findByIdAndUser_Id(otherCheckinId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todoService.generate(
+                userId, new TodoGenerateRequest("checkin", otherCheckinId)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("타 유저 세션 sourceId로 generate 시 FORBIDDEN 예외를 발생시킨다")
+    void generate_chatSourceId_otherUser_throwsForbidden() {
+        UUID otherSessionId = UUID.randomUUID();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));
+        when(sessionRepository.findByIdAndUser_Id(otherSessionId, userId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> todoService.generate(
+                userId, new TodoGenerateRequest("chat", otherSessionId)
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FORBIDDEN));
+    }
+
+    @Test
     @DisplayName("suggested 상태이고 어제 날짜인 Todo는 expired로 응답한다")
     void getTodos_expiredSuggestedTask_returnsExpiredStatus() {
         OffsetDateTime yesterday = OffsetDateTime.now(AppConstants.ZONE).minusDays(1);


### PR DESCRIPTION
## Summary

- `POST /v1/todos/generate` 중복 생성 방어 및 DB 유니크 인덱스 추가
- `GET /v1/todos` 의 `expired` 상태 계산/필터 정합성 수정
- `POST /v1/todos/{todoId}/checkin` 에서 만료 Todo를 `422 TODO_EXPIRED` 로 명확히 구분
- 요청 DTO의 `source` / `status` 값을 컨트롤러 경계에서 검증
- `X-User-Id` 신뢰 모델 제거는 별도 보안 리팩토링 이슈 `#20` 으로 분리

## 주요 변경

| 파일 | 내용 |
|---|---|
| `ErrorCode` | `TODO_ALREADY_GENERATED`, `TODO_EXPIRED` 추가 |
| `TodoGenerateRequest`, `TodoCheckinRequest` | `@Pattern` 기반 입력 검증 추가 |
| `TodoResponse` | 상태 오버라이드에 `TaskStatus` 사용 |
| `BehaviorTaskRepository` | 중복 suggested Todo 존재 여부 조회 메서드 추가 |
| `TodoService` | 중복 생성 차단, `expired` 필터 정합성 수정, 유니크 제약 예외 변환 |
| `V12__prevent_duplicate_suggested_todos.sql` | source 컨텍스트별 suggested Todo 중복 방지 인덱스 추가 |
| `TodoServiceTest`, `TodoControllerTest` | expired 조회, 만료 체크인, 중복 생성, DTO 검증 테스트 추가 |

## 설계 메모

- `expired` 는 계속 응답 계산 상태로 유지하되, `status=expired` 조회가 실제로 동작하도록 필터 순서를 수정했습니다.
- 같은 날 같은 source 컨텍스트의 미처리 Todo 재생성은 `409 TODO_ALREADY_GENERATED` 로 차단합니다.
- 보안 이슈는 JWT 머지와 별개로 `X-User-Id` 헤더 신뢰를 제거해야 하므로 이번 PR에서 직접 섞지 않았습니다.

## Test plan

- [x] `./gradlew test --tests "com.mio.todo.*"`

Closes #18

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Generate and manage daily todos from check-ins and chat sessions
  * Mark todos as completed or skipped with emotional feedback tracking
  * Filter todos by date and completion status
  * Onboarding requirement for todo access

* **Bug Fixes**
  * Prevent duplicate daily todo suggestions
  * Properly handle and reject expired todos

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->