### PR TITLE
fix: DailyTestContent JSONB 역직렬화 NPE 방어 처리

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -76,7 +76,7 @@ public class AuthService {
                 user.getSocialProvider(), user.getSignupStep());
 
         LoginResponse.UserInfo userInfo = null;
-        if (!isNewUser.get() && "COMPLETED".equals(user.getSignupStep())) {
+        if (!isNewUser.get() && user.getSignupStep().equals("COMPLETED")) {
             userInfo = new LoginResponse.UserInfo(
                     user.getId().toString(),
                     user.getNickname(),
@@ -105,7 +105,7 @@ public class AuthService {
     public SignupCompleteResponse completeSignup(UUID userId, SignupCompleteRequest request) {
         User user = findUser(userId);
 
-        if (!"SOCIAL_AUTHENTICATED".equals(user.getSignupStep())) {
+        if (!user.getSignupStep().equals("SOCIAL_AUTHENTICATED")) {
             throw new BusinessException(ErrorCode.SIGNUP_STEP_INVALID);
         }
 

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
     // Daily Test
     DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),
     DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
-    INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "D002", "데일리 테스트 콘텐츠가 올바르지 않습니다"),
+    INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "INVALID_DAILY_TEST_CONTENT", "데일리 테스트 콘텐츠가 올바르지 않습니다"),
 
     // Todo
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     // Daily Test
     DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),
     DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
+    INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "D002", "데일리 테스트 콘텐츠가 올바르지 않습니다"),
 
     // Todo
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -44,7 +44,7 @@ public enum ErrorCode {
     // Daily Test
     DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),
     DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
-    INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "INVALID_DAILY_TEST_CONTENT", "데일리 테스트 콘텐츠가 올바르지 않습니다"),
+    INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "INVALID_DAILY_TEST_CONTENT", "데일리 테스트 콘텐츠가 올바르지 않습니다."),
 
     // Todo
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),

--- a/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
@@ -43,6 +43,11 @@ public record DailyTestContent(List<Question> questions) {
                 throw new IllegalArgumentException("Option text must not be null or blank");
             }
             if (tags != null) {
+                tags.forEach(tag -> {
+                    if (tag == null) {
+                        throw new IllegalArgumentException("Option tags must not contain null elements");
+                    }
+                });
                 tags = List.copyOf(tags);
             }
         }

--- a/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
@@ -8,6 +8,10 @@ public record DailyTestContent(List<Question> questions) {
         if (questions == null || questions.isEmpty()) {
             throw new IllegalArgumentException("questions must not be null or empty");
         }
+        questions.forEach(q -> {
+            if (q == null) throw new IllegalArgumentException("questions must not contain null elements");
+        });
+        questions = List.copyOf(questions);
     }
 
     public record Question(String id, int order, String text, List<Option> options) {
@@ -22,6 +26,10 @@ public record DailyTestContent(List<Question> questions) {
             if (options == null || options.isEmpty()) {
                 throw new IllegalArgumentException("Question options must not be null or empty");
             }
+            options.forEach(o -> {
+                if (o == null) throw new IllegalArgumentException("options must not contain null elements");
+            });
+            options = List.copyOf(options);
         }
     }
 
@@ -33,6 +41,9 @@ public record DailyTestContent(List<Question> questions) {
             }
             if (text == null || text.isBlank()) {
                 throw new IllegalArgumentException("Option text must not be null or blank");
+            }
+            if (tags != null) {
+                tags = List.copyOf(tags);
             }
         }
     }

--- a/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestContent.java
@@ -4,7 +4,36 @@ import java.util.List;
 
 public record DailyTestContent(List<Question> questions) {
 
-    public record Question(String id, int order, String text, List<Option> options) {}
+    public DailyTestContent {
+        if (questions == null || questions.isEmpty()) {
+            throw new IllegalArgumentException("questions must not be null or empty");
+        }
+    }
 
-    public record Option(String id, String text, int score, List<String> tags) {}
+    public record Question(String id, int order, String text, List<Option> options) {
+
+        public Question {
+            if (id == null || id.isBlank()) {
+                throw new IllegalArgumentException("Question id must not be null or blank");
+            }
+            if (text == null || text.isBlank()) {
+                throw new IllegalArgumentException("Question text must not be null or blank");
+            }
+            if (options == null || options.isEmpty()) {
+                throw new IllegalArgumentException("Question options must not be null or empty");
+            }
+        }
+    }
+
+    public record Option(String id, String text, int score, List<String> tags) {
+
+        public Option {
+            if (id == null || id.isBlank()) {
+                throw new IllegalArgumentException("Option id must not be null or blank");
+            }
+            if (text == null || text.isBlank()) {
+                throw new IllegalArgumentException("Option text must not be null or blank");
+            }
+        }
+    }
 }

