### PR TITLE
fix: allow dev token pilot telemetry

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -58,6 +58,7 @@ public class AiDecisionLogger {
                     .policyVersion(decision.policyVersion())
                     .promptVersion(PROMPT_VERSION)
                     .securityLevel(decision.securityLevel().name())
+                    .riskLevel(decision.riskLevel() != null ? decision.riskLevel().name() : null)
                     .generationMode(decision.generationMode().name())
                     .deliveryMode(decision.deliveryMode().name())
                     .action(decision.action().name())

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -33,6 +33,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private static final Set<String> WHITELIST = Set.of(
             "POST /v1/auth/login",
             "POST /v1/auth/refresh",
+            "POST /v1/auth/dev/token",
             "GET /v1/health"
     );
 
@@ -41,6 +42,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
+        if ("/error".equals(request.getRequestURI())) {
+            return true;
+        }
         String key = request.getMethod() + " " + request.getRequestURI();
         return WHITELIST.contains(key);
     }

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.mio.config;
 
 import com.mio.auth.filter.JwtAuthenticationFilter;
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +23,7 @@ public class SecurityConfig {
 
     private static final String[] PUBLIC_ENDPOINTS = {
             "/actuator/health",
+            "/error",
             "/v1/auth/**",
             "/api-docs/**",
             "/swagger-ui/**",
@@ -35,6 +37,7 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC, DispatcherType.ERROR).permitAll()
                         .requestMatchers(PUBLIC_ENDPOINTS).permitAll()
                         .anyRequest().authenticated())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -1,0 +1,69 @@
+package com.mio.ai.orchestrator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.domain.AiPolicyDecision;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.repository.AiPolicyDecisionRepository;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.security.SecurityAssessment;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class AiDecisionLoggerTest {
+
+    private final AiPolicyDecisionRepository repository = mock(AiPolicyDecisionRepository.class);
+    private final AiDecisionLogger logger = new AiDecisionLogger(repository, new ObjectMapper());
+
+    @Test
+    @DisplayName("정책 결정의 risk_level을 집계 컬럼에도 저장한다")
+    void logPersistsRiskLevelColumn() {
+        PolicyDecision decision = new PolicyDecision(
+                "pd_test",
+                DecisionAction.GENERATE,
+                GenerationMode.NORMAL,
+                DeliveryMode.SPECULATIVE,
+                SecurityLevel.CLEAN,
+                true,
+                true,
+                false,
+                InterventionHints.empty(),
+                "test-policy",
+                RiskLevel.CLEAR_LOW
+        );
+
+        logger.log(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(),
+                SecurityAssessment.clean(),
+                100,
+                10,
+                false,
+                false,
+                null,
+                null
+        );
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getRiskLevel()).isEqualTo("CLEAR_LOW");
+    }
+}

--- a/src/test/java/com/mio/auth/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/mio/auth/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,43 @@
+package com.mio.auth.filter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.auth.service.JwtTokenService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class JwtAuthenticationFilterTest {
+
+    private final TestableJwtAuthenticationFilter filter =
+            new TestableJwtAuthenticationFilter(mock(JwtTokenService.class), new ObjectMapper());
+
+    @Test
+    @DisplayName("개발용 JWT 발급 엔드포인트는 인증 필터를 건너뛴다")
+    void devTokenEndpointSkipsJwtFilter() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/v1/auth/dev/token");
+
+        assertThat(filter.exposedShouldNotFilter(request)).isTrue();
+    }
+
+    @Test
+    @DisplayName("에러 dispatch는 인증 필터를 건너뛴다")
+    void errorDispatchSkipsJwtFilter() {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/error");
+
+        assertThat(filter.exposedShouldNotFilter(request)).isTrue();
+    }
+
+    private static class TestableJwtAuthenticationFilter extends JwtAuthenticationFilter {
+
+        TestableJwtAuthenticationFilter(JwtTokenService jwtTokenService, ObjectMapper objectMapper) {
+            super(jwtTokenService, objectMapper);
+        }
+
+        boolean exposedShouldNotFilter(MockHttpServletRequest request) {
+            return shouldNotFilter(request);
+        }
+    }
+}


### PR DESCRIPTION
## Why
During the Phase 2 real-LLM pilot, the dev token endpoint was still blocked by the JWT filter whitelist, SSE async/error dispatches produced access-denied noise after the response was committed, and `ai_policy_decisions.risk_level` stayed null even though trace risk was present.

## What
- whitelist `POST /v1/auth/dev/token` in `JwtAuthenticationFilter`
- permit ASYNC/ERROR dispatcher types for SSE completion/error dispatches
- persist `PolicyDecision.riskLevel` into the `ai_policy_decisions.risk_level` column
- add focused regression tests

## Test Plan
- `./gradlew test --tests "com.mio.auth.filter.JwtAuthenticationFilterTest" --tests "com.mio.ai.orchestrator.AiDecisionLoggerTest" --tests "com.mio.auth.controller.DevAuthControllerTest"`
- `./gradlew test`

Follow-up to #96.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed null pointer exceptions when AI risk levels are not available
  * Improved error request handling by bypassing JWT authentication for error dispatches
  * Added development token endpoint to authentication bypass allowlist

* **Tests**
  * Added test coverage for AI decision logging with null risk levels
  * Added test coverage for JWT filter bypass behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->