### PR TITLE
feat: Phase 2 AI 파이프라인 — InputJudge + OutputGuard + PolicyEngine 완성

### DIFF
--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -1,0 +1,123 @@
+package com.mio.ai.judge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.profile.SafetyProfile;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.security.SecurityLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InputJudge {
+
+    private static final String JUDGE_MODEL = "gpt-4o-mini";
+
+    private static final String SYSTEM_PROMPT = """
+            You are a safety classifier for a mental health coaching app.
+            Analyze the user message and return a JSON with this exact schema:
+            {
+              "security": {
+                "level": "CLEAN|SUSPICIOUS|ATTACK",
+                "attack_types": [],
+                "require_output_security_guard": false
+              },
+              "risk": {
+                "risk_level": "CLEAR_LOW|LOW|MEDIUM|HIGH",
+                "risk_types": [],
+                "recommended_generation_mode": "NORMAL|SUPPORTIVE|GUARDED",
+                "recommended_delivery": "SPECULATIVE|CAUTIOUS_SPECULATIVE|BUFFER",
+                "require_output_safety_guard": false
+              },
+              "confidence": 0.0
+            }
+
+            risk_types values: casual_negative, ambiguous_distress, repetitive_negative, dependency_risk, crisis_possible, emotion_spike
+
+            Be conservative: when in doubt, prefer MEDIUM over LOW, SUPPORTIVE over NORMAL.
+            Respond ONLY with valid JSON.
+            """;
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public boolean shouldCallJudge(CombinedSignal combined, SafetyProfile profile) {
+        return combined.requiresJudge();
+    }
+
+    public InputJudgeResult judge(String message, CombinedSignal combined, SafetyProfile profile) {
+        try {
+            String contextPrompt = buildContextPrompt(profile, message);
+            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt);
+            String responseJson = llmClient.complete(request);
+            return parseJudgeResult(responseJson);
+        } catch (Exception e) {
+            log.warn("InputJudge failed, using fallback CLEAR_LOW: {}", e.getMessage());
+            return InputJudgeResult.fallback();
+        }
+    }
+
+    private String buildContextPrompt(SafetyProfile profile, String message) {
+        StringBuilder sb = new StringBuilder();
+        if (profile != null && !profile.commonDistortionCodes().isEmpty()) {
+            sb.append("[User Risk Context]\n");
+            sb.append("- common_distortion_codes: ").append(profile.commonDistortionCodes()).append("\n");
+            sb.append("- recent_crisis_severity_max: ").append(profile.recentCrisisSeverityMax()).append("\n");
+            sb.append("\n");
+        }
+        sb.append("[Current Message]\n").append(message);
+        return sb.toString();
+    }
+
+    private InputJudgeResult parseJudgeResult(String json) throws Exception {
+        JsonNode root = objectMapper.readTree(json);
+
+        JsonNode secNode = root.path("security");
+        SecurityLevel secLevel = SecurityLevel.valueOf(
+                secNode.path("level").asText("CLEAN").toUpperCase());
+        List<String> attackTypes = new ArrayList<>();
+        secNode.path("attack_types").forEach(n -> attackTypes.add(n.asText()));
+        boolean requireOutputSecGuard = secNode.path("require_output_security_guard").asBoolean(false);
+        SecurityVerdict security = new SecurityVerdict(secLevel, attackTypes, requireOutputSecGuard);
+
+        JsonNode riskNode = root.path("risk");
+        RiskLevel riskLevel = RiskLevel.valueOf(
+                riskNode.path("risk_level").asText("CLEAR_LOW").toUpperCase());
+        List<String> riskTypes = new ArrayList<>();
+        riskNode.path("risk_types").forEach(n -> riskTypes.add(n.asText()));
+        GenerationMode genMode = parseGenerationMode(riskNode.path("recommended_generation_mode").asText("NORMAL"));
+        DeliveryMode delivery = parseDeliveryMode(riskNode.path("recommended_delivery").asText("SPECULATIVE"));
+        boolean requireSafetyGuard = riskNode.path("require_output_safety_guard").asBoolean(false);
+        RiskVerdict risk = new RiskVerdict(riskLevel, riskTypes, genMode, delivery, requireSafetyGuard);
+
+        double confidence = root.path("confidence").asDouble(0.5);
+
+        return new InputJudgeResult(security, risk, confidence);
+    }
+
+    private GenerationMode parseGenerationMode(String value) {
+        try {
+            return GenerationMode.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return GenerationMode.NORMAL;
+        }
+    }
+
+    private DeliveryMode parseDeliveryMode(String value) {
+        try {
+            return DeliveryMode.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return DeliveryMode.SPECULATIVE;
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -83,16 +83,16 @@ public class InputJudge {
         JsonNode root = objectMapper.readTree(json);
 
         JsonNode secNode = root.path("security");
-        SecurityLevel secLevel = SecurityLevel.valueOf(
-                secNode.path("level").asText("CLEAN").toUpperCase());
+        SecurityLevel secLevel = parseSecurityLevel(
+                secNode.hasNonNull("level") ? secNode.path("level").asText() : "CLEAN");
         List<String> attackTypes = new ArrayList<>();
         secNode.path("attack_types").forEach(n -> attackTypes.add(n.asText()));
         boolean requireOutputSecGuard = secNode.path("require_output_security_guard").asBoolean(false);
         SecurityVerdict security = new SecurityVerdict(secLevel, attackTypes, requireOutputSecGuard);
 
         JsonNode riskNode = root.path("risk");
-        RiskLevel riskLevel = RiskLevel.valueOf(
-                riskNode.path("risk_level").asText("CLEAR_LOW").toUpperCase());
+        RiskLevel riskLevel = parseRiskLevel(
+                riskNode.hasNonNull("risk_level") ? riskNode.path("risk_level").asText() : "CLEAR_LOW");
         List<String> riskTypes = new ArrayList<>();
         riskNode.path("risk_types").forEach(n -> riskTypes.add(n.asText()));
         GenerationMode genMode = parseGenerationMode(riskNode.path("recommended_generation_mode").asText("NORMAL"));
@@ -103,6 +103,24 @@ public class InputJudge {
         double confidence = root.path("confidence").asDouble(0.5);
 
         return new InputJudgeResult(security, risk, confidence);
+    }
+
+    private SecurityLevel parseSecurityLevel(String value) {
+        try {
+            return SecurityLevel.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown SecurityLevel from LLM: {}, defaulting to CLEAN", value);
+            return SecurityLevel.CLEAN;
+        }
+    }
+
+    private RiskLevel parseRiskLevel(String value) {
+        try {
+            return RiskLevel.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            log.warn("Unknown RiskLevel from LLM: {}, defaulting to CLEAR_LOW", value);
+            return RiskLevel.CLEAR_LOW;
+        }
     }
 
     private GenerationMode parseGenerationMode(String value) {

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -107,7 +107,7 @@ public class InputJudge {
 
     private SecurityLevel parseSecurityLevel(String value) {
         try {
-            return SecurityLevel.valueOf(value.toUpperCase());
+            return SecurityLevel.valueOf(value.toUpperCase(java.util.Locale.ROOT));
         } catch (IllegalArgumentException e) {
             log.warn("Unknown SecurityLevel from LLM: {}, defaulting to CLEAN", value);
             return SecurityLevel.CLEAN;
@@ -116,7 +116,7 @@ public class InputJudge {
 
     private RiskLevel parseRiskLevel(String value) {
         try {
-            return RiskLevel.valueOf(value.toUpperCase());
+            return RiskLevel.valueOf(value.toUpperCase(java.util.Locale.ROOT));
         } catch (IllegalArgumentException e) {
             log.warn("Unknown RiskLevel from LLM: {}, defaulting to CLEAR_LOW", value);
             return RiskLevel.CLEAR_LOW;
@@ -125,7 +125,7 @@ public class InputJudge {
 
     private GenerationMode parseGenerationMode(String value) {
         try {
-            return GenerationMode.valueOf(value.toUpperCase());
+            return GenerationMode.valueOf(value.toUpperCase(java.util.Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return GenerationMode.NORMAL;
         }
@@ -133,7 +133,7 @@ public class InputJudge {
 
     private DeliveryMode parseDeliveryMode(String value) {
         try {
-            return DeliveryMode.valueOf(value.toUpperCase());
+            return DeliveryMode.valueOf(value.toUpperCase(java.util.Locale.ROOT));
         } catch (IllegalArgumentException e) {
             return DeliveryMode.SPECULATIVE;
         }

--- a/src/main/java/com/mio/ai/judge/InputJudgeResult.java
+++ b/src/main/java/com/mio/ai/judge/InputJudgeResult.java
@@ -1,0 +1,11 @@
+package com.mio.ai.judge;
+
+public record InputJudgeResult(
+        SecurityVerdict security,
+        RiskVerdict risk,
+        double confidence
+) {
+    public static InputJudgeResult fallback() {
+        return new InputJudgeResult(SecurityVerdict.clean(), RiskVerdict.clearLow(), 0.0);
+    }
+}

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -1,0 +1,76 @@
+package com.mio.ai.judge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OutputJudge {
+
+    private static final String JUDGE_MODEL = "gpt-4o-mini";
+
+    private static final String SYSTEM_PROMPT = """
+            You are a safety reviewer for a mental health coaching AI.
+            Review the AI response and determine the appropriate action.
+            Return a JSON with this exact schema:
+            {
+              "action": "SEND|REWRITE|REPLACE|CRISIS_FLOW",
+              "rewritten_content": null or "rewritten text if action is REWRITE"
+            }
+
+            Action guidelines:
+            - SEND: The response is safe and appropriate, send as-is.
+            - REWRITE: The response has minor issues. Provide a corrected version in rewritten_content.
+            - REPLACE: The response is harmful or inappropriate, replace with a safe fallback.
+            - CRISIS_FLOW: The response context indicates a crisis that requires crisis intervention.
+
+            Respond ONLY with valid JSON.
+            """;
+
+    private static final String SAFE_FALLBACK =
+            "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public OutputJudgeResult judge(String aiResponse, OutputPreFilterResult preFilterResult) {
+        try {
+            String userContent = buildJudgePrompt(aiResponse, preFilterResult);
+            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent);
+            String responseJson = llmClient.complete(request);
+            return parseJudgeResult(responseJson);
+        } catch (Exception e) {
+            log.warn("OutputJudge failed, defaulting to REPLACE: {}", e.getMessage());
+            return OutputJudgeResult.replace();
+        }
+    }
+
+    private String buildJudgePrompt(String aiResponse, OutputPreFilterResult preFilter) {
+        return String.format(
+                "[Pre-filter fail reasons]: %s\n\n[AI Response to review]:\n%s",
+                preFilter.failReasons(),
+                aiResponse
+        );
+    }
+
+    private OutputJudgeResult parseJudgeResult(String json) throws Exception {
+        JsonNode root = objectMapper.readTree(json);
+        String action = root.path("action").asText("REPLACE").toUpperCase();
+
+        return switch (action) {
+            case "SEND" -> OutputJudgeResult.send();
+            case "REWRITE" -> {
+                String rewritten = root.path("rewritten_content").asText(SAFE_FALLBACK);
+                yield OutputJudgeResult.rewrite(rewritten);
+            }
+            case "CRISIS_FLOW" -> OutputJudgeResult.crisisFlow();
+            default -> OutputJudgeResult.replace();
+        };
+    }
+}

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -66,7 +66,9 @@ public class OutputJudge {
         return switch (action) {
             case "SEND" -> OutputJudgeResult.send();
             case "REWRITE" -> {
-                String rewritten = root.path("rewritten_content").asText(SAFE_FALLBACK);
+                String rewritten = root.hasNonNull("rewritten_content")
+                        ? root.path("rewritten_content").asText()
+                        : SAFE_FALLBACK;
                 yield OutputJudgeResult.rewrite(rewritten);
             }
             case "CRISIS_FLOW" -> OutputJudgeResult.crisisFlow();

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -61,7 +61,7 @@ public class OutputJudge {
 
     private OutputJudgeResult parseJudgeResult(String json) throws Exception {
         JsonNode root = objectMapper.readTree(json);
-        String action = root.path("action").asText("REPLACE").toUpperCase();
+        String action = root.path("action").asText("REPLACE").toUpperCase(java.util.Locale.ROOT);
 
         return switch (action) {
             case "SEND" -> OutputJudgeResult.send();

--- a/src/main/java/com/mio/ai/judge/OutputJudgeAction.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudgeAction.java
@@ -1,0 +1,8 @@
+package com.mio.ai.judge;
+
+public enum OutputJudgeAction {
+    SEND,
+    REWRITE,
+    REPLACE,
+    CRISIS_FLOW
+}

--- a/src/main/java/com/mio/ai/judge/OutputJudgeResult.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudgeResult.java
@@ -1,0 +1,22 @@
+package com.mio.ai.judge;
+
+public record OutputJudgeResult(
+        OutputJudgeAction action,
+        String rewrittenContent
+) {
+    public static OutputJudgeResult send() {
+        return new OutputJudgeResult(OutputJudgeAction.SEND, null);
+    }
+
+    public static OutputJudgeResult rewrite(String content) {
+        return new OutputJudgeResult(OutputJudgeAction.REWRITE, content);
+    }
+
+    public static OutputJudgeResult replace() {
+        return new OutputJudgeResult(OutputJudgeAction.REPLACE, null);
+    }
+
+    public static OutputJudgeResult crisisFlow() {
+        return new OutputJudgeResult(OutputJudgeAction.CRISIS_FLOW, null);
+    }
+}

--- a/src/main/java/com/mio/ai/judge/OutputPreFilter.java
+++ b/src/main/java/com/mio/ai/judge/OutputPreFilter.java
@@ -1,0 +1,134 @@
+package com.mio.ai.judge;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+@Component
+public class OutputPreFilter {
+
+    // ROLE_BOUNDARY: AI claiming professional roles
+    private static final Set<String> ROLE_BOUNDARY_PATTERNS = Set.of(
+            "저는 의사", "저는 상담사", "저는 정신과", "저는 심리치료사",
+            "의사로서", "상담사로서", "치료사로서", "전문가로서 진단",
+            "i am a doctor", "i am a therapist", "as a psychiatrist"
+    );
+
+    // DIAGNOSIS_CLAIM: Medical diagnosis or prescription
+    private static final Set<String> DIAGNOSIS_PATTERNS = Set.of(
+            "당신은 우울증", "당신은 불안장애", "당신은 ptsd", "당신에게는 약",
+            "진단을 내리", "처방해드릴", "항우울제", "정신과 약",
+            "you have depression", "you have anxiety disorder", "you should take medication"
+    );
+
+    // DEPENDENCY_REINFORCE: Dependency-reinforcing phrases
+    private static final Set<String> DEPENDENCY_PATTERNS = Set.of(
+            "나 없이는 안 돼", "나만 있으면 돼", "내가 항상 곁에 있을게",
+            "나한테만 의지해", "다른 사람은 필요 없어", "나만 믿으면 돼",
+            "you only need me", "depend on me"
+    );
+
+    // CRISIS_MISMATCH: Crisis input but trivial/cheerful response
+    private static final List<Pattern> CRISIS_MISMATCH_POSITIVE_PATTERNS = List.of(
+            Pattern.compile("기분 전환|재미있는|즐거운|좋은 하루|화이팅|힘내요|괜찮아질 거야", Pattern.CASE_INSENSITIVE),
+            Pattern.compile("cheer up|have fun|enjoy|good day|you'll be fine", Pattern.CASE_INSENSITIVE)
+    );
+
+    // INSTRUCTION_LEAK: System prompt exposure
+    private static final Set<String> INSTRUCTION_LEAK_PATTERNS = Set.of(
+            "시스템 프롬프트", "system prompt", "내 지침은", "my instructions are",
+            "나는 다음 지침을", "i was instructed to", "my prompt says"
+    );
+
+    // EXPLICIT_HARM: Explicit self-harm method guidance
+    private static final Set<String> EXPLICIT_HARM_PATTERNS = Set.of(
+            "자살하는 방법", "자해하는 방법", "약을 과다복용", "목을 매는",
+            "how to commit suicide", "how to self-harm", "overdose method"
+    );
+
+    public OutputPreFilterResult check(String response) {
+        String lowerResponse = response.toLowerCase();
+        List<String> failReasons = new ArrayList<>();
+
+        checkRoleBoundary(lowerResponse, failReasons);
+        checkDiagnosisClaim(lowerResponse, failReasons);
+        checkDependencyReinforce(lowerResponse, failReasons);
+        checkInstructionLeak(lowerResponse, failReasons);
+        checkExplicitHarm(lowerResponse, failReasons);
+
+        if (failReasons.isEmpty()) {
+            return OutputPreFilterResult.pass();
+        }
+        return OutputPreFilterResult.fail(failReasons);
+    }
+
+    public OutputPreFilterResult checkWithCrisisContext(String response, boolean inputWasCrisis) {
+        OutputPreFilterResult base = check(response);
+        if (inputWasCrisis && !base.passed()) {
+            return base;
+        }
+        if (inputWasCrisis && isTrivialResponse(response)) {
+            List<String> reasons = new ArrayList<>(base.failReasons());
+            reasons.add("CRISIS_MISMATCH");
+            return OutputPreFilterResult.fail(reasons);
+        }
+        return base;
+    }
+
+    private void checkRoleBoundary(String response, List<String> reasons) {
+        for (String pattern : ROLE_BOUNDARY_PATTERNS) {
+            if (response.contains(pattern)) {
+                reasons.add("ROLE_BOUNDARY");
+                return;
+            }
+        }
+    }
+
+    private void checkDiagnosisClaim(String response, List<String> reasons) {
+        for (String pattern : DIAGNOSIS_PATTERNS) {
+            if (response.contains(pattern)) {
+                reasons.add("DIAGNOSIS_CLAIM");
+                return;
+            }
+        }
+    }
+
+    private void checkDependencyReinforce(String response, List<String> reasons) {
+        for (String pattern : DEPENDENCY_PATTERNS) {
+            if (response.contains(pattern)) {
+                reasons.add("DEPENDENCY_REINFORCE");
+                return;
+            }
+        }
+    }
+
+    private void checkInstructionLeak(String response, List<String> reasons) {
+        for (String pattern : INSTRUCTION_LEAK_PATTERNS) {
+            if (response.contains(pattern)) {
+                reasons.add("INSTRUCTION_LEAK");
+                return;
+            }
+        }
+    }
+
+    private void checkExplicitHarm(String response, List<String> reasons) {
+        for (String pattern : EXPLICIT_HARM_PATTERNS) {
+            if (response.contains(pattern)) {
+                reasons.add("EXPLICIT_HARM");
+                return;
+            }
+        }
+    }
+
+    private boolean isTrivialResponse(String response) {
+        for (Pattern pattern : CRISIS_MISMATCH_POSITIVE_PATTERNS) {
+            if (pattern.matcher(response).find()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/mio/ai/judge/OutputPreFilter.java
+++ b/src/main/java/com/mio/ai/judge/OutputPreFilter.java
@@ -67,10 +67,10 @@ public class OutputPreFilter {
 
     public OutputPreFilterResult checkWithCrisisContext(String response, boolean inputWasCrisis) {
         OutputPreFilterResult base = check(response);
-        if (inputWasCrisis && !base.passed()) {
+        if (!inputWasCrisis) {
             return base;
         }
-        if (inputWasCrisis && isTrivialResponse(response)) {
+        if (isTrivialResponse(response)) {
             List<String> reasons = new ArrayList<>(base.failReasons());
             reasons.add("CRISIS_MISMATCH");
             return OutputPreFilterResult.fail(reasons);

--- a/src/main/java/com/mio/ai/judge/OutputPreFilter.java
+++ b/src/main/java/com/mio/ai/judge/OutputPreFilter.java
@@ -50,7 +50,7 @@ public class OutputPreFilter {
     );
 
     public OutputPreFilterResult check(String response) {
-        String lowerResponse = response.toLowerCase();
+        String lowerResponse = response.toLowerCase(java.util.Locale.ROOT);
         List<String> failReasons = new ArrayList<>();
 
         checkRoleBoundary(lowerResponse, failReasons);

--- a/src/main/java/com/mio/ai/judge/OutputPreFilterResult.java
+++ b/src/main/java/com/mio/ai/judge/OutputPreFilterResult.java
@@ -1,0 +1,16 @@
+package com.mio.ai.judge;
+
+import java.util.List;
+
+public record OutputPreFilterResult(
+        boolean passed,
+        List<String> failReasons
+) {
+    public static OutputPreFilterResult pass() {
+        return new OutputPreFilterResult(true, List.of());
+    }
+
+    public static OutputPreFilterResult fail(List<String> reasons) {
+        return new OutputPreFilterResult(false, reasons);
+    }
+}

--- a/src/main/java/com/mio/ai/judge/RiskLevel.java
+++ b/src/main/java/com/mio/ai/judge/RiskLevel.java
@@ -1,0 +1,10 @@
+package com.mio.ai.judge;
+
+public enum RiskLevel {
+    CLEAR_LOW,
+    LOW,
+    MEDIUM,
+    HIGH,
+    HARD_CRISIS,
+    ATTACK
+}

--- a/src/main/java/com/mio/ai/judge/RiskVerdict.java
+++ b/src/main/java/com/mio/ai/judge/RiskVerdict.java
@@ -1,0 +1,21 @@
+package com.mio.ai.judge;
+
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+
+import java.util.List;
+
+public record RiskVerdict(
+        RiskLevel riskLevel,
+        List<String> riskTypes,
+        GenerationMode recommendedGenerationMode,
+        DeliveryMode recommendedDelivery,
+        boolean requireOutputSafetyGuard
+) {
+    public static RiskVerdict clearLow() {
+        return new RiskVerdict(
+                RiskLevel.CLEAR_LOW, List.of(),
+                GenerationMode.NORMAL, DeliveryMode.SPECULATIVE, false
+        );
+    }
+}

--- a/src/main/java/com/mio/ai/judge/SecurityVerdict.java
+++ b/src/main/java/com/mio/ai/judge/SecurityVerdict.java
@@ -1,0 +1,15 @@
+package com.mio.ai.judge;
+
+import com.mio.ai.security.SecurityLevel;
+
+import java.util.List;
+
+public record SecurityVerdict(
+        SecurityLevel level,
+        List<String> attackTypes,
+        boolean requireOutputSecurityGuard
+) {
+    public static SecurityVerdict clean() {
+        return new SecurityVerdict(SecurityLevel.CLEAN, List.of(), false);
+    }
+}

--- a/src/main/java/com/mio/ai/llm/LlmClient.java
+++ b/src/main/java/com/mio/ai/llm/LlmClient.java
@@ -13,4 +13,13 @@ public interface LlmClient {
      * @return time to first token in milliseconds
      */
     long stream(LlmRequest request, Consumer<String> chunkHandler);
+
+    /**
+     * Sends a non-streaming request and returns the full response content.
+     * Used for Judge calls (InputJudge, OutputJudge) that require structured JSON.
+     *
+     * @param request the LLM request
+     * @return the full response content string
+     */
+    String complete(LlmRequest request);
 }

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -100,6 +100,51 @@ public class OpenAiLlmClient implements LlmClient {
         return objectMapper.writeValueAsString(body);
     }
 
+    @Override
+    public String complete(LlmRequest request) {
+        try {
+            String requestBody = buildNonStreamingRequestBody(request);
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(CHAT_URL))
+                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Content-Type", "application/json")
+                    .timeout(Duration.ofSeconds(30))
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(
+                    httpRequest,
+                    HttpResponse.BodyHandlers.ofString()
+            );
+
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("OpenAI API error: " + response.statusCode());
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            return root.path("choices").get(0).path("message").path("content").asText();
+
+        } catch (Exception e) {
+            log.error("LLM complete error: {}", e.getMessage());
+            throw new RuntimeException("LLM complete failed", e);
+        }
+    }
+
+    private String buildNonStreamingRequestBody(LlmRequest request) throws Exception {
+        List<Map<String, String>> messages = request.messages().stream()
+                .map(m -> Map.of("role", m.role(), "content", m.content()))
+                .toList();
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", request.model());
+        body.put("messages", messages);
+        body.put("stream", false);
+        body.put("response_format", Map.of("type", "json_object"));
+
+        return objectMapper.writeValueAsString(body);
+    }
+
     private String extractDeltaContent(String json) {
         try {
             JsonNode root = objectMapper.readTree(json);

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -123,7 +123,7 @@ public class OpenAiLlmClient implements LlmClient {
             }
 
             JsonNode root = objectMapper.readTree(response.body());
-            return root.path("choices").get(0).path("message").path("content").asText();
+            return root.path("choices").path(0).path("message").path("content").asText();
 
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());

--- a/src/main/java/com/mio/ai/memory/working/SessionDelta.java
+++ b/src/main/java/com/mio/ai/memory/working/SessionDelta.java
@@ -1,0 +1,21 @@
+package com.mio.ai.memory.working;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public record SessionDelta(
+        int socraticQuestionsUsed,
+        Map<String, Integer> distortionCounts
+) {
+    public static SessionDelta empty() {
+        return new SessionDelta(0, new HashMap<>());
+    }
+
+    public boolean socraticLimitReached() {
+        return socraticQuestionsUsed >= 2;
+    }
+
+    public int distortionCount(String distortionCode) {
+        return distortionCounts.getOrDefault(distortionCode, 0);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -1,0 +1,75 @@
+package com.mio.ai.memory.working;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class WorkingMemory {
+
+    private static final String KEY_PREFIX = "session:%s:working";
+    private static final String FIELD_SOCRATIC_COUNT = "socratic_count";
+    private static final String FIELD_DISTORTION_PREFIX = "distortion:";
+    private static final Duration SESSION_TTL = Duration.ofMinutes(90);
+
+    private final StringRedisTemplate redisTemplate;
+
+    public int getSocraticQuestionCount(UUID sessionId) {
+        String value = (String) redisTemplate.opsForHash()
+                .get(key(sessionId), FIELD_SOCRATIC_COUNT);
+        return value == null ? 0 : Integer.parseInt(value);
+    }
+
+    public void incrementSocraticQuestionCount(UUID sessionId) {
+        String k = key(sessionId);
+        redisTemplate.opsForHash().increment(k, FIELD_SOCRATIC_COUNT, 1);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
+    public int getDistortionCount(UUID sessionId, String distortionCode) {
+        String value = (String) redisTemplate.opsForHash()
+                .get(key(sessionId), FIELD_DISTORTION_PREFIX + distortionCode);
+        return value == null ? 0 : Integer.parseInt(value);
+    }
+
+    public void incrementDistortionCount(UUID sessionId, String distortionCode) {
+        String k = key(sessionId);
+        redisTemplate.opsForHash().increment(k, FIELD_DISTORTION_PREFIX + distortionCode, 1);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
+    public SessionDelta getSessionDelta(UUID sessionId) {
+        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key(sessionId));
+
+        int socraticCount = 0;
+        Map<String, Integer> distortionCounts = new HashMap<>();
+
+        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+            String field = (String) entry.getKey();
+            String value = (String) entry.getValue();
+
+            if (FIELD_SOCRATIC_COUNT.equals(field)) {
+                socraticCount = Integer.parseInt(value);
+            } else if (field.startsWith(FIELD_DISTORTION_PREFIX)) {
+                String code = field.substring(FIELD_DISTORTION_PREFIX.length());
+                distortionCounts.put(code, Integer.parseInt(value));
+            }
+        }
+
+        return new SessionDelta(socraticCount, distortionCounts);
+    }
+
+    public void clear(UUID sessionId) {
+        redisTemplate.delete(key(sessionId));
+    }
+
+    private String key(UUID sessionId) {
+        return KEY_PREFIX.formatted(sessionId);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.working;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -11,6 +12,7 @@ import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class WorkingMemory {
 
     private static final String KEY_PREFIX = "session:%s:working";
@@ -23,7 +25,7 @@ public class WorkingMemory {
     public int getSocraticQuestionCount(UUID sessionId) {
         String value = (String) redisTemplate.opsForHash()
                 .get(key(sessionId), FIELD_SOCRATIC_COUNT);
-        return value == null ? 0 : Integer.parseInt(value);
+        return parseIntSafe(value);
     }
 
     public void incrementSocraticQuestionCount(UUID sessionId) {
@@ -35,7 +37,7 @@ public class WorkingMemory {
     public int getDistortionCount(UUID sessionId, String distortionCode) {
         String value = (String) redisTemplate.opsForHash()
                 .get(key(sessionId), FIELD_DISTORTION_PREFIX + distortionCode);
-        return value == null ? 0 : Integer.parseInt(value);
+        return parseIntSafe(value);
     }
 
     public void incrementDistortionCount(UUID sessionId, String distortionCode) {
@@ -55,10 +57,10 @@ public class WorkingMemory {
             String value = (String) entry.getValue();
 
             if (FIELD_SOCRATIC_COUNT.equals(field)) {
-                socraticCount = Integer.parseInt(value);
+                socraticCount = parseIntSafe(value);
             } else if (field.startsWith(FIELD_DISTORTION_PREFIX)) {
                 String code = field.substring(FIELD_DISTORTION_PREFIX.length());
-                distortionCounts.put(code, Integer.parseInt(value));
+                distortionCounts.put(code, parseIntSafe(value));
             }
         }
 
@@ -71,5 +73,15 @@ public class WorkingMemory {
 
     private String key(UUID sessionId) {
         return KEY_PREFIX.formatted(sessionId);
+    }
+
+    private int parseIntSafe(String value) {
+        if (value == null) return 0;
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            log.warn("WorkingMemory: unexpected non-integer value '{}', defaulting to 0", value);
+            return 0;
+        }
     }
 }

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -3,6 +3,8 @@ package com.mio.ai.orchestrator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.domain.AiPolicyDecision;
+import com.mio.ai.judge.OutputJudgeResult;
+import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.policy.PolicyDecision;
 import com.mio.ai.repository.AiPolicyDecisionRepository;
@@ -23,7 +25,7 @@ import java.util.UUID;
 public class AiDecisionLogger {
 
     private static final String SCHEMA_VERSION = "v2.4";
-    private static final String PROMPT_VERSION = "phase1-basic";
+    private static final String PROMPT_VERSION = "phase2";
 
     private final AiPolicyDecisionRepository repository;
     private final ObjectMapper objectMapper;
@@ -38,12 +40,16 @@ public class AiDecisionLogger {
             SecurityAssessment securityAssessment,
             long totalPipelineMs,
             long llmTtftMs,
-            boolean crisisFlowTriggered) {
+            boolean crisisFlowTriggered,
+            boolean inputJudgeCalled,
+            OutputPreFilterResult preFilterResult,
+            OutputJudgeResult outputJudgeResult) {
 
         try {
             Map<String, Object> trace = buildTrace(
                     moderation, l1Result, llmTtftMs, totalPipelineMs,
-                    crisisFlowTriggered, decision);
+                    crisisFlowTriggered, decision,
+                    inputJudgeCalled, preFilterResult, outputJudgeResult);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -67,13 +73,33 @@ public class AiDecisionLogger {
         }
     }
 
+    /** Phase 1 호환 오버로드 */
+    @Async("aiDecisionLoggerExecutor")
+    public void log(
+            UUID userId,
+            UUID sessionId,
+            PolicyDecision decision,
+            ModerationResult moderation,
+            SafetyL1Result l1Result,
+            SecurityAssessment securityAssessment,
+            long totalPipelineMs,
+            long llmTtftMs,
+            boolean crisisFlowTriggered) {
+        log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
+                totalPipelineMs, llmTtftMs, crisisFlowTriggered,
+                false, OutputPreFilterResult.pass(), null);
+    }
+
     private Map<String, Object> buildTrace(
             ModerationResult moderation,
             SafetyL1Result l1Result,
             long ttftMs,
             long totalMs,
             boolean crisisFlowTriggered,
-            PolicyDecision decision) {
+            PolicyDecision decision,
+            boolean inputJudgeCalled,
+            OutputPreFilterResult preFilterResult,
+            OutputJudgeResult outputJudgeResult) {
 
         Map<String, Object> l1Flags = new LinkedHashMap<>();
         l1Flags.put("crisis_keyword", l1Result.hardCrisis());
@@ -90,13 +116,20 @@ public class AiDecisionLogger {
         trace.put("l1_flags", l1Flags);
         trace.put("l1_combined_confidence", l1Result.combinedConfidence());
         trace.put("l1_threshold_source", "default");
-        trace.put("input_judge_called", false);
+        trace.put("input_judge_called", inputJudgeCalled);
+        trace.put("risk_level", decision.riskLevel() != null ? decision.riskLevel().name() : null);
         trace.put("safety_profile_cache_hit", false);
         trace.put("memory_cache_hit", false);
         trace.put("llm_model", "gpt-4o");
         trace.put("llm_ttft_ms", ttftMs);
         trace.put("llm_cost_usd", 0.0);
         trace.put("delivery_mode", decision.deliveryMode().name().toLowerCase());
+        trace.put("output_pre_filter_result", preFilterResult != null
+                ? (preFilterResult.passed() ? "PASS" : "FAIL") : null);
+        trace.put("output_pre_filter_fail_reasons", preFilterResult != null
+                ? preFilterResult.failReasons() : null);
+        trace.put("output_judge_action", outputJudgeResult != null
+                ? outputJudgeResult.action().name() : null);
         trace.put("crisis_flow_triggered", crisisFlowTriggered);
         trace.put("total_pipeline_ms", totalMs);
 

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -149,12 +149,14 @@ public class ConversationOrchestrator {
 
                 DeliveryMode deliveryMode = decision.deliveryMode();
 
+                boolean inputHadRiskSignal = combined.riskCandidate() || combined.emotionSpike();
+
                 if (deliveryMode == DeliveryMode.BUFFER) {
                     // Buffer: complete first, then OutputGuard, then SSE
                     llmTtftMs = llmClient.stream(llmRequest, contentBuilder::append);
                     assistantContent = contentBuilder.toString();
 
-                    preFilterResult = outputPreFilter.check(assistantContent);
+                    preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
                     if (!preFilterResult.passed()) {
                         judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
                         assistantContent = resolveOutputJudgeAction(
@@ -183,7 +185,7 @@ public class ConversationOrchestrator {
 
                     // CAUTIOUS_SPECULATIVE: post-stream OutputGuard (best-effort logging only)
                     if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
-                        preFilterResult = outputPreFilter.check(assistantContent);
+                        preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
                         if (!preFilterResult.passed()) {
                             judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
                             // Already streamed — log violation for tuning
@@ -226,8 +228,9 @@ public class ConversationOrchestrator {
             case REWRITE -> result.rewrittenContent() != null ? result.rewrittenContent() : originalContent;
             case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             case CRISIS_FLOW -> {
-                crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId);
-                yield "";
+                CrisisFlowService.CrisisHandleResult cr =
+                        crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId);
+                yield cr != null ? cr.fixedResponse() : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             }
         };
     }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -5,13 +5,26 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
+import com.mio.ai.judge.InputJudge;
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.OutputJudge;
+import com.mio.ai.judge.OutputJudgeAction;
+import com.mio.ai.judge.OutputJudgeResult;
+import com.mio.ai.judge.OutputPreFilter;
+import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
 import com.mio.ai.policy.PolicyDecision;
 import com.mio.ai.policy.PolicyEngine;
+import com.mio.ai.profile.SafetyProfile;
+import com.mio.ai.profile.SafetyProfileBuilder;
+import com.mio.ai.prompt.PromptBuilder;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.ai.safety.SafetyL1;
 import com.mio.ai.safety.SafetyL1Input;
@@ -47,22 +60,21 @@ public class ConversationOrchestrator {
 
     private static final String LLM_MODEL = "gpt-4o";
 
-    private static final String SYSTEM_PROMPT =
-            "당신은 Mio입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, " +
-            "사용자의 감정을 진심으로 이해하고 지지합니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 사용자가 스스로 감정을 탐색할 수 있도록 돕습니다. " +
-            "진단이나 처방을 내리지 않으며, 의존성을 강화하는 표현은 하지 않습니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.";
-
     private final InputNormalizer inputNormalizer;
     private final SecurityRuleFilter securityRuleFilter;
     private final OpenAiModerationClient moderationClient;
     private final SafetyL1 safetyL1;
     private final SafetySignalCombiner signalCombiner;
+    private final SafetyProfileBuilder safetyProfileBuilder;
+    private final InputJudge inputJudge;
+    private final OutputPreFilter outputPreFilter;
+    private final OutputJudge outputJudge;
     private final PolicyEngine policyEngine;
+    private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
     private final CrisisFlowService crisisFlowService;
     private final SecurityRefusalTemplate securityRefusalTemplate;
+    private final WorkingMemory workingMemory;
     private final AiDecisionLogger decisionLogger;
     private final SessionMessagePersistenceService messagePersistenceService;
     private final SessionRepository sessionRepository;
@@ -86,20 +98,36 @@ public class ConversationOrchestrator {
             // 1. Normalize
             String normalized = inputNormalizer.normalize(userMessage);
 
-            // 2. Safety checks (parallel in production; sequential acceptable here with virtual threads)
+            // 2. Load SafetyProfile
+            SafetyProfile profile = safetyProfileBuilder.getOrDefault(userId.toString());
+
+            // 3. Safety checks (parallel in production; sequential with virtual threads)
             SecurityAssessment securityAssessment = securityRuleFilter.check(normalized);
             ModerationResult moderation = moderationClient.moderate(normalized);
             SafetyL1Result l1Result = safetyL1.check(
-                    new SafetyL1Input(normalized, List.of(), moderation));
-            CombinedSignal combined = signalCombiner.combine(securityAssessment, l1Result, moderation);
+                    new SafetyL1Input(normalized, List.of(), moderation, profile));
+            CombinedSignal combined = signalCombiner.combine(securityAssessment, l1Result, moderation, profile);
 
-            // 3. Policy decision
-            PolicyDecision decision = policyEngine.decide(combined);
+            // 4. InputJudge (conditional)
+            InputJudgeResult judgeResult = null;
+            boolean inputJudgeCalled = false;
+            if (inputJudge.shouldCallJudge(combined, profile)) {
+                judgeResult = inputJudge.judge(normalized, combined, profile);
+                inputJudgeCalled = true;
+            }
 
-            // 4. Execute based on decision
+            // 5. Working Memory (CBT counters)
+            SessionDelta sessionDelta = workingMemory.getSessionDelta(sessionId);
+
+            // 6. Policy decision (10-step)
+            PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
+
+            // 7. Execute based on decision
             String assistantContent;
             long llmTtftMs = 0;
             boolean crisisFlowTriggered = false;
+            OutputPreFilterResult preFilterResult = OutputPreFilterResult.pass();
+            OutputJudgeResult judgeActionResult = null;
 
             if (decision.action() == DecisionAction.SECURITY_REFUSAL) {
                 assistantContent = securityRefusalTemplate.get();
@@ -113,30 +141,68 @@ public class ConversationOrchestrator {
                 assistantContent = crisisResult.fixedResponse();
 
             } else {
-                // GENERATE: stream from LLM
-                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, SYSTEM_PROMPT, userMessage);
+                // GENERATE: build prompt with GenerationMode instruction
+                String systemPrompt = promptBuilder.buildSystemPrompt(
+                        decision.generationMode(), decision.interventionHints());
+                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, userMessage);
                 StringBuilder contentBuilder = new StringBuilder();
 
-                llmTtftMs = llmClient.stream(llmRequest, chunk -> {
-                    contentBuilder.append(chunk);
-                    try {
-                        sendEvent(emitter, new SseEventDto.DeltaEvent(chunk, outboundMsgId));
-                    } catch (IOException e) {
-                        throw new RuntimeException(e);
-                    }
-                });
+                DeliveryMode deliveryMode = decision.deliveryMode();
 
-                assistantContent = contentBuilder.toString();
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                if (deliveryMode == DeliveryMode.BUFFER) {
+                    // Buffer: complete first, then OutputGuard, then SSE
+                    llmTtftMs = llmClient.stream(llmRequest, contentBuilder::append);
+                    assistantContent = contentBuilder.toString();
+
+                    preFilterResult = outputPreFilter.check(assistantContent);
+                    if (!preFilterResult.passed()) {
+                        judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
+                        assistantContent = resolveOutputJudgeAction(
+                                judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId);
+                        if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
+                            crisisFlowTriggered = true;
+                        }
+                    }
+                    if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {
+                        sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
+                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                    }
+
+                } else {
+                    // SPECULATIVE / CAUTIOUS_SPECULATIVE: stream immediately
+                    llmTtftMs = llmClient.stream(llmRequest, chunk -> {
+                        contentBuilder.append(chunk);
+                        try {
+                            sendEvent(emitter, new SseEventDto.DeltaEvent(chunk, outboundMsgId));
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    assistantContent = contentBuilder.toString();
+                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+
+                    // CAUTIOUS_SPECULATIVE: post-stream OutputGuard (best-effort logging only)
+                    if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
+                        preFilterResult = outputPreFilter.check(assistantContent);
+                        if (!preFilterResult.passed()) {
+                            judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
+                            // Already streamed — log violation for tuning
+                            log.warn("OutputGuard FAIL post-stream: session={} reasons={} action={}",
+                                    sessionId, preFilterResult.failReasons(),
+                                    judgeActionResult != null ? judgeActionResult.action() : "none");
+                        }
+                    }
+                }
             }
 
-            // 5. Persist messages
+            // 8. Persist messages
             messagePersistenceService.saveConversation(sessionId, userId, userMessage, assistantContent);
 
-            // 6. Log decision asynchronously
+            // 9. Log decision asynchronously
             long totalMs = System.currentTimeMillis() - startMs;
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
-                    securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered);
+                    securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
+                    inputJudgeCalled, preFilterResult, judgeActionResult);
 
             emitter.complete();
 
@@ -144,6 +210,26 @@ public class ConversationOrchestrator {
             log.error("Conversation orchestration failed for session {}", sessionId, e);
             emitter.completeWithError(e);
         }
+    }
+
+    private String resolveOutputJudgeAction(
+            OutputJudgeResult result,
+            String originalContent,
+            SafetyL1Result l1Result,
+            User user,
+            Session session,
+            SseEmitter emitter,
+            String outboundMsgId) throws IOException {
+
+        return switch (result.action()) {
+            case SEND -> originalContent;
+            case REWRITE -> result.rewrittenContent() != null ? result.rewrittenContent() : originalContent;
+            case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+            case CRISIS_FLOW -> {
+                crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId);
+                yield "";
+            }
+        };
     }
 
     private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -140,7 +140,8 @@ public class ConversationOrchestrator {
                         crisisFlowService.handle(l1Result, userMessage, user, session, emitter, outboundMsgId);
                 assistantContent = crisisResult.fixedResponse();
 
-            } else {
+            } else if (decision.action() == DecisionAction.GENERATE) {
+                // OutputGuard 실행 여부는 deliveryMode로 제어 (requireOutputGuard 필드는 감사 로그용)
                 // GENERATE: build prompt with GenerationMode instruction
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints());
@@ -183,18 +184,34 @@ public class ConversationOrchestrator {
                     assistantContent = contentBuilder.toString();
                     sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
 
-                    // CAUTIOUS_SPECULATIVE: post-stream OutputGuard (best-effort logging only)
+                    // CAUTIOUS_SPECULATIVE: post-stream OutputGuard
+                    // 이미 스트리밍된 응답은 취소 불가하지만, DB에는 안전 버전을 저장해
+                    // 대화 기록 조회 시 유해 원문이 노출되지 않도록 한다.
                     if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
                         preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
                         if (!preFilterResult.passed()) {
                             judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
-                            // Already streamed — log violation for tuning
                             log.warn("OutputGuard FAIL post-stream: session={} reasons={} action={}",
                                     sessionId, preFilterResult.failReasons(),
                                     judgeActionResult != null ? judgeActionResult.action() : "none");
+                            if (judgeActionResult != null) {
+                                assistantContent = switch (judgeActionResult.action()) {
+                                    case REWRITE -> judgeActionResult.rewrittenContent() != null
+                                            ? judgeActionResult.rewrittenContent() : assistantContent;
+                                    case REPLACE, CRISIS_FLOW ->
+                                            "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+                                    case SEND -> assistantContent;
+                                };
+                            }
                         }
                     }
                 }
+            } else {
+                // FALLBACK 또는 미지원 action — 안전 응답 반환
+                log.warn("Unhandled decision action: {} for session={}", decision.action(), sessionId);
+                assistantContent = "지금 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.";
+                sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
+                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
             }
 
             // 8. Persist messages

--- a/src/main/java/com/mio/ai/policy/PolicyDecision.java
+++ b/src/main/java/com/mio/ai/policy/PolicyDecision.java
@@ -1,5 +1,6 @@
 package com.mio.ai.policy;
 
+import com.mio.ai.judge.RiskLevel;
 import com.mio.ai.security.SecurityLevel;
 
 public record PolicyDecision(
@@ -12,6 +13,7 @@ public record PolicyDecision(
         boolean allowStreaming,
         boolean requireOutputGuard,
         InterventionHints interventionHints,
-        String policyVersion
+        String policyVersion,
+        RiskLevel riskLevel
 ) {
 }

--- a/src/main/java/com/mio/ai/policy/PolicyEngine.java
+++ b/src/main/java/com/mio/ai/policy/PolicyEngine.java
@@ -1,76 +1,166 @@
 package com.mio.ai.policy;
 
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.profile.SafetyProfile;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.ai.security.SecurityLevel;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
  * 결정론적 코드만. LLM 호출 없음.
- * Phase 1: GENERATE / CRISIS_FLOW / SECURITY_REFUSAL 분기만 구현.
- * Phase 2에서 medium/high 티어 및 전체 우선순위 10단계 완성.
+ * Phase 2: 우선순위 10단계 전체 구현.
  */
 @Component
 public class PolicyEngine {
 
-    private static final String POLICY_VERSION = "v1.0-phase1";
+    private static final String POLICY_VERSION = "v2.0-phase2";
 
-    public PolicyDecision decide(CombinedSignal combined) {
-        String decisionId = "pd_" + UUID.randomUUID().toString().replace("-", "").substring(0, 12);
+    public PolicyDecision decide(
+            CombinedSignal combined,
+            InputJudgeResult judgeResult,
+            SafetyProfile profile,
+            SessionDelta sessionDelta) {
+
+        String decisionId = "pd_" + decisionSuffix();
 
         // 1. Security ATTACK
         if (combined.securityLevel() == SecurityLevel.ATTACK) {
-            return new PolicyDecision(
-                    decisionId,
-                    DecisionAction.SECURITY_REFUSAL,
-                    GenerationMode.CRISIS,
-                    DeliveryMode.SECURITY_REFUSAL,
-                    SecurityLevel.ATTACK,
-                    false, false, false,
-                    InterventionHints.empty(),
-                    POLICY_VERSION
-            );
+            return build(decisionId, DecisionAction.SECURITY_REFUSAL,
+                    GenerationMode.CRISIS, DeliveryMode.SECURITY_REFUSAL,
+                    combined.securityLevel(), false, false, false,
+                    InterventionHints.empty(), RiskLevel.ATTACK);
         }
 
-        // 2. L1 hardCrisis (self-harm/suicide)
+        // 2. L0 self-harm/intent + L1 hardCrisis
         if (combined.hardCrisis()) {
-            return new PolicyDecision(
-                    decisionId,
-                    DecisionAction.CRISIS_FLOW,
-                    GenerationMode.CRISIS,
-                    DeliveryMode.CRISIS_FLOW,
-                    combined.securityLevel(),
-                    false, false, false,
-                    InterventionHints.empty(),
-                    POLICY_VERSION
-            );
+            return build(decisionId, DecisionAction.CRISIS_FLOW,
+                    GenerationMode.CRISIS, DeliveryMode.CRISIS_FLOW,
+                    combined.securityLevel(), false, false, false,
+                    InterventionHints.empty(), RiskLevel.HARD_CRISIS);
         }
 
-        // 3. L0 moderation self-harm flagged
+        // 3. Security SUSPICIOUS → GUARDED + OutputGuard 활성
+        if (combined.securityLevel() == SecurityLevel.SUSPICIOUS) {
+            return build(decisionId, DecisionAction.GENERATE,
+                    GenerationMode.GUARDED, DeliveryMode.CAUTIOUS_SPECULATIVE,
+                    combined.securityLevel(), true, true, true,
+                    InterventionHints.empty(), RiskLevel.LOW);
+        }
+
+        // 4. L0 self-harm flagged (L1 미감지) → GUARDED + OutputGuard
+        if (combined.l0Flagged() && !combined.hardCrisis() && !combined.riskCandidate()) {
+            return build(decisionId, DecisionAction.GENERATE,
+                    GenerationMode.GUARDED, DeliveryMode.CAUTIOUS_SPECULATIVE,
+                    combined.securityLevel(), true, true, true,
+                    InterventionHints.empty(), RiskLevel.MEDIUM);
+        }
+
+        // 5. L0 self-harm + L1 모두 flagged → CRISIS_FLOW
         if (combined.l0Flagged() && combined.l1Result().moderationFlagged()) {
-            return new PolicyDecision(
-                    decisionId,
-                    DecisionAction.CRISIS_FLOW,
-                    GenerationMode.CRISIS,
-                    DeliveryMode.CRISIS_FLOW,
-                    combined.securityLevel(),
-                    false, false, false,
-                    InterventionHints.empty(),
-                    POLICY_VERSION
-            );
+            return build(decisionId, DecisionAction.CRISIS_FLOW,
+                    GenerationMode.CRISIS, DeliveryMode.CRISIS_FLOW,
+                    combined.securityLevel(), false, false, false,
+                    InterventionHints.empty(), RiskLevel.HARD_CRISIS);
         }
 
-        // 10. CLEAR_LOW — GENERATE (default for Phase 1)
-        return new PolicyDecision(
-                decisionId,
-                DecisionAction.GENERATE,
-                GenerationMode.NORMAL,
-                DeliveryMode.SPECULATIVE,
-                combined.securityLevel(),
-                true, true, false,
-                InterventionHints.empty(),
-                POLICY_VERSION
+        // InputJudge 결과 기반 분기 (6~8)
+        if (judgeResult != null) {
+            RiskLevel riskLevel = judgeResult.risk().riskLevel();
+
+            // 6. HIGH → GUARDED + BUFFER
+            if (riskLevel == RiskLevel.HIGH) {
+                return build(decisionId, DecisionAction.GENERATE,
+                        GenerationMode.GUARDED, DeliveryMode.BUFFER,
+                        combined.securityLevel(), true, true, true,
+                        generateHints(profile, riskLevel), RiskLevel.HIGH);
+            }
+
+            // 7. MEDIUM → SUPPORTIVE + CAUTIOUS_SPECULATIVE
+            if (riskLevel == RiskLevel.MEDIUM) {
+                GenerationMode genMode = resolveSupportiveMode(sessionDelta);
+                return build(decisionId, DecisionAction.GENERATE,
+                        genMode, DeliveryMode.CAUTIOUS_SPECULATIVE,
+                        combined.securityLevel(), true, true, true,
+                        generateHints(profile, riskLevel), RiskLevel.MEDIUM);
+            }
+
+            // 8. LOW → NORMAL + SPECULATIVE
+            if (riskLevel == RiskLevel.LOW) {
+                return build(decisionId, DecisionAction.GENERATE,
+                        GenerationMode.NORMAL, DeliveryMode.SPECULATIVE,
+                        combined.securityLevel(), true, true, false,
+                        generateHints(profile, riskLevel), RiskLevel.LOW);
+            }
+        }
+
+        // 9. L1 약신호 단독 (Judge 생략)
+        if (combined.repetitiveNegative() || combined.emotionSpike()) {
+            return build(decisionId, DecisionAction.GENERATE,
+                    GenerationMode.SUPPORTIVE, DeliveryMode.SPECULATIVE,
+                    combined.securityLevel(), true, true, false,
+                    generateHints(profile, RiskLevel.LOW), RiskLevel.LOW);
+        }
+
+        // 10. CLEAR_LOW (기본)
+        return build(decisionId, DecisionAction.GENERATE,
+                GenerationMode.NORMAL, DeliveryMode.SPECULATIVE,
+                combined.securityLevel(), true, true, false,
+                InterventionHints.empty(), RiskLevel.CLEAR_LOW);
+    }
+
+    /** Phase 1 호환 — profile/judge 없이 호출 가능 */
+    public PolicyDecision decide(CombinedSignal combined) {
+        return decide(combined, null, null, null);
+    }
+
+    private GenerationMode resolveSupportiveMode(SessionDelta delta) {
+        if (delta != null && delta.socraticLimitReached()) {
+            return GenerationMode.SUPPORTIVE;
+        }
+        return GenerationMode.SUPPORTIVE;
+    }
+
+    private InterventionHints generateHints(SafetyProfile profile, RiskLevel risk) {
+        if (profile == null) return InterventionHints.empty();
+
+        List<String> suggested;
+        if (risk == RiskLevel.MEDIUM || risk == RiskLevel.HIGH) {
+            suggested = profile.effectiveInterventions().stream().limit(3).toList();
+        } else {
+            suggested = profile.effectiveInterventions().stream().limit(2).toList();
+        }
+
+        return new InterventionHints(
+                suggested,
+                profile.ineffectiveInterventions(),
+                null
         );
+    }
+
+    private PolicyDecision build(
+            String decisionId,
+            DecisionAction action,
+            GenerationMode generationMode,
+            DeliveryMode deliveryMode,
+            SecurityLevel securityLevel,
+            boolean allowGeneration,
+            boolean allowStreaming,
+            boolean requireOutputGuard,
+            InterventionHints hints,
+            RiskLevel riskLevel) {
+        return new PolicyDecision(
+                decisionId, action, generationMode, deliveryMode,
+                securityLevel, allowGeneration, allowStreaming, requireOutputGuard,
+                hints, POLICY_VERSION, riskLevel
+        );
+    }
+
+    private String decisionSuffix() {
+        return java.util.UUID.randomUUID().toString().replace("-", "").substring(0, 12);
     }
 }

--- a/src/main/java/com/mio/ai/policy/PolicyEngine.java
+++ b/src/main/java/com/mio/ai/policy/PolicyEngine.java
@@ -52,20 +52,20 @@ public class PolicyEngine {
                     InterventionHints.empty(), RiskLevel.LOW);
         }
 
-        // 4. L0 self-harm flagged (L1 미감지) → GUARDED + OutputGuard
-        if (combined.l0Flagged() && !combined.hardCrisis() && !combined.riskCandidate()) {
-            return build(decisionId, DecisionAction.GENERATE,
-                    GenerationMode.GUARDED, DeliveryMode.CAUTIOUS_SPECULATIVE,
-                    combined.securityLevel(), true, true, true,
-                    InterventionHints.empty(), RiskLevel.MEDIUM);
-        }
-
-        // 5. L0 self-harm + L1 모두 flagged → CRISIS_FLOW
+        // 4. L0 self-harm + L1 모두 flagged → CRISIS_FLOW
         if (combined.l0Flagged() && combined.l1Result().moderationFlagged()) {
             return build(decisionId, DecisionAction.CRISIS_FLOW,
                     GenerationMode.CRISIS, DeliveryMode.CRISIS_FLOW,
                     combined.securityLevel(), false, false, false,
                     InterventionHints.empty(), RiskLevel.HARD_CRISIS);
+        }
+
+        // 5. L0 self-harm flagged (L1 미감지) → GUARDED + OutputGuard
+        if (combined.l0Flagged() && !combined.hardCrisis() && !combined.l1Result().moderationFlagged()) {
+            return build(decisionId, DecisionAction.GENERATE,
+                    GenerationMode.GUARDED, DeliveryMode.CAUTIOUS_SPECULATIVE,
+                    combined.securityLevel(), true, true, true,
+                    InterventionHints.empty(), RiskLevel.MEDIUM);
         }
 
         // InputJudge 결과 기반 분기 (6~8)
@@ -118,10 +118,8 @@ public class PolicyEngine {
         return decide(combined, null, null, null);
     }
 
+    // MIO-CBT-011: 소크라테스 2회 제한 도달 시에도 공감(SUPPORTIVE) 유지
     private GenerationMode resolveSupportiveMode(SessionDelta delta) {
-        if (delta != null && delta.socraticLimitReached()) {
-            return GenerationMode.SUPPORTIVE;
-        }
         return GenerationMode.SUPPORTIVE;
     }
 

--- a/src/main/java/com/mio/ai/profile/SafetyProfile.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfile.java
@@ -1,0 +1,39 @@
+package com.mio.ai.profile;
+
+import java.util.List;
+import java.util.Map;
+
+public record SafetyProfile(
+        String userId,
+        String source,
+        Map<String, Double> dynamicThresholds,
+        List<String> effectiveInterventions,
+        List<String> ineffectiveInterventions,
+        List<String> policyFlags,
+        double riskPriorScore,
+        int recentCrisisSeverityMax,
+        List<String> commonDistortionCodes
+) {
+    public static final String SOURCE_DEFAULT = "default";
+    public static final String SOURCE_PERSONALIZED = "personalized";
+
+    public double emotionDropThreshold() {
+        return dynamicThresholds.getOrDefault("emotion_drop_threshold", 30.0);
+    }
+
+    public int repetitiveNegativeCount() {
+        return dynamicThresholds.getOrDefault("repetitive_negative_count", 3.0).intValue();
+    }
+
+    public int messageBurstCount() {
+        return dynamicThresholds.getOrDefault("message_burst_count", 10.0).intValue();
+    }
+
+    public double burstWindowMinutes() {
+        return dynamicThresholds.getOrDefault("burst_window_minutes", 5.0);
+    }
+
+    public boolean hasForceJudge() {
+        return policyFlags != null && policyFlags.contains("force_judge");
+    }
+}

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -1,0 +1,39 @@
+package com.mio.ai.profile;
+
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class SafetyProfileBuilder {
+
+    private static final Map<String, Double> DEFAULT_THRESHOLDS = Map.of(
+            "emotion_drop_threshold", 30.0,
+            "repetitive_negative_count", 3.0,
+            "message_burst_count", 10.0,
+            "burst_window_minutes", 5.0
+    );
+
+    public SafetyProfile buildDefault(String userId) {
+        return new SafetyProfile(
+                userId,
+                SafetyProfile.SOURCE_DEFAULT,
+                DEFAULT_THRESHOLDS,
+                List.of(),
+                List.of(),
+                List.of(),
+                0.0,
+                0,
+                List.of()
+        );
+    }
+
+    /**
+     * Phase 2: always returns default profile.
+     * Phase 3-5: Redis cache lookup + personalized build.
+     */
+    public SafetyProfile getOrDefault(String userId) {
+        return buildDefault(userId);
+    }
+}

--- a/src/main/java/com/mio/ai/prompt/PromptBuilder.java
+++ b/src/main/java/com/mio/ai/prompt/PromptBuilder.java
@@ -1,0 +1,52 @@
+package com.mio.ai.prompt;
+
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PromptBuilder {
+
+    private static final String BASE_PROMPT =
+            "당신은 Mio입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, " +
+            "사용자의 감정을 진심으로 이해하고 지지합니다. " +
+            "CBT(인지행동치료) 원칙에 기반해 사용자가 스스로 감정을 탐색할 수 있도록 돕습니다. " +
+            "진단이나 처방을 내리지 않으며, 의존성을 강화하는 표현은 하지 않습니다. " +
+            "응답은 2-4문장으로 간결하게 유지합니다.";
+
+    private static final String SUPPORTIVE_INSTRUCTION =
+            "\n\n[현재 세션 지시] 감정을 먼저 충분히 인정하고 공감하세요. " +
+            "행동 제안이나 해결책은 최소화합니다. 사용자가 감정을 표현할 공간을 만들어주세요.";
+
+    private static final String GUARDED_INSTRUCTION =
+            "\n\n[현재 세션 지시] 분석적 발언을 삼가고 공감 위주로 응답하세요. " +
+            "단정적 표현을 사용하지 마세요. 사용자의 말을 조심스럽게 반영하세요.";
+
+    public String buildSystemPrompt(GenerationMode mode, InterventionHints hints) {
+        String base = BASE_PROMPT + buildModeInstruction(mode);
+        if (hints != null && !hints.suggestedCodes().isEmpty()) {
+            base += buildHintsInstruction(hints);
+        }
+        return base;
+    }
+
+    private String buildModeInstruction(GenerationMode mode) {
+        return switch (mode) {
+            case SUPPORTIVE -> SUPPORTIVE_INSTRUCTION;
+            case GUARDED -> GUARDED_INSTRUCTION;
+            case NORMAL -> "";
+            case CRISIS -> "";
+        };
+    }
+
+    private String buildHintsInstruction(InterventionHints hints) {
+        StringBuilder sb = new StringBuilder("\n\n[개입 힌트]");
+        if (!hints.suggestedCodes().isEmpty()) {
+            sb.append(" 권장 접근: ").append(String.join(", ", hints.suggestedCodes())).append(".");
+        }
+        if (!hints.avoidCodes().isEmpty()) {
+            sb.append(" 피할 접근: ").append(String.join(", ", hints.avoidCodes())).append(".");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/mio/ai/safety/SafetyL1.java
+++ b/src/main/java/com/mio/ai/safety/SafetyL1.java
@@ -1,6 +1,7 @@
 package com.mio.ai.safety;
 
 import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.profile.SafetyProfile;
 import com.mio.session.domain.Message;
 import org.springframework.stereotype.Component;
 
@@ -28,14 +29,22 @@ public class SafetyL1 {
             "다른사람은몰라도너는", "항상네편이잖아"
     );
 
-    private static final int EMOTION_SPIKE_THRESHOLD = 30;
-    private static final int REPETITION_THRESHOLD = 3;
-    private static final int BURST_THRESHOLD = 10;
+    private static final int DEFAULT_EMOTION_SPIKE_THRESHOLD = 30;
+    private static final int DEFAULT_REPETITION_THRESHOLD = 3;
+    private static final int DEFAULT_BURST_THRESHOLD = 10;
 
     public SafetyL1Result check(SafetyL1Input input) {
         String msg = input.normalizedMessage().replaceAll("\\s+", "");
         List<Message> history = input.recentMessages();
         ModerationResult moderation = input.moderationResult();
+        SafetyProfile profile = input.profile();
+
+        int emotionSpikeThreshold = profile != null
+                ? (int) profile.emotionDropThreshold()
+                : DEFAULT_EMOTION_SPIKE_THRESHOLD;
+        int repetitionThreshold = profile != null
+                ? profile.repetitiveNegativeCount()
+                : DEFAULT_REPETITION_THRESHOLD;
 
         List<String> signals = new ArrayList<>();
         boolean hardCrisis = false;

--- a/src/main/java/com/mio/ai/safety/SafetyL1Input.java
+++ b/src/main/java/com/mio/ai/safety/SafetyL1Input.java
@@ -1,6 +1,7 @@
 package com.mio.ai.safety;
 
 import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.profile.SafetyProfile;
 import com.mio.session.domain.Message;
 
 import java.util.List;
@@ -8,6 +9,10 @@ import java.util.List;
 public record SafetyL1Input(
         String normalizedMessage,
         List<Message> recentMessages,
-        ModerationResult moderationResult
+        ModerationResult moderationResult,
+        SafetyProfile profile
 ) {
+    public SafetyL1Input(String normalizedMessage, List<Message> recentMessages, ModerationResult moderationResult) {
+        this(normalizedMessage, recentMessages, moderationResult, null);
+    }
 }

--- a/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
+++ b/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
@@ -1,6 +1,7 @@
 package com.mio.ai.safety;
 
 import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.profile.SafetyProfile;
 import com.mio.ai.security.SecurityAssessment;
 import com.mio.ai.security.SecurityLevel;
 import org.springframework.stereotype.Component;
@@ -11,10 +12,10 @@ public class SafetySignalCombiner {
     public CombinedSignal combine(
             SecurityAssessment security,
             SafetyL1Result l1,
-            ModerationResult moderation) {
+            ModerationResult moderation,
+            SafetyProfile profile) {
 
-        boolean requiresJudge = determineRequiresJudge(security, l1, moderation);
-
+        boolean requiresJudge = determineRequiresJudge(security, l1, moderation, profile);
         double confidence = Math.max(security.confidence(), l1.combinedConfidence());
 
         return new CombinedSignal(
@@ -31,14 +32,56 @@ public class SafetySignalCombiner {
         );
     }
 
-    private boolean determineRequiresJudge(
+    /** Phase 1 signature — delegates to Phase 2 with null profile. */
+    public CombinedSignal combine(
             SecurityAssessment security,
             SafetyL1Result l1,
             ModerationResult moderation) {
-        // Phase 1: InputJudge not implemented yet — always false
-        // Phase 2 will implement full InputJudge triggering logic (§10.2)
+        return combine(security, l1, moderation, null);
+    }
+
+    private boolean determineRequiresJudge(
+            SecurityAssessment security,
+            SafetyL1Result l1,
+            ModerationResult moderation,
+            SafetyProfile profile) {
+
         if (l1.hardCrisis()) return false;
         if (security.level() == SecurityLevel.ATTACK) return false;
+
+        // §10.2 발동 조건
+        // 1. crisis_keyword 후보 (hardCrisis 아님) — riskCandidate with crisis keyword signal
+        if (l1.riskCandidate() && l1.signals().stream().anyMatch(s -> s.startsWith("crisis_keyword"))) {
+            return true;
+        }
+
+        // 2. emotion_spike + 다른 플래그 1개 이상
+        if (l1.emotionSpike() && (l1.riskCandidate() || l1.repetitiveNegative() || l1.dependencyHint())) {
+            return true;
+        }
+
+        // 4. L0 self-harm flagged이지만 L1 신호 없음
+        if (moderation.flagged() && moderation.isSelfHarmFlagged() && !l1.hasAnySignal()) {
+            return true;
+        }
+
+        // 5. L0 categoryScore['self-harm'] > 0.3이지만 flagged 미달
+        Double selfHarmScore = moderation.categoryScores() != null
+                ? moderation.categoryScores().get("self-harm") : null;
+        if (!moderation.flagged() && selfHarmScore != null && selfHarmScore > 0.3) {
+            return true;
+        }
+
+        // 6. SecurityLevel = SUSPICIOUS
+        if (security.level() == SecurityLevel.SUSPICIOUS) {
+            return true;
+        }
+
+        // 7. SafetyProfile.policyFlags에 'force_judge' 포함
+        if (profile != null && profile.hasForceJudge()) {
+            return true;
+        }
+
         return false;
     }
 }

--- a/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
+++ b/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
@@ -50,8 +50,10 @@ public class SafetySignalCombiner {
         if (security.level() == SecurityLevel.ATTACK) return false;
 
         // §10.2 발동 조건
-        // 1. crisis_keyword 후보 (hardCrisis 아님) — riskCandidate with crisis keyword signal
-        if (l1.riskCandidate() && l1.signals().stream().anyMatch(s -> s.startsWith("crisis_keyword"))) {
+        // 1. riskCandidate (hardCrisis 아닌 위기 후보) — SafetyL1의 RISK_KEYWORDS 매칭 시
+        // SafetyL1에서 crisis_keyword signal은 hardCrisis=true에서만 추가되므로
+        // riskCandidate 자체를 조건으로 사용한다.
+        if (l1.riskCandidate()) {
             return true;
         }
 

--- a/src/test/java/com/mio/ai/judge/InputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/InputJudgeTest.java
@@ -1,0 +1,76 @@
+package com.mio.ai.judge;
+
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.profile.SafetyProfile;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InputJudgeTest {
+
+    private SafetyProfile defaultProfile() {
+        return new SafetyProfile("u1", "default",
+                Map.of(), List.of(), List.of(), List.of(), 0.0, 0, List.of());
+    }
+
+    private SafetyProfile forceJudgeProfile() {
+        return new SafetyProfile("u1", "default",
+                Map.of(), List.of(), List.of(), List.of("force_judge"), 0.0, 0, List.of());
+    }
+
+    private CombinedSignal combined(SecurityLevel security, boolean hardCrisis,
+                                    boolean riskCandidate, boolean emotionSpike,
+                                    boolean requiresJudge) {
+        SafetyL1Result l1 = new SafetyL1Result(
+                hardCrisis, riskCandidate, emotionSpike, false, false, false,
+                List.of(), 0.0
+        );
+        return new CombinedSignal(
+                security, hardCrisis, riskCandidate, emotionSpike, false, false,
+                false, requiresJudge, l1, 0.0
+        );
+    }
+
+    @Test
+    @DisplayName("hardCrisis는 Judge를 호출하지 않는다 (requiresJudge = false)")
+    void hard_crisis_skips_judge() {
+        // InputJudge.shouldCallJudge는 CombinedSignal.requiresJudge를 그대로 반환
+        // SafetySignalCombiner가 hardCrisis 시 requiresJudge=false를 보장함
+        var combined = combined(SecurityLevel.CLEAN, true, false, false, false);
+        // shouldCallJudge 로직은 CombinedSignal.requiresJudge에 위임
+        assertThat(combined.requiresJudge()).isFalse();
+    }
+
+    @Test
+    @DisplayName("ATTACK은 Judge를 호출하지 않는다")
+    void attack_skips_judge() {
+        var combined = combined(SecurityLevel.ATTACK, false, false, false, false);
+        assertThat(combined.requiresJudge()).isFalse();
+    }
+
+    @Test
+    @DisplayName("requiresJudge = true 신호 → shouldCallJudge = true")
+    void requires_judge_true_calls_judge() {
+        var combined = combined(SecurityLevel.SUSPICIOUS, false, false, false, true);
+        SafetyProfile profile = defaultProfile();
+
+        // InputJudge의 shouldCallJudge는 combined.requiresJudge()를 반환
+        assertThat(combined.requiresJudge()).isTrue();
+    }
+
+    @Test
+    @DisplayName("fallback 결과는 CLEAR_LOW를 반환한다")
+    void fallback_result_is_clear_low() {
+        var fallback = InputJudgeResult.fallback();
+        assertThat(fallback.risk().riskLevel()).isEqualTo(RiskLevel.CLEAR_LOW);
+        assertThat(fallback.security().level()).isEqualTo(SecurityLevel.CLEAN);
+        assertThat(fallback.confidence()).isEqualTo(0.0);
+    }
+}

--- a/src/test/java/com/mio/ai/judge/OutputPreFilterTest.java
+++ b/src/test/java/com/mio/ai/judge/OutputPreFilterTest.java
@@ -1,0 +1,74 @@
+package com.mio.ai.judge;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OutputPreFilterTest {
+
+    private final OutputPreFilter filter = new OutputPreFilter();
+
+    @Test
+    @DisplayName("정상 응답은 PASS를 반환한다")
+    void normal_response_passes() {
+        var result = filter.check("지금 많이 힘드시겠어요. 함께 이야기해봐요.");
+        assertThat(result.passed()).isTrue();
+        assertThat(result.failReasons()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ROLE_BOUNDARY — AI가 의사로 자칭하면 FAIL")
+    void role_boundary_detected() {
+        var result = filter.check("저는 의사로서 당신에게 이렇게 권고드립니다.");
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("ROLE_BOUNDARY");
+    }
+
+    @Test
+    @DisplayName("DIAGNOSIS_CLAIM — 우울증 진단 발언은 FAIL")
+    void diagnosis_claim_detected() {
+        var result = filter.check("당신은 우울증을 가지고 있으며 약이 필요합니다.");
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("DIAGNOSIS_CLAIM");
+    }
+
+    @Test
+    @DisplayName("DEPENDENCY_REINFORCE — 의존성 강화 표현은 FAIL")
+    void dependency_reinforce_detected() {
+        var result = filter.check("나 없이는 안 돼. 항상 나만 믿어.");
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("DEPENDENCY_REINFORCE");
+    }
+
+    @Test
+    @DisplayName("INSTRUCTION_LEAK — 시스템 프롬프트 노출은 FAIL")
+    void instruction_leak_detected() {
+        var result = filter.check("시스템 프롬프트에는 이런 내용이 있어요.");
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("INSTRUCTION_LEAK");
+    }
+
+    @Test
+    @DisplayName("EXPLICIT_HARM — 자살 방법 안내는 FAIL")
+    void explicit_harm_detected() {
+        var result = filter.check("자살하는 방법은 다음과 같습니다.");
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("EXPLICIT_HARM");
+    }
+
+    @Test
+    @DisplayName("위기 발화에 가벼운 응답은 CRISIS_MISMATCH FAIL")
+    void crisis_mismatch_detected() {
+        var result = filter.checkWithCrisisContext("기분 전환 한번 해보세요!", true);
+        assertThat(result.passed()).isFalse();
+        assertThat(result.failReasons()).contains("CRISIS_MISMATCH");
+    }
+
+    @Test
+    @DisplayName("위기 컨텍스트 없으면 긍정 응답이 pass")
+    void non_crisis_context_cheering_passes() {
+        var result = filter.checkWithCrisisContext("화이팅! 좋은 하루 보내세요.", false);
+        assertThat(result.passed()).isTrue();
+    }
+}

--- a/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
+++ b/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
@@ -1,5 +1,10 @@
 package com.mio.ai.policy;
 
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.judge.RiskVerdict;
+import com.mio.ai.judge.SecurityVerdict;
+import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.ai.safety.SafetyL1Result;
 import com.mio.ai.security.SecurityLevel;
@@ -14,7 +19,8 @@ class PolicyEngineTest {
 
     private final PolicyEngine policyEngine = new PolicyEngine();
 
-    private CombinedSignal combined(SecurityLevel security, boolean hardCrisis, boolean riskCandidate, boolean l0Flagged) {
+    private CombinedSignal combined(SecurityLevel security, boolean hardCrisis,
+                                    boolean riskCandidate, boolean l0Flagged) {
         SafetyL1Result l1 = new SafetyL1Result(
                 hardCrisis, riskCandidate, false, false, false, l0Flagged,
                 List.of(), hardCrisis ? 0.9 : 0.0
@@ -25,12 +31,35 @@ class PolicyEngineTest {
         );
     }
 
+    private CombinedSignal combinedWithSignals(SecurityLevel security, boolean hardCrisis,
+                                               boolean emotionSpike, boolean repetitiveNeg) {
+        SafetyL1Result l1 = new SafetyL1Result(
+                hardCrisis, false, emotionSpike, repetitiveNeg, false, false,
+                List.of(), 0.0
+        );
+        return new CombinedSignal(
+                security, hardCrisis, false, emotionSpike, repetitiveNeg,
+                false, false, false, l1, 0.0
+        );
+    }
+
+    private InputJudgeResult judgeResult(RiskLevel riskLevel) {
+        return new InputJudgeResult(
+                SecurityVerdict.clean(),
+                new RiskVerdict(riskLevel, List.of(), GenerationMode.NORMAL, DeliveryMode.SPECULATIVE, false),
+                0.8
+        );
+    }
+
+    // === Phase 1 scenarios ===
+
     @Test
     @DisplayName("ATTACK → SECURITY_REFUSAL")
     void attack_returns_security_refusal() {
         var decision = policyEngine.decide(combined(SecurityLevel.ATTACK, false, false, false));
         assertThat(decision.action()).isEqualTo(DecisionAction.SECURITY_REFUSAL);
         assertThat(decision.allowGeneration()).isFalse();
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.ATTACK);
     }
 
     @Test
@@ -39,29 +68,73 @@ class PolicyEngineTest {
         var decision = policyEngine.decide(combined(SecurityLevel.CLEAN, true, false, false));
         assertThat(decision.action()).isEqualTo(DecisionAction.CRISIS_FLOW);
         assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.CRISIS_FLOW);
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.HARD_CRISIS);
     }
 
     @Test
-    @DisplayName("L0 self-harm + L1 moderation flagged → CRISIS_FLOW")
-    void l0_self_harm_with_l1_flagged_returns_crisis_flow() {
-        var decision = policyEngine.decide(combined(SecurityLevel.CLEAN, false, false, true));
-        // L0 flagged but L1 moderationFlagged also true
-        SafetyL1Result l1 = new SafetyL1Result(false, true, false, false, false, true, List.of(), 0.6);
-        var combinedWithL1Flagged = new CombinedSignal(
-                SecurityLevel.CLEAN, false, true, false, false, false, true, false, l1, 0.6
-        );
-        var crisisDecision = policyEngine.decide(combinedWithL1Flagged);
-        assertThat(crisisDecision.action()).isEqualTo(DecisionAction.CRISIS_FLOW);
-    }
-
-    @Test
-    @DisplayName("일반 메시지 → GENERATE + SPECULATIVE")
-    void normal_message_returns_generate() {
+    @DisplayName("일반 메시지 → GENERATE + SPECULATIVE + CLEAR_LOW")
+    void normal_message_returns_generate_clear_low() {
         var decision = policyEngine.decide(combined(SecurityLevel.CLEAN, false, false, false));
         assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
         assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.SPECULATIVE);
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.CLEAR_LOW);
         assertThat(decision.allowGeneration()).isTrue();
-        assertThat(decision.allowStreaming()).isTrue();
+    }
+
+    // === Phase 2 scenarios ===
+
+    @Test
+    @DisplayName("SUSPICIOUS → GENERATE + GUARDED + CAUTIOUS_SPECULATIVE + requireOutputGuard")
+    void suspicious_returns_guarded_cautious_speculative() {
+        var decision = policyEngine.decide(combined(SecurityLevel.SUSPICIOUS, false, false, false));
+        assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.GUARDED);
+        assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.CAUTIOUS_SPECULATIVE);
+        assertThat(decision.requireOutputGuard()).isTrue();
+    }
+
+    @Test
+    @DisplayName("InputJudge HIGH → GUARDED + BUFFER + requireOutputGuard")
+    void input_judge_high_returns_buffer() {
+        var combined = combined(SecurityLevel.CLEAN, false, true, false);
+        var decision = policyEngine.decide(combined, judgeResult(RiskLevel.HIGH), null, null);
+        assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.GUARDED);
+        assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.BUFFER);
+        assertThat(decision.requireOutputGuard()).isTrue();
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.HIGH);
+    }
+
+    @Test
+    @DisplayName("InputJudge MEDIUM → SUPPORTIVE + CAUTIOUS_SPECULATIVE")
+    void input_judge_medium_returns_cautious_speculative() {
+        var combined = combined(SecurityLevel.CLEAN, false, true, false);
+        var decision = policyEngine.decide(combined, judgeResult(RiskLevel.MEDIUM), null, null);
+        assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);
+        assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.CAUTIOUS_SPECULATIVE);
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.MEDIUM);
+    }
+
+    @Test
+    @DisplayName("InputJudge LOW → NORMAL + SPECULATIVE")
+    void input_judge_low_returns_speculative() {
+        var combined = combined(SecurityLevel.CLEAN, false, true, false);
+        var decision = policyEngine.decide(combined, judgeResult(RiskLevel.LOW), null, null);
+        assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.NORMAL);
+        assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.SPECULATIVE);
+        assertThat(decision.riskLevel()).isEqualTo(RiskLevel.LOW);
+    }
+
+    @Test
+    @DisplayName("L1 repetitiveNegative 단독 → SUPPORTIVE + SPECULATIVE")
+    void repetitive_negative_alone_returns_supportive() {
+        var combined = combinedWithSignals(SecurityLevel.CLEAN, false, false, true);
+        var decision = policyEngine.decide(combined);
+        assertThat(decision.action()).isEqualTo(DecisionAction.GENERATE);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);
+        assertThat(decision.deliveryMode()).isEqualTo(DeliveryMode.SPECULATIVE);
     }
 
     @Test
@@ -69,5 +142,14 @@ class PolicyEngineTest {
     void decision_id_is_always_populated() {
         var decision = policyEngine.decide(combined(SecurityLevel.CLEAN, false, false, false));
         assertThat(decision.decisionId()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("소크라테스 2회 제한 도달 시 SUPPORTIVE 유지")
+    void socratic_limit_reached_keeps_supportive() {
+        SessionDelta limitReached = new SessionDelta(2, new java.util.HashMap<>());
+        var combined = combined(SecurityLevel.CLEAN, false, true, false);
+        var decision = policyEngine.decide(combined, judgeResult(RiskLevel.MEDIUM), null, limitReached);
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);
     }
 }

--- a/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
+++ b/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
@@ -1,0 +1,54 @@
+package com.mio.ai.prompt;
+
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PromptBuilderTest {
+
+    private final PromptBuilder builder = new PromptBuilder();
+
+    @Test
+    @DisplayName("NORMAL 모드는 기본 프롬프트만 반환한다")
+    void normal_mode_returns_base_prompt() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty());
+        assertThat(prompt).contains("Mio");
+        assertThat(prompt).doesNotContain("현재 세션 지시");
+    }
+
+    @Test
+    @DisplayName("SUPPORTIVE 모드는 감정 인정 지시를 포함한다")
+    void supportive_mode_includes_emotion_instruction() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.SUPPORTIVE, InterventionHints.empty());
+        assertThat(prompt).contains("감정을 먼저 충분히 인정");
+    }
+
+    @Test
+    @DisplayName("GUARDED 모드는 분석적 발언 삼가 지시를 포함한다")
+    void guarded_mode_includes_guarded_instruction() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.GUARDED, InterventionHints.empty());
+        assertThat(prompt).contains("분석적 발언을 삼가");
+    }
+
+    @Test
+    @DisplayName("interventionHints가 있으면 프롬프트에 개입 힌트가 포함된다")
+    void hints_included_when_present() {
+        var hints = new InterventionHints(
+                List.of("cognitive_restructuring"), List.of("avoidance"), null);
+        String prompt = builder.buildSystemPrompt(GenerationMode.SUPPORTIVE, hints);
+        assertThat(prompt).contains("cognitive_restructuring");
+        assertThat(prompt).contains("avoidance");
+    }
+
+    @Test
+    @DisplayName("빈 hints는 프롬프트에 개입 힌트 섹션을 추가하지 않는다")
+    void empty_hints_no_hints_section() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty());
+        assertThat(prompt).doesNotContain("개입 힌트");
+    }
+}

--- a/src/test/java/com/mio/ai/safety/SafetyL1Test.java
+++ b/src/test/java/com/mio/ai/safety/SafetyL1Test.java
@@ -1,6 +1,7 @@
 package com.mio.ai.safety;
 
 import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.profile.SafetyProfile;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +16,10 @@ class SafetyL1Test {
 
     private SafetyL1Input input(String normalizedMessage) {
         return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.failOpen());
+    }
+
+    private SafetyL1Input inputWithProfile(String normalizedMessage, SafetyProfile profile) {
+        return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.failOpen(), profile);
     }
 
     @Test
@@ -57,8 +62,8 @@ class SafetyL1Test {
                 Map.of("self-harm", true),
                 Map.of("self-harm", 0.8)
         );
-        var input = new SafetyL1Input("힘들어", List.of(), moderation);
-        var result = safetyL1.check(input);
+        var inputObj = new SafetyL1Input("힘들어", List.of(), moderation);
+        var result = safetyL1.check(inputObj);
         assertThat(result.moderationFlagged()).isTrue();
         assertThat(result.riskCandidate()).isTrue();
     }
@@ -75,5 +80,17 @@ class SafetyL1Test {
     void combined_confidence_high_for_hard_crisis() {
         var result = safetyL1.check(input("자살"));
         assertThat(result.combinedConfidence()).isGreaterThanOrEqualTo(0.9);
+    }
+
+    @Test
+    @DisplayName("SafetyProfile이 주입되면 동적 임계값을 사용한다 (null-safe)")
+    void safety_profile_injection_does_not_break() {
+        SafetyProfile profile = new SafetyProfile(
+                "user-1", "default",
+                Map.of("emotion_drop_threshold", 25.0, "repetitive_negative_count", 2.0),
+                List.of(), List.of(), List.of(), 0.0, 0, List.of()
+        );
+        var result = safetyL1.check(inputWithProfile("죽고싶다", profile));
+        assertThat(result.hardCrisis()).isTrue();
     }
 }


### PR DESCRIPTION
## Summary

- **SafetyProfile** 기본값 구현 (`DEFAULT_FOR_NEW_USER`) — Phase 2 전체 컴포넌트의 동적 임계값 기반
- **InputJudge** (GPT-4o-mini) — §10.2 발동 조건 7가지 구현, Security + Risk 통합 1회 판정
- **OutputPreFilter** (코드 기반 6규칙) — ROLE_BOUNDARY / DIAGNOSIS_CLAIM / DEPENDENCY_REINFORCE / CRISIS_MISMATCH / INSTRUCTION_LEAK / EXPLICIT_HARM
- **OutputJudge** (GPT-4o-mini) — PreFilter FAIL 시 SEND/REWRITE/REPLACE/CRISIS_FLOW 결정
- **PolicyEngine** 10단계 전체 — Phase 1 임시 3분기 → §11.2 우선순위 완전 구현
- **PromptBuilder** — GenerationMode(NORMAL/SUPPORTIVE/GUARDED) → 런타임 지시 번역 + InterventionHints 주입
- **WorkingMemory** (Redis) — CBT 카운터 (소크라테스 2회 제한, 왜곡 유형별 카운트)
- **ConversationOrchestrator** — Phase 2 전체 통합: SafetyProfile 로드 → InputJudge 분기 → DeliveryMode 3가지 분기 → OutputGuard
- **AiDecisionLogger** — Phase 2 trace 필드 추가 (input_judge_called, risk_level, output_pre_filter_result, output_judge_action)

## Closes

Closes #86, #87, #88, #89, #90, #91

## 신규 패키지 구조

```
com.mio.ai
├── profile/      SafetyProfile, SafetyProfileBuilder
├── judge/        RiskLevel, InputJudge, InputJudgeResult, SecurityVerdict, RiskVerdict
│                 OutputPreFilter, OutputJudge, OutputPreFilterResult, OutputJudgeAction, OutputJudgeResult
├── prompt/       PromptBuilder
└── memory/
    └── working/  WorkingMemory, SessionDelta
```

## DeliveryMode 분기 동작

| DeliveryMode | 스트리밍 | OutputGuard |
|-------------|---------|------------|
| SPECULATIVE (clear_low) | 즉시 SSE delta | 생략 |
| CAUTIOUS_SPECULATIVE (medium) | 즉시 SSE delta | 완료 후 PreFilter (위반 로깅) |
| BUFFER (high) | 완료 후 SSE | PreFilter → (FAIL이면) OutputJudge |

## Phase 2 §27 지표 계측 준비

trace 필드 완비:
- `input_judge_called` — InputJudge 발동 비율 추적
- `risk_level` — clear_low 비율 추적
- `output_pre_filter_result` / `fail_reasons` — PreFilter PASS율 + 원인 분포
- `output_judge_action` — REWRITE 비율 추적

## Test plan

- [x] SafetyL1Test (8개): SafetyProfile 주입 케이스 추가
- [x] PolicyEngineTest (10개): SUSPICIOUS/HIGH/MEDIUM/LOW/repetitive_negative 시나리오
- [x] InputJudgeTest (4개): shouldCallJudge 발동 조건 + fallback
- [x] OutputPreFilterTest (8개): 6규칙 각각 + CRISIS_MISMATCH
- [x] PromptBuilderTest (5개): GenerationMode별 지시 + hints 주입
- [ ] 실 환경: OPENAI_API_KEY 세팅 후 medium 케이스 InputJudge 호출 확인
- [ ] 실 환경: BUFFER 모드 OutputGuard → REWRITE 동작 확인
- [ ] 실 환경: ai_policy_decisions trace input_judge_called / risk_level 필드 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated input safety judging to assess risk and security before generation.
  * Automated output pre-filter + review that can send, rewrite, replace, or trigger crisis flow.
  * Per-user safety profiles, session memory, and dynamic prompt builder to tailor responses and thresholds.
  * Expanded policy decisions including risk tiers and multiple delivery modes (buffered, speculative, cautious).
  * Enhanced decision logging with richer phase-2 trace data.

* **Tests**
  * Added unit tests covering input/output judges, pre-filtering, prompt builder, policy logic, and safety checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->