### PR TITLE
fix: User 엔티티 marketingAgree 필드 추가 및 agreeConsent() 파라미터 오용 수정

### DIFF
--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -44,6 +44,11 @@ public class User {
     @Builder.Default
     private boolean notificationAgree = true;
 
+    /** 마케팅 활용 동의 (선택) */
+    @Column(name = "marketing_agree", nullable = false)
+    @Builder.Default
+    private boolean marketingAgree = false;
+
     /** 개인정보 및 감정 데이터 활용 동의 */
     @Column(name = "privacy_consent", nullable = false)
     private boolean privacyConsent;
@@ -105,9 +110,9 @@ public class User {
         this.preferredCharacterId = characterId;
     }
 
-    public void agreeConsent(boolean privacyConsent, boolean notificationAgree) {
+    public void agreeConsent(boolean privacyConsent, boolean marketingAgree) {
         this.privacyConsent = privacyConsent;
-        this.notificationAgree = notificationAgree;
+        this.marketingAgree = marketingAgree;
         this.signupStep = SignupStep.CONSENT_AGREED;
     }
     public void completeProfile(String nickname, String ageRange, String gender) {

--- a/src/main/resources/db/migration/V16__add_marketing_agree_to_users.sql
+++ b/src/main/resources/db/migration/V16__add_marketing_agree_to_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN marketing_agree BOOLEAN NOT NULL DEFAULT FALSE;

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -164,7 +164,26 @@ class AuthServiceTest {
 
         assertThat(response.signupStep()).isEqualTo(SignupStep.CONSENT_AGREED);
         assertThat(user.getSignupStep()).isEqualTo(SignupStep.CONSENT_AGREED);
+        assertThat(user.isMarketingAgree()).isFalse();
         verify(userConsentRepository).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("마케팅 동의 시 marketingAgree가 true로 설정된다")
+    void agreeConsent_marketingAgreed_setsMarketingAgreeTrue() {
+        User user = buildUser(USER_ID, "kakao", "social-123", SignupStep.SOCIAL_AUTHENTICATED, "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        ConsentRequest request = new ConsentRequest(List.of(
+                new ConsentRequest.ConsentItem("terms", true, "v1"),
+                new ConsentRequest.ConsentItem("privacy", true, "v1"),
+                new ConsentRequest.ConsentItem("age_verification", true, "v1"),
+                new ConsentRequest.ConsentItem("marketing", true, "v1")
+        ));
+
+        authService.agreeConsent(USER_ID, request);
+
+        assertThat(user.isMarketingAgree()).isTrue();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `User` 엔티티에 `marketing_agree` 필드가 없어 마케팅 동의값이 `notification_agree`에 덮어쓰이던 버그 수정
- `marketingAgree` 필드 신규 추가, `agreeConsent()` 파라미터명 정정
- Flyway 마이그레이션 V16 추가 (`marketing_agree BOOLEAN NOT NULL DEFAULT FALSE`)

## Changes

- `User.java` — `marketingAgree` 필드 추가, `agreeConsent()` 파라미터 `notificationAgree` → `marketingAgree`
- `V16__add_marketing_agree_to_users.sql` — `users` 테이블에 `marketing_agree` 컬럼 추가 마이그레이션
- `AuthServiceTest` — `agreeConsent_validRequest` 성공 케이스 assertion 추가, 마케팅 동의 true 케이스 신규 테스트 추가

## Test Plan

- [x] `agreeConsent_validRequest_transitionsToConsentAgreed` — 필수 약관 모두 동의 시 정상 전이 확인
- [x] `agreeConsent_marketingAgreed_setsMarketingAgreeTrue` — 마케팅 동의 시 `marketingAgree=true` 확인
- [x] `./gradlew test` 전체 빌드 통과 확인

Closes #47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added marketing consent preference. Users can now control whether they receive marketing communications as part of their account consent settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->