### PR TITLE
fix: /actuator/health JWT 필터 화이트리스트 경로 수정

### DIFF
--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -33,7 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final Set<String> WHITELIST = Set.of(
             "POST /v1/auth/login",
             "POST /v1/auth/refresh",
-            "GET /v1/health"
+            "GET /actuator/health"
     );
 
     private final JwtTokenService jwtTokenService;


### PR DESCRIPTION
## Summary

- `JwtAuthenticationFilter` WHITELIST의 `GET /v1/health` → `GET /actuator/health` 경로 수정
- JWT 필터는 SecurityConfig보다 먼저 실행되므로 WHITELIST 경로가 잘못되면 `permitAll()` 설정이 무효화됨

## 원인 분석

```java
// 수정 전
"GET /v1/health"    // 잘못된 경로

// 수정 후
"GET /actuator/health"    // 실제 Actuator 헬스 엔드포인트 경로
```

## Test plan

- [ ] `curl http://localhost:8080/actuator/health` → JWT 없이 200 응답 확인
- [ ] 인증이 필요한 엔드포인트는 여전히 401 반환하는지 확인

Closes #23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the health check endpoint from `/v1/health` to `/actuator/health` to bypass JWT authentication requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->