### PR TITLE
fix: session_meta SSE 이벤트 필드명 msg_id → message_id 수정

### DIFF
--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -14,7 +14,7 @@ public sealed interface SseEventDto
     String eventName();
 
     record SessionMetaEvent(
-            @JsonProperty("message_id") String msgId,
+            @JsonProperty("message_id") String messageId,
             @JsonProperty("received_at") OffsetDateTime receivedAt
     ) implements SseEventDto {
         @Override public String eventName() { return "session_meta"; }

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -14,7 +14,7 @@ public sealed interface SseEventDto
     String eventName();
 
     record SessionMetaEvent(
-            @JsonProperty("msg_id") String msgId,
+            @JsonProperty("message_id") String msgId,
             @JsonProperty("received_at") OffsetDateTime receivedAt
     ) implements SseEventDto {
         @Override public String eventName() { return "session_meta"; }


### PR DESCRIPTION
## Summary
- `SseEventDto.SessionMetaEvent`의 `@JsonProperty("msg_id")`를 `@JsonProperty("message_id")`로 수정
- API 명세서 `04_Session_Message_세션_메시지.md`의 session_meta 이벤트 스펙과 일치

## Test plan
- [ ] 세션 생성 후 메시지 전송 시 SSE 스트림 수신 확인
- [ ] `session_meta` 이벤트 페이로드에 `message_id` 키로 전달되는지 확인
- [ ] `delta` / `done` 이벤트의 `msg_id` 필드는 변경 없음 확인

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated a JSON property name in server-sent event payloads: "message_id" replaces "msg_id". Integrations and consumers parsing these events should update their parsing/handling to match the new field name.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->