### PR TITLE
feat: 로컬 개발용 테스트 JWT 발급 엔드포인트 추가

### DIFF
--- a/src/main/java/com/mio/auth/controller/DevAuthController.java
+++ b/src/main/java/com/mio/auth/controller/DevAuthController.java
@@ -10,6 +10,7 @@ import com.mio.user.repository.UserRepository;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -19,6 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/auth/dev")
 @RequiredArgsConstructor
+@Profile("local")
 @ConditionalOnProperty(
         name = "auth.dev-token-enabled",
         havingValue = "true",

--- a/src/main/java/com/mio/auth/controller/DevAuthController.java
+++ b/src/main/java/com/mio/auth/controller/DevAuthController.java
@@ -1,0 +1,49 @@
+package com.mio.auth.controller;
+
+import com.mio.auth.dto.DevTokenRequest;
+import com.mio.auth.dto.DevTokenResponse;
+import com.mio.auth.service.JwtTokenService;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import com.mio.user.repository.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/auth/dev")
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "auth.dev-token-enabled",
+        havingValue = "true",
+        matchIfMissing = false
+)
+public class DevAuthController {
+
+    private static final String DEV_DEVICE_ID = "dev-device";
+    private static final int EXPIRES_IN = 900;
+
+    private final JwtTokenService jwtTokenService;
+    private final UserRepository userRepository;
+
+    @PostMapping("/token")
+    public ResponseEntity<ApiResponse<DevTokenResponse>> issueDevToken(
+            @Valid @RequestBody DevTokenRequest request) {
+        var user = userRepository.findById(request.userId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String token = jwtTokenService.generateAccessToken(
+                user.getId().toString(),
+                DEV_DEVICE_ID,
+                user.isMinor()
+        );
+
+        return ResponseEntity.ok(ApiResponse.ok(new DevTokenResponse(token, EXPIRES_IN)));
+    }
+}

--- a/src/main/java/com/mio/auth/dto/DevTokenRequest.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenRequest.java
@@ -1,0 +1,11 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record DevTokenRequest(
+        @NotNull @JsonProperty("user_id") UUID userId
+) {
+}

--- a/src/main/java/com/mio/auth/dto/DevTokenResponse.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenResponse.java
@@ -1,0 +1,9 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record DevTokenResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") int expiresIn
+) {
+}

--- a/src/main/resources/application-local.yml.example
+++ b/src/main/resources/application-local.yml.example
@@ -23,3 +23,6 @@ logging:
 
 notification:
   test-endpoint-enabled: true
+
+auth:
+  dev-token-enabled: true

--- a/src/test/java/com/mio/auth/controller/DevAuthControllerTest.java
+++ b/src/test/java/com/mio/auth/controller/DevAuthControllerTest.java
@@ -1,0 +1,26 @@
+package com.mio.auth.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DevAuthControllerTest {
+
+    @Test
+    @DisplayName("개발용 JWT 발급 컨트롤러는 local profile과 명시 property가 모두 필요하다")
+    void devAuthControllerRequiresLocalProfileAndExplicitProperty() {
+        Profile profile = DevAuthController.class.getAnnotation(Profile.class);
+        ConditionalOnProperty condition = DevAuthController.class.getAnnotation(ConditionalOnProperty.class);
+
+        assertThat(profile).isNotNull();
+        assertThat(profile.value()).containsExactly("local");
+
+        assertThat(condition).isNotNull();
+        assertThat(condition.name()).containsExactly("auth.dev-token-enabled");
+        assertThat(condition.havingValue()).isEqualTo("true");
+        assertThat(condition.matchIfMissing()).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

- `POST /v1/auth/dev/token` 엔드포인트 추가 — `user_id`(UUID)를 받아 `access_token` 반환
- `@ConditionalOnProperty(auth.dev-token-enabled=true)` 로 프로덕션 노출 차단 (`NotificationTestController`와 동일 패턴)
- `application-local.yml.example`에 `auth.dev-token-enabled: true` 추가

## 사용법

```bash
curl -X POST http://localhost:8080/v1/auth/dev/token \
  -H "Content-Type: application/json" \
  -d '{"user_id": "<UUID>"}'
```

응답:
```json
{
  "success": true,
  "data": {
    "access_token": "eyJ...",
    "expires_in": 900
  }
}
```

## Test plan

- [ ] `application-local.yml`에 `auth.dev-token-enabled: true` 설정 후 `/v1/auth/dev/token` 호출 → 토큰 발급 확인
- [ ] 발급받은 토큰으로 인증 필요 엔드포인트 호출 → 인증 성공 확인
- [ ] `auth.dev-token-enabled` 미설정(기본값 false) 시 엔드포인트 404 확인
- [ ] 존재하지 않는 `user_id` 요청 시 404 반환 확인

Closes #95

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Developer token generation for local development/testing, returning an access token valid for 15 minutes (900s) when enabled via config.

* **Documentation**
  * Example local configuration updated to show how to enable the developer token feature.

* **Tests**
  * Added tests to ensure the developer token endpoint is only active under the intended local/config conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->