### PR TITLE
fix: ErrorCode 코드 문자열을 API 명세 기준으로 수정

### DIFF
--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // Common
-    INVALID_INPUT(HttpStatus.BAD_REQUEST, "INVALID_INPUT", "잘못된 입력입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 오류가 발생했습니다."),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR", "잘못된 입력입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "서버 오류가 발생했습니다."),
     RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE_NOT_FOUND", "요청한 리소스를 찾을 수 없습니다."),
     DUPLICATE_REQUEST(HttpStatus.CONFLICT, "DUPLICATE_REQUEST", "중복된 요청입니다."),
 
@@ -24,8 +24,8 @@ public enum ErrorCode {
 
     // User
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
-    USER_SUSPENDED(HttpStatus.FORBIDDEN, "USER_SUSPENDED", "이용이 제한된 계정입니다."),
-    USER_WITHDRAWN(HttpStatus.GONE, "USER_WITHDRAWN", "탈퇴한 계정입니다."),
+    USER_SUSPENDED(HttpStatus.FORBIDDEN, "ACCOUNT_SUSPENDED", "이용이 제한된 계정입니다."),
+    USER_WITHDRAWN(HttpStatus.GONE, "GONE", "탈퇴한 계정입니다."),
     ONBOARDING_REQUIRED(HttpStatus.FORBIDDEN, "ONBOARDING_REQUIRED", "온보딩을 먼저 완료해야 합니다."),
 
     // Onboarding
@@ -56,10 +56,11 @@ public enum ErrorCode {
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_TOKEN_NOT_FOUND", "디바이스 토큰을 찾을 수 없습니다."),
 
     // Rate Limit
-    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMIT_EXCEEDED", "요청 한도를 초과했습니다."),
+    RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", "요청 한도를 초과했습니다."),
 
     // External
     UPSTREAM_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "UPSTREAM_UNAVAILABLE", "외부 서비스가 일시적으로 응답하지 않습니다."),
+    UPSTREAM_BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "UPSTREAM_BAD_GATEWAY", "외부 서비스로부터 잘못된 응답을 받았습니다."),
     PROVIDER_MISMATCH(HttpStatus.CONFLICT, "PROVIDER_MISMATCH", "동일 이메일로 다른 소셜 계정이 이미 존재합니다."),
     INVALID_PROVIDER(HttpStatus.BAD_REQUEST, "INVALID_PROVIDER", "지원하지 않는 소셜 로그인 제공자입니다."),
     SIGNUP_STEP_INVALID(HttpStatus.FORBIDDEN, "SIGNUP_STEP_INVALID", "현재 가입 단계에서 허용되지 않는 요청입니다."),

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -152,7 +152,7 @@ class DailyTestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test
@@ -167,7 +167,7 @@ class DailyTestControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test
@@ -184,7 +184,7 @@ class DailyTestControllerTest {
                                 }
                                 """))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test

--- a/src/test/java/com/mio/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/mio/notification/controller/NotificationControllerTest.java
@@ -69,7 +69,7 @@ class NotificationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"title\":\"\",\"body\":\"내용\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -101,7 +101,7 @@ class SessionControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"character_id\":\"" + invalidCharacterId + "\"}"))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test

--- a/src/test/java/com/mio/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/mio/todo/controller/TodoControllerTest.java
@@ -98,7 +98,7 @@ class TodoControllerTest {
                                 new TodoGenerateRequest("pattern", null)
                         )))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test
@@ -183,7 +183,7 @@ class TodoControllerTest {
                                 new TodoCheckinRequest("done", 60, 30, "...")
                         )))
                 .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.error.code").value("INVALID_INPUT"));
+                .andExpect(jsonPath("$.error.code").value("VALIDATION_ERROR"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- 공통 에러코드 명세(`00_공통_및_공통_에러코드.md`)와 `ErrorCode` enum의 코드 문자열 불일치 수정
- 클라이언트가 명세와 다른 에러 코드를 수신하던 버그 해결
- 명세에만 있고 구현이 없던 `UPSTREAM_BAD_GATEWAY(502)` 추가

| 열거 상수 | 기존 코드 | 수정 코드 |
|-----------|-----------|-----------|
| `INVALID_INPUT` | `INVALID_INPUT` | `VALIDATION_ERROR` |
| `INTERNAL_SERVER_ERROR` | `INTERNAL_SERVER_ERROR` | `INTERNAL_ERROR` |
| `USER_SUSPENDED` | `USER_SUSPENDED` | `ACCOUNT_SUSPENDED` |
| `USER_WITHDRAWN` | `USER_WITHDRAWN` | `GONE` |
| `RATE_LIMIT_EXCEEDED` | `RATE_LIMIT_EXCEEDED` | `RATE_LIMITED` |
| `UPSTREAM_BAD_GATEWAY` | (없음) | `UPSTREAM_BAD_GATEWAY` ← 신규 |

## Test plan

- [x] `./gradlew compileJava` 통과
- [x] 열거 상수명은 유지하므로 기존 Java 코드 참조 (`ErrorCode.INVALID_INPUT` 등) 영향 없음

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated several error code values returned in API error responses (validation, internal, account status, rate-limit, and related error codes).
* **Tests**
  * Updated automated tests to assert the new error code values in relevant API validation and error scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->