### PR TITLE
refactor: @PrePersist 타임존을 ZoneOffset.UTC로 명시화

### DIFF
--- a/src/main/java/com/mio/ai/domain/AiPolicyDecision.java
+++ b/src/main/java/com/mio/ai/domain/AiPolicyDecision.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -65,6 +66,6 @@ public class AiPolicyDecision {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/CbtPattern.java
+++ b/src/main/java/com/mio/ai/domain/CbtPattern.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -57,6 +58,6 @@ public class CbtPattern {
 
     @PrePersist
     protected void onCreate() {
-        lastSeenAt = OffsetDateTime.now();
+        lastSeenAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/CharacterInteraction.java
+++ b/src/main/java/com/mio/ai/domain/CharacterInteraction.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 /**
@@ -50,6 +51,6 @@ public class CharacterInteraction {
     @PrePersist
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/EmotionalState.java
+++ b/src/main/java/com/mio/ai/domain/EmotionalState.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -47,6 +48,6 @@ public class EmotionalState {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/MemoryEmbedding.java
+++ b/src/main/java/com/mio/ai/domain/MemoryEmbedding.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -41,7 +42,7 @@ public class MemoryEmbedding {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
         if (sensitivity == null) {
             sensitivity = "normal";
         }

--- a/src/main/java/com/mio/ai/domain/SafetyRiskDaily.java
+++ b/src/main/java/com/mio/ai/domain/SafetyRiskDaily.java
@@ -7,6 +7,7 @@ import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -58,12 +59,12 @@ public class SafetyRiskDaily {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/SafetyRiskDaily.java
+++ b/src/main/java/com/mio/ai/domain/SafetyRiskDaily.java
@@ -59,8 +59,9 @@ public class SafetyRiskDaily {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
-        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
     }
 
     @PreUpdate

--- a/src/main/java/com/mio/ai/domain/UserMemoryEvent.java
+++ b/src/main/java/com/mio/ai/domain/UserMemoryEvent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 /**
@@ -47,6 +48,6 @@ public class UserMemoryEvent {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
+++ b/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 /**
@@ -62,6 +63,6 @@ public class UserMemoryPreference {
     @PrePersist
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/checkin/domain/Checkin.java
+++ b/src/main/java/com/mio/checkin/domain/Checkin.java
@@ -4,6 +4,7 @@ import com.mio.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
 
+import com.mio.common.AppConstants;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -64,10 +65,11 @@ public class Checkin {
     @PrePersist
     protected void onCreate() {
         if (checkinDate == null) {
-            checkinDate = LocalDate.now();
+            checkinDate = LocalDate.now(AppConstants.ZONE);
         }
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
-        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
     }
 
     @PreUpdate

--- a/src/main/java/com/mio/checkin/domain/Checkin.java
+++ b/src/main/java/com/mio/checkin/domain/Checkin.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -65,12 +66,12 @@ public class Checkin {
         if (checkinDate == null) {
             checkinDate = LocalDate.now();
         }
-        createdAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/common/audit/AuditLog.java
+++ b/src/main/java/com/mio/common/audit/AuditLog.java
@@ -6,6 +6,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -44,6 +45,6 @@ public class AuditLog {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/crisis/domain/CrisisEvent.java
+++ b/src/main/java/com/mio/crisis/domain/CrisisEvent.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -51,6 +52,6 @@ public class CrisisEvent {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/dailytest/domain/DailyTest.java
+++ b/src/main/java/com/mio/dailytest/domain/DailyTest.java
@@ -7,6 +7,7 @@ import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -39,6 +40,6 @@ public class DailyTest {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/dailytest/domain/DailyTestResponse.java
+++ b/src/main/java/com/mio/dailytest/domain/DailyTestResponse.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -41,6 +42,6 @@ public class DailyTestResponse {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/notification/domain/DeviceToken.java
+++ b/src/main/java/com/mio/notification/domain/DeviceToken.java
@@ -55,8 +55,9 @@ public class DeviceToken {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
-        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
     }
 
     @PreUpdate

--- a/src/main/java/com/mio/notification/domain/DeviceToken.java
+++ b/src/main/java/com/mio/notification/domain/DeviceToken.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -54,12 +55,12 @@ public class DeviceToken {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/notification/domain/NotificationSetting.java
+++ b/src/main/java/com/mio/notification/domain/NotificationSetting.java
@@ -83,8 +83,9 @@ public class NotificationSetting {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
-        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
     }
 
     @PreUpdate

--- a/src/main/java/com/mio/notification/domain/NotificationSetting.java
+++ b/src/main/java/com/mio/notification/domain/NotificationSetting.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -82,12 +83,12 @@ public class NotificationSetting {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/notification/domain/ProactiveCareLog.java
+++ b/src/main/java/com/mio/notification/domain/ProactiveCareLog.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -51,14 +52,14 @@ public class ProactiveCareLog {
             return;
         }
         this.notificationStatus = "OPENED";
-        this.respondedAt = OffsetDateTime.now();
+        this.respondedAt = OffsetDateTime.now(ZoneOffset.UTC);
         this.responseAction = "tapped";
     }
 
     @PrePersist
     protected void onCreate() {
         if (sentAt == null) {
-            sentAt = OffsetDateTime.now();
+            sentAt = OffsetDateTime.now(ZoneOffset.UTC);
         }
     }
 }

--- a/src/main/java/com/mio/report/domain/WeeklyReport.java
+++ b/src/main/java/com/mio/report/domain/WeeklyReport.java
@@ -8,6 +8,7 @@ import org.hibernate.type.SqlTypes;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -77,7 +78,7 @@ public class WeeklyReport {
 
     public void markAsGenerated() {
         this.status = "GENERATED";
-        this.generatedAt = OffsetDateTime.now();
+        this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PrePersist

--- a/src/main/java/com/mio/session/domain/CbtReconstruction.java
+++ b/src/main/java/com/mio/session/domain/CbtReconstruction.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -81,6 +82,6 @@ public class CbtReconstruction {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/session/domain/Message.java
+++ b/src/main/java/com/mio/session/domain/Message.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.UUID;
 
@@ -63,6 +64,6 @@ public class Message {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -5,6 +5,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Objects;
 import java.util.UUID;
@@ -57,7 +58,7 @@ public class Session {
 
     @PrePersist
     protected void onCreate() {
-        startedAt = OffsetDateTime.now();
+        startedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void end() {
@@ -66,7 +67,7 @@ public class Session {
                     com.mio.common.error.ErrorCode.SESSION_ALREADY_ENDED);
         }
         this.status = SessionStatus.ENDED;
-        this.endedAt = OffsetDateTime.now();
+        this.endedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public boolean isEnded() {
@@ -79,7 +80,7 @@ public class Session {
 
     public void incrementMessageCount() {
         this.messageCount += 1;
-        this.lastMessageAt = OffsetDateTime.now();
+        this.lastMessageAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void updateAvgEmotionScore(int newScore) {

--- a/src/main/java/com/mio/session/domain/SessionSummary.java
+++ b/src/main/java/com/mio/session/domain/SessionSummary.java
@@ -7,6 +7,7 @@ import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -66,6 +67,6 @@ public class SessionSummary {
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
+++ b/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Service
@@ -43,7 +44,7 @@ public class SessionMessagePersistenceService {
 
         saveMessage(session, user, MessageRole.USER, userContent);
         saveMessage(session, user, MessageRole.ASSISTANT, assistantContent);
-        sessionRepository.incrementMessageCountAndSetLastMessageAt(session.getId(), 2, OffsetDateTime.now());
+        sessionRepository.incrementMessageCountAndSetLastMessageAt(session.getId(), 2, OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     private void saveMessage(Session session, User user, MessageRole role, String content) {

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -114,17 +115,17 @@ public class User {
         this.nickname = "탈퇴한 사용자";
         this.email = null;
         this.status = "DELETED";
-        this.deletedAt = OffsetDateTime.now();
+        this.deletedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.now();
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/user/domain/UserConsent.java
+++ b/src/main/java/com/mio/user/domain/UserConsent.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -37,7 +38,7 @@ public class UserConsent {
     @PrePersist
     protected void onCreate() {
         if (agreedAt == null) {
-            agreedAt = OffsetDateTime.now();
+            agreedAt = OffsetDateTime.now(ZoneOffset.UTC);
         }
     }
 }

--- a/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
+++ b/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Entity
@@ -63,6 +64,6 @@ public class UserOnboardingAnswer {
         this.preferredStyle = preferredStyle;
         this.characterRecommendations = characterRecommendationsJson;
         this.responses = responsesJson;
-        this.submittedAt = OffsetDateTime.now();
+        this.submittedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/main/java/com/mio/user/job/DataRetentionJob.java
+++ b/src/main/java/com/mio/user/job/DataRetentionJob.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 @Slf4j
@@ -23,7 +24,7 @@ public class DataRetentionJob {
     @Scheduled(cron = "0 0 0 * * *")
     @Transactional
     public void hardDeleteExpiredUsers() {
-        OffsetDateTime cutoff = OffsetDateTime.now().minusDays(RETENTION_DAYS);
+        OffsetDateTime cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusDays(RETENTION_DAYS);
         List<User> targets = userRepository.findAllByStatusAndDeletedAtBefore("DELETED", cutoff);
 
         if (targets.isEmpty()) {

--- a/src/main/java/com/mio/user/job/DataRetentionJob.java
+++ b/src/main/java/com/mio/user/job/DataRetentionJob.java
@@ -21,7 +21,7 @@ public class DataRetentionJob {
 
     private final UserRepository userRepository;
 
-    @Scheduled(cron = "0 0 0 * * *")
+    @Scheduled(cron = "0 0 0 * * *", zone = "UTC")
     @Transactional
     public void hardDeleteExpiredUsers() {
         OffsetDateTime cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusDays(RETENTION_DAYS);

--- a/src/test/java/com/mio/user/domain/UserTest.java
+++ b/src/test/java/com/mio/user/domain/UserTest.java
@@ -1,0 +1,49 @@
+package com.mio.user.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneOffset;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserTest {
+
+    @Test
+    @DisplayName("onCreate는 createdAt과 updatedAt을 UTC로 저장한다")
+    void onCreate_setsUtcTimestamps() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+
+        user.onCreate();
+
+        assertThat(user.getCreatedAt()).isNotNull();
+        assertThat(user.getUpdatedAt()).isNotNull();
+        assertThat(user.getCreatedAt().getOffset()).isEqualTo(ZoneOffset.UTC);
+        assertThat(user.getUpdatedAt().getOffset()).isEqualTo(ZoneOffset.UTC);
+    }
+
+    @Test
+    @DisplayName("softDelete는 deletedAt을 UTC로 저장하고 상태를 DELETED로 바꾼다")
+    void softDelete_setsUtcDeletedAt() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .email("test@example.com")
+                .nickname("닉네임")
+                .privacyConsent(true)
+                .build();
+
+        user.softDelete("anonymized-social-id");
+
+        assertThat(user.getStatus()).isEqualTo("DELETED");
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(user.getDeletedAt().getOffset()).isEqualTo(ZoneOffset.UTC);
+        assertThat(user.getEmail()).isNull();
+        assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자");
+        assertThat(user.getSocialId()).isEqualTo("anonymized-social-id");
+    }
+}


### PR DESCRIPTION
## Summary

- 전체 엔티티(25파일)의 `@PrePersist` 메서드에서 `OffsetDateTime.now()` → `OffsetDateTime.now(ZoneOffset.UTC)` 로 변경
- 대상: User, Session, Message, DailyTest, DailyTestResponse, Checkin, WeeklyReport, CrisisEvent, AuditLog, DeviceToken, NotificationSetting, AI 도메인 엔티티 등 전체
- `AppConstants.ZONE`(비즈니스 날짜 계산용) 및 `TimeConfig` 빈은 변경 없음

## Why

`OffsetDateTime.now()`는 JVM 기본 타임존에 의존해 환경마다 동작이 달라질 수 있었습니다. PostgreSQL `TIMESTAMPTZ`는 내부적으로 UTC를 저장하므로 `ZoneOffset.UTC` 명시는 의도를 명확히 하고 JVM 설정과 무관하게 일관된 동작을 보장합니다.

## Test plan

- [ ] 빌드 성공 확인 (`./gradlew build`)
- [ ] 엔티티 저장 시 `created_at` 값이 올바르게 저장되는지 확인
- [ ] `AppConstants.ZONE` 기반 비즈니스 날짜 로직(`LocalDate.now(AppConstants.ZONE)`)에 영향 없는지 확인

Closes #15

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized persisted and lifecycle timestamps to use UTC across the platform (sessions, messages, notifications, check-ins, reports, audits, user events/preferences, memory records, retention jobs, etc.) for consistent creation/update times regardless of system timezone.

* **Tests**
  * Added unit tests validating user lifecycle timestamps and soft-delete behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/29?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->