### PR TITLE
feat: Phase 3-2 Working Memory 풀 구현 — Redis 세션 버퍼 + SessionDelta 확장

### DIFF
--- a/src/main/java/com/mio/ai/memory/working/SessionDelta.java
+++ b/src/main/java/com/mio/ai/memory/working/SessionDelta.java
@@ -1,14 +1,19 @@
 package com.mio.ai.memory.working;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public record SessionDelta(
         int socraticQuestionsUsed,
-        Map<String, Integer> distortionCounts
+        Map<String, Integer> distortionCounts,
+        int sessionRiskAccumulation,
+        Set<String> activatedBeliefIds,
+        Set<String> currentSessionTriggers
 ) {
     public static SessionDelta empty() {
-        return new SessionDelta(0, new HashMap<>());
+        return new SessionDelta(0, new HashMap<>(), 0, new HashSet<>(), new HashSet<>());
     }
 
     public boolean socraticLimitReached() {

--- a/src/main/java/com/mio/ai/memory/working/SessionDelta.java
+++ b/src/main/java/com/mio/ai/memory/working/SessionDelta.java
@@ -1,7 +1,5 @@
 package com.mio.ai.memory.working;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,7 +11,7 @@ public record SessionDelta(
         Set<String> currentSessionTriggers
 ) {
     public static SessionDelta empty() {
-        return new SessionDelta(0, new HashMap<>(), 0, new HashSet<>(), new HashSet<>());
+        return new SessionDelta(0, Map.of(), 0, Set.of(), Set.of());
     }
 
     public boolean socraticLimitReached() {

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -1,78 +1,194 @@
 package com.mio.ai.memory.working;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
+/**
+ * Phase 3-2 Working Memory — Redis 세션 버퍼.
+ *
+ * 키 구조:
+ *   session:{id}:messages  → List (최근 10턴 = 20개, LPUSH 최신 우선)
+ *   session:{id}:working   → Hash (socratic_count, distortion:*, risk_accumulation)
+ *   session:{id}:beliefs   → Set  (activatedBeliefIds)
+ *   session:{id}:triggers  → Set  (currentSessionTriggers)
+ */
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class WorkingMemory {
 
-    private static final String KEY_PREFIX = "session:%s:working";
-    private static final String FIELD_SOCRATIC_COUNT = "socratic_count";
+    private static final int MAX_MESSAGES = 20; // 10턴 = user + assistant × 10
+
+    private static final String MESSAGES_KEY  = "session:%s:messages";
+    private static final String WORKING_KEY   = "session:%s:working";
+    private static final String BELIEFS_KEY   = "session:%s:beliefs";
+    private static final String TRIGGERS_KEY  = "session:%s:triggers";
+
+    private static final String FIELD_SOCRATIC_COUNT   = "socratic_count";
+    private static final String FIELD_RISK_ACCUMULATION = "risk_accumulation";
     private static final String FIELD_DISTORTION_PREFIX = "distortion:";
+
     private static final Duration SESSION_TTL = Duration.ofMinutes(90);
 
     private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    // ── 메시지 버퍼 ─────────────────────────────────────────────
+
+    public void appendMessage(UUID sessionId, String role, String content) {
+        String key = messagesKey(sessionId);
+        String json = serialize(new WorkingMessage(role, content, System.currentTimeMillis()));
+        if (json == null) return;
+
+        redisTemplate.opsForList().leftPush(key, json);
+        redisTemplate.opsForList().trim(key, 0, MAX_MESSAGES - 1);
+        redisTemplate.expire(key, SESSION_TTL);
+    }
+
+    public List<WorkingMessage> getRecentMessages(UUID sessionId) {
+        List<String> raw = redisTemplate.opsForList().range(messagesKey(sessionId), 0, MAX_MESSAGES - 1);
+        if (raw == null || raw.isEmpty()) return Collections.emptyList();
+
+        return raw.stream()
+                .map(this::deserialize)
+                .filter(m -> m != null)
+                // LPUSH 순서는 최신이 앞 → 오래된 순서로 뒤집어 반환
+                .collect(java.util.stream.Collectors.collectingAndThen(
+                        java.util.stream.Collectors.toList(),
+                        list -> { Collections.reverse(list); return list; }
+                ));
+    }
+
+    // ── CBT 카운터 ───────────────────────────────────────────────
 
     public int getSocraticQuestionCount(UUID sessionId) {
-        String value = (String) redisTemplate.opsForHash()
-                .get(key(sessionId), FIELD_SOCRATIC_COUNT);
+        String value = (String) redisTemplate.opsForHash().get(workingKey(sessionId), FIELD_SOCRATIC_COUNT);
         return parseIntSafe(value);
     }
 
     public void incrementSocraticQuestionCount(UUID sessionId) {
-        String k = key(sessionId);
+        String k = workingKey(sessionId);
         redisTemplate.opsForHash().increment(k, FIELD_SOCRATIC_COUNT, 1);
         redisTemplate.expire(k, SESSION_TTL);
     }
 
     public int getDistortionCount(UUID sessionId, String distortionCode) {
         String value = (String) redisTemplate.opsForHash()
-                .get(key(sessionId), FIELD_DISTORTION_PREFIX + distortionCode);
+                .get(workingKey(sessionId), FIELD_DISTORTION_PREFIX + distortionCode);
         return parseIntSafe(value);
     }
 
     public void incrementDistortionCount(UUID sessionId, String distortionCode) {
-        String k = key(sessionId);
+        String k = workingKey(sessionId);
         redisTemplate.opsForHash().increment(k, FIELD_DISTORTION_PREFIX + distortionCode, 1);
         redisTemplate.expire(k, SESSION_TTL);
     }
 
+    // ── 리스크 누적 ──────────────────────────────────────────────
+
+    public void incrementRiskAccumulation(UUID sessionId) {
+        String k = workingKey(sessionId);
+        redisTemplate.opsForHash().increment(k, FIELD_RISK_ACCUMULATION, 1);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
+    // ── 활성 신념 / 트리거 태그 ───────────────────────────────────
+
+    public void addActivatedBeliefId(UUID sessionId, String beliefId) {
+        String k = beliefsKey(sessionId);
+        redisTemplate.opsForSet().add(k, beliefId);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
+    public void addSessionTrigger(UUID sessionId, String triggerTag) {
+        String k = triggersKey(sessionId);
+        redisTemplate.opsForSet().add(k, triggerTag);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
+    // ── 전체 조회 ────────────────────────────────────────────────
+
     public SessionDelta getSessionDelta(UUID sessionId) {
-        Map<Object, Object> entries = redisTemplate.opsForHash().entries(key(sessionId));
+        Map<Object, Object> workingEntries = redisTemplate.opsForHash().entries(workingKey(sessionId));
+        Set<String> beliefIds = redisTemplate.opsForSet().members(beliefsKey(sessionId));
+        Set<String> triggers  = redisTemplate.opsForSet().members(triggersKey(sessionId));
 
         int socraticCount = 0;
+        int riskAccumulation = 0;
         Map<String, Integer> distortionCounts = new HashMap<>();
 
-        for (Map.Entry<Object, Object> entry : entries.entrySet()) {
+        for (Map.Entry<Object, Object> entry : workingEntries.entrySet()) {
             String field = (String) entry.getKey();
             String value = (String) entry.getValue();
 
             if (FIELD_SOCRATIC_COUNT.equals(field)) {
                 socraticCount = parseIntSafe(value);
+            } else if (FIELD_RISK_ACCUMULATION.equals(field)) {
+                riskAccumulation = parseIntSafe(value);
             } else if (field.startsWith(FIELD_DISTORTION_PREFIX)) {
                 String code = field.substring(FIELD_DISTORTION_PREFIX.length());
                 distortionCounts.put(code, parseIntSafe(value));
             }
         }
 
-        return new SessionDelta(socraticCount, distortionCounts);
+        return new SessionDelta(
+                socraticCount,
+                distortionCounts,
+                riskAccumulation,
+                beliefIds != null ? beliefIds : new HashSet<>(),
+                triggers  != null ? triggers  : new HashSet<>()
+        );
     }
+
+    // ── 세션 종료 ─────────────────────────────────────────────────
 
     public void clear(UUID sessionId) {
-        redisTemplate.delete(key(sessionId));
+        redisTemplate.delete(List.of(
+                messagesKey(sessionId),
+                workingKey(sessionId),
+                beliefsKey(sessionId),
+                triggersKey(sessionId)
+        ));
     }
 
-    private String key(UUID sessionId) {
-        return KEY_PREFIX.formatted(sessionId);
+    // ── 키 빌더 ──────────────────────────────────────────────────
+
+    private String messagesKey(UUID sessionId)  { return MESSAGES_KEY.formatted(sessionId); }
+    private String workingKey(UUID sessionId)   { return WORKING_KEY.formatted(sessionId); }
+    private String beliefsKey(UUID sessionId)   { return BELIEFS_KEY.formatted(sessionId); }
+    private String triggersKey(UUID sessionId)  { return TRIGGERS_KEY.formatted(sessionId); }
+
+    // ── 직렬화 ───────────────────────────────────────────────────
+
+    private String serialize(WorkingMessage msg) {
+        try {
+            return objectMapper.writeValueAsString(msg);
+        } catch (JsonProcessingException e) {
+            log.warn("WorkingMemory: failed to serialize message", e);
+            return null;
+        }
+    }
+
+    private WorkingMessage deserialize(String json) {
+        try {
+            return objectMapper.readValue(json, WorkingMessage.class);
+        } catch (Exception e) {
+            log.warn("WorkingMemory: failed to deserialize message: {}", json, e);
+            return null;
+        }
     }
 
     private int parseIntSafe(String value) {

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -8,9 +8,9 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,7 +37,7 @@ public class WorkingMemory {
     private static final String BELIEFS_KEY   = "session:%s:beliefs";
     private static final String TRIGGERS_KEY  = "session:%s:triggers";
 
-    private static final String FIELD_SOCRATIC_COUNT   = "socratic_count";
+    private static final String FIELD_SOCRATIC_COUNT    = "socratic_count";
     private static final String FIELD_RISK_ACCUMULATION = "risk_accumulation";
     private static final String FIELD_DISTORTION_PREFIX = "distortion:";
 
@@ -49,27 +49,36 @@ public class WorkingMemory {
     // ── 메시지 버퍼 ─────────────────────────────────────────────
 
     public void appendMessage(UUID sessionId, String role, String content) {
-        String key = messagesKey(sessionId);
-        String json = serialize(new WorkingMessage(role, content, System.currentTimeMillis()));
-        if (json == null) return;
+        try {
+            String key = messagesKey(sessionId);
+            String json = serialize(new WorkingMessage(role, content, System.currentTimeMillis()));
+            if (json == null) return;
 
-        redisTemplate.opsForList().leftPush(key, json);
-        redisTemplate.opsForList().trim(key, 0, MAX_MESSAGES - 1);
-        redisTemplate.expire(key, SESSION_TTL);
+            redisTemplate.opsForList().leftPush(key, json);
+            redisTemplate.opsForList().trim(key, 0, MAX_MESSAGES - 1);
+            redisTemplate.expire(key, SESSION_TTL);
+        } catch (Exception e) {
+            log.warn("WorkingMemory.appendMessage failed for sessionId={} — skipping", sessionId, e);
+        }
     }
 
     public List<WorkingMessage> getRecentMessages(UUID sessionId) {
-        List<String> raw = redisTemplate.opsForList().range(messagesKey(sessionId), 0, MAX_MESSAGES - 1);
-        if (raw == null || raw.isEmpty()) return Collections.emptyList();
+        try {
+            List<String> raw = redisTemplate.opsForList().range(messagesKey(sessionId), 0, MAX_MESSAGES - 1);
+            if (raw == null || raw.isEmpty()) return Collections.emptyList();
 
-        return raw.stream()
-                .map(this::deserialize)
-                .filter(m -> m != null)
-                // LPUSH 순서는 최신이 앞 → 오래된 순서로 뒤집어 반환
-                .collect(java.util.stream.Collectors.collectingAndThen(
-                        java.util.stream.Collectors.toList(),
-                        list -> { Collections.reverse(list); return list; }
-                ));
+            List<WorkingMessage> messages = new ArrayList<>();
+            for (String json : raw) {
+                WorkingMessage msg = deserialize(json);
+                if (msg != null) messages.add(msg);
+            }
+            // LPUSH 순서는 최신이 앞 → 오래된 순서로 뒤집어 반환
+            Collections.reverse(messages);
+            return messages;
+        } catch (Exception e) {
+            log.warn("WorkingMemory.getRecentMessages failed for sessionId={} — returning empty", sessionId, e);
+            return Collections.emptyList();
+        }
     }
 
     // ── CBT 카운터 ───────────────────────────────────────────────
@@ -148,20 +157,24 @@ public class WorkingMemory {
                 socraticCount,
                 distortionCounts,
                 riskAccumulation,
-                beliefIds != null ? beliefIds : new HashSet<>(),
-                triggers  != null ? triggers  : new HashSet<>()
+                beliefIds != null ? beliefIds : Set.of(),
+                triggers  != null ? triggers  : Set.of()
         );
     }
 
     // ── 세션 종료 ─────────────────────────────────────────────────
 
     public void clear(UUID sessionId) {
-        redisTemplate.delete(List.of(
-                messagesKey(sessionId),
-                workingKey(sessionId),
-                beliefsKey(sessionId),
-                triggersKey(sessionId)
-        ));
+        try {
+            redisTemplate.delete(List.of(
+                    messagesKey(sessionId),
+                    workingKey(sessionId),
+                    beliefsKey(sessionId),
+                    triggersKey(sessionId)
+            ));
+        } catch (Exception e) {
+            log.warn("WorkingMemory.clear failed for sessionId={} — TTL will expire keys", sessionId, e);
+        }
     }
 
     // ── 키 빌더 ──────────────────────────────────────────────────

--- a/src/main/java/com/mio/ai/memory/working/WorkingMessage.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMessage.java
@@ -1,0 +1,15 @@
+package com.mio.ai.memory.working;
+
+public record WorkingMessage(
+        String role,
+        String content,
+        long timestampMs
+) {
+    public static WorkingMessage user(String content) {
+        return new WorkingMessage("user", content, System.currentTimeMillis());
+    }
+
+    public static WorkingMessage assistant(String content) {
+        return new WorkingMessage("assistant", content, System.currentTimeMillis());
+    }
+}

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -229,7 +229,11 @@ public class ConversationOrchestrator {
             // 8. Persist messages
             messagePersistenceService.saveConversation(sessionId, userId, userMessage, assistantContent, userSignal);
 
-            // 9. Log decision asynchronously
+            // 9. Working Memory — 메시지 버퍼에 이번 턴 기록
+            workingMemory.appendMessage(sessionId, "user", userMessage);
+            workingMemory.appendMessage(sessionId, "assistant", assistantContent);
+
+            // 10. Log decision
             long totalMs = System.currentTimeMillis() - startMs;
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -1,5 +1,6 @@
 package com.mio.session.service;
 
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -31,6 +32,7 @@ public class SessionService {
     private final UserRepository userRepository;
     private final SessionMessagePersistenceService sessionMessagePersistenceService;
     private final ConversationOrchestrator conversationOrchestrator;
+    private final WorkingMemory workingMemory;
 
     @Transactional
     public SessionResponse createSession(UUID userId, CreateSessionRequest request) {
@@ -87,7 +89,9 @@ public class SessionService {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
         session.end();
-        return EndSessionResponse.from(sessionRepository.save(session));
+        EndSessionResponse response = EndSessionResponse.from(sessionRepository.save(session));
+        workingMemory.clear(sessionId);
+        return response;
     }
 
     public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request, SseEmitter emitter) {

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -11,10 +11,12 @@ import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.core.NestedExceptionUtils;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Objects;
@@ -90,7 +92,13 @@ public class SessionService {
         }
         session.end();
         EndSessionResponse response = EndSessionResponse.from(sessionRepository.save(session));
-        workingMemory.clear(sessionId);
+        // Redis 정리는 트랜잭션 커밋 후 실행 — 커넥션 점유 최소화
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                workingMemory.clear(sessionId);
+            }
+        });
         return response;
     }
 

--- a/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
+++ b/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
@@ -1,0 +1,186 @@
+package com.mio.ai.memory.working;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.ListOperations;
+import org.springframework.data.redis.core.SetOperations;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+class WorkingMemoryTest {
+
+    private StringRedisTemplate redisTemplate;
+    private ListOperations<String, String> listOps;
+    private HashOperations<String, Object, Object> hashOps;
+    private SetOperations<String, String> setOps;
+    private WorkingMemory workingMemory;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redisTemplate = mock(StringRedisTemplate.class);
+        listOps = mock(ListOperations.class);
+        hashOps = mock(HashOperations.class);
+        setOps = mock(SetOperations.class);
+
+        given(redisTemplate.opsForList()).willReturn(listOps);
+        given(redisTemplate.opsForHash()).willReturn(hashOps);
+        given(redisTemplate.opsForSet()).willReturn(setOps);
+
+        workingMemory = new WorkingMemory(redisTemplate, objectMapper);
+    }
+
+    @Test
+    @DisplayName("appendMessage는 LPUSH 후 LTRIM(0, 19)을 실행한다")
+    void appendMessage_calls_lpush_and_ltrim() {
+        UUID sessionId = UUID.randomUUID();
+        given(listOps.leftPush(anyString(), anyString())).willReturn(1L);
+
+        workingMemory.appendMessage(sessionId, "user", "안녕하세요");
+
+        verify(listOps).leftPush(contains(sessionId.toString()), anyString());
+        verify(listOps).trim(contains(sessionId.toString()), eq(0L), eq(19L));
+        verify(redisTemplate).expire(contains(sessionId.toString()), eq(Duration.ofMinutes(90)));
+    }
+
+    @Test
+    @DisplayName("getRecentMessages는 LRANGE 결과를 오래된 순서로 반환한다")
+    void getRecentMessages_reverses_order_to_chronological() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        WorkingMessage oldest = new WorkingMessage("user", "첫 메시지", 1000L);
+        WorkingMessage newest = new WorkingMessage("assistant", "최신 응답", 2000L);
+
+        // Redis는 LPUSH 최신 우선 → 리스트 순서는 newest, oldest
+        List<String> redisOrder = List.of(
+                objectMapper.writeValueAsString(newest),
+                objectMapper.writeValueAsString(oldest)
+        );
+        given(listOps.range(anyString(), eq(0L), eq(19L))).willReturn(redisOrder);
+
+        List<WorkingMessage> result = workingMemory.getRecentMessages(sessionId);
+
+        assertThat(result).hasSize(2);
+        // 반환 순서는 오래된 것부터 (chronological)
+        assertThat(result.get(0).content()).isEqualTo("첫 메시지");
+        assertThat(result.get(1).content()).isEqualTo("최신 응답");
+    }
+
+    @Test
+    @DisplayName("getRecentMessages는 빈 리스트 반환 시 emptyList를 반환한다")
+    void getRecentMessages_empty_redis_returns_empty_list() {
+        UUID sessionId = UUID.randomUUID();
+        given(listOps.range(anyString(), anyLong(), anyLong())).willReturn(List.of());
+
+        List<WorkingMessage> result = workingMemory.getRecentMessages(sessionId);
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("getSocraticQuestionCount는 Redis hash에서 값을 읽는다")
+    void getSocraticQuestionCount_reads_from_hash() {
+        UUID sessionId = UUID.randomUUID();
+        given(hashOps.get(anyString(), eq("socratic_count"))).willReturn("2");
+
+        int count = workingMemory.getSocraticQuestionCount(sessionId);
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("null 값이면 0을 반환한다")
+    void getSocraticQuestionCount_null_returns_zero() {
+        UUID sessionId = UUID.randomUUID();
+        given(hashOps.get(anyString(), anyString())).willReturn(null);
+
+        int count = workingMemory.getSocraticQuestionCount(sessionId);
+
+        assertThat(count).isZero();
+    }
+
+    @Test
+    @DisplayName("incrementSocraticQuestionCount는 HINCRBY와 expire를 실행한다")
+    void incrementSocraticQuestionCount_increments_and_sets_ttl() {
+        UUID sessionId = UUID.randomUUID();
+        given(hashOps.increment(anyString(), anyString(), anyLong())).willReturn(1L);
+
+        workingMemory.incrementSocraticQuestionCount(sessionId);
+
+        verify(hashOps).increment(contains(sessionId.toString()), eq("socratic_count"), eq(1L));
+        verify(redisTemplate).expire(contains(sessionId.toString()), eq(Duration.ofMinutes(90)));
+    }
+
+    @Test
+    @DisplayName("getSessionDelta는 모든 필드를 합산하여 반환한다")
+    void getSessionDelta_aggregates_all_fields() {
+        UUID sessionId = UUID.randomUUID();
+
+        given(hashOps.entries(contains("working"))).willReturn(Map.of(
+                "socratic_count", "1",
+                "risk_accumulation", "3",
+                "distortion:catastrophizing", "2",
+                "distortion:all_or_nothing", "1"
+        ));
+        given(setOps.members(contains("beliefs"))).willReturn(Set.of("belief-uuid-1"));
+        given(setOps.members(contains("triggers"))).willReturn(Set.of("work_pressure", "family"));
+
+        SessionDelta delta = workingMemory.getSessionDelta(sessionId);
+
+        assertThat(delta.socraticQuestionsUsed()).isEqualTo(1);
+        assertThat(delta.sessionRiskAccumulation()).isEqualTo(3);
+        assertThat(delta.distortionCount("catastrophizing")).isEqualTo(2);
+        assertThat(delta.distortionCount("all_or_nothing")).isEqualTo(1);
+        assertThat(delta.activatedBeliefIds()).containsExactly("belief-uuid-1");
+        assertThat(delta.currentSessionTriggers()).containsExactlyInAnyOrder("work_pressure", "family");
+    }
+
+    @Test
+    @DisplayName("socraticLimitReached는 2회 이상 시 true다")
+    void socraticLimitReached_returns_true_at_two() {
+        SessionDelta delta2 = new SessionDelta(2, Map.of(), 0, Set.of(), Set.of());
+        SessionDelta delta1 = new SessionDelta(1, Map.of(), 0, Set.of(), Set.of());
+
+        assertThat(delta2.socraticLimitReached()).isTrue();
+        assertThat(delta1.socraticLimitReached()).isFalse();
+    }
+
+    @Test
+    @DisplayName("clear는 4개 키를 모두 삭제한다")
+    void clear_deletes_all_four_keys() {
+        UUID sessionId = UUID.randomUUID();
+
+        workingMemory.clear(sessionId);
+
+        verify(redisTemplate).delete(argThat((List<String> keys) ->
+                keys.size() == 4 && keys.stream().allMatch(k -> k.contains(sessionId.toString()))
+        ));
+    }
+
+    @Test
+    @DisplayName("addSessionTrigger는 SADD와 expire를 실행한다")
+    void addSessionTrigger_adds_to_set_and_sets_ttl() {
+        UUID sessionId = UUID.randomUUID();
+        given(setOps.add(anyString(), any(String[].class))).willReturn(1L);
+
+        workingMemory.addSessionTrigger(sessionId, "work_pressure");
+
+        verify(setOps).add(contains(sessionId.toString()), eq("work_pressure"));
+        verify(redisTemplate).expire(contains(sessionId.toString()), eq(Duration.ofMinutes(90)));
+    }
+}

--- a/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
+++ b/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
@@ -147,7 +147,7 @@ class PolicyEngineTest {
     @Test
     @DisplayName("소크라테스 2회 제한 도달 시 SUPPORTIVE 유지")
     void socratic_limit_reached_keeps_supportive() {
-        SessionDelta limitReached = new SessionDelta(2, new java.util.HashMap<>());
+        SessionDelta limitReached = new SessionDelta(2, new java.util.HashMap<>(), 0, new java.util.HashSet<>(), new java.util.HashSet<>());
         var combined = combined(SecurityLevel.CLEAN, false, true, false);
         var decision = policyEngine.decide(combined, judgeResult(RiskLevel.MEDIUM), null, limitReached);
         assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -1,5 +1,6 @@
 package com.mio.session.service;
 
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -40,6 +41,7 @@ class SessionServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private SessionMessagePersistenceService sessionMessagePersistenceService;
     @Mock private ConversationOrchestrator conversationOrchestrator;
+    @Mock private WorkingMemory workingMemory;
 
     private SessionService sessionService;
     private UUID userId;
@@ -48,7 +50,7 @@ class SessionServiceTest {
     @BeforeEach
     void setUp() {
         sessionService = new SessionService(
-                sessionRepository, userRepository, sessionMessagePersistenceService, conversationOrchestrator
+                sessionRepository, userRepository, sessionMessagePersistenceService, conversationOrchestrator, workingMemory
         );
         userId = UUID.randomUUID();
         mockUser = User.builder()

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -4,6 +4,9 @@ spring:
     username: mio
     password: mio
 
+  flyway:
+    validate-on-migrate: false
+
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 요약

Phase 3-2: Working Memory를 최근 10턴 메시지 버퍼 + 세션 내 누적 신호 관리로 확장한다. Phase 3-3 SessionConsolidator가 세션 종료 시 이 버퍼를 참조해 요약·임베딩·패턴 갱신을 수행한다.

## 관련 이슈

- Closes #99

## 변경 사항

### WorkingMessage (신규)
- `role`, `content`, `timestampMs` record

### WorkingMemory (확장)
- Redis 키 4개 관리: `session:{id}:messages`, `session:{id}:working`, `session:{id}:beliefs`, `session:{id}:triggers`
- `appendMessage(sessionId, role, content)`: LPUSH + LTRIM(0,19) — 10턴(20메시지) 상한
- `getRecentMessages(sessionId)`: LRANGE 후 chronological 정렬로 반환
- `incrementRiskAccumulation`, `addActivatedBeliefId`, `addSessionTrigger` 추가
- `clear(sessionId)`: 4개 키 전체 삭제

### SessionDelta (확장)
- `sessionRiskAccumulation`, `activatedBeliefIds`, `currentSessionTriggers` 필드 추가

### ConversationOrchestrator
- 매 턴 메시지 저장 후 `workingMemory.appendMessage` 호출 (user + assistant)

### SessionService
- `endSession()` 에서 `workingMemory.clear(sessionId)` 호출

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] Breaking change가 있습니다.

## 테스트

```bash
./gradlew test --tests "com.mio.ai.memory.working.WorkingMemoryTest"
```

- LPUSH + LTRIM(0,19) 실행 검증
- getRecentMessages chronological 정렬 확인
- getSessionDelta 전 필드 집계 검증
- clear 4개 키 삭제 검증
- socraticLimitReached 2회 판정

## 배포 / 롤백

- Rollout: Redis 기존 키 없으면 빈 값으로 자동 시작, 기존 세션 무영향
- Rollback: 코드 롤백 후 Redis TTL(90분) 만료 대기 또는 수동 DEL

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversations are recorded per-turn with timestamps.
  * Session state now tracks risk accumulation, activated beliefs, and session triggers.
  * APIs to append and read recent session messages and aggregate session state.

* **Bug Fixes**
  * Session cleanup now removes all session-related data after session end (post-commit).

* **Tests**
  * Added tests covering message buffering, counters, session aggregation, and cleanup.

* **Chores**
  * Test config adjusted to relax migration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->