### PR TITLE
feat: 체크인 도메인 구현 (#72)

### DIFF
--- a/src/main/java/com/mio/checkin/controller/CheckinController.java
+++ b/src/main/java/com/mio/checkin/controller/CheckinController.java
@@ -1,0 +1,65 @@
+package com.mio.checkin.controller;
+
+import com.mio.checkin.dto.*;
+import com.mio.checkin.service.CheckinService;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/checkins")
+@RequiredArgsConstructor
+public class CheckinController {
+
+    private final CheckinService checkinService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<CheckinResponse>> submit(
+            Principal principal,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
+            @Valid @RequestBody CheckinRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.ok(checkinService.submit(resolveUserId(principal), request, idempotencyKey)));
+    }
+
+    @PutMapping("/{checkinId}")
+    public ResponseEntity<ApiResponse<CheckinResponse>> update(
+            Principal principal,
+            @PathVariable UUID checkinId,
+            @Valid @RequestBody CheckinUpdateRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                checkinService.update(resolveUserId(principal), checkinId, request)));
+    }
+
+    @GetMapping("/today")
+    public ResponseEntity<ApiResponse<CheckinTodayResponse>> getToday(Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(checkinService.getToday(resolveUserId(principal))));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<List<CheckinResponse>>> getHistory(
+            Principal principal,
+            @RequestParam(required = false) String cursor) {
+        return ResponseEntity.ok(ApiResponse.ok(checkinService.getHistory(resolveUserId(principal), cursor)));
+    }
+
+    private UUID resolveUserId(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        try {
+            return UUID.fromString(principal.getName());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+    }
+}

