### PR TITLE
fix: createSession character_id 허용 목록 검증 추가

### DIFF
--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -48,7 +48,7 @@ public class SessionService {
                 ? request.characterId()
                 : user.getPreferredCharacterId();
 
-        if (!ALLOWED_CHARACTER_IDS.contains(characterId)) {
+        if (characterId == null || !ALLOWED_CHARACTER_IDS.contains(characterId)) {
             throw new BusinessException(ErrorCode.INVALID_CHARACTER_ID);
         }
 

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -22,11 +22,14 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class SessionService {
+
+    private static final Set<String> ALLOWED_CHARACTER_IDS = Set.of("mio", "bau", "rumi", "momo", "chichi");
 
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
@@ -44,6 +47,10 @@ public class SessionService {
         String characterId = (request.characterId() != null && !request.characterId().isBlank())
                 ? request.characterId()
                 : user.getPreferredCharacterId();
+
+        if (!ALLOWED_CHARACTER_IDS.contains(characterId)) {
+            throw new BusinessException(ErrorCode.INVALID_CHARACTER_ID);
+        }
 
         if (sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)) {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);


### PR DESCRIPTION
## Summary
- `SessionService.createSession()`에 `character_id` 허용 목록 검증 추가
- 허용 값: `mio`, `bau`, `rumi`, `momo`, `chichi`
- 범위 외 값 입력 시 `INVALID_CHARACTER_ID (400)` 반환
- `ErrorCode.INVALID_CHARACTER_ID`는 기존에 이미 정의되어 있으며 재활용

## Test plan
- [ ] 허용 값(`mio`, `bau` 등)으로 세션 생성 요청 시 201 정상 응답 확인
- [ ] 허용 값 외(`"unknown"`, `""` 등)로 요청 시 400 INVALID_CHARACTER_ID 반환 확인
- [ ] `character_id` 미전달 시 `user.preferredCharacterId` 사용하며 유효값이면 정상 처리 확인

Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Session creation now validates the selected character. Attempts to create a session with a missing or disallowed character are rejected and return a clear error message, preventing invalid character selections from being processed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->