### PR TITLE
fix: 캐릭터 미선택 시 mio 자동 설정 경로 추가

### DIFF
--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
@@ -1,8 +1,7 @@
 package com.mio.onboarding.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.validation.constraints.NotBlank;
 
 public record CharacterSelectRequest(
-        @JsonProperty("character_id") @NotBlank String characterId
+        @JsonProperty("character_id") String characterId
 ) {}

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -104,7 +104,11 @@ public class OnboardingService {
 
     @Transactional
     public CharacterSelectResponse selectCharacter(UUID userId, CharacterSelectRequest request) {
-        if (!VALID_CHARACTER_IDS.contains(request.characterId())) {
+        String characterId = (request.characterId() == null || request.characterId().isBlank())
+                ? "mio"
+                : request.characterId();
+
+        if (!VALID_CHARACTER_IDS.contains(characterId)) {
             throw new BusinessException(ErrorCode.INVALID_CHARACTER_ID);
         }
 
@@ -113,7 +117,7 @@ public class OnboardingService {
             throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
         }
 
-        user.completeOnboarding(request.characterId());
+        user.completeOnboarding(characterId);
         return new CharacterSelectResponse(user.getPreferredCharacterId(), user.getSignupStep());
     }
 


### PR DESCRIPTION
## Summary

- `CharacterSelectRequest.characterId`의 `@NotBlank` 제약 제거 — null/빈값 허용
- `OnboardingService.selectCharacter()`에서 null/blank 입력 시 `"mio"` 기본값 적용
- 유효하지 않은 캐릭터 ID는 여전히 `INVALID_CHARACTER_ID(400)` 반환

## Test plan

- [x] `./gradlew test --tests "com.mio.onboarding.service.OnboardingServiceTest"` 통과
- [x] `character_id` 생략 시 → `mio` 자동 선택
- [x] `character_id: "invalid"` → `INVALID_CHARACTER_ID` 반환

Closes #35

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated character selection request structure and moved validation logic to the service layer.

* **Improvements**
  * Character selection now defaults to "mio" when no character is specified and validates selections against allowed character IDs for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->