### PR TITLE
fix: SESSION_ALREADY_ENDED 에러코드 문자열 GONE으로 수정

### DIFF
--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     // Session
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
     SESSION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "SESSION_ALREADY_ACTIVE", "이미 진행 중인 활성 세션이 있습니다."),
-    SESSION_ALREADY_ENDED(HttpStatus.GONE, "SESSION_ALREADY_ENDED", "이미 종료된 세션입니다."),
+    SESSION_ALREADY_ENDED(HttpStatus.GONE, "GONE", "이미 종료된 세션입니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 
     // Daily Test

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -152,6 +152,6 @@ class SessionControllerTest {
         mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
                         .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isGone())
-                .andExpect(jsonPath("$.error.code").value("SESSION_ALREADY_ENDED"));
+                .andExpect(jsonPath("$.error.code").value("GONE"));
     }
 }


### PR DESCRIPTION
## Summary
- `ErrorCode.SESSION_ALREADY_ENDED`의 code 문자열을 `"SESSION_ALREADY_ENDED"` → `"GONE"`으로 수정
- 공통 에러코드 테이블: HTTP 410 응답의 code 문자열은 `GONE`으로 통일
- `USER_WITHDRAWN`이 이미 올바르게 `"GONE"`을 사용하고 있으며, SESSION_ALREADY_ENDED도 동일하게 맞춤

## Test plan
- [ ] 종료된 세션에 메시지 전송 시 `{"error":{"code":"GONE",...}}` 응답 반환 확인
- [ ] 종료된 세션 종료 재요청 시 동일하게 GONE 코드 반환 확인

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the error code identifier returned when attempting to end an already-ended session from "SESSION_ALREADY_ENDED" to "GONE" (HTTP 410); the user-facing message remains unchanged.
* **Tests**
  * Adjusted tests to expect the new error code for the already-ended session scenario.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/56?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->