### PR TITLE
fix: OnboardingService.submitStep1() signupStep 가드 추가

### DIFF
--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.onboarding.dto.*;
+import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.domain.UserOnboardingAnswer;
 import com.mio.user.repository.UserOnboardingAnswerRepository;
@@ -48,6 +49,9 @@ public class OnboardingService {
         }
 
         User user = findUser(userId);
+        if (user.getSignupStep().ordinal() < SignupStep.PROFILE_COMPLETED.ordinal()) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
         answer.updateStep1(request.emotionState(), toJson(request.responses()));
         user.updateOnboardingStep(1);

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -51,6 +51,7 @@ class OnboardingServiceTest {
     @Test
     @DisplayName("1단계 제출 성공 시 onboarding_step이 1을 반환한다")
     void submitStep1_success_returnsStep1() {
+        mockUser.completeProfile("테스트", null, null);
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
         when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
@@ -61,6 +62,19 @@ class OnboardingServiceTest {
 
         assertThat(response.onboardingStep()).isEqualTo(1);
         assertThat(mockUser.getOnboardingStep()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("1단계는 PROFILE_COMPLETED 이전 signupStep이면 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
+    void submitStep1_signupStepNotReady_throws() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.submitStep1(
+                userId, new OnboardingStep1Request("anxious", List.of())
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `OnboardingService.submitStep1()`에 `signupStep` 사전 조건 검증 가드 추가
- `PROFILE_COMPLETED` 이전 단계 사용자가 Step1을 호출하면 `ONBOARDING_STEP_NOT_COMPLETED` 예외 반환
- `submitStep2()`, `submitStep3()`는 이미 동일한 가드를 보유하고 있어 Step1만 누락된 상태였음

## Changes

- `OnboardingService.submitStep1()` — signupStep ordinal 비교 가드 추가
- `OnboardingServiceTest` — 성공 케이스에 `completeProfile()` 전제 조건 추가, 가드 실패 테스트 신규 추가

## Test Plan

- [x] `submitStep1_success_returnsStep1` — PROFILE_COMPLETED 이후 정상 처리 확인
- [x] `submitStep1_signupStepNotReady_throws` — PROFILE_COMPLETED 이전 호출 시 ONBOARDING_STEP_NOT_COMPLETED 예외 확인
- [x] `./gradlew test` 전체 빌드 통과 확인

Closes #46

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened onboarding flow validation: users must now complete their profile setup before proceeding with the first onboarding step. Submitting before completion will result in an error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->