### PR TITLE
fix: completeOnboarding() onboardingStep = 4 누락 수정

### DIFF
--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -97,6 +97,7 @@ public class User {
 
     public void completeOnboarding(String characterId) {
         this.preferredCharacterId = characterId;
+        this.onboardingStep = 4;
         this.signupStep = SignupStep.ONBOARDING_COMPLETED;
     }
 

--- a/src/test/java/com/mio/user/domain/UserTest.java
+++ b/src/test/java/com/mio/user/domain/UserTest.java
@@ -27,6 +27,22 @@ class UserTest {
     }
 
     @Test
+    @DisplayName("completeOnboarding은 onboardingStep을 4로 설정한다")
+    void completeOnboarding_setsOnboardingStepFour() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+
+        user.completeOnboarding("mio");
+
+        assertThat(user.getOnboardingStep()).isEqualTo(4);
+        assertThat(user.getPreferredCharacterId()).isEqualTo("mio");
+        assertThat(user.getSignupStep()).isEqualTo(SignupStep.ONBOARDING_COMPLETED);
+    }
+
+    @Test
     @DisplayName("softDelete는 deletedAt을 UTC로 저장하고 상태를 DELETED로 바꾼다")
     void softDelete_setsUtcDeletedAt() {
         User user = User.builder()


### PR DESCRIPTION
## Summary

- `User.completeOnboarding()`에서 `onboardingStep = 4` 설정이 누락되어 캐릭터 선택 완료 후에도 `onboardingStep`이 3에 머무르는 버그 수정
- `signupStep`은 `ONBOARDING_COMPLETED`로 정상 전환되었으나 `onboardingStep` 미동기화
- `UserTest`에 `completeOnboarding` 검증 테스트 추가

## Test plan

- [x] `UserTest.completeOnboarding_setsOnboardingStepFour` — onboardingStep=4, preferredCharacterId, signupStep 모두 검증
- [x] 기존 `UserTest` 테스트 전체 통과

Closes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracking of user onboarding completion to ensure all progress stages are properly recorded when onboarding finishes.

* **Tests**
  * Added test coverage for onboarding completion behavior to verify correct state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->