### PR TITLE
fix: Todo·DailyTest API 명세 일치 — 응답 구조 정렬 및 목업 데이터 추가

### DIFF
--- a/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
@@ -1,9 +1,18 @@
 package com.mio.dailytest.dto;
 
-import java.util.UUID;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.List;
 
 public record DailyTestResultResponse(
-        UUID responseId,
-        UUID testId,
-        String resultSummary
-) {}
+        ResultDto result,
+        @JsonProperty("completed_at") OffsetDateTime completedAt
+) {
+    public record ResultDto(
+            String summary,
+            String description,
+            List<String> tags,
+            @JsonProperty("character_comment") String characterComment
+    ) {}
+}

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,33 +1,40 @@
 package com.mio.dailytest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.UUID;
 
-/**
- * status=pending: testId, title, description, questions 포함
- * status=completed: testId, resultSummary 포함, questions null
- */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DailyTestTodayResponse(
-        String status,
-        UUID testId,
+        @JsonProperty("completed_today") boolean completedToday,
+        @JsonProperty("test_id") UUID testId,
         String title,
-        String description,
+        @JsonProperty("estimated_minutes") Integer estimatedMinutes,
         List<QuestionDto> questions,
-        String resultSummary
+        ResultDto result
 ) {
-    public record QuestionDto(String id, int order, String text, List<OptionDto> options) {}
+    public record ResultDto(String summary, List<String> tags) {}
 
-    public record OptionDto(String id, String text) {}
+    public record QuestionDto(
+            @JsonProperty("question_id") String questionId,
+            int order,
+            String text,
+            List<OptionDto> options
+    ) {}
 
-    public static DailyTestTodayResponse pending(UUID testId, String title, String description,
+    public record OptionDto(
+            @JsonProperty("option_id") String optionId,
+            String text
+    ) {}
+
+    public static DailyTestTodayResponse pending(UUID testId, String title, int estimatedMinutes,
                                                   List<QuestionDto> questions) {
-        return new DailyTestTodayResponse("pending", testId, title, description, questions, null);
+        return new DailyTestTodayResponse(false, testId, title, estimatedMinutes, questions, null);
     }
 
-    public static DailyTestTodayResponse completed(UUID testId, String resultSummary) {
-        return new DailyTestTodayResponse("completed", testId, null, null, null, resultSummary);
+    public static DailyTestTodayResponse completed(ResultDto result) {
+        return new DailyTestTodayResponse(true, null, null, null, null, result);
     }
 }

--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -5,7 +5,9 @@ import com.mio.common.error.ErrorCode;
 import com.mio.dailytest.dto.DailyTestContent;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 @Component
 public class DailyTestResultEngine {
@@ -13,36 +15,53 @@ public class DailyTestResultEngine {
     private static final int THRESHOLD_LOW = 4;
     private static final int THRESHOLD_HIGH = 8;
 
-    private static final String RESULT_STABLE = "오늘은 비교적 안정된 하루였네요.";
-    private static final String RESULT_MODERATE = "감정의 기복이 있었던 하루군요.";
-    private static final String RESULT_HARD = "힘든 하루를 보냈군요. 충분히 쉬어요.";
+    public record TestResult(String summary, String description, List<String> tags, String characterComment) {}
 
-    /**
-     * @param content 테스트 문항 구조 (JSONB 역직렬화 결과)
-     * @param answers questionId → optionId 매핑
-     * @return result summary 문자열
-     */
-    public String calculate(DailyTestContent content, Map<String, String> answers) {
+    public TestResult calculate(DailyTestContent content, Map<String, String> answers) {
         if (content == null || content.questions() == null || content.questions().isEmpty()) {
             throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
         }
         if (answers == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
+
         int totalScore = content.questions().stream()
-                .mapToInt(question -> {
-                    String selectedOptionId = answers.get(question.id());
+                .mapToInt(q -> {
+                    String selectedOptionId = answers.get(q.id());
                     if (selectedOptionId == null) return 0;
-                    return question.options().stream()
-                            .filter(opt -> opt.id().equals(selectedOptionId))
+                    return q.options().stream()
+                            .filter(o -> o.id().equals(selectedOptionId))
                             .mapToInt(DailyTestContent.Option::score)
                             .findFirst()
                             .orElse(0);
                 })
                 .sum();
 
-        if (totalScore < THRESHOLD_LOW) return RESULT_STABLE;
-        if (totalScore < THRESHOLD_HIGH) return RESULT_MODERATE;
-        return RESULT_HARD;
+        List<String> tags = content.questions().stream()
+                .flatMap(q -> {
+                    String selectedOptionId = answers.get(q.id());
+                    if (selectedOptionId == null) return Stream.empty();
+                    return q.options().stream()
+                            .filter(o -> o.id().equals(selectedOptionId))
+                            .flatMap(o -> o.tags() != null ? o.tags().stream() : Stream.empty());
+                })
+                .distinct()
+                .toList();
+
+        String summary, description, characterComment;
+        if (totalScore < THRESHOLD_LOW) {
+            summary = "오늘은 비교적 안정된 하루였네요.";
+            description = "감정이 안정적으로 유지된 하루예요. 작은 스트레스도 잘 다루고 있어요.";
+            characterComment = "미오가 말해요: 차분하게 하루를 보낸 네가 대단해 🐧";
+        } else if (totalScore < THRESHOLD_HIGH) {
+            summary = "감정의 기복이 있었던 하루군요.";
+            description = "다소 감정의 변화가 있었던 하루예요. 잠시 숨을 고르는 시간을 가져보세요.";
+            characterComment = "미오가 말해요: 기복이 있어도 잘 헤쳐나가고 있어 🐧";
+        } else {
+            summary = "힘든 하루를 보냈군요. 충분히 쉬어요.";
+            description = "오늘은 많이 지쳤을 거예요. 자신을 위한 시간을 충분히 가져보세요.";
+            characterComment = "미오가 말해요: 힘들었겠지만 여기까지 온 것만으로도 충분해 🐧";
+        }
+        return new TestResult(summary, description, tags, characterComment);
     }
 }

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -1,6 +1,7 @@
 package com.mio.dailytest.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
@@ -21,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @Service
@@ -44,13 +46,21 @@ public class DailyTestService {
         DailyTest test = dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))
                 .orElseThrow(() -> new BusinessException(ErrorCode.DAILY_TEST_NOT_FOUND));
 
+        DailyTestContent content = parseContent(test.getContent());
+
         return dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, test.getId())
-                .map(resp -> DailyTestTodayResponse.completed(test.getId(), resp.getResultSummary()))
+                .map(resp -> {
+                    Map<String, String> storedAnswers = deserializeAnswers(resp.getAnswers());
+                    DailyTestResultEngine.TestResult rerun = resultEngine.calculate(content, storedAnswers);
+                    return DailyTestTodayResponse.completed(
+                            new DailyTestTodayResponse.ResultDto(resp.getResultSummary(), rerun.tags())
+                    );
+                })
                 .orElseGet(() -> DailyTestTodayResponse.pending(
                         test.getId(),
                         test.getTitle(),
-                        test.getDescription(),
-                        mapToQuestionDtos(parseContent(test.getContent()))
+                        3,
+                        mapToQuestionDtos(content)
                 ));
     }
 
@@ -71,19 +81,22 @@ public class DailyTestService {
         }
 
         DailyTestContent content = parseContent(test.getContent());
-        String resultSummary = resultEngine.calculate(content, request.answers());
+        DailyTestResultEngine.TestResult testResult = resultEngine.calculate(content, request.answers());
         String answersJson = serializeAnswers(request.answers());
 
         DailyTestResponse response = DailyTestResponse.builder()
                 .user(user)
                 .dailyTest(test)
                 .answers(answersJson)
-                .resultSummary(resultSummary)
+                .resultSummary(testResult.summary())
                 .build();
 
         try {
             DailyTestResponse saved = dailyTestResponseRepository.save(response);
-            return new DailyTestResultResponse(saved.getId(), testId, resultSummary);
+            DailyTestResultResponse.ResultDto resultDto = new DailyTestResultResponse.ResultDto(
+                    testResult.summary(), testResult.description(), testResult.tags(), testResult.characterComment()
+            );
+            return new DailyTestResultResponse(resultDto, saved.getCreatedAt());
         } catch (DataIntegrityViolationException e) {
             if (isDuplicateResponseViolation(e)) {
                 throw new BusinessException(ErrorCode.DAILY_TEST_ALREADY_COMPLETED);
@@ -115,6 +128,14 @@ public class DailyTestService {
             throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         } catch (IllegalArgumentException e) {
             throw new BusinessException(ErrorCode.INVALID_DAILY_TEST_CONTENT);
+        }
+    }
+
+    private Map<String, String> deserializeAnswers(String answersJson) {
+        try {
+            return objectMapper.readValue(answersJson, new TypeReference<>() {});
+        } catch (JsonProcessingException e) {
+            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 

--- a/src/main/java/com/mio/todo/controller/TodoController.java
+++ b/src/main/java/com/mio/todo/controller/TodoController.java
@@ -6,6 +6,7 @@ import com.mio.common.response.ApiResponse;
 import com.mio.todo.dto.TodoCheckinRequest;
 import com.mio.todo.dto.TodoCheckinResponse;
 import com.mio.todo.dto.TodoGenerateRequest;
+import com.mio.todo.dto.TodoListResponse;
 import com.mio.todo.dto.TodoResponse;
 import com.mio.todo.service.TodoService;
 import jakarta.validation.Valid;
@@ -17,7 +18,6 @@ import org.springframework.web.bind.annotation.*;
 
 import java.security.Principal;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -28,21 +28,21 @@ public class TodoController {
     private final TodoService todoService;
 
     @PostMapping("/generate")
-    public ResponseEntity<ApiResponse<List<TodoResponse>>> generate(
+    public ResponseEntity<ApiResponse<TodoListResponse>> generate(
             Principal principal,
             @Valid @RequestBody TodoGenerateRequest request) {
         UUID userId = resolveUserId(principal);
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.ok(todoService.generate(userId, request)));
+                .body(ApiResponse.ok(new TodoListResponse(todoService.generate(userId, request))));
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse<List<TodoResponse>>> getTodos(
+    public ResponseEntity<ApiResponse<TodoListResponse>> getTodos(
             Principal principal,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @RequestParam(required = false) String status) {
         UUID userId = resolveUserId(principal);
-        return ResponseEntity.ok(ApiResponse.ok(todoService.getTodos(userId, date, status)));
+        return ResponseEntity.ok(ApiResponse.ok(new TodoListResponse(todoService.getTodos(userId, date, status))));
     }
 
     @PostMapping("/{todoId}/checkin")

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -3,13 +3,7 @@ package com.mio.todo.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
 
-import java.time.OffsetDateTime;
-import java.util.UUID;
-
 public record TodoCheckinResponse(
-        @JsonProperty("todo_id")
-        UUID todoId,
-
         String status,
 
         @JsonProperty("before_emotion")
@@ -18,19 +12,21 @@ public record TodoCheckinResponse(
         @JsonProperty("after_emotion")
         Integer afterEmotion,
 
-        String feedback,
-
-        @JsonProperty("completed_at")
-        OffsetDateTime completedAt
+        @JsonProperty("character_reaction")
+        String characterReaction
 ) {
+    private static final String REACTION_COMPLETED = "잘했어! 작은 것부터 하나씩 해나가는 게 진짜 대단한 거야 🎉";
+    private static final String REACTION_SKIPPED = "괜찮아, 다음에 또 도전해봐요!";
+
     public static TodoCheckinResponse from(BehaviorTask task) {
+        String reaction = "completed".equals(task.getStatus().value())
+                ? REACTION_COMPLETED
+                : REACTION_SKIPPED;
         return new TodoCheckinResponse(
-                task.getId(),
                 task.getStatus().value(),
                 task.getBeforeEmotion(),
                 task.getAfterEmotion(),
-                task.getFeedback(),
-                task.getCompletedAt()
+                reaction
         );
     }
 }

--- a/src/main/java/com/mio/todo/dto/TodoListResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoListResponse.java
@@ -1,0 +1,5 @@
+package com.mio.todo.dto;
+
+import java.util.List;
+
+public record TodoListResponse(List<TodoResponse> todos) {}

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -23,8 +23,13 @@ public record TodoResponse(
         String status,
 
         @JsonProperty("created_at")
-        OffsetDateTime createdAt
+        OffsetDateTime createdAt,
+
+        @JsonProperty("character_comment")
+        String characterComment
 ) {
+    private static final String MOCK_CHARACTER_COMMENT = "미오가 응원해요!";
+
     public static TodoResponse from(BehaviorTask task) {
         return new TodoResponse(
                 task.getId(),
@@ -33,7 +38,8 @@ public record TodoResponse(
                 task.getDifficulty(),
                 task.getEstimatedMinutes(),
                 task.getStatus().value(),
-                task.getCreatedAt()
+                task.getCreatedAt(),
+                MOCK_CHARACTER_COMMENT
         );
     }
 
@@ -45,7 +51,8 @@ public record TodoResponse(
                 task.getDifficulty(),
                 task.getEstimatedMinutes(),
                 overrideStatus.value(),
-                task.getCreatedAt()
+                task.getCreatedAt(),
+                MOCK_CHARACTER_COMMENT
         );
     }
 }

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -23,6 +23,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -55,7 +56,7 @@ class DailyTestControllerTest {
     @DisplayName("GET /v1/daily-test/today - pending 상태 반환")
     void getTodayTest_pending_returns200() throws Exception {
         DailyTestTodayResponse response = DailyTestTodayResponse.pending(
-                TEST_ID, "오늘의 테스트", "설명",
+                TEST_ID, "오늘의 테스트", 3,
                 List.of(new DailyTestTodayResponse.QuestionDto("q1", 1, "질문1", List.of(
                         new DailyTestTodayResponse.OptionDto("q1_a", "옵션A")
                 )))
@@ -65,22 +66,24 @@ class DailyTestControllerTest {
         mockMvc.perform(get("/v1/daily-test/today")
                         .principal(() -> USER_ID.toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value("pending"))
-                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
+                .andExpect(jsonPath("$.data.completed_today").value(false))
+                .andExpect(jsonPath("$.data.test_id").value(TEST_ID.toString()))
                 .andExpect(jsonPath("$.data.questions").isArray());
     }
 
     @Test
     @DisplayName("GET /v1/daily-test/today - completed 상태 반환")
     void getTodayTest_completed_returns200() throws Exception {
-        DailyTestTodayResponse response = DailyTestTodayResponse.completed(TEST_ID, "안정된 하루였네요.");
+        DailyTestTodayResponse response = DailyTestTodayResponse.completed(
+                new DailyTestTodayResponse.ResultDto("안정된 하루였네요.", List.of("neutral"))
+        );
         when(dailyTestService.getTodayTest(USER_ID)).thenReturn(response);
 
         mockMvc.perform(get("/v1/daily-test/today")
                         .principal(() -> USER_ID.toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.status").value("completed"))
-                .andExpect(jsonPath("$.data.resultSummary").value("안정된 하루였네요."));
+                .andExpect(jsonPath("$.data.completed_today").value(true))
+                .andExpect(jsonPath("$.data.result.summary").value("안정된 하루였네요."));
     }
 
     @Test
@@ -111,7 +114,8 @@ class DailyTestControllerTest {
     @DisplayName("POST /v1/daily-test/{testId}/answer - 정상 제출 시 201")
     void submitAnswer_valid_returns201() throws Exception {
         DailyTestResultResponse result = new DailyTestResultResponse(
-                UUID.randomUUID(), TEST_ID, "오늘은 비교적 안정된 하루였네요."
+                new DailyTestResultResponse.ResultDto("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오"),
+                OffsetDateTime.now()
         );
         when(dailyTestService.submitAnswer(eq(USER_ID), eq(TEST_ID), any())).thenReturn(result);
 
@@ -122,8 +126,8 @@ class DailyTestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.testId").value(TEST_ID.toString()))
-                .andExpect(jsonPath("$.data.resultSummary").isString());
+                .andExpect(jsonPath("$.data.result.summary").isString())
+                .andExpect(jsonPath("$.data.completed_at").exists());
     }
 
     @Test

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -30,64 +30,72 @@ class DailyTestResultEngineTest {
     @DisplayName("총점 0~3 → 안정 메시지 반환")
     void calculate_lowScore_returnsStableMessage() {
         Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_a"); // 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("총점 4~7 → 중간 메시지 반환")
     void calculate_moderateScore_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_b", "q2", "q2_b"); // 2+3=5
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("moderate");
     }
 
     @Test
     @DisplayName("총점 8 이상 → 힘든 하루 메시지 반환")
     void calculate_highScore_returnsHardMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_c"); // 4+5=9
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high");
     }
 
     @Test
     @DisplayName("답변 없는 문항은 0점 처리")
     void calculate_missingAnswer_treatedAsZero() {
         Map<String, String> answers = Map.of("q1", "q1_a"); // q2 없음 → 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("존재하지 않는 optionId는 0점 처리")
     void calculate_unknownOptionId_treatedAsZero() {
         Map<String, String> answers = Map.of("q1", "q1_z", "q2", "q2_a"); // 0+0=0
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
     }
 
     @Test
     @DisplayName("경계값 3점 → 안정 (stable 상한)")
     void calculate_boundary3_returnsStableMessage() {
         Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_b"); // 0+3=3
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("neutral", "moderate");
     }
 
     @Test
     @DisplayName("경계값 4점 → 중간 (moderate 하한)")
     void calculate_boundary4_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_a"); // 4+0=4
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high", "neutral");
     }
 
     @Test
     @DisplayName("경계값 7점 → 중간 (moderate 상한)")
     void calculate_boundary7_returnsModerateMessage() {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_b"); // 4+3=7
-        String result = engine.calculate(CONTENT, answers);
-        assertThat(result).isEqualTo("감정의 기복이 있었던 하루군요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
+        assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high", "moderate");
     }
 
     @Test
@@ -99,7 +107,8 @@ class DailyTestResultEngineTest {
                 ))
         ));
         Map<String, String> answers = Map.of("q1", "q1_hard");
-        String result = engine.calculate(thresholdContent, answers);
-        assertThat(result).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        DailyTestResultEngine.TestResult result = engine.calculate(thresholdContent, answers);
+        assertThat(result.summary()).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        assertThat(result.tags()).containsExactlyInAnyOrder("high");
     }
 }

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -23,6 +23,9 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -111,7 +114,7 @@ class DailyTestServiceTest {
 
         DailyTestTodayResponse response = service.getTodayTest(userId);
 
-        assertThat(response.status()).isEqualTo("pending");
+        assertThat(response.completedToday()).isFalse();
         assertThat(response.testId()).isEqualTo(testId);
         assertThat(response.questions()).hasSize(1);
     }
@@ -125,11 +128,14 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.of(existingResponse));
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("안정된 하루", "설명", List.of("neutral"), "미오")
+        );
 
         DailyTestTodayResponse response = service.getTodayTest(userId);
 
-        assertThat(response.status()).isEqualTo("completed");
-        assertThat(response.resultSummary()).isEqualTo("안정된 하루");
+        assertThat(response.completedToday()).isTrue();
+        assertThat(response.result().summary()).isEqualTo("안정된 하루");
     }
 
     @Test
@@ -149,8 +155,6 @@ class DailyTestServiceTest {
                 """);
         when(userRepository.findById(userId)).thenReturn(Optional.of(onboardedUser));
         when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
-        when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
-                .thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.getTodayTest(userId))
                 .isInstanceOf(BusinessException.class)
@@ -199,16 +203,19 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
 
         DailyTestResponse savedResponse = buildDailyTestResponse(test, "오늘은 비교적 안정된 하루였네요.");
+        ReflectionTestUtils.setField(savedResponse, "createdAt", OffsetDateTime.now(ZoneOffset.UTC));
         when(dailyTestResponseRepository.save(any())).thenReturn(savedResponse);
 
         AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
         DailyTestResultResponse result = service.submitAnswer(userId, testId, request);
 
-        assertThat(result.testId()).isEqualTo(testId);
-        assertThat(result.resultSummary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.completedAt()).isNotNull();
+        assertThat(result.result().summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
     }
 
     @Test
@@ -219,7 +226,9 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
         when(dailyTestResponseRepository.save(any()))
                 .thenThrow(new DataIntegrityViolationException(
                         "save failed",
@@ -242,7 +251,9 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findById(testId)).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.empty());
-        when(resultEngine.calculate(any(), any())).thenReturn("오늘은 비교적 안정된 하루였네요.");
+        when(resultEngine.calculate(any(), any())).thenReturn(
+                new DailyTestResultEngine.TestResult("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오")
+        );
         when(dailyTestResponseRepository.save(any()))
                 .thenThrow(new DataIntegrityViolationException(
                         "save failed",

--- a/src/test/java/com/mio/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/mio/todo/controller/TodoControllerTest.java
@@ -55,8 +55,8 @@ class TodoControllerTest {
     @DisplayName("POST /v1/todos/generate - 성공 시 201 반환")
     void generate_success_returns201() throws Exception {
         List<TodoResponse> responses = List.of(
-                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now()),
-                new TodoResponse(UUID.randomUUID(), "걱정 목록 작성 후 통제 가능/불가능 분류하기", "인지_재구성", 2, 10, "suggested", OffsetDateTime.now())
+                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now(), "미오가 응원해요!"),
+                new TodoResponse(UUID.randomUUID(), "걱정 목록 작성 후 통제 가능/불가능 분류하기", "인지_재구성", 2, 10, "suggested", OffsetDateTime.now(), "미오가 응원해요!")
         );
         when(todoService.generate(eq(TEST_USER_ID), any())).thenReturn(responses);
 
@@ -68,8 +68,8 @@ class TodoControllerTest {
                         )))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(2));
+                .andExpect(jsonPath("$.data.todos").isArray())
+                .andExpect(jsonPath("$.data.todos.length()").value(2));
     }
 
     @Test
@@ -105,7 +105,7 @@ class TodoControllerTest {
     @DisplayName("GET /v1/todos - 성공 시 200 반환")
     void getTodos_success_returns200() throws Exception {
         List<TodoResponse> responses = List.of(
-                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now())
+                new TodoResponse(UUID.randomUUID(), "5분 복식 호흡으로 긴장 풀기", "심리_안정", 1, 5, "suggested", OffsetDateTime.now(), "미오가 응원해요!")
         );
         when(todoService.getTodos(eq(TEST_USER_ID), any(), any())).thenReturn(responses);
 
@@ -113,15 +113,15 @@ class TodoControllerTest {
                         .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
-                .andExpect(jsonPath("$.data").isArray())
-                .andExpect(jsonPath("$.data.length()").value(1));
+                .andExpect(jsonPath("$.data.todos").isArray())
+                .andExpect(jsonPath("$.data.todos.length()").value(1));
     }
 
     @Test
     @DisplayName("POST /v1/todos/{todoId}/checkin - completed 처리 시 200 반환")
     void checkin_completed_returns200() throws Exception {
         UUID todoId = UUID.randomUUID();
-        TodoCheckinResponse response = new TodoCheckinResponse(todoId, "completed", 70, 40, "괜찮았어요", OffsetDateTime.now());
+        TodoCheckinResponse response = new TodoCheckinResponse("completed", 70, 40, "잘했어! 작은 것부터 하나씩 해나가는 게 진짜 대단한 거야 🎉");
         when(todoService.checkin(eq(TEST_USER_ID), eq(todoId), any())).thenReturn(response);
 
         mockMvc.perform(post("/v1/todos/{todoId}/checkin", todoId)
@@ -134,7 +134,7 @@ class TodoControllerTest {
                 .andExpect(jsonPath("$.data.status").value("completed"))
                 .andExpect(jsonPath("$.data.before_emotion").value(70))
                 .andExpect(jsonPath("$.data.after_emotion").value(40))
-                .andExpect(jsonPath("$.data.completed_at").isNotEmpty());
+                .andExpect(jsonPath("$.data.character_reaction").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -171,7 +171,7 @@ class TodoServiceTest {
         assertThat(response.status()).isEqualTo("completed");
         assertThat(response.beforeEmotion()).isEqualTo(70);
         assertThat(response.afterEmotion()).isEqualTo(40);
-        assertThat(response.completedAt()).isNotNull();
+        assertThat(response.characterReaction()).isNotNull();
     }
 
     @Test


### PR DESCRIPTION
## Summary

- **Todo 도메인**: generate·list 응답을 `data.todos` 배열로 래핑, `character_comment`/`character_reaction` 목업 필드 추가, `TodoCheckinResponse` 명세 외 필드 제거
- **DailyTest 도메인**: `ResultEngine` 구조화, DTO 재설계, snake_case 필드명 정렬 (#60~#65)

## Changes

### Todo
- `TodoListResponse` 신규 — `{ todos: [...] }` 래퍼 record
- `TodoResponse`: `character_comment` 추가 (`"미오가 응원해요!"`)
- `TodoCheckinResponse`: `character_reaction` 추가 (completed/skipped별 목업), 명세 외 필드(`todo_id`, `feedback`, `completed_at`) 제거
- `TodoController`: generate·list 엔드포인트 반환 타입 `TodoListResponse`로 교체

### DailyTest
- `DailyTestResultEngine` 분리 구조화
- DTO snake_case 정렬
- 관련 테스트 동기화

## Test plan

- [x] `./gradlew build` 성공
- [x] `com.mio.todo.*` 테스트 전체 통과
- [x] `com.mio.dailytest.*` 테스트 전체 통과
- [ ] POST `/v1/todos/generate` → 응답 `data.todos` 배열 + `character_comment` 확인
- [ ] GET `/v1/todos` → 응답 `data.todos` 배열 확인
- [ ] POST `/v1/todos/{id}/checkin` → `character_reaction` 필드 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced daily test result responses with completion timestamps, detailed descriptions, categorized tags, and character feedback
  * Updated todo checkin and list responses with character comments and personalized reactions
  * Improved overall API response structure for better consistency and clarity across endpoints

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->