--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -26,6 +26,9 @@ public class DailyTestResultEngine {
         if (content == null || content.questions() == null || content.questions().isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
+        if (answers == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
         int totalScore = content.questions().stream()
                 .mapToInt(question -> {
                     String selectedOptionId = answers.get(question.id());

--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -1,5 +1,7 @@
 package com.mio.dailytest.service;
 
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
 import com.mio.dailytest.dto.DailyTestContent;
 import org.springframework.stereotype.Component;
 
@@ -21,6 +23,9 @@ public class DailyTestResultEngine {
      * @return result summary 문자열
      */
     public String calculate(DailyTestContent content, Map<String, String> answers) {
+        if (content == null || content.questions() == null || content.questions().isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+        }
         int totalScore = content.questions().stream()
                 .mapToInt(question -> {
                     String selectedOptionId = answers.get(question.id());

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -109,6 +109,8 @@ public class DailyTestService {
             return objectMapper.readValue(contentJson, DailyTestContent.class);
         } catch (JsonProcessingException e) {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
     }
 

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -108,10 +108,14 @@ public class DailyTestService {
         try {
             return objectMapper.readValue(contentJson, DailyTestContent.class);
         } catch (JsonProcessingException e) {
-            if (e.getCause() instanceof IllegalArgumentException) {
-                throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+            for (Throwable cause = e; cause != null; cause = cause.getCause()) {
+                if (cause instanceof IllegalArgumentException) {
+                    throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+                }
             }
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
     }
 

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -108,9 +108,10 @@ public class DailyTestService {
         try {
             return objectMapper.readValue(contentJson, DailyTestContent.class);
         } catch (JsonProcessingException e) {
+            if (e.getCause() instanceof IllegalArgumentException) {
+                throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+            }
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        } catch (IllegalArgumentException e) {
-            throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
     }
 

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -133,6 +133,32 @@ class DailyTestServiceTest {
     }
 
     @Test
+    @DisplayName("getTodayTest - content tags에 null 요소가 있으면 INVALID_DAILY_TEST_CONTENT")
+    void getTodayTest_invalidTagElement_throwsInvalidDailyTestContent() {
+        DailyTest test = buildDailyTest("""
+                {
+                  "questions": [
+                    {
+                      "id": "q1", "order": 1, "text": "질문1",
+                      "options": [
+                        {"id": "q1_a", "text": "옵션A", "score": 0, "tags": [null]}
+                      ]
+                    }
+                  ]
+                }
+                """);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
+        when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
+        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
+                .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getTodayTest(userId))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+    }
+
+    @Test
     @DisplayName("submitAnswer - 오늘 날짜가 아닌 테스트는 DAILY_TEST_NOT_FOUND")
     void submitAnswer_notTodayTest_throwsNotFound() {
         DailyTest oldTest = buildDailyTest(LocalDate.now(AppConstants.ZONE).minusDays(1));
@@ -234,10 +260,18 @@ class DailyTestServiceTest {
     }
 
     private DailyTest buildDailyTest(LocalDate date) {
+        return buildDailyTest(date, CONTENT_JSON);
+    }
+
+    private DailyTest buildDailyTest(String content) {
+        return buildDailyTest(LocalDate.now(AppConstants.ZONE), content);
+    }
+
+    private DailyTest buildDailyTest(LocalDate date, String content) {
         DailyTest test = DailyTest.builder()
                 .title("오늘의 테스트")
                 .description("설명")
-                .content(CONTENT_JSON)
+                .content(content)
                 .activeDate(date)
                 .build();
         ReflectionTestUtils.setField(test, "id", testId);


### PR DESCRIPTION
## Summary

- `DailyTestContent` record에 compact constructor를 추가해 `questions`·`Question`·`Option` 각 필드의 null/blank/empty 검증
- `ErrorCode`에 `INVALID_DAILY_TEST_CONTENT (400, D002)` 추가
- `DailyTestService.parseContent()`에서 `IllegalArgumentException`을 `BusinessException`으로 변환
- `DailyTestResultEngine.calculate()`에 최종 방어 가드 추가 (content null 또는 questions 비어있을 경우)

## Why

JSONB 컬럼에 잘못된 데이터가 저장될 경우 역직렬화 후 NPE가 발생했습니다. 검증 책임을 DTO 생성 시점으로 끌어당겨 서비스 로직에서 null 처리를 제거합니다.

## Test plan

- [ ] 정상 콘텐츠로 데일리 테스트 제출 → 기존 동작 유지 확인
- [ ] questions 비어있는 JSONB → 400 INVALID_DAILY_TEST_CONTENT 반환 확인
- [ ] Question id/text null → 400 반환 확인
- [ ] Option id/text null → 400 반환 확인

Closes #13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for daily test content (questions, options, tags) to reject missing, empty, or malformed submissions and return a clear invalid-content error.
  * Parsing now maps malformed test payloads to the invalid-content error instead of generic failures.
  * Input checks prevent score computation on invalid content, avoiding incorrect results.

* **Improvements**
  * Adjusted login/signup step checks to improve equality handling and reduce unexpected auth flow issues.

* **Tests**
  * Added a test ensuring malformed tags trigger the invalid-content error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->