### PR TITLE
fix: GET /v1/sessions/active 온보딩 완료 가드 추가

### DIFF
--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -66,6 +66,10 @@ public class SessionService {
 
     @Transactional(readOnly = true)
     public Optional<ActiveSessionResponse> getActiveSession(UUID userId) {
+        User user = findUser(userId);
+        if (!user.getSignupStep().isOnboardingComplete()) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
         return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)
                 .map(ActiveSessionResponse::from);
     }

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -150,6 +150,7 @@ class SessionServiceTest {
     @Test
     @DisplayName("활성 세션이 없으면 getActiveSession은 Optional.empty를 반환한다")
     void getActiveSession_noSession_returnsNull() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(Optional.empty());
 
         Optional<ActiveSessionResponse> response = sessionService.getActiveSession(userId);
@@ -160,6 +161,7 @@ class SessionServiceTest {
     @Test
     @DisplayName("활성 세션이 있으면 getActiveSession은 세션 정보를 반환한다")
     void getActiveSession_hasSession_returnsSession() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         Session session = Session.builder()
                 .user(mockUser)
                 .characterId("mio")

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -176,6 +176,22 @@ class SessionServiceTest {
     }
 
     @Test
+    @DisplayName("온보딩 미완료 사용자가 활성 세션 조회 시 ONBOARDING_REQUIRED 예외가 발생한다")
+    void getActiveSession_onboardingIncomplete_throws() {
+        User incompleteUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-id")
+                .privacyConsent(true)
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(incompleteUser));
+
+        assertThatThrownBy(() -> sessionService.getActiveSession(userId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_REQUIRED));
+    }
+
+    @Test
     @DisplayName("이미 종료된 세션을 종료하면 SESSION_ALREADY_ENDED 예외가 발생한다")
     void endSession_alreadyEnded_throws() {
         UUID sessionId = UUID.randomUUID();


### PR DESCRIPTION
## Summary
- `SessionService.getActiveSession()`에 온보딩 완료 여부 검사 추가
- `createSession()`과 동일하게 `signupStep.isOnboardingComplete()` 미충족 시 `ONBOARDING_REQUIRED(403)` 반환
- 온보딩 미완료 사용자가 활성 세션을 조회할 수 없도록 방어

## Test plan
- [ ] 온보딩 미완료 계정으로 `GET /v1/sessions/active` 요청 시 403 ONBOARDING_REQUIRED 반환 확인
- [ ] 온보딩 완료 계정으로 동일 요청 시 정상 응답(200 또는 204) 확인

Closes #52

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Active session access now requires completed onboarding; attempts to fetch an active session for users with incomplete onboarding return an onboarding-required error.

* **Tests**
  * Updated tests to cover user lookup and the onboarding-required behavior for active session access, including both no-active-session and has-active-session scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->