### PR TITLE
fix: 에러 응답 포맷 명세 일치 — trace_id error 객체 내부로 이동

### DIFF
--- a/src/main/java/com/mio/common/error/ErrorResponse.java
+++ b/src/main/java/com/mio/common/error/ErrorResponse.java
@@ -10,6 +10,10 @@ public record ErrorResponse(ErrorDetail error) {
         return new ErrorResponse(new ErrorDetail(errorCode.getCode(), errorCode.getMessage(), traceId));
     }
 
+    public static ErrorResponse of(ErrorCode errorCode, String customMessage, String traceId) {
+        return new ErrorResponse(new ErrorDetail(errorCode.getCode(), customMessage, traceId));
+    }
+
     public record ErrorDetail(
             String code,
             String message,

--- a/src/main/java/com/mio/common/error/ErrorResponse.java
+++ b/src/main/java/com/mio/common/error/ErrorResponse.java
@@ -2,26 +2,17 @@ package com.mio.common.error;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import lombok.Builder;
 
-@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record ErrorResponse(
-        boolean success,
-        Object data,
-        ErrorDetail error,
-        Meta meta
-) {
+public record ErrorResponse(ErrorDetail error) {
+
     public static ErrorResponse of(ErrorCode errorCode, String traceId) {
-        return ErrorResponse.builder()
-                .success(false)
-                .data(null)
-                .error(new ErrorDetail(errorCode.getCode(), errorCode.getMessage()))
-                .meta(new Meta(traceId))
-                .build();
+        return new ErrorResponse(new ErrorDetail(errorCode.getCode(), errorCode.getMessage(), traceId));
     }
 
-    public record ErrorDetail(String code, String message) {}
-
-    public record Meta(@JsonProperty("trace_id") String traceId) {}
+    public record ErrorDetail(
+            String code,
+            String message,
+            @JsonProperty("trace_id") String traceId
+    ) {}
 }

--- a/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
@@ -33,9 +33,7 @@ public class GlobalExceptionHandler {
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining(", "));
         log.warn("ValidationException: {}", message);
-        var error = new ErrorResponse(
-                new ErrorResponse.ErrorDetail(ErrorCode.INVALID_INPUT.getCode(), message, getTraceId(request)));
-        return ResponseEntity.badRequest().body(error);
+        return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message, getTraceId(request)));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
@@ -33,11 +33,8 @@ public class GlobalExceptionHandler {
                 .map(FieldError::getDefaultMessage)
                 .collect(Collectors.joining(", "));
         log.warn("ValidationException: {}", message);
-        var error = ErrorResponse.builder()
-                .success(false)
-                .error(new ErrorResponse.ErrorDetail(ErrorCode.INVALID_INPUT.getCode(), message))
-                .meta(new ErrorResponse.Meta(getTraceId(request)))
-                .build();
+        var error = new ErrorResponse(
+                new ErrorResponse.ErrorDetail(ErrorCode.INVALID_INPUT.getCode(), message, getTraceId(request)));
         return ResponseEntity.badRequest().body(error);
     }
 


### PR DESCRIPTION
## Summary
- `ErrorResponse`에서 `success`, `data`, `meta` 필드 제거
- `trace_id`를 `meta` 객체 대신 `error` 객체 내부로 이동
- 명세 기준 에러 응답 포맷: `{"error":{"code":"...","message":"...","trace_id":"..."}}`
- `GlobalExceptionHandler.handleValidationException`의 수동 빌더 호출도 새 구조에 맞게 수정

## Before / After
**Before:**
```json
{"success": false, "error": {"code": "GONE", "message": "..."}, "meta": {"trace_id": "..."}}
```
**After:**
```json
{"error": {"code": "GONE", "message": "...", "trace_id": "..."}}
```

## Test plan
- [ ] 비즈니스 예외 발생 시 응답 구조 확인 — `success` 필드 없음, `trace_id`가 `error` 내부에 있음
- [ ] 유효성 검사 실패(400) 시 동일 포맷 확인
- [ ] 인증 오류(401), 접근 거부(403), 서버 오류(500)도 동일 포맷 확인

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Error responses now surface a unique trace_id in the JSON payload for faster diagnostics and support.
  * API error payloads have been simplified and standardized to a single error object for clearer, more consistent responses.
  * Validation errors remain HTTP 400 and continue to return the original validation message along with the trace_id.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->