### PR TITLE
fix: 알림 도메인 명세 일치 — app_version 저장·403/404 분리·crisis_detected 메시지·중복 경로 제거

### DIFF
--- a/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestResultEngine.java
@@ -28,7 +28,7 @@ public class DailyTestResultEngine {
         int totalScore = content.questions().stream()
                 .mapToInt(q -> {
                     String selectedOptionId = answers.get(q.id());
-                    if (selectedOptionId == null) return 0;
+                    if (selectedOptionId == null || q.options() == null) return 0;
                     return q.options().stream()
                             .filter(o -> o.id().equals(selectedOptionId))
                             .mapToInt(DailyTestContent.Option::score)
@@ -40,10 +40,10 @@ public class DailyTestResultEngine {
         List<String> tags = content.questions().stream()
                 .flatMap(q -> {
                     String selectedOptionId = answers.get(q.id());
-                    if (selectedOptionId == null) return Stream.empty();
+                    if (selectedOptionId == null || q.options() == null) return Stream.empty();
                     return q.options().stream()
                             .filter(o -> o.id().equals(selectedOptionId))
-                            .flatMap(o -> o.tags() != null ? o.tags().stream() : Stream.empty());
+                            .flatMap(o -> o.tags() != null ? o.tags().stream().filter(t -> t != null) : Stream.empty());
                 })
                 .distinct()
                 .toList();

--- a/src/main/java/com/mio/dailytest/service/DailyTestService.java
+++ b/src/main/java/com/mio/dailytest/service/DailyTestService.java
@@ -31,6 +31,7 @@ public class DailyTestService {
 
     private static final String DUPLICATE_RESPONSE_CONSTRAINT =
             "daily_test_responses_user_id_daily_test_id_key";
+    private static final int DEFAULT_ESTIMATED_MINUTES = 3;
 
     private final DailyTestRepository dailyTestRepository;
     private final DailyTestResponseRepository dailyTestResponseRepository;
@@ -51,6 +52,7 @@ public class DailyTestService {
         return dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, test.getId())
                 .map(resp -> {
                     Map<String, String> storedAnswers = deserializeAnswers(resp.getAnswers());
+                    // summary는 저장된 값 사용, tags는 저장하지 않으므로 재계산
                     DailyTestResultEngine.TestResult rerun = resultEngine.calculate(content, storedAnswers);
                     return DailyTestTodayResponse.completed(
                             new DailyTestTodayResponse.ResultDto(resp.getResultSummary(), rerun.tags())
@@ -59,7 +61,7 @@ public class DailyTestService {
                 .orElseGet(() -> DailyTestTodayResponse.pending(
                         test.getId(),
                         test.getTitle(),
-                        3,
+                        DEFAULT_ESTIMATED_MINUTES,
                         mapToQuestionDtos(content)
                 ));
     }
@@ -132,6 +134,9 @@ public class DailyTestService {
     }
 
     private Map<String, String> deserializeAnswers(String answersJson) {
+        if (answersJson == null || answersJson.isBlank()) {
+            return Map.of();
+        }
         try {
             return objectMapper.readValue(answersJson, new TypeReference<>() {});
         } catch (JsonProcessingException e) {

--- a/src/main/java/com/mio/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/mio/notification/controller/DeviceTokenController.java
@@ -14,7 +14,7 @@ import java.security.Principal;
 import java.util.Map;
 
 @RestController
-@RequestMapping({"/v1/notifications/devices", "/v1/user/device-token"})
+@RequestMapping("/v1/notifications/devices")
 @RequiredArgsConstructor
 public class DeviceTokenController {
 

--- a/src/main/java/com/mio/notification/controller/NotificationSettingController.java
+++ b/src/main/java/com/mio/notification/controller/NotificationSettingController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 import java.security.Principal;
 
 @RestController
-@RequestMapping({"/v1/notifications/settings", "/v1/user/notification-settings"})
+@RequestMapping("/v1/notifications/settings")
 @RequiredArgsConstructor
 public class NotificationSettingController {
 

--- a/src/main/java/com/mio/notification/domain/DeviceToken.java
+++ b/src/main/java/com/mio/notification/domain/DeviceToken.java
@@ -34,6 +34,9 @@ public class DeviceToken {
     @Column(name = "token", nullable = false)
     private String token;
 
+    @Column(name = "app_version")
+    private String appVersion;
+
     @Column(name = "is_valid", nullable = false)
     @Builder.Default
     private boolean isValid = true;
@@ -44,8 +47,9 @@ public class DeviceToken {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
-    public void refreshToken(String newToken) {
+    public void refreshToken(String newToken, String newAppVersion) {
         this.token = newToken;
+        this.appVersion = newAppVersion;
         this.isValid = true;
     }
 

--- a/src/main/java/com/mio/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/mio/notification/service/DeviceTokenService.java
@@ -28,7 +28,7 @@ public class DeviceTokenService {
 
         DeviceToken token = deviceTokenRepository.findByUser_IdAndDeviceId(userId, request.deviceId())
                 .map(existing -> {
-                    existing.refreshToken(request.pushToken());
+                    existing.refreshToken(request.pushToken(), request.appVersion());
                     return existing;
                 })
                 .orElseGet(() -> deviceTokenRepository.save(
@@ -37,6 +37,7 @@ public class DeviceTokenService {
                                 .deviceId(request.deviceId())
                                 .platform(request.platform())
                                 .token(request.pushToken())
+                                .appVersion(request.appVersion())
                                 .build()
                 ));
 

--- a/src/main/java/com/mio/notification/service/NotificationMessageMapper.java
+++ b/src/main/java/com/mio/notification/service/NotificationMessageMapper.java
@@ -19,6 +19,8 @@ public class NotificationMessageMapper {
                     new NotificationMessage("마음 살피기", "요즘 힘들어 보여서요. 잠깐 마음을 들여다볼까요?");
             case "report_weekly" ->
                     new NotificationMessage("주간 리포트", "이번 주 리포트가 준비됐어요. 지금 확인해보세요.");
+            case "crisis_detected" ->
+                    new NotificationMessage("마음이 걱정돼요", "미오가 함께할게요. 지금 대화를 시작해보세요.");
             default ->
                     new NotificationMessage("Mio 알림", "새로운 알림이 도착했어요.");
         };

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -122,8 +122,11 @@ public class NotificationService {
 
     @Transactional
     public NotificationReadResponse markNotificationAsRead(UUID userId, UUID notificationId) {
-        ProactiveCareLog logEntry = proactiveCareLogRepository.findByIdAndUser_Id(notificationId, userId)
+        ProactiveCareLog logEntry = proactiveCareLogRepository.findById(notificationId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        if (!logEntry.getUser().getId().equals(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
         logEntry.markOpened();
         proactiveCareLogRepository.save(logEntry);
         return new NotificationReadResponse(logEntry.getId(), logEntry.getNotificationStatus(), logEntry.getRespondedAt());

--- a/src/main/java/com/mio/notification/service/NotificationSettingService.java
+++ b/src/main/java/com/mio/notification/service/NotificationSettingService.java
@@ -40,8 +40,14 @@ public class NotificationSettingService {
 
     @Transactional
     public NotificationSettingResponse update(UUID userId, NotificationSettingUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         NotificationSetting setting = notificationSettingRepository.findByUser_Id(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+                .orElseGet(() -> notificationSettingRepository.save(
+                        NotificationSetting.builder()
+                                .user(user)
+                                .build()
+                ));
 
         LocalTime morningTime = parseTime(request.checkinTime() == null ? null : request.checkinTime().morning());
         LocalTime afternoonTime = parseTime(request.checkinTime() == null ? null : request.checkinTime().afternoon());

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -2,6 +2,7 @@ package com.mio.todo.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.domain.TaskStatus;
 
 public record TodoCheckinResponse(
         String status,
@@ -19,7 +20,7 @@ public record TodoCheckinResponse(
     private static final String REACTION_SKIPPED = "괜찮아, 다음에 또 도전해봐요!";
 
     public static TodoCheckinResponse from(BehaviorTask task) {
-        String reaction = "completed".equals(task.getStatus().value())
+        String reaction = TaskStatus.COMPLETED == task.getStatus()
                 ? REACTION_COMPLETED
                 : REACTION_SKIPPED;
         return new TodoCheckinResponse(

--- a/src/main/resources/db/migration/V17__add_app_version_to_device_tokens.sql
+++ b/src/main/resources/db/migration/V17__add_app_version_to_device_tokens.sql
@@ -1,0 +1,2 @@
+-- device_tokens 테이블에 app_version 컬럼 추가 (명세 POST /v1/notifications/devices 필수 필드)
+ALTER TABLE device_tokens ADD COLUMN app_version TEXT;

--- a/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
+++ b/src/test/java/com/mio/dailytest/controller/DailyTestControllerTest.java
@@ -113,9 +113,10 @@ class DailyTestControllerTest {
     @Test
     @DisplayName("POST /v1/daily-test/{testId}/answer - 정상 제출 시 201")
     void submitAnswer_valid_returns201() throws Exception {
+        OffsetDateTime fixedAt = OffsetDateTime.parse("2026-05-28T12:00:00Z");
         DailyTestResultResponse result = new DailyTestResultResponse(
                 new DailyTestResultResponse.ResultDto("오늘은 비교적 안정된 하루였네요.", "설명", List.of("neutral"), "미오"),
-                OffsetDateTime.now()
+                fixedAt
         );
         when(dailyTestService.submitAnswer(eq(USER_ID), eq(TEST_ID), any())).thenReturn(result);
 
@@ -126,7 +127,10 @@ class DailyTestControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(jsonPath("$.data.result.summary").isString())
+                .andExpect(jsonPath("$.data.result.summary").value("오늘은 비교적 안정된 하루였네요."))
+                .andExpect(jsonPath("$.data.result.description").value("설명"))
+                .andExpect(jsonPath("$.data.result.tags[0]").value("neutral"))
+                .andExpect(jsonPath("$.data.result.character_comment").value("미오"))
                 .andExpect(jsonPath("$.data.completed_at").exists());
     }
 

--- a/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestResultEngineTest.java
@@ -32,7 +32,9 @@ class DailyTestResultEngineTest {
         Map<String, String> answers = Map.of("q1", "q1_a", "q2", "q2_a"); // 0+0=0
         DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
         assertThat(result.summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.description()).isEqualTo("감정이 안정적으로 유지된 하루예요. 작은 스트레스도 잘 다루고 있어요.");
         assertThat(result.tags()).containsExactlyInAnyOrder("neutral");
+        assertThat(result.characterComment()).isEqualTo("미오가 말해요: 차분하게 하루를 보낸 네가 대단해 🐧");
     }
 
     @Test
@@ -41,7 +43,9 @@ class DailyTestResultEngineTest {
         Map<String, String> answers = Map.of("q1", "q1_b", "q2", "q2_b"); // 2+3=5
         DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
         assertThat(result.summary()).isEqualTo("감정의 기복이 있었던 하루군요.");
+        assertThat(result.description()).isEqualTo("다소 감정의 변화가 있었던 하루예요. 잠시 숨을 고르는 시간을 가져보세요.");
         assertThat(result.tags()).containsExactlyInAnyOrder("moderate");
+        assertThat(result.characterComment()).isEqualTo("미오가 말해요: 기복이 있어도 잘 헤쳐나가고 있어 🐧");
     }
 
     @Test
@@ -50,7 +54,9 @@ class DailyTestResultEngineTest {
         Map<String, String> answers = Map.of("q1", "q1_c", "q2", "q2_c"); // 4+5=9
         DailyTestResultEngine.TestResult result = engine.calculate(CONTENT, answers);
         assertThat(result.summary()).isEqualTo("힘든 하루를 보냈군요. 충분히 쉬어요.");
+        assertThat(result.description()).isEqualTo("오늘은 많이 지쳤을 거예요. 자신을 위한 시간을 충분히 가져보세요.");
         assertThat(result.tags()).containsExactlyInAnyOrder("high");
+        assertThat(result.characterComment()).isEqualTo("미오가 말해요: 힘들었겠지만 여기까지 온 것만으로도 충분해 🐧");
     }
 
     @Test

--- a/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
+++ b/src/test/java/com/mio/dailytest/service/DailyTestServiceTest.java
@@ -128,14 +128,15 @@ class DailyTestServiceTest {
         when(dailyTestRepository.findByActiveDate(LocalDate.now(AppConstants.ZONE))).thenReturn(Optional.of(test));
         when(dailyTestResponseRepository.findByUser_IdAndDailyTest_Id(userId, testId))
                 .thenReturn(Optional.of(existingResponse));
+        // 재계산 결과는 저장된 summary와 다른 값 사용 → summary 출처가 DB임을 검증
         when(resultEngine.calculate(any(), any())).thenReturn(
-                new DailyTestResultEngine.TestResult("안정된 하루", "설명", List.of("neutral"), "미오")
+                new DailyTestResultEngine.TestResult("재계산된_다른_요약", "설명", List.of("neutral"), "미오")
         );
 
         DailyTestTodayResponse response = service.getTodayTest(userId);
 
         assertThat(response.completedToday()).isTrue();
-        assertThat(response.result().summary()).isEqualTo("안정된 하루");
+        assertThat(response.result().summary()).isEqualTo("안정된 하루"); // 저장된 값 사용
     }
 
     @Test
@@ -208,14 +209,18 @@ class DailyTestServiceTest {
         );
 
         DailyTestResponse savedResponse = buildDailyTestResponse(test, "오늘은 비교적 안정된 하루였네요.");
-        ReflectionTestUtils.setField(savedResponse, "createdAt", OffsetDateTime.now(ZoneOffset.UTC));
+        OffsetDateTime fixedAt = OffsetDateTime.of(2026, 5, 28, 12, 0, 0, 0, ZoneOffset.UTC);
+        ReflectionTestUtils.setField(savedResponse, "createdAt", fixedAt);
         when(dailyTestResponseRepository.save(any())).thenReturn(savedResponse);
 
         AnswerSubmitRequest request = new AnswerSubmitRequest(Map.of("q1", "q1_a"));
         DailyTestResultResponse result = service.submitAnswer(userId, testId, request);
 
-        assertThat(result.completedAt()).isNotNull();
+        assertThat(result.completedAt()).isEqualTo(fixedAt);
         assertThat(result.result().summary()).isEqualTo("오늘은 비교적 안정된 하루였네요.");
+        assertThat(result.result().description()).isEqualTo("설명");
+        assertThat(result.result().tags()).containsExactly("neutral");
+        assertThat(result.result().characterComment()).isEqualTo("미오");
     }
 
     @Test

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -148,7 +148,7 @@ class NotificationServiceTest {
                 .notificationStatus("SENT")
                 .sentAt(OffsetDateTime.now())
                 .build();
-        when(proactiveCareLogRepository.findByIdAndUser_Id(notificationId, userId)).thenReturn(Optional.of(logEntry));
+        when(proactiveCareLogRepository.findById(notificationId)).thenReturn(Optional.of(logEntry));
 
         NotificationReadResponse response = notificationService.markNotificationAsRead(userId, notificationId);
 

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -35,7 +35,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -158,6 +162,45 @@ class NotificationServiceTest {
         verify(proactiveCareLogRepository).save(captor.capture());
         assertThat(captor.getValue().getNotificationStatus()).isEqualTo("OPENED");
         assertThat(captor.getValue().getRespondedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 알림을 열람하면 FORBIDDEN 예외를 발생시킨다")
+    void markNotificationAsRead_otherUsersLog_throwsForbidden() {
+        UUID notificationId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        User otherUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("other-social-id")
+                .privacyConsent(true)
+                .build();
+        setUserId(otherUser, otherUserId);
+
+        ProactiveCareLog logEntry = ProactiveCareLog.builder()
+                .id(notificationId)
+                .user(otherUser)
+                .triggerCode("checkin_reminder_morning")
+                .notificationStatus("SENT")
+                .sentAt(OffsetDateTime.now())
+                .build();
+        when(proactiveCareLogRepository.findById(notificationId)).thenReturn(Optional.of(logEntry));
+
+        assertThatThrownBy(() -> notificationService.markNotificationAsRead(userId, notificationId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 알림을 열람하면 NOTIFICATION_NOT_FOUND 예외를 발생시킨다")
+    void markNotificationAsRead_logNotFound_throwsNotificationNotFound() {
+        UUID notificationId = UUID.randomUUID();
+        when(proactiveCareLogRepository.findById(notificationId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.markNotificationAsRead(userId, notificationId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND));
     }
 
     @Test

--- a/src/test/java/com/mio/notification/service/NotificationSettingServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationSettingServiceTest.java
@@ -91,15 +91,19 @@ class NotificationSettingServiceTest {
     }
 
     @Test
-    @DisplayName("알림 설정이 없으면 update 시 NOTIFICATION_NOT_FOUND 예외를 발생시킨다")
-    void update_settingNotFound_throwsNotificationNotFound() {
-        when(notificationSettingRepository.findByUser_Id(userId)).thenReturn(Optional.empty());
+    @DisplayName("알림 설정이 없으면 update 시 기본값으로 설정을 생성한 뒤 업데이트를 적용한다")
+    void update_settingAbsent_createsDefaultThenUpdates() {
+        NotificationSetting created = NotificationSetting.builder().user(user).build();
 
-        assertThatThrownBy(() -> notificationSettingService.update(userId,
-                new NotificationSettingUpdateRequest(false, null, null, null)))
-                .isInstanceOf(BusinessException.class)
-                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
-                        .isEqualTo(ErrorCode.NOTIFICATION_NOT_FOUND));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(notificationSettingRepository.findByUser_Id(userId)).thenReturn(Optional.empty());
+        when(notificationSettingRepository.save(any())).thenReturn(created);
+
+        NotificationSettingResponse response = notificationSettingService.update(userId,
+                new NotificationSettingUpdateRequest(false, null, null, null));
+
+        assertThat(response.checkinEnabled()).isFalse();
+        verify(notificationSettingRepository).save(any());
     }
 
     @Test
@@ -109,6 +113,7 @@ class NotificationSettingServiceTest {
                 .user(user)
                 .build();
 
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(notificationSettingRepository.findByUser_Id(userId)).thenReturn(Optional.of(setting));
 
         NotificationSettingResponse response = notificationSettingService.update(userId,

--- a/src/test/java/com/mio/todo/controller/TodoControllerTest.java
+++ b/src/test/java/com/mio/todo/controller/TodoControllerTest.java
@@ -69,7 +69,9 @@ class TodoControllerTest {
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.todos").isArray())
-                .andExpect(jsonPath("$.data.todos.length()").value(2));
+                .andExpect(jsonPath("$.data.todos.length()").value(2))
+                .andExpect(jsonPath("$.data.todos[0].character_comment").isNotEmpty())
+                .andExpect(jsonPath("$.data.todos[1].character_comment").isNotEmpty());
     }
 
     @Test
@@ -114,7 +116,8 @@ class TodoControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data.todos").isArray())
-                .andExpect(jsonPath("$.data.todos.length()").value(1));
+                .andExpect(jsonPath("$.data.todos.length()").value(1))
+                .andExpect(jsonPath("$.data.todos[0].character_comment").isNotEmpty());
     }
 
     @Test

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -171,7 +171,7 @@ class TodoServiceTest {
         assertThat(response.status()).isEqualTo("completed");
         assertThat(response.beforeEmotion()).isEqualTo(70);
         assertThat(response.afterEmotion()).isEqualTo(40);
-        assertThat(response.characterReaction()).isNotNull();
+        assertThat(response.characterReaction()).isNotBlank();
     }
 
     @Test


### PR DESCRIPTION
## Summary

알림 도메인 검증 결과 발견된 명세 불일치 5건을 수정한다.

- **[C1] `app_version` DB 미저장**: `DeviceToken` 엔티티에 컬럼 추가, `register()`에서 저장/갱신
- **[C2] 403/404 미분리**: `markNotificationAsRead`에서 `findById` + 소유권 체크 분리 → 타인 알림 접근 시 403 반환
- **[C3] `crisis_detected` 메시지 매핑 없음**: `NotificationMessageMapper`에 케이스 추가
- **[H5] `update()` vs `getOrCreate()` 불일치**: 설정 없으면 예외 대신 기본값 생성 후 업데이트
- **[M6] 중복 API 경로**: 명세 외 레거시 경로(`/v1/user/notification-settings`, `/v1/user/device-token`) 제거

`DELIVERED` 상태 미구현(#70)은 FE 수신 확인 API 추가가 선행되어야 하므로 별도 이슈로 보류.

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `DeviceToken.java` | `app_version` 필드 추가, `refreshToken(String, String)` 시그니처 변경 |
| `DeviceTokenService.java` | `register()` — `appVersion` 저장/갱신 |
| `NotificationMessageMapper.java` | `crisis_detected` 케이스 추가 |
| `NotificationService.java` | `markNotificationAsRead` 403/404 분리 |
| `NotificationSettingService.java` | `update()` getOrCreate 패턴 적용 |
| `NotificationSettingController.java` | 레거시 경로 제거 |
| `DeviceTokenController.java` | 레거시 경로 제거 |
| `V17__add_app_version_to_device_tokens.sql` | `device_tokens.app_version TEXT` 컬럼 추가 |

## Test plan

- [x] `./gradlew build` 통과
- [x] `NotificationServiceTest` — `markNotificationAsRead` mock `findById`로 교체
- [x] `NotificationSettingServiceTest` — `update` getOrCreate 동작 케이스 교체

## 관련 이슈

- Closes #71 (알림 도메인 명세 불일치 수정)
- 보류: #70 (`DELIVERED` 상태 수신 확인 API)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Crisis alert notifications added.
  * Device app version is now tracked on registration.

* **Bug Fixes**
  * Better null-safety for daily test scoring and tag computation.
  * Answer deserialization now safely handles missing/blank data.
  * Stronger access control when marking notifications as read.

* **Improvements**
  * Notification settings are auto-created when absent.
  * Notification API endpoints simplified.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->