### PR TITLE
fix: DailyTest API 명세 일치 — ResultEngine 구조화, DTO 재설계, snake_case 추가

### DIFF
--- a/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
@@ -1,9 +1,18 @@
 package com.mio.dailytest.dto;
 
-import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public record DailyTestResultResponse(
-        UUID responseId,
-        UUID testId,
-        String resultSummary
-) {}
+        ResultDto result,
+        @JsonProperty("completed_at") OffsetDateTime completedAt
+) {
+    public record ResultDto(
+            String summary,
+            String description,
+            List<String> tags,
+            @JsonProperty("character_comment") String characterComment
+    ) {}
+}

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,33 +1,40 @@
 package com.mio.dailytest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.UUID;
 
-/**
- * status=pending: testId, title, description, questions 포함
- * status=completed: testId, resultSummary 포함, questions null
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DailyTestTodayResponse(
-        String status,
-        UUID testId,
+        @JsonProperty("completed_today") boolean completedToday,
+        @JsonProperty("test_id") UUID testId,
         String title,
-        String description,
+        @JsonProperty("estimated_minutes") Integer estimatedMinutes,
         List<QuestionDto> questions,
-        String resultSummary
+        ResultDto result
 ) {
-    public record QuestionDto(String id, int order, String text, List<OptionDto> options) {}
+    public record ResultDto(String summary, List<String> tags) {}
 
-    public record OptionDto(String id, String text) {}
+    public record QuestionDto(
+            @JsonProperty("question_id") String questionId,
+            int order,
+            String text,
+            List<OptionDto> options
+    ) {}
 
-    public static DailyTestTodayResponse pending(UUID testId, String title, String description,
+    public record OptionDto(
+            @JsonProperty("option_id") String optionId,
+            String text
+    ) {}
+
+    public static DailyTestTodayResponse pending(UUID testId, String title, int estimatedMinutes,
                                                   List<QuestionDto> questions) {
-        return new DailyTestTodayResponse("pending", testId, title, description, questions, null);
+        return new DailyTestTodayResponse(false, testId, title, estimatedMinutes, questions, null);
     }
 
-    public static DailyTestTodayResponse completed(UUID testId, String resultSummary) {
-        return new DailyTestTodayResponse("completed", testId, null, null, null, resultSummary);
+    public static DailyTestTodayResponse completed(ResultDto result) {
+        return new DailyTestTodayResponse(true, null, null, null, null, result);
     }
 }

--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -5,7 +5,9 @@ import com.mio.common.error.ErrorCode;
 import com.mio.dailytest.dto.DailyTestContent;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Component
 public class DailyTestResultEngine {
@@ -13,36 +15,53 @@ public class DailyTestResultEngine {
     private static final int THRESHOLD_LOW = 4;
     private static final int THRESHOLD_HIGH = 8;
 
-    private static final String RESULT_STABLE = "오늘은 비교적 안정된 하루였네요.";
-    private static final String RESULT_MODERATE = "감정의 기복이 있었던 하루군요.";
-    private static final String RESULT_HARD = "힘든 하루를 보냈군요. 충분히 쉬어요.";
+    public record TestResult(String summary, String description, List<String> tags, String characterComment) {}
 
-    /**
-     * @param content 테스트 문항 구조 (JSONB 역직렬화 결과)
-     * @param answers questionId → optionId 매핑
-     * @return result summary 문자열
-     */
-    public String calculate(DailyTestContent content, Map<String, String> answers) {
+    public TestResult calculate(DailyTestContent content, Map<String, String> answers) {
         if (content == null || content.questions() == null || content.questions().isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
         if (answers == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
+
         int totalScore = content.questions().stream()
-                .mapToInt(question -> {
-                    String selectedOptionId = answers.get(question.id());
+                .mapToInt(q -> {
+                    String selectedOptionId = answers.get(q.id());
                     if (selectedOptionId == null) return 0;
-                    return question.options().stream()
-                            .filter(opt -> opt.id().equals(selectedOptionId))
+                    return q.options().stream()
+                            .filter(o -> o.id().equals(selectedOptionId))
                             .mapToInt(DailyTestContent.Option::score)
                             .findFirst()
                             .orElse(0);
                 })
                 .sum();
 
-        if (totalScore < THRESHOLD_LOW) return RESULT_STABLE;
-        if (totalScore < THRESHOLD_HIGH) return RESULT_MODERATE;
-        return RESULT_HARD;
+        List<String> tags = content.questions().stream()
+                .flatMap(q -> {
+                    String selectedOptionId = answers.get(q.id());
+                    if (selectedOptionId == null) return Stream.empty();
+                    return q.options().stream()
+                            .filter(o -> o.id().equals(selectedOptionId))
+                            .flatMap(o -> o.tags() != null ? o.tags().stream() : Stream.empty());
+                })
+                .distinct()
+                .toList();
+
+        String summary, description, characterComment;
+        if (totalScore < THRESHOLD_LOW) {
+            summary = "오늘은 비교적 안정된 하루였네요.";
+            description = "감정이 안정적으로 유지된 하루예요. 작은 스트레스도 잘 다루고 있어요.";
+            characterComment = "미오가 말해요: 차분하게 하루를 보낸 네가 대단해 🐧";
+        } else if (totalScore < THRESHOLD_HIGH) {
+            summary = "감정의 기복이 있었던 하루군요.";
+            description = "다소 감정의 변화가 있었던 하루예요. 잠시 숨을 고르는 시간을 가져보세요.";
+            characterComment = "미오가 말해요: 기복이 있어도 잘 헤쳐나가고 있어 🐧";
+        } else {
+            summary = "힘든 하루를 보냈군요. 충분히 쉬어요.";
+            description = "오늘은 많이 지쳤을 거예요. 자신을 위한 시간을 충분히 가져보세요.";
+            characterComment = "미오가 말해요: 힘들었겠지만 여기까지 온 것만으로도 충분해 🐧";
+        }
+        return new TestResult(summary, description, tags, characterComment);
     }
 }

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -1,6 +1,7 @@
 package com.mio.dailytest.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -44,13 +46,21 @@ public class DailyTestService {
         DailyTest test = dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))
                 .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
 
+        DailyTestContent content = parseContent(test.getContent());
+
         return dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, test.getId())
-                .map(resp -> DailyTestTodayResponse.completed(test.getId(), resp.getResultSummary()))
+                .map(resp -> {
+                    Map<String, String> storedAnswers = deserializeAnswers(resp.getAnswers());
+                    DailyTestResultEngine.TestResult rerun = resultEngine.calculate(content, storedAnswers);
+                    return DailyTestTodayResponse.completed(
+                            new DailyTestTodayResponse.ResultDto(resp.getResultSummary(), rerun.tags())
+                    );
+                })
                 .orElseGet(() -> DailyTestTodayResponse.pending(
                         test.getId(),
                         test.getTitle(),
-                        test.getDescription(),
-                        mapToQuestionDtos(parseContent(test.getContent()))
+                        3,
+                        mapToQuestionDtos(content)
                 ));
     }
 
@@ -71,19 +81,22 @@ public class DailyTestService {
         }
 
         DailyTestContent content = parseContent(test.getContent());
-        String resultSummary = resultEngine.calculate(content, request.answers());
+        DailyTestResultEngine.TestResult testResult = resultEngine.calculate(content, request.answers());
         String answersJson = serializeAnswers(request.answers());
 
         DailyTestResponse response = DailyTestResponse.builder()
                 .user(user)
                 .dailyTest(test)
                 .answers(answersJson)
-                .resultSummary(resultSummary)
+                .resultSummary(testResult.summary())
                 .build();
 
         try {
             DailyTestResponse saved = dailyTestResponseRepository.save(response);
-            return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
+            DailyTestResultResponse.ResultDto resultDto = new DailyTestResultResponse.ResultDto(
+                    testResult.summary(), testResult.description(), testResult.tags(), testResult.characterComment()
+            );
+            return new DailyTestResultResponse(resultDto, saved.getCreatedAt());
         } catch (DataIntegrityViolationException e) {
             if (isDuplicateResponseViolation(e)) {
                 throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
@@ -115,6 +128,14 @@ public class DailyTestService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+        }
+    }
+
+    private Map<String, String> deserializeAnswers(String answersJson) {
+        try {
+            return objectMapper.readValue(answersJson, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,7 +56,7 @@ class DailyTestControllerTest {
     @DisplayName("GET /v1/daily-test/today - pending 상태 반환")
     void getTodayTest_pending_returns200() throws Exception {
         DailyTestTodayResponse response = DailyTestTodayResponse.pending(
-                TEST_ID, "오늘의 테스트", "설명",
+                TEST_ID, "오늘의 테스트", 3,
                 List.of(new DailyTestTodayResponse.QuestionDto("q1", 1, "질문1", List.of(
                         new DailyTestTodayResponse.OptionDto("q1_a", "옵션A")
                 )))
@@ -65,22 +66,24 @@ class DailyTestControllerTest {
         mockMvc.perform(get("/v1/daily-test/today")
                         .principal(() -> USER_ID.toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value("pending"))
-                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
+                .andExpect(jsonPath("$.data.completed_today").value(false))
+                .andExpect(jsonPath("$.data.test_id").value(TEST_ID.toString()))
                 .andExpect(jsonPath("$.data.questions").isArray());
     }
 
     @Test
     @DisplayName("GET /v1/daily-test/today - completed 상태 반환")
     void getTodayTest_completed_returns200() throws Exception {
-        DailyTestTodayResponse response = DailyTestTodayResponse.completed(TEST_ID, "안정된 하루였네요.");
+        DailyTestTodayResponse response = DailyTestTodayResponse.completed(
+                new DailyTestTodayResponse.ResultDto("안정된 하루였네요.", List.of("neutral"))
+        );
         when(dailyTestService.getTodayTest(USER_ID)).thenReturn(response);
 
         mockMvc.perform(get("/v1/daily-test/today")
                         .principal(() -> USER_ID.toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value("completed"))
-                .andExpect(jsonPath("$.data.resultSummary").value("안정된 하루였네요."));
+                .andExpect(jsonPath("$.data.completed_today").value(true))
+                .andExpect(jsonPath("$.data.result.summary").value("안정된 하루였네요."));
     }
 
     @Test
@@ -111,7 +114,8 @@ class DailyTestControllerTest {
     @DisplayName("POST /v1/daily-test/{testId}/answer - 정상 제출 시 201")
     void submitAnswer_valid_returns201() throws Exception {
         DailyTestResultResponse result = new DailyTestResultResponse(
-                UUID.randomUUID(), TEST_ID, "오늘은 비교적 안정된 하루였네요."
+                new DailyTestResultResponse.ResultDto("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오"),
+                OffsetDateTime.now()
         );
         when(dailyTestService.submitAnswer(eq(USER_ID), eq(TEST_ID), any())).thenReturn(result);
 
@@ -122,8 +126,8 @@ class DailyTestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
-                .andExpect(jsonPath("$.data.resultSummary").isString());
+                .andExpect(jsonPath("$.data.result.summary").isString())
+                .andExpect(jsonPath("$.data.completed_at").exists());
     }
 
     @Test

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -30,64 +30,72 @@ class DailyTestResultEngineTest {
     @DisplayName("총점 0~3 → 안정 메시지 반환")
     void calculate_lowScore_returnsStableMessage() {
         Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_a"); // 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("총점 4~7 → 중간 메시지 반환")
     void calculate_moderateScore_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_b", "q2", "q2_b"); // 2+3=5
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("moderate");
     }
 
     @Test
     @DisplayName("총점 8 이상 → 힘든 하루 메시지 반환")
     void calculate_highScore_returnsHardMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_c"); // 4+5=9
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high");
     }
 
     @Test
     @DisplayName("답변 없는 문항은 0점 처리")
     void calculate_missingAnswer_treatedAsZero() {
         Map<String, String> answers = Map.of("q1", "q1_a"); // q2 없음 → 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("존재하지 않는 optionId는 0점 처리")
     void calculate_unknownOptionId_treatedAsZero() {
         Map<String, String> answers = Map.of("q1", "q1_z", "q2", "q2_a"); // 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("경계값 3점 → 안정 (stable 상한)")
     void calculate_boundary3_returnsStableMessage() {
         Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_b"); // 0+3=3
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral", "moderate");
     }
 
     @Test
     @DisplayName("경계값 4점 → 중간 (moderate 하한)")
     void calculate_boundary4_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_a"); // 4+0=4
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high", "neutral");
     }
 
     @Test
     @DisplayName("경계값 7점 → 중간 (moderate 상한)")
     void calculate_boundary7_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_b"); // 4+3=7
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high", "moderate");
     }
 
     @Test
@@ -99,7 +107,8 @@ class DailyTestResultEngineTest {
                 ))
         ));
         Map<String, String> answers = Map.of("q1", "q1_hard");
-        String result = engine.calculate(thresholdContent, answers);
-        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(thresholdContent, answers);
+        assertThat(result.summary()).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high");
     }
 }

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -23,6 +23,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -111,7 +114,7 @@ class DailyTestServiceTest {
 
         DailyTestTodayResponse response = service.getTodayTest(userId);
 
-        assertThat(response.status()).isEqualTo("pending");
+        assertThat(response.completedToday()).isFalse();
         assertThat(response.testId()).isEqualTo(testId);
         assertThat(response.questions()).hasSize(1);
     }
@@ -125,11 +128,14 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.of(existingResponse));
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("안정된 하루", "설명", List.of("neutral"), "미오")
+        );
 
         DailyTestTodayResponse response = service.getTodayTest(userId);
 
-        assertThat(response.status()).isEqualTo("completed");
-        assertThat(response.resultSummary()).isEqualTo("안정된 하루");
+        assertThat(response.completedToday()).isTrue();
+        assertThat(response.result().summary()).isEqualTo("안정된 하루");
     }
 
     @Test
@@ -149,8 +155,6 @@ class DailyTestServiceTest {
                 """);
         when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
         when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
-        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
-                .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.getTodayTest(userId))
                 .isInstanceOf(BusinessException.class)
@@ -199,16 +203,19 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
 
         DailyTestResponse savedResponse = buildDailyTestResponse(test, "오늘은 비교적 안정된 하루였네요.");
+        ReflectionTestUtils.setField(savedResponse, "createdAt", OffsetDateTime.now(ZoneOffset.UTC));
         when(dailyTestResponseRepository.save(any())).thenReturn(savedResponse);
 
         AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
         DailyTestResultResponse result = service.submitAnswer(userId, testId, request);
 
-        assertThat(result.testId()).isEqualTo(testId);
-        assertThat(result.resultSummary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.completedAt()).isNotNull();
+        assertThat(result.result().summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
     }
 
     @Test
@@ -219,7 +226,9 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
         when(dailyTestResponseRepository.save(any()))
                 .thenThrow(new DataIntegrityViolationException(
                         "save failed",
@@ -242,7 +251,9 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
         when(dailyTestResponseRepository.save(any()))
                 .thenThrow(new DataIntegrityViolationException(
                         "save failed",


### PR DESCRIPTION
## 요약

- `DailyTestResultEngine.calculate()`가 구조화된 `TestResult` 레코드 반환하도록 변경 (`summary`, `description`, `tags[]`, `characterComment`)
- `DailyTestResultResponse`를 `result: {...}` + `completed_at` 구조로 재설계
- `DailyTestTodayResponse`에 `completed_today` boolean, `estimated_minutes`, `result: {summary, tags[]}` 중첩 객체 추가 및 per-field `@JsonProperty` snake_case 적용
- `DailyTestService` completed 분기에서 저장된 `answers` JSON으로 engine 재실행해 태그 파생
- `DailyTestResultEngineTest`, `DailyTestServiceTest`, `DailyTestControllerTest` 변경된 구조 반영

Closes #60, #61, #62, #63, #64, #65

## 테스트 계획

- [x] `./gradlew test --tests "com.mio.dailytest.*"` — 빌드 성공
- [x] `./gradlew test` (전체 스위트) — 빌드 성공
- [ ] `GET /v1/daily-test/today` pending 응답: `completed_today: false`, `test_id`, `estimated_minutes`, `questions` 포함 확인
- [ ] `GET /v1/daily-test/today` completed 응답: `completed_today: true`, `result.summary`, `result.tags` 포함 확인
- [ ] `POST /v1/daily-test/{testId}/answer` 응답: `result.summary`, `result.description`, `result.tags`, `result.character_comment`, `completed_at` 포함 확인