--- a/src/main/java/com/mio/checkin/controller/CheckinController.java
+++ b/src/main/java/com/mio/checkin/controller/CheckinController.java
@@ -23,7 +23,7 @@ public class CheckinController {
     private final CheckinService checkinService;
 
     @PostMapping
-    public ResponseEntity<ApiResponse<CheckinResponse>> submit(
+    public ResponseEntity<ApiResponse<CheckinCreateResponse>> submit(
             Principal principal,
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody CheckinRequest request) {
@@ -32,7 +32,7 @@ public class CheckinController {
     }
 
     @PutMapping("/{checkinId}")
-    public ResponseEntity<ApiResponse<CheckinResponse>> update(
+    public ResponseEntity<ApiResponse<CheckinUpdateResponse>> update(
             Principal principal,
             @PathVariable UUID checkinId,
             @Valid @RequestBody CheckinUpdateRequest request) {

--- a/src/main/java/com/mio/checkin/domain/Checkin.java
+++ b/src/main/java/com/mio/checkin/domain/Checkin.java
@@ -41,8 +41,8 @@ public class Checkin {
     private String emotionType;
 
     /** 감정 강도 1~5 (체크인용). CBT 측정용 emotion_score 0~100 과 혼용 금지 */
-    @Column(name = "emoji_score", nullable = false)
-    private int emojiScore;
+    @Column(name = "condition_score", nullable = false)
+    private int conditionScore;
 
     @Column(name = "checkin_date", nullable = false, updatable = false)
     private LocalDate checkinDate;
@@ -61,6 +61,15 @@ public class Checkin {
 
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
+
+    public void update(String emotionType, Integer conditionScore, byte[] memoCiphertext, String memoDekId) {
+        if (emotionType != null) this.emotionType = emotionType;
+        if (conditionScore != null) this.conditionScore = conditionScore;
+        if (memoCiphertext != null) {
+            this.memoCiphertext = memoCiphertext;
+            this.memoDekId = memoDekId;
+        }
+    }
 
     @PrePersist
     protected void onCreate() {

--- a/src/main/java/com/mio/checkin/domain/Checkin.java
+++ b/src/main/java/com/mio/checkin/domain/Checkin.java
@@ -62,10 +62,10 @@ public class Checkin {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
-    public void update(String emotionType, Integer conditionScore, byte[] memoCiphertext, String memoDekId) {
+    public void update(String emotionType, Integer conditionScore, byte[] memoCiphertext, String memoDekId, boolean updateMemo) {
         if (emotionType != null) this.emotionType = emotionType;
         if (conditionScore != null) this.conditionScore = conditionScore;
-        if (memoCiphertext != null) {
+        if (updateMemo) {
             this.memoCiphertext = memoCiphertext;
             this.memoDekId = memoDekId;
         }

--- a/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
@@ -7,13 +7,12 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CheckinResponse(
+public record CheckinCreateResponse(
         @JsonProperty("checkin_id") UUID checkinId,
         @JsonProperty("time_of_day") String timeOfDay,
         @JsonProperty("emotion_type") String emotionType,
         @JsonProperty("condition_score") int conditionScore,
         String memo,
         @JsonProperty("ai_response") String aiResponse,
-        @JsonProperty("created_at") OffsetDateTime createdAt,
-        @JsonProperty("updated_at") OffsetDateTime updatedAt
+        @JsonProperty("created_at") OffsetDateTime createdAt
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinRequest.java
@@ -1,0 +1,11 @@
+package com.mio.checkin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.*;
+
+public record CheckinRequest(
+        @NotBlank @JsonProperty("time_of_day") String timeOfDay,
+        @NotBlank @JsonProperty("emotion_type") String emotionType,
+        @NotNull @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
+        @Size(max = 200) String memo
+) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinResponse.java
@@ -1,0 +1,20 @@
+package com.mio.checkin.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record CheckinResponse(
+        @JsonProperty("checkin_id") UUID checkinId,
+        @JsonProperty("time_of_day") String timeOfDay,
+        @JsonProperty("emotion_type") String emotionType,
+        @JsonProperty("condition_score") int conditionScore,
+        String memo,
+        @JsonProperty("ai_response") String aiResponse,
+        @JsonProperty("character_id") String characterId,
+        @JsonProperty("created_at") OffsetDateTime createdAt,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
+) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
@@ -1,0 +1,13 @@
+package com.mio.checkin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record CheckinTodayResponse(
+        LocalDate date,
+        List<CheckinResponse> checkins,
+        @JsonProperty("completed_slots") List<String> completedSlots,
+        @JsonProperty("available_slots") List<String> availableSlots
+) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.mio.checkin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+public record CheckinUpdateRequest(
+        @JsonProperty("emotion_type") String emotionType,
+        @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
+        @Size(max = 200) String memo
+) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
@@ -7,13 +7,12 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public record CheckinResponse(
+public record CheckinUpdateResponse(
         @JsonProperty("checkin_id") UUID checkinId,
         @JsonProperty("time_of_day") String timeOfDay,
         @JsonProperty("emotion_type") String emotionType,
         @JsonProperty("condition_score") int conditionScore,
         String memo,
         @JsonProperty("ai_response") String aiResponse,
-        @JsonProperty("created_at") OffsetDateTime createdAt,
         @JsonProperty("updated_at") OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/checkin/repository/CheckinRepository.java
+++ b/src/main/java/com/mio/checkin/repository/CheckinRepository.java
@@ -1,9 +1,14 @@
 package com.mio.checkin.repository;
 
 import com.mio.checkin.domain.Checkin;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -19,4 +24,14 @@ public interface CheckinRepository extends JpaRepository<Checkin, UUID> {
     boolean existsByUser_IdAndCheckinDateAndTimeOfDay(UUID userId, LocalDate checkinDate, String timeOfDay);
 
     List<Checkin> findTop3ByUser_IdOrderByCreatedAtDesc(UUID userId);
+
+    List<Checkin> findByUser_IdAndCheckinDate(UUID userId, LocalDate checkinDate);
+
+    @Query("SELECT c FROM Checkin c WHERE c.user.id = :userId AND c.createdAt < :cursor ORDER BY c.createdAt DESC")
+    Slice<Checkin> findByUser_IdAndCreatedAtBefore(@Param("userId") UUID userId,
+                                                    @Param("cursor") OffsetDateTime cursor,
+                                                    Pageable pageable);
+
+    @Query("SELECT c FROM Checkin c WHERE c.user.id = :userId ORDER BY c.createdAt DESC")
+    Slice<Checkin> findByUser_IdOrderByCreatedAtDesc(@Param("userId") UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -16,6 +16,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -84,10 +86,14 @@ public class CheckinService {
         CheckinResponse response = toResponse(checkin, request.memo());
 
         if (idempotencyKey != null) {
-            redisTemplate.opsForValue().set(
-                    idempotencyKey(idempotencyKey),
-                    serializeResponse(response),
-                    IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
+            final String cacheKey = idempotencyKey(idempotencyKey);
+            final String cacheValue = serializeResponse(response);
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    redisTemplate.opsForValue().set(cacheKey, cacheValue, IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
+                }
+            });
         }
 
         return response;
@@ -110,16 +116,17 @@ public class CheckinService {
             throw new BusinessException(ErrorCode.CHECKIN_NOT_TODAY);
         }
 
+        boolean updateMemo = request.memo() != null;
         byte[] ciphertext = null;
         String dekId = null;
-        if (request.memo() != null && !request.memo().isBlank()) {
+        if (updateMemo && !request.memo().isBlank()) {
             ciphertext = messageEncryptor.encrypt(request.memo().getBytes(StandardCharsets.UTF_8));
             dekId = messageEncryptor.dekId();
         }
 
-        checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId);
+        checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId, updateMemo);
 
-        String memo = request.memo();
+        String memo = updateMemo && !request.memo().isBlank() ? request.memo() : null;
         return toResponse(checkin, memo);
     }
 

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -1,5 +1,8 @@
 package com.mio.checkin.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mio.checkin.domain.Checkin;
 import com.mio.checkin.dto.*;
 import com.mio.checkin.repository.CheckinRepository;
@@ -22,7 +25,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
@@ -41,6 +43,9 @@ public class CheckinService {
     private static final List<String> ALL_SLOTS = List.of("morning", "afternoon", "evening");
     private static final int PAGE_SIZE = 20;
     private static final long IDEMPOTENCY_TTL_SECONDS = 86400L;
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 
     private final CheckinRepository checkinRepository;
     private final UserRepository userRepository;
@@ -55,7 +60,9 @@ public class CheckinService {
         if (idempotencyKey != null) {
             String cached = redisTemplate.opsForValue().get(idempotencyKey(idempotencyKey));
             if (cached != null) {
-                return deserializeResponse(cached);
+                CheckinResponse cachedResponse = deserializeResponse(cached);
+                if (cachedResponse != null) return cachedResponse;
+                // 역직렬화 실패 → 캐시 미스로 처리하여 정상 플로우 진행
             }
         }
 
@@ -126,7 +133,9 @@ public class CheckinService {
 
         checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId, updateMemo);
 
-        String memo = updateMemo && !request.memo().isBlank() ? request.memo() : null;
+        String memo = updateMemo
+                ? (!request.memo().isBlank() ? request.memo() : null)
+                : decryptMemo(checkin);
         return toResponse(checkin, memo);
     }
 
@@ -214,28 +223,20 @@ public class CheckinService {
     }
 
     private static String serializeResponse(CheckinResponse response) {
-        String memoEncoded = response.memo() != null
-                ? Base64.getEncoder().encodeToString(response.memo().getBytes(StandardCharsets.UTF_8))
-                : "";
-        return response.checkinId() + "|" + response.timeOfDay() + "|" + response.emotionType()
-                + "|" + response.conditionScore() + "|" + response.createdAt() + "|" + memoEncoded;
+        try {
+            return MAPPER.writeValueAsString(response);
+        } catch (Exception e) {
+            log.warn("idempotency 응답 직렬화 실패", e);
+            return null;
+        }
     }
 
     private static CheckinResponse deserializeResponse(String cached) {
-        String[] parts = cached.split("\\|", 6);
-        String memo = parts.length > 5 && !parts[5].isEmpty()
-                ? new String(Base64.getDecoder().decode(parts[5]), StandardCharsets.UTF_8)
-                : null;
-        return new CheckinResponse(
-                UUID.fromString(parts[0]),
-                parts[1],
-                parts[2],
-                Integer.parseInt(parts[3]),
-                memo,
-                null,
-                null,
-                OffsetDateTime.parse(parts[4]),
-                null
-        );
+        try {
+            return MAPPER.readValue(cached, CheckinResponse.class);
+        } catch (Exception e) {
+            log.warn("idempotency 캐시 역직렬화 실패 — 캐시 미스로 처리", e);
+            return null;
+        }
     }
 }

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -1,0 +1,234 @@
+package com.mio.checkin.service;
+
+import com.mio.checkin.domain.Checkin;
+import com.mio.checkin.dto.*;
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CheckinService {
+
+    private static final Set<String> VALID_EMOTIONS = Set.of(
+            "happy", "calm", "anxious", "sad", "angry", "ashamed", "numb", "tired", "confused"
+    );
+    private static final Set<String> VALID_SLOTS = Set.of("morning", "afternoon", "evening");
+    private static final List<String> ALL_SLOTS = List.of("morning", "afternoon", "evening");
+    private static final int PAGE_SIZE = 20;
+    private static final long IDEMPOTENCY_TTL_SECONDS = 86400L;
+
+    private final CheckinRepository checkinRepository;
+    private final UserRepository userRepository;
+    private final MessageEncryptor messageEncryptor;
+    private final StringRedisTemplate redisTemplate;
+
+    @Transactional
+    public CheckinResponse submit(UUID userId, CheckinRequest request, String idempotencyKey) {
+        validateSlot(request.timeOfDay());
+        validateEmotion(request.emotionType());
+
+        if (idempotencyKey != null) {
+            String cached = redisTemplate.opsForValue().get(idempotencyKey(idempotencyKey));
+            if (cached != null) {
+                return deserializeResponse(cached);
+            }
+        }
+
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
+        if (checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(userId, today, request.timeOfDay())) {
+            throw new BusinessException(ErrorCode.ALREADY_CHECKED_IN);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        byte[] ciphertext = null;
+        String dekId = null;
+        if (request.memo() != null && !request.memo().isBlank()) {
+            ciphertext = messageEncryptor.encrypt(request.memo().getBytes(StandardCharsets.UTF_8));
+            dekId = messageEncryptor.dekId();
+        }
+
+        Checkin checkin = checkinRepository.save(Checkin.builder()
+                .user(user)
+                .timeOfDay(request.timeOfDay())
+                .emotionType(request.emotionType())
+                .conditionScore(request.conditionScore())
+                .memoCiphertext(ciphertext)
+                .memoDekId(dekId)
+                .build());
+
+        CheckinResponse response = toResponse(checkin, request.memo());
+
+        if (idempotencyKey != null) {
+            redisTemplate.opsForValue().set(
+                    idempotencyKey(idempotencyKey),
+                    serializeResponse(response),
+                    IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+
+        return response;
+    }
+
+    @Transactional
+    public CheckinResponse update(UUID userId, UUID checkinId, CheckinUpdateRequest request) {
+        if (request.emotionType() == null && request.conditionScore() == null && request.memo() == null) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        if (request.emotionType() != null) validateEmotion(request.emotionType());
+
+        Checkin checkin = checkinRepository.findByIdAndUser_Id(checkinId, userId)
+                .orElseThrow(() -> checkinRepository.existsById(checkinId)
+                        ? new BusinessException(ErrorCode.CHECKIN_FORBIDDEN)
+                        : new BusinessException(ErrorCode.CHECKIN_NOT_FOUND));
+
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
+        if (!checkin.getCheckinDate().equals(today)) {
+            throw new BusinessException(ErrorCode.CHECKIN_NOT_TODAY);
+        }
+
+        byte[] ciphertext = null;
+        String dekId = null;
+        if (request.memo() != null && !request.memo().isBlank()) {
+            ciphertext = messageEncryptor.encrypt(request.memo().getBytes(StandardCharsets.UTF_8));
+            dekId = messageEncryptor.dekId();
+        }
+
+        checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId);
+
+        String memo = request.memo();
+        return toResponse(checkin, memo);
+    }
+
+    @Transactional(readOnly = true)
+    public CheckinTodayResponse getToday(UUID userId) {
+        LocalDate today = LocalDate.now(AppConstants.ZONE);
+        List<Checkin> checkins = checkinRepository.findByUser_IdAndCheckinDate(userId, today);
+
+        List<String> completedSlots = checkins.stream()
+                .map(Checkin::getTimeOfDay)
+                .toList();
+
+        List<String> availableSlots = ALL_SLOTS.stream()
+                .filter(slot -> !completedSlots.contains(slot))
+                .toList();
+
+        List<CheckinResponse> responses = checkins.stream()
+                .map(c -> toResponse(c, decryptMemo(c)))
+                .toList();
+
+        return new CheckinTodayResponse(today, responses, completedSlots, availableSlots);
+    }
+
+    @Transactional(readOnly = true)
+    public List<CheckinResponse> getHistory(UUID userId, String cursor) {
+        PageRequest pageable = PageRequest.of(0, PAGE_SIZE);
+        Slice<Checkin> slice;
+
+        if (cursor != null) {
+            OffsetDateTime cursorTime;
+            try {
+                cursorTime = OffsetDateTime.parse(
+                        new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8));
+            } catch (Exception e) {
+                throw new BusinessException(ErrorCode.INVALID_INPUT);
+            }
+            slice = checkinRepository.findByUser_IdAndCreatedAtBefore(userId, cursorTime, pageable);
+        } else {
+            slice = checkinRepository.findByUser_IdOrderByCreatedAtDesc(userId, pageable);
+        }
+
+        return slice.getContent().stream()
+                .map(c -> toResponse(c, decryptMemo(c)))
+                .toList();
+    }
+
+    private CheckinResponse toResponse(Checkin checkin, String memo) {
+        return new CheckinResponse(
+                checkin.getId(),
+                checkin.getTimeOfDay(),
+                checkin.getEmotionType(),
+                checkin.getConditionScore(),
+                memo,
+                checkin.getAiResponse(),
+                checkin.getCharacterId(),
+                checkin.getCreatedAt(),
+                checkin.getUpdatedAt()
+        );
+    }
+
+    private String decryptMemo(Checkin checkin) {
+        if (checkin.getMemoCiphertext() == null) return null;
+        try {
+            return new String(messageEncryptor.decrypt(checkin.getMemoCiphertext()), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.warn("memo 복호화 실패 checkinId={}", checkin.getId(), e);
+            return null;
+        }
+    }
+
+    private void validateSlot(String timeOfDay) {
+        if (!VALID_SLOTS.contains(timeOfDay)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private void validateEmotion(String emotionType) {
+        if (!VALID_EMOTIONS.contains(emotionType)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private static String idempotencyKey(String key) {
+        return "idempotency:" + key;
+    }
+
+    private static String serializeResponse(CheckinResponse response) {
+        String memoEncoded = response.memo() != null
+                ? Base64.getEncoder().encodeToString(response.memo().getBytes(StandardCharsets.UTF_8))
+                : "";
+        return response.checkinId() + "|" + response.timeOfDay() + "|" + response.emotionType()
+                + "|" + response.conditionScore() + "|" + response.createdAt() + "|" + memoEncoded;
+    }
+
+    private static CheckinResponse deserializeResponse(String cached) {
+        String[] parts = cached.split("\\|", 6);
+        String memo = parts.length > 5 && !parts[5].isEmpty()
+                ? new String(Base64.getDecoder().decode(parts[5]), StandardCharsets.UTF_8)
+                : null;
+        return new CheckinResponse(
+                UUID.fromString(parts[0]),
+                parts[1],
+                parts[2],
+                Integer.parseInt(parts[3]),
+                memo,
+                null,
+                null,
+                OffsetDateTime.parse(parts[4]),
+                null
+        );
+    }
+}

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -132,11 +132,7 @@ public class CheckinService {
         }
 
         checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId, updateMemo);
-
-        String memo = updateMemo
-                ? (!request.memo().isBlank() ? request.memo() : null)
-                : decryptMemo(checkin);
-        return toResponse(checkin, memo);
+        return toResponse(checkin, decryptMemo(checkin));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -1,8 +1,6 @@
 package com.mio.checkin.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mio.checkin.domain.Checkin;
 import com.mio.checkin.dto.*;
 import com.mio.checkin.repository.CheckinRepository;
@@ -43,24 +41,24 @@ public class CheckinService {
     private static final List<String> ALL_SLOTS = List.of("morning", "afternoon", "evening");
     private static final int PAGE_SIZE = 20;
     private static final long IDEMPOTENCY_TTL_SECONDS = 86400L;
-    private static final ObjectMapper MAPPER = new ObjectMapper()
-            .registerModule(new JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
+    private static final int RATE_LIMIT_MAX = 4;
+    private static final long RATE_LIMIT_TTL_SECONDS = 3600L;
     private final CheckinRepository checkinRepository;
     private final UserRepository userRepository;
     private final MessageEncryptor messageEncryptor;
     private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
 
     @Transactional
-    public CheckinResponse submit(UUID userId, CheckinRequest request, String idempotencyKey) {
+    public CheckinCreateResponse submit(UUID userId, CheckinRequest request, String idempotencyKey) {
         validateSlot(request.timeOfDay());
         validateEmotion(request.emotionType());
+        checkRateLimit(userId);
 
         if (idempotencyKey != null) {
             String cached = redisTemplate.opsForValue().get(idempotencyKey(idempotencyKey));
             if (cached != null) {
-                CheckinResponse cachedResponse = deserializeResponse(cached);
+                CheckinCreateResponse cachedResponse = deserializeResponse(cached);
                 if (cachedResponse != null) return cachedResponse;
                 // 역직렬화 실패 → 캐시 미스로 처리하여 정상 플로우 진행
             }
@@ -73,6 +71,10 @@ public class CheckinService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (!user.getSignupStep().isOnboardingComplete()) {
+            throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
+        }
 
         byte[] ciphertext = null;
         String dekId = null;
@@ -90,7 +92,7 @@ public class CheckinService {
                 .memoDekId(dekId)
                 .build());
 
-        CheckinResponse response = toResponse(checkin, request.memo());
+        CheckinCreateResponse response = toCreateResponse(checkin, request.memo());
 
         if (idempotencyKey != null) {
             final String cacheKey = idempotencyKey(idempotencyKey);
@@ -107,7 +109,7 @@ public class CheckinService {
     }
 
     @Transactional
-    public CheckinResponse update(UUID userId, UUID checkinId, CheckinUpdateRequest request) {
+    public CheckinUpdateResponse update(UUID userId, UUID checkinId, CheckinUpdateRequest request) {
         if (request.emotionType() == null && request.conditionScore() == null && request.memo() == null) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
@@ -132,7 +134,7 @@ public class CheckinService {
         }
 
         checkin.update(request.emotionType(), request.conditionScore(), ciphertext, dekId, updateMemo);
-        return toResponse(checkin, decryptMemo(checkin));
+        return toUpdateResponse(checkin, decryptMemo(checkin));
     }
 
     @Transactional(readOnly = true)
@@ -178,6 +180,30 @@ public class CheckinService {
                 .toList();
     }
 
+    private CheckinCreateResponse toCreateResponse(Checkin checkin, String memo) {
+        return new CheckinCreateResponse(
+                checkin.getId(),
+                checkin.getTimeOfDay(),
+                checkin.getEmotionType(),
+                checkin.getConditionScore(),
+                memo,
+                checkin.getAiResponse(),
+                checkin.getCreatedAt()
+        );
+    }
+
+    private CheckinUpdateResponse toUpdateResponse(Checkin checkin, String memo) {
+        return new CheckinUpdateResponse(
+                checkin.getId(),
+                checkin.getTimeOfDay(),
+                checkin.getEmotionType(),
+                checkin.getConditionScore(),
+                memo,
+                checkin.getAiResponse(),
+                checkin.getUpdatedAt()
+        );
+    }
+
     private CheckinResponse toResponse(Checkin checkin, String memo) {
         return new CheckinResponse(
                 checkin.getId(),
@@ -186,7 +212,6 @@ public class CheckinService {
                 checkin.getConditionScore(),
                 memo,
                 checkin.getAiResponse(),
-                checkin.getCharacterId(),
                 checkin.getCreatedAt(),
                 checkin.getUpdatedAt()
         );
@@ -214,22 +239,34 @@ public class CheckinService {
         }
     }
 
+    private void checkRateLimit(UUID userId) {
+        String key = "checkin:ratelimit:" + userId;
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count == null) return;
+        if (count == 1) {
+            redisTemplate.expire(key, RATE_LIMIT_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+        if (count > RATE_LIMIT_MAX) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
     private static String idempotencyKey(String key) {
         return "idempotency:" + key;
     }
 
-    private static String serializeResponse(CheckinResponse response) {
+    private String serializeResponse(CheckinCreateResponse response) {
         try {
-            return MAPPER.writeValueAsString(response);
+            return objectMapper.writeValueAsString(response);
         } catch (Exception e) {
             log.warn("idempotency 응답 직렬화 실패", e);
             return null;
         }
     }
 
-    private static CheckinResponse deserializeResponse(String cached) {
+    private CheckinCreateResponse deserializeResponse(String cached) {
         try {
-            return MAPPER.readValue(cached, CheckinResponse.class);
+            return objectMapper.readValue(cached, CheckinCreateResponse.class);
         } catch (Exception e) {
             log.warn("idempotency 캐시 역직렬화 실패 — 캐시 미스로 처리", e);
             return null;

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -46,6 +46,12 @@ public enum ErrorCode {
     DAILY_TEST_ALREADY_COMPLETED(HttpStatus.CONFLICT, "DAILY_TEST_ALREADY_COMPLETED", "이미 완료한 데일리 테스트입니다."),
     INVALID_DAILY_TEST_CONTENT(HttpStatus.BAD_REQUEST, "INVALID_DAILY_TEST_CONTENT", "데일리 테스트 콘텐츠가 올바르지 않습니다."),
 
+    // Checkin
+    ALREADY_CHECKED_IN(HttpStatus.CONFLICT, "ALREADY_CHECKED_IN", "해당 슬롯에 이미 체크인이 완료됐습니다."),
+    CHECKIN_NOT_FOUND(HttpStatus.NOT_FOUND, "CHECKIN_NOT_FOUND", "존재하지 않는 체크인입니다."),
+    CHECKIN_FORBIDDEN(HttpStatus.FORBIDDEN, "CHECKIN_FORBIDDEN", "접근 권한이 없습니다."),
+    CHECKIN_NOT_TODAY(HttpStatus.UNPROCESSABLE_ENTITY, "BUSINESS_RULE_VIOLATION", "당일 체크인만 수정할 수 있습니다."),
+
     // Todo
     TODO_NOT_FOUND(HttpStatus.NOT_FOUND, "TODO_NOT_FOUND", "존재하지 않는 할 일입니다."),
     TODO_ALREADY_COMPLETED(HttpStatus.CONFLICT, "TODO_ALREADY_COMPLETED", "이미 완료 또는 처리된 할 일입니다."),

--- a/src/main/resources/db/migration/V18__rename_emoji_score_to_condition_score.sql
+++ b/src/main/resources/db/migration/V18__rename_emoji_score_to_condition_score.sql
@@ -1,0 +1,7 @@
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns
+             WHERE table_name = 'checkins' AND column_name = 'emoji_score') THEN
+    ALTER TABLE checkins RENAME COLUMN emoji_score TO condition_score;
+  END IF;
+END$$;

--- a/src/test/java/com/mio/checkin/controller/CheckinControllerTest.java
+++ b/src/test/java/com/mio/checkin/controller/CheckinControllerTest.java
@@ -53,14 +53,21 @@ class CheckinControllerTest {
     private CheckinResponse sampleResponse() {
         return new CheckinResponse(
                 CHECKIN_ID, "morning", "anxious", 3,
-                "메모", null, null,
+                "메모", null,
                 OffsetDateTime.now(ZoneOffset.UTC), null);
+    }
+
+    private CheckinCreateResponse sampleCreateResponse() {
+        return new CheckinCreateResponse(
+                CHECKIN_ID, "morning", "anxious", 3,
+                "메모", null,
+                OffsetDateTime.now(ZoneOffset.UTC));
     }
 
     @Test
     @DisplayName("POST /v1/checkins - 정상 등록 시 201 반환")
     void submit_success_returns201() throws Exception {
-        when(checkinService.submit(any(), any(), any())).thenReturn(sampleResponse());
+        when(checkinService.submit(any(), any(), any())).thenReturn(sampleCreateResponse());
 
         mockMvc.perform(post("/v1/checkins")
                         .principal(() -> TEST_USER_ID.toString())
@@ -132,10 +139,10 @@ class CheckinControllerTest {
     @Test
     @DisplayName("PUT /v1/checkins/{id} - 정상 수정 시 200 반환")
     void update_success_returns200() throws Exception {
-        CheckinResponse updated = new CheckinResponse(
+        CheckinUpdateResponse updated = new CheckinUpdateResponse(
                 CHECKIN_ID, "morning", "calm", 4,
-                "나아졌어", null, null,
-                OffsetDateTime.now(ZoneOffset.UTC), OffsetDateTime.now(ZoneOffset.UTC));
+                "나아졌어", null,
+                OffsetDateTime.now(ZoneOffset.UTC));
         when(checkinService.update(any(), any(), any())).thenReturn(updated);
 
         mockMvc.perform(put("/v1/checkins/" + CHECKIN_ID)

--- a/src/test/java/com/mio/checkin/controller/CheckinControllerTest.java
+++ b/src/test/java/com/mio/checkin/controller/CheckinControllerTest.java
@@ -1,0 +1,194 @@
+package com.mio.checkin.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.auth.filter.JwtAuthenticationFilter;
+import com.mio.checkin.dto.*;
+import com.mio.checkin.service.CheckinService;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        value = CheckinController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class},
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        }
+)
+@Import(GlobalExceptionHandler.class)
+class CheckinControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @Autowired private ObjectMapper objectMapper;
+    @MockBean private CheckinService checkinService;
+
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
+    private static final UUID CHECKIN_ID = UUID.randomUUID();
+
+    private CheckinResponse sampleResponse() {
+        return new CheckinResponse(
+                CHECKIN_ID, "morning", "anxious", 3,
+                "메모", null, null,
+                OffsetDateTime.now(ZoneOffset.UTC), null);
+    }
+
+    @Test
+    @DisplayName("POST /v1/checkins - 정상 등록 시 201 반환")
+    void submit_success_returns201() throws Exception {
+        when(checkinService.submit(any(), any(), any())).thenReturn(sampleResponse());
+
+        mockMvc.perform(post("/v1/checkins")
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"time_of_day":"morning","emotion_type":"anxious","condition_score":3,"memo":"메모"}
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.time_of_day").value("morning"))
+                .andExpect(jsonPath("$.data.emotion_type").value("anxious"))
+                .andExpect(jsonPath("$.data.condition_score").value(3));
+    }
+
+    @Test
+    @DisplayName("POST /v1/checkins - 중복 슬롯 시 409 반환")
+    void submit_duplicateSlot_returns409() throws Exception {
+        when(checkinService.submit(any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.ALREADY_CHECKED_IN));
+
+        mockMvc.perform(post("/v1/checkins")
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"time_of_day":"morning","emotion_type":"anxious","condition_score":3}
+                                """))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("ALREADY_CHECKED_IN"));
+    }
+
+    @Test
+    @DisplayName("POST /v1/checkins - condition_score 범위 외 시 400 반환")
+    void submit_invalidScore_returns400() throws Exception {
+        mockMvc.perform(post("/v1/checkins")
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"time_of_day":"morning","emotion_type":"anxious","condition_score":6}
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /v1/checkins - principal 없으면 401 반환")
+    void submit_noPrincipal_returns401() throws Exception {
+        mockMvc.perform(post("/v1/checkins")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"time_of_day":"morning","emotion_type":"anxious","condition_score":3}
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("POST /v1/checkins - 온보딩 미완료 시 403 반환")
+    void submit_onboardingRequired_returns403() throws Exception {
+        when(checkinService.submit(any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.ONBOARDING_REQUIRED));
+
+        mockMvc.perform(post("/v1/checkins")
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"time_of_day":"morning","emotion_type":"anxious","condition_score":3}
+                                """))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.error.code").value("ONBOARDING_REQUIRED"));
+    }
+
+    @Test
+    @DisplayName("PUT /v1/checkins/{id} - 정상 수정 시 200 반환")
+    void update_success_returns200() throws Exception {
+        CheckinResponse updated = new CheckinResponse(
+                CHECKIN_ID, "morning", "calm", 4,
+                "나아졌어", null, null,
+                OffsetDateTime.now(ZoneOffset.UTC), OffsetDateTime.now(ZoneOffset.UTC));
+        when(checkinService.update(any(), any(), any())).thenReturn(updated);
+
+        mockMvc.perform(put("/v1/checkins/" + CHECKIN_ID)
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"emotion_type":"calm","condition_score":4,"memo":"나아졌어"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.emotion_type").value("calm"))
+                .andExpect(jsonPath("$.data.condition_score").value(4));
+    }
+
+    @Test
+    @DisplayName("PUT /v1/checkins/{id} - 익일 수정 시도 시 422 반환")
+    void update_notToday_returns422() throws Exception {
+        when(checkinService.update(any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.CHECKIN_NOT_TODAY));
+
+        mockMvc.perform(put("/v1/checkins/" + CHECKIN_ID)
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"memo":"수정"}
+                                """))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.error.code").value("BUSINESS_RULE_VIOLATION"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/checkins/today - 오늘 현황 반환")
+    void getToday_returns200() throws Exception {
+        CheckinTodayResponse today = new CheckinTodayResponse(
+                LocalDate.now(), List.of(sampleResponse()),
+                List.of("morning"), List.of("afternoon", "evening"));
+        when(checkinService.getToday(any())).thenReturn(today);
+
+        mockMvc.perform(get("/v1/checkins/today")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.completed_slots[0]").value("morning"))
+                .andExpect(jsonPath("$.data.available_slots").isArray());
+    }
+
+    @Test
+    @DisplayName("GET /v1/checkins - 이력 목록 반환")
+    void getHistory_returns200() throws Exception {
+        when(checkinService.getHistory(any(), isNull())).thenReturn(List.of(sampleResponse()));
+
+        mockMvc.perform(get("/v1/checkins")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data[0].time_of_day").value("morning"));
+    }
+}

--- a/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
@@ -137,6 +137,20 @@ class CheckinServiceTest {
         }
 
         @Test
+        @DisplayName("memo 빈 문자열 전달 시 메모 삭제")
+        void update_clearMemo() {
+            Checkin c = checkinToday("morning", "anxious", 2);
+            setField(c, "memoCiphertext", new byte[]{1, 2, 3});
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
+
+            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest(null, null, ""));
+
+            assertThat(result.memo()).isNull();
+            assertThat(c.getMemoCiphertext()).isNull();
+        }
+
+        @Test
         @DisplayName("존재하지 않는 체크인 시 CHECKIN_NOT_FOUND")
         void update_notFound_throws() {
             when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.empty());

--- a/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
@@ -1,5 +1,8 @@
 package com.mio.checkin.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mio.checkin.domain.Checkin;
 import com.mio.checkin.dto.*;
 import com.mio.checkin.repository.CheckinRepository;
@@ -7,6 +10,7 @@ import com.mio.common.AppConstants;
 import com.mio.common.crypto.StubMessageEncryptor;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -47,13 +51,17 @@ class CheckinServiceTest {
 
     @BeforeEach
     void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         checkinService = new CheckinService(
-                checkinRepository, userRepository, new StubMessageEncryptor(), redisTemplate);
+                checkinRepository, userRepository, new StubMessageEncryptor(), redisTemplate, objectMapper);
         userId = UUID.randomUUID();
         user = User.builder()
                 .socialProvider("kakao")
                 .socialId("kakao-001")
                 .privacyConsent(true)
+                .signupStep(SignupStep.ONBOARDING_COMPLETED)
                 .build();
     }
 
@@ -64,11 +72,13 @@ class CheckinServiceTest {
         @Test
         @DisplayName("정상 등록 시 응답 데이터 반환")
         void submit_success() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.increment(anyString())).thenReturn(1L);
             when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(any(), any(), any())).thenReturn(false);
             when(userRepository.findById(userId)).thenReturn(Optional.of(user));
             when(checkinRepository.save(any())).thenReturn(checkin("morning", "anxious", 3));
 
-            CheckinResponse result = checkinService.submit(userId,
+            CheckinCreateResponse result = checkinService.submit(userId,
                     new CheckinRequest("morning", "anxious", 3, "메모"), null);
 
             assertThat(result.timeOfDay()).isEqualTo("morning");
@@ -106,16 +116,17 @@ class CheckinServiceTest {
         void submit_idempotencyHit_returnsCached() throws Exception {
             UUID checkinId = UUID.randomUUID();
             OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-            CheckinResponse cached = new CheckinResponse(checkinId, "morning", "calm", 4, null, null, null, now, null);
-            String cachedJson = new com.fasterxml.jackson.databind.ObjectMapper()
-                    .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
-                    .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+            CheckinCreateResponse cached = new CheckinCreateResponse(checkinId, "morning", "calm", 4, null, null, now);
+            String cachedJson = new ObjectMapper()
+                    .registerModule(new JavaTimeModule())
+                    .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                     .writeValueAsString(cached);
 
             when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.increment(anyString())).thenReturn(1L);
             when(valueOps.get("idempotency:idem-001")).thenReturn(cachedJson);
 
-            CheckinResponse result = checkinService.submit(userId,
+            CheckinCreateResponse result = checkinService.submit(userId,
                     new CheckinRequest("morning", "calm", 4, null), "idem-001");
 
             assertThat(result.checkinId()).isEqualTo(checkinId);
@@ -133,7 +144,7 @@ class CheckinServiceTest {
             Checkin c = checkinToday("morning", "anxious", 2);
             when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
 
-            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+            CheckinUpdateResponse result = checkinService.update(userId, UUID.randomUUID(),
                     new CheckinUpdateRequest("calm", 4, "나아졌어"));
 
             assertThat(result.emotionType()).isEqualTo("calm");
@@ -150,7 +161,7 @@ class CheckinServiceTest {
             setField(c, "memoCiphertext", existing);
             when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
 
-            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+            CheckinUpdateResponse result = checkinService.update(userId, UUID.randomUUID(),
                     new CheckinUpdateRequest("calm", null, null));
 
             assertThat(result.emotionType()).isEqualTo("calm");
@@ -164,7 +175,7 @@ class CheckinServiceTest {
             setField(c, "memoCiphertext", new byte[]{1, 2, 3});
             when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
 
-            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+            CheckinUpdateResponse result = checkinService.update(userId, UUID.randomUUID(),
                     new CheckinUpdateRequest(null, null, ""));
 
             assertThat(result.memo()).isNull();

--- a/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
@@ -103,13 +103,17 @@ class CheckinServiceTest {
 
         @Test
         @DisplayName("Idempotency-Key 캐시 히트 시 저장 없이 캐시 응답 반환")
-        void submit_idempotencyHit_returnsCached() {
+        void submit_idempotencyHit_returnsCached() throws Exception {
             UUID checkinId = UUID.randomUUID();
             OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-            String cached = checkinId + "|morning|calm|4|" + now + "|";
+            CheckinResponse cached = new CheckinResponse(checkinId, "morning", "calm", 4, null, null, null, now, null);
+            String cachedJson = new com.fasterxml.jackson.databind.ObjectMapper()
+                    .registerModule(new com.fasterxml.jackson.datatype.jsr310.JavaTimeModule())
+                    .disable(com.fasterxml.jackson.databind.SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                    .writeValueAsString(cached);
 
             when(redisTemplate.opsForValue()).thenReturn(valueOps);
-            when(valueOps.get("idempotency:idem-001")).thenReturn(cached);
+            when(valueOps.get("idempotency:idem-001")).thenReturn(cachedJson);
 
             CheckinResponse result = checkinService.submit(userId,
                     new CheckinRequest("morning", "calm", 4, null), "idem-001");
@@ -134,6 +138,23 @@ class CheckinServiceTest {
 
             assertThat(result.emotionType()).isEqualTo("calm");
             assertThat(result.conditionScore()).isEqualTo(4);
+            assertThat(result.memo()).isEqualTo("나아졌어");
+        }
+
+        @Test
+        @DisplayName("memo 미전달(null) 시 기존 메모 응답에 포함")
+        void update_memoNotProvided_returnsExistingMemo() {
+            Checkin c = checkinToday("morning", "anxious", 2);
+            // StubMessageEncryptor: encrypt/decrypt가 평문 그대로 반환
+            byte[] existing = "기존메모".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+            setField(c, "memoCiphertext", existing);
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
+
+            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest("calm", null, null));
+
+            assertThat(result.emotionType()).isEqualTo("calm");
+            assertThat(result.memo()).isEqualTo("기존메모");
         }
 
         @Test

--- a/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinServiceTest.java
@@ -1,0 +1,257 @@
+package com.mio.checkin.service;
+
+import com.mio.checkin.domain.Checkin;
+import com.mio.checkin.dto.*;
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.crypto.StubMessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CheckinServiceTest {
+
+    @Mock private CheckinRepository checkinRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOps;
+
+    private CheckinService checkinService;
+    private UUID userId;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        checkinService = new CheckinService(
+                checkinRepository, userRepository, new StubMessageEncryptor(), redisTemplate);
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .socialProvider("kakao")
+                .socialId("kakao-001")
+                .privacyConsent(true)
+                .build();
+    }
+
+    @Nested
+    @DisplayName("POST /v1/checkins — 체크인 등록")
+    class Submit {
+
+        @Test
+        @DisplayName("정상 등록 시 응답 데이터 반환")
+        void submit_success() {
+            when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(any(), any(), any())).thenReturn(false);
+            when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+            when(checkinRepository.save(any())).thenReturn(checkin("morning", "anxious", 3));
+
+            CheckinResponse result = checkinService.submit(userId,
+                    new CheckinRequest("morning", "anxious", 3, "메모"), null);
+
+            assertThat(result.timeOfDay()).isEqualTo("morning");
+            assertThat(result.emotionType()).isEqualTo("anxious");
+            assertThat(result.conditionScore()).isEqualTo(3);
+            assertThat(result.memo()).isEqualTo("메모");
+        }
+
+        @Test
+        @DisplayName("동일 슬롯 중복 체크인 시 ALREADY_CHECKED_IN")
+        void submit_duplicateSlot_throws() {
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get(anyString())).thenReturn(null);
+            when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(any(), any(), eq("morning"))).thenReturn(true);
+
+            assertThatThrownBy(() -> checkinService.submit(userId,
+                    new CheckinRequest("morning", "anxious", 3, null), "idem-key"))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.ALREADY_CHECKED_IN));
+        }
+
+        @Test
+        @DisplayName("유효하지 않은 emotion_type 시 INVALID_INPUT")
+        void submit_invalidEmotion_throws() {
+            assertThatThrownBy(() -> checkinService.submit(userId,
+                    new CheckinRequest("morning", "unknown", 3, null), null))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+
+        @Test
+        @DisplayName("Idempotency-Key 캐시 히트 시 저장 없이 캐시 응답 반환")
+        void submit_idempotencyHit_returnsCached() {
+            UUID checkinId = UUID.randomUUID();
+            OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+            String cached = checkinId + "|morning|calm|4|" + now + "|";
+
+            when(redisTemplate.opsForValue()).thenReturn(valueOps);
+            when(valueOps.get("idempotency:idem-001")).thenReturn(cached);
+
+            CheckinResponse result = checkinService.submit(userId,
+                    new CheckinRequest("morning", "calm", 4, null), "idem-001");
+
+            assertThat(result.checkinId()).isEqualTo(checkinId);
+            verify(checkinRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("PUT /v1/checkins/{id} — 체크인 수정")
+    class Update {
+
+        @Test
+        @DisplayName("당일 체크인 정상 수정")
+        void update_success() {
+            Checkin c = checkinToday("morning", "anxious", 2);
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
+
+            CheckinResponse result = checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest("calm", 4, "나아졌어"));
+
+            assertThat(result.emotionType()).isEqualTo("calm");
+            assertThat(result.conditionScore()).isEqualTo(4);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 체크인 시 CHECKIN_NOT_FOUND")
+        void update_notFound_throws() {
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.empty());
+            when(checkinRepository.existsById(any())).thenReturn(false);
+
+            assertThatThrownBy(() -> checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest("calm", 3, null)))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CHECKIN_NOT_FOUND));
+        }
+
+        @Test
+        @DisplayName("타인의 체크인 접근 시 CHECKIN_FORBIDDEN")
+        void update_forbidden_throws() {
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.empty());
+            when(checkinRepository.existsById(any())).thenReturn(true);
+
+            assertThatThrownBy(() -> checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest(null, null, "수정")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CHECKIN_FORBIDDEN));
+        }
+
+        @Test
+        @DisplayName("익일 이후 수정 시도 시 CHECKIN_NOT_TODAY")
+        void update_notToday_throws() {
+            Checkin c = checkinYesterday("morning", "anxious", 2);
+            when(checkinRepository.findByIdAndUser_Id(any(), eq(userId))).thenReturn(Optional.of(c));
+
+            assertThatThrownBy(() -> checkinService.update(userId, UUID.randomUUID(),
+                    new CheckinUpdateRequest(null, null, "수정")))
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.CHECKIN_NOT_TODAY));
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/checkins/today — 오늘 현황")
+    class GetToday {
+
+        @Test
+        @DisplayName("morning 완료 시 completed/available 슬롯 분리")
+        void getToday_slotsPartitioned() {
+            LocalDate today = LocalDate.now(AppConstants.ZONE);
+            when(checkinRepository.findByUser_IdAndCheckinDate(userId, today))
+                    .thenReturn(List.of(checkinToday("morning", "calm", 3)));
+
+            CheckinTodayResponse result = checkinService.getToday(userId);
+
+            assertThat(result.completedSlots()).containsExactly("morning");
+            assertThat(result.availableSlots()).containsExactlyInAnyOrder("afternoon", "evening");
+        }
+
+        @Test
+        @DisplayName("체크인 없으면 available_slots 3개 전부 반환")
+        void getToday_noCheckin_allAvailable() {
+            when(checkinRepository.findByUser_IdAndCheckinDate(any(), any())).thenReturn(List.of());
+
+            CheckinTodayResponse result = checkinService.getToday(userId);
+
+            assertThat(result.checkins()).isEmpty();
+            assertThat(result.availableSlots()).hasSize(3);
+        }
+    }
+
+    @Nested
+    @DisplayName("GET /v1/checkins — 이력 조회")
+    class GetHistory {
+
+        @Test
+        @DisplayName("커서 없이 최신순 반환")
+        void getHistory_noCursor() {
+            when(checkinRepository.findByUser_IdOrderByCreatedAtDesc(eq(userId), any(Pageable.class)))
+                    .thenReturn(new SliceImpl<>(List.of(checkinToday("evening", "calm", 3))));
+
+            List<CheckinResponse> result = checkinService.getHistory(userId, null);
+
+            assertThat(result).hasSize(1);
+            assertThat(result.get(0).timeOfDay()).isEqualTo("evening");
+        }
+    }
+
+    // ── 헬퍼 ──
+
+    private Checkin checkin(String slot, String emotion, int score) {
+        return Checkin.builder()
+                .user(user)
+                .timeOfDay(slot)
+                .emotionType(emotion)
+                .conditionScore(score)
+                .build();
+    }
+
+    private Checkin checkinToday(String slot, String emotion, int score) {
+        Checkin c = checkin(slot, emotion, score);
+        setField(c, "checkinDate", LocalDate.now(AppConstants.ZONE));
+        return c;
+    }
+
+    private Checkin checkinYesterday(String slot, String emotion, int score) {
+        Checkin c = checkin(slot, emotion, score);
+        setField(c, "checkinDate", LocalDate.now(AppConstants.ZONE).minusDays(1));
+        return c;
+    }
+
+    private static void setField(Object target, String fieldName, Object value) {
+        try {
+            var f = target.getClass().getDeclaredField(fieldName);
+            f.setAccessible(true);
+            f.set(target, value);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/mio/todo/service/TodoServiceTest.java
+++ b/src/test/java/com/mio/todo/service/TodoServiceTest.java
@@ -91,7 +91,7 @@ class TodoServiceTest {
                 .user(completedUser)
                 .timeOfDay("morning")
                 .emotionType("anxious")
-                .emojiScore(3)
+                .conditionScore(3)
                 .build();
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(completedUser));


### PR DESCRIPTION
 ## 요약  

   일 3회(morning/afternoon/evening) 슬롯 기반 체크인 API를 구현합니다.
   감정 유형·컨디션 점수 기록, 당일 현황 조회, 커서 페이지네이션 이력 조회를 포함합니다.

   ## 관련 이슈
   - Closes #72

   ## 변경 사항
   - V18 마이그레이션: `emoji_score` → `condition_score` 컬럼 조건부 rename (이미 적용된 DB에서 무해하게 skip)
   - Checkin 엔티티: `conditionScore`·`update()`·`characterId` 필드 추가
   - CheckinRepository: 오늘 현황·커서 페이지네이션·이력 조회 쿼리 추가
   - CheckinService: `submit`·`update`·`getToday`·`getHistory` 구현
   - CheckinController: `Principal` 패턴으로 userId 추출 (TodoController와 동일)
   - CheckinResponse: `character_id` 필드 추가
   - ErrorCode: `CHECKIN_NOT_FOUND`·`CHECKIN_FORBIDDEN` 코드 문자열 구체화

   ## 영향 범위
   - [x] API 스펙 또는 응답 형식이 변경됩니다.
   - [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
   - [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
   - [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
   - [x] 로깅 / 모니터링 포인트가 변경됩니다.
   - [ ] Breaking change 가 있습니다.

   ## 테스트
   ### 실행 커맨드
   ```bash
   ./gradlew test --tests "com.mio.checkin.*"
   ```

   ### 확인 내용
   - **CheckinServiceTest (12건)**: submit 정상/중복/감정오류/idempotency 캐시 히트, update 정상/미존재/권한없음/익일, getToday 슬롯 분리/체크인 없음, getHistory 커서 없이 최신순
   - **CheckinControllerTest (8건)**: 201 정상 등록, 409 중복 슬롯, 400 score 범위 외, 401 principal 없음, 403 온보딩 미완료, 200 수정, 422 익일 수정, 200 today·history 조회

   ## 중점 리뷰 포인트
   - `CheckinService.serializeResponse`: memo를 Base64 인코딩하여 pipe 구분자 충돌 방지 — 포맷 변경이 기존 Redis 캐시와 호환되지 않으나 TTL 24h이므로 자연 만료 후 정합성 회복
   - `update()` no-op 방어: 세 필드 모두 null 요청 시 400 반환
   - cursor 검증: Base64/OffsetDateTime 파싱 실패 시 500 대신 400 반환

   ## 배포 / 롤백
   - **Rollout**: Flyway V18 자동 실행 (조건부 — 이미 rename된 환경에서는 no-op)
   - cursor 검증: Base64/OffsetDateTime 파싱 실패 시 500 대신 400 반환

   ## 배포 / 롤백
   - **Rollout**: Flyway V18 자동 실행 (조건부 — 이미 rename된 환경에서는 no-op)
   - **Rollback**: V18은 rename이므로 롤백 시 `condition_score` → `emoji_score` 수동 rename 필요
   
   ## 체크리스트
   - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
   - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
   - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
   - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
   - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New check‑in REST endpoints: submit (supports Idempotency‑Key), update, today status, and history with cursor pagination.
  * Condition score (1–5) replaces prior rating; memo support with encrypted storage and decrypted display.
  * Enforced slot rules, onboarding gate, rate‑limiting, and clear business error responses for check‑in flows.

* **Database Migration**
  * Safe rename of rating column to condition score.

* **Tests**
  * Comprehensive controller and service tests covering success paths and edge cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Yarr-mio/mio_server/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->