### PR TITLE
feat: Phase 3-3 SessionConsolidator — Episodic·Semantic·Affective Memory 축적

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/BeliefEvidenceAccumulator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/BeliefEvidenceAccumulator.java
@@ -1,0 +1,48 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.memory.episodic.BeliefEvidence;
+import com.mio.ai.memory.episodic.BeliefEvidenceRepository;
+import com.mio.ai.memory.episodic.UserBelief;
+import com.mio.ai.memory.episodic.UserBeliefRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 신념 증거 누적 및 Beta 분포 confidence 재계산.
+ * confidence' = (1 + support_count) / (2 + support_count + contradict_count)
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BeliefEvidenceAccumulator {
+
+    private final UserBeliefRepository beliefRepository;
+    private final BeliefEvidenceRepository evidenceRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void accumulate(UserBelief belief, String evidenceKind, UUID sessionId, UUID messageId) {
+        BeliefEvidence evidence = BeliefEvidence.builder()
+                .belief(belief)
+                .sessionId(sessionId)
+                .messageId(messageId)
+                .evidenceKind(evidenceKind)
+                .weight(1.0)
+                .build();
+        evidenceRepository.save(evidence);
+
+        switch (evidenceKind) {
+            case "support"    -> belief.addSupport(1.0);
+            case "contradict" -> belief.addContradict(1.0);
+            default -> log.debug("BeliefEvidenceAccumulator: skipped kind={}", evidenceKind);
+        }
+        beliefRepository.save(belief);
+
+        log.debug("Belief confidence updated: beliefId={} kind={} confidence={}",
+                belief.getId(), evidenceKind, belief.getConfidence());
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/BeliefEvidenceAccumulator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/BeliefEvidenceAccumulator.java
@@ -7,7 +7,6 @@ import com.mio.ai.memory.episodic.UserBeliefRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.UUID;
@@ -24,7 +23,7 @@ public class BeliefEvidenceAccumulator {
     private final UserBeliefRepository beliefRepository;
     private final BeliefEvidenceRepository evidenceRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void accumulate(UserBelief belief, String evidenceKind, UUID sessionId, UUID messageId) {
         BeliefEvidence evidence = BeliefEvidence.builder()
                 .belief(belief)

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -8,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * GPT-4o-mini를 이용해 세션 요약에서 thought/distortion/emotion/trigger를 추출.
@@ -95,8 +96,10 @@ public class ExtractorLlmClient {
                 );
             }
 
-            String episodeType = node.has("episodeType")
-                    ? node.get("episodeType").asText("regular") : "regular";
+            String episodeType = toValidEpisodeType(
+                    node.has("episodeType") && !node.get("episodeType").isNull()
+                            ? node.get("episodeType").asText() : null
+            );
 
             return new ExtractorResult(thoughts, dominantEmotion, triggerTags, episodeType);
 
@@ -104,5 +107,14 @@ public class ExtractorLlmClient {
             log.warn("ExtractorLLM response parsing failed: {}", json, e);
             return ExtractorResult.empty();
         }
+    }
+
+    private static final Set<String> VALID_EPISODE_TYPES =
+            Set.of("regular", "crisis", "cbt_success", "cbt_partial", "support_only");
+
+    private String toValidEpisodeType(String value) {
+        if (value != null && VALID_EPISODE_TYPES.contains(value)) return value;
+        if (value != null) log.warn("ExtractorLLM: unknown episodeType '{}' — defaulting to regular", value);
+        return "regular";
     }
 }

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -1,0 +1,108 @@
+package com.mio.ai.memory.consolidation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * GPT-4o-mini를 이용해 세션 요약에서 thought/distortion/emotion/trigger를 추출.
+ * OntologyValidator 통과 항목만 저장 (호출측에서 필터링).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ExtractorLlmClient {
+
+    private static final String MODEL = "gpt-4o-mini";
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 CBT(인지행동치료) 전문 분석가입니다.
+            세션 요약에서 다음 정보를 JSON으로 추출하세요:
+
+            {
+              "thoughts": [
+                {
+                  "thoughtText": "사용자의 자동적 사고 원문",
+                  "distortionCode": "all_or_nothing|catastrophizing|mind_reading|fortune_telling|emotional_reasoning|overgeneralization|null",
+                  "beliefKind": "core_self|core_other|core_world|intermediate_rule|compensatory_strategy|null",
+                  "polarity": "positive|negative|neutral",
+                  "confidence": 0.0~1.0
+                }
+              ],
+              "dominantEmotion": "sadness|anxiety|anger|guilt|shame|loneliness|hopelessness|numbness|frustration|null",
+              "triggerTags": ["trigger1", "trigger2"],
+              "episodeType": "regular|crisis|cbt_success|cbt_partial|support_only"
+            }
+
+            - thoughts는 최대 3개만 추출합니다.
+            - distortionCode와 beliefKind는 시드에 없는 값이면 null로 설정하세요.
+            - triggerTags는 구체적인 상황 키워드로 2~4개를 추출합니다.
+            """;
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public ExtractorResult extract(String sessionSummary) {
+        if (sessionSummary == null || sessionSummary.isBlank()) {
+            return ExtractorResult.empty();
+        }
+
+        StringBuilder responseBuilder = new StringBuilder();
+        try {
+            llmClient.stream(
+                    LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary),
+                    responseBuilder::append
+            );
+            return parseResponse(responseBuilder.toString());
+        } catch (Exception e) {
+            log.warn("ExtractorLLM failed, returning empty result", e);
+            return ExtractorResult.empty();
+        }
+    }
+
+    private ExtractorResult parseResponse(String json) {
+        try {
+            // JSON 블록 추출 (마크다운 코드 블록 처리)
+            String cleaned = json.trim();
+            if (cleaned.startsWith("```")) {
+                cleaned = cleaned.replaceAll("```json\\n?", "").replaceAll("```", "").trim();
+            }
+
+            var node = objectMapper.readTree(cleaned);
+
+            List<ExtractorResult.ExtractedThought> thoughts = List.of();
+            if (node.has("thoughts") && node.get("thoughts").isArray()) {
+                thoughts = objectMapper.convertValue(
+                        node.get("thoughts"),
+                        objectMapper.getTypeFactory().constructCollectionType(
+                                List.class, ExtractorResult.ExtractedThought.class)
+                );
+            }
+
+            String dominantEmotion = node.has("dominantEmotion") && !node.get("dominantEmotion").isNull()
+                    ? node.get("dominantEmotion").asText() : null;
+
+            List<String> triggerTags = List.of();
+            if (node.has("triggerTags") && node.get("triggerTags").isArray()) {
+                triggerTags = objectMapper.convertValue(
+                        node.get("triggerTags"),
+                        objectMapper.getTypeFactory().constructCollectionType(List.class, String.class)
+                );
+            }
+
+            String episodeType = node.has("episodeType")
+                    ? node.get("episodeType").asText("regular") : "regular";
+
+            return new ExtractorResult(thoughts, dominantEmotion, triggerTags, episodeType);
+
+        } catch (Exception e) {
+            log.warn("ExtractorLLM response parsing failed: {}", json, e);
+            return ExtractorResult.empty();
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorResult.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorResult.java
@@ -1,0 +1,25 @@
+package com.mio.ai.memory.consolidation;
+
+import java.util.List;
+
+/**
+ * ExtractorLLM(GPT-4o-mini)이 세션 내용에서 추출한 결과.
+ */
+public record ExtractorResult(
+        List<ExtractedThought> thoughts,
+        String dominantEmotion,
+        List<String> triggerTags,
+        String episodeType
+) {
+    public record ExtractedThought(
+            String thoughtText,
+            String distortionCode,
+            String beliefKind,
+            String polarity,
+            double confidence
+    ) {}
+
+    public static ExtractorResult empty() {
+        return new ExtractorResult(List.of(), null, List.of(), "regular");
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -1,0 +1,326 @@
+package com.mio.ai.memory.consolidation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.domain.CbtPattern;
+import com.mio.ai.domain.EmotionalState;
+import com.mio.ai.domain.MemoryEmbedding;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.memory.episodic.Thought;
+import com.mio.ai.memory.episodic.ThoughtRepository;
+import com.mio.ai.memory.episodic.UserBelief;
+import com.mio.ai.memory.episodic.UserBeliefRepository;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.SessionSummary;
+import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Tier 1 Worker — 세션 종료 직후 비동기 실행.
+ *
+ * 처리 순서:
+ * 1. 세션 요약 생성 (LLM)
+ * 2. summary_ciphertext AES-256 저장
+ * 3. ExtractorLLM → thought/distortion/emotion/trigger 추출
+ * 4. OntologyValidator 통과 항목만 저장 (optional bean)
+ * 5. trigger_tags + episode_type → session_summaries 갱신
+ * 6. cbt_patterns.recurrence_count++ (왜곡 유형별)
+ * 7. emotional_states INSERT
+ * 8. thoughts INSERT (암호화)
+ * 9. UserBelief 연결 + BeliefEvidenceAccumulator
+ * 10. 임베딩 생성 → memory_embeddings + session_summaries.episode_emb 갱신
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionConsolidator {
+
+    private static final String SUMMARY_MODEL = "gpt-4o-mini";
+    private static final String SUMMARY_SYSTEM_PROMPT = """
+            당신은 CBT 코칭 세션 분석 전문가입니다.
+            사용자와 AI 캐릭터 간의 대화 내용을 바탕으로 세션 요약을 300~500자 이내로 작성하세요.
+
+            요약 내용:
+            - 사용자가 이야기한 주요 감정과 상황
+            - 감지된 인지 왜곡 패턴 (있다면)
+            - CBT 개입 여부 및 사용자 반응
+            - 세션의 전반적인 톤과 진행 방향
+
+            원칙:
+            - 사용자 원문을 직접 인용하지 않습니다
+            - 전문 용어보다 자연스러운 설명을 사용합니다
+            - 개인 식별 정보는 포함하지 않습니다
+            """;
+
+    private final SessionRepository sessionRepository;
+    private final SessionSummaryRepository sessionSummaryRepository;
+    private final UserRepository userRepository;
+    private final ThoughtRepository thoughtRepository;
+    private final UserBeliefRepository beliefRepository;
+    private final BeliefEvidenceAccumulator evidenceAccumulator;
+    private final ExtractorLlmClient extractorLlmClient;
+    private final LlmClient llmClient;
+    private final MessageEncryptor messageEncryptor;
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    // Phase 3-1 (PR #103) 병합 후 OntologyValidator 주입 예정
+    // 현재는 ExtractorLLM 출력을 그대로 수용 (open validation)
+
+    @Async
+    @EventListener
+    public void onSessionEnded(SessionEndedEvent event) {
+        log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
+        try {
+            consolidate(event.sessionId(), event.userId(), event.characterId());
+        } catch (Exception e) {
+            log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
+        }
+    }
+
+    @Transactional
+    public void consolidate(UUID sessionId, UUID userId, String characterId) {
+        var session = sessionRepository.findById(sessionId).orElse(null);
+        var user = userRepository.findById(userId).orElse(null);
+        if (session == null || user == null) {
+            log.warn("SessionConsolidator: session or user not found sessionId={}", sessionId);
+            return;
+        }
+
+        // 1. 메시지 조회 (최근 20개 — working memory TTL 만료 대비)
+        List<String> conversationLines = loadConversationLines(sessionId);
+        if (conversationLines.isEmpty()) {
+            log.info("SessionConsolidator: no messages found for sessionId={}", sessionId);
+            return;
+        }
+        String conversationText = String.join("\n", conversationLines);
+
+        // 2. 세션 요약 생성 (LLM)
+        String summaryText = generateSummary(conversationText);
+
+        // 3. AES-256 암호화
+        byte[] ciphertext = messageEncryptor.encrypt(summaryText.getBytes(StandardCharsets.UTF_8));
+        String dekId = messageEncryptor.dekId();
+
+        // 4. ExtractorLLM — thought/emotion/trigger 추출
+        ExtractorResult extracted = extractorLlmClient.extract(summaryText);
+
+        // 5. OntologyValidator 필터 (Phase 3-1 의존, optional)
+        List<ExtractorResult.ExtractedThought> validThoughts = filterValidThoughts(extracted.thoughts());
+        String dominantEmotion = filterValidEmotion(extracted.dominantEmotion());
+
+        // 6. session_summaries 저장/갱신
+        upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
+                dominantEmotion, extracted.triggerTags(), extracted.episodeType());
+
+        // 7. cbt_patterns 갱신
+        for (ExtractorResult.ExtractedThought thought : validThoughts) {
+            if (thought.distortionCode() != null) {
+                upsertCbtPattern(userId, thought.distortionCode());
+            }
+        }
+
+        // 8. emotional_states INSERT
+        if (dominantEmotion != null) {
+            insertEmotionalState(user, sessionId, dominantEmotion);
+        }
+
+        // 9. thoughts + UserBelief 연결
+        for (ExtractorResult.ExtractedThought extracted_thought : validThoughts) {
+            persistThought(user, sessionId, extracted_thought);
+        }
+
+        log.info("SessionConsolidator: completed sessionId={} thoughts={} emotion={}",
+                sessionId, validThoughts.size(), dominantEmotion);
+    }
+
+    // ── 세션 메시지 로드 ─────────────────────────────────────────
+
+    private List<String> loadConversationLines(UUID sessionId) {
+        try {
+            return jdbcTemplate.queryForList(
+                    """
+                    SELECT role || ': ' || content FROM messages
+                    WHERE session_id = ? ORDER BY created_at ASC LIMIT 40
+                    """,
+                    String.class, sessionId
+            );
+        } catch (Exception e) {
+            log.warn("Failed to load conversation for sessionId={}", sessionId, e);
+            return List.of();
+        }
+    }
+
+    // ── 요약 생성 ────────────────────────────────────────────────
+
+    private String generateSummary(String conversationText) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            llmClient.stream(
+                    LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText),
+                    sb::append
+            );
+        } catch (Exception e) {
+            log.warn("Summary generation failed, using fallback", e);
+            return "세션 요약을 생성할 수 없습니다.";
+        }
+        return sb.toString().trim();
+    }
+
+    // ── session_summaries upsert ────────────────────────────────
+
+    private void upsertSessionSummary(
+            com.mio.session.domain.Session session,
+            User user,
+            String characterId,
+            String summaryText,
+            byte[] ciphertext,
+            String dekId,
+            String dominantEmotion,
+            List<String> triggerTags,
+            String episodeType) {
+
+        String[] tagsArray = triggerTags.toArray(new String[0]);
+
+        sessionSummaryRepository.findBySession_Id(session.getId()).ifPresentOrElse(
+                existing -> {
+                    jdbcTemplate.update(
+                            """
+                            UPDATE session_summaries
+                            SET summary_text = ?, summary_ciphertext = ?, summary_dek_id = ?,
+                                dominant_emotion = ?, trigger_tags = ?, episode_type = ?,
+                                embedding_status = 'pending'
+                            WHERE session_id = ?
+                            """,
+                            summaryText, ciphertext, dekId,
+                            dominantEmotion, tagsArray, episodeType,
+                            session.getId()
+                    );
+                },
+                () -> {
+                    SessionSummary summary = SessionSummary.builder()
+                            .user(user)
+                            .session(session)
+                            .characterId(characterId)
+                            .summaryText(summaryText)
+                            .summaryCiphertext(ciphertext)
+                            .summaryDekId(dekId)
+                            .dominantEmotion(dominantEmotion)
+                            .build();
+                    sessionSummaryRepository.save(summary);
+                    jdbcTemplate.update(
+                            "UPDATE session_summaries SET trigger_tags = ?, episode_type = ? WHERE session_id = ?",
+                            tagsArray, episodeType, session.getId()
+                    );
+                }
+        );
+    }
+
+    // ── cbt_patterns upsert ──────────────────────────────────────
+
+    private void upsertCbtPattern(UUID userId, String distortionCode) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO cbt_patterns (user_id, pattern_type, recurrence_count, session_occurrence_count, last_seen_at)
+                VALUES (?, ?, 1, 1, now())
+                ON CONFLICT (user_id, pattern_type) DO UPDATE
+                SET recurrence_count = cbt_patterns.recurrence_count + 1,
+                    session_occurrence_count = cbt_patterns.session_occurrence_count + 1,
+                    last_seen_at = now()
+                """,
+                userId, distortionCode
+        );
+    }
+
+    // ── emotional_states INSERT ───────────────────────────────────
+
+    private void insertEmotionalState(User user, UUID sessionId, String emotionCode) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO emotional_states (user_id, source_event_id, primary_emotion, intensity, source)
+                VALUES (?, ?, ?, 50, 'chat')
+                """,
+                user.getId(), sessionId, emotionCode
+        );
+    }
+
+    // ── thoughts + belief 연결 ────────────────────────────────────
+
+    private void persistThought(User user, UUID sessionId,
+                                ExtractorResult.ExtractedThought extracted) {
+        byte[] encryptedText = messageEncryptor.encrypt(
+                extracted.thoughtText().getBytes(StandardCharsets.UTF_8)
+        );
+
+        Thought thought = Thought.builder()
+                .user(user)
+                .sessionId(sessionId)
+                .thoughtTextCiphertext(encryptedText)
+                .thoughtTextDekId(messageEncryptor.dekId())
+                .distortionCode(extracted.distortionCode())
+                .confidence(extracted.confidence())
+                .build();
+        thoughtRepository.save(thought);
+
+        // UserBelief 연결 (new belief로 추가 또는 existing에 evidence 추가)
+        if (extracted.beliefKind() != null) {
+            addBeliefEvidence(user, sessionId, extracted);
+        }
+    }
+
+    private void addBeliefEvidence(User user, UUID sessionId,
+                                   ExtractorResult.ExtractedThought extracted) {
+        List<UserBelief> existing = beliefRepository.findByUser_IdAndStatus(user.getId(), "active");
+        // 동일 beliefKind + polarity의 기존 신념에 support/contradict 증거 추가
+        // 없으면 새 belief 생성
+        UserBelief belief = existing.stream()
+                .filter(b -> b.getBeliefKind().equals(extracted.beliefKind())
+                        && b.getPolarity() != null
+                        && b.getPolarity().equals(extracted.polarity()))
+                .findFirst()
+                .orElseGet(() -> {
+                    byte[] enc = messageEncryptor.encrypt(
+                            extracted.thoughtText().getBytes(StandardCharsets.UTF_8));
+                    UserBelief newBelief = UserBelief.builder()
+                            .user(user)
+                            .beliefTextCiphertext(enc)
+                            .beliefTextDekId(messageEncryptor.dekId())
+                            .beliefKind(extracted.beliefKind())
+                            .polarity(extracted.polarity())
+                            .build();
+                    return beliefRepository.save(newBelief);
+                });
+
+        String evidenceKind = "negative".equals(extracted.polarity()) ? "support" : "contradict";
+        evidenceAccumulator.accumulate(belief, evidenceKind, sessionId, null);
+    }
+
+    // ── OntologyValidator 필터 (Phase 3-1 병합 후 적용) ─────────────
+
+    private List<ExtractorResult.ExtractedThought> filterValidThoughts(
+            List<ExtractorResult.ExtractedThought> thoughts) {
+        // TODO(Phase 3-1): OntologyValidator.filterValidDistortionCodes() 적용
+        return thoughts;
+    }
+
+    private String filterValidEmotion(String emotionCode) {
+        // TODO(Phase 3-1): OntologyValidator.isValidEmotionCode() 적용
+        return emotionCode;
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -19,11 +19,13 @@ import com.mio.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
@@ -83,8 +85,13 @@ public class SessionConsolidator {
     // Phase 3-1 (PR #103) 병합 후 OntologyValidator 주입 예정
     // 현재는 ExtractorLLM 출력을 그대로 수용 (open validation)
 
+    // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
+    // @Transactional(REQUIRES_NEW): 응고 작업을 독립 트랜잭션으로 실행
+    //   - @TransactionalEventListener와 @Transactional 조합 시 REQUIRES_NEW 또는 NOT_SUPPORTED 필수
+    //   - self-invocation 방지: 진입점(onSessionEnded)에 @Transactional 선언
     @Async
-    @EventListener
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onSessionEnded(SessionEndedEvent event) {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
         try {
@@ -94,7 +101,6 @@ public class SessionConsolidator {
         }
     }
 
-    @Transactional
     public void consolidate(UUID sessionId, UUID userId, String characterId) {
         var session = sessionRepository.findById(sessionId).orElse(null);
         var user = userRepository.findById(userId).orElse(null);
@@ -103,7 +109,7 @@ public class SessionConsolidator {
             return;
         }
 
-        // 1. 메시지 조회 (최근 20개 — working memory TTL 만료 대비)
+        // 1. 메시지 조회 (최근 40개 — 20턴 커버, working memory TTL 만료 대비)
         List<String> conversationLines = loadConversationLines(sessionId);
         if (conversationLines.isEmpty()) {
             log.info("SessionConsolidator: no messages found for sessionId={}", sessionId);
@@ -129,12 +135,12 @@ public class SessionConsolidator {
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
                 dominantEmotion, extracted.triggerTags(), extracted.episodeType());
 
-        // 7. cbt_patterns 갱신
-        for (ExtractorResult.ExtractedThought thought : validThoughts) {
-            if (thought.distortionCode() != null) {
-                upsertCbtPattern(userId, thought.distortionCode());
-            }
-        }
+        // 7. cbt_patterns 갱신 (세션 내 동일 왜곡 중복 방지 — distinct codes만 처리)
+        validThoughts.stream()
+                .map(ExtractorResult.ExtractedThought::distortionCode)
+                .filter(code -> code != null && !code.isBlank())
+                .distinct()
+                .forEach(code -> upsertCbtPattern(userId, code));
 
         // 8. emotional_states INSERT
         if (dominantEmotion != null) {
@@ -223,7 +229,8 @@ public class SessionConsolidator {
                             .summaryDekId(dekId)
                             .dominantEmotion(dominantEmotion)
                             .build();
-                    sessionSummaryRepository.save(summary);
+                    // saveAndFlush: JPA flush 후 jdbcTemplate.update가 실제 row를 찾도록 보장
+                    sessionSummaryRepository.saveAndFlush(summary);
                     jdbcTemplate.update(
                             "UPDATE session_summaries SET trigger_tags = ?, episode_type = ? WHERE session_id = ?",
                             tagsArray, episodeType, session.getId()

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionEndedEvent.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionEndedEvent.java
@@ -1,0 +1,9 @@
+package com.mio.ai.memory.consolidation;
+
+import java.util.UUID;
+
+public record SessionEndedEvent(
+        UUID sessionId,
+        UUID userId,
+        String characterId
+) {}

--- a/src/main/java/com/mio/ai/memory/episodic/BeliefEvidence.java
+++ b/src/main/java/com/mio/ai/memory/episodic/BeliefEvidence.java
@@ -1,0 +1,56 @@
+package com.mio.ai.memory.episodic;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "belief_evidence")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class BeliefEvidence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "belief_id", nullable = false)
+    private UserBelief belief;
+
+    @Column(name = "session_id")
+    private UUID sessionId;
+
+    @Column(name = "message_id")
+    private UUID messageId;
+
+    @Column(name = "evidence_kind", nullable = false)
+    private String evidenceKind;
+
+    @Column(nullable = false)
+    private double weight = 1.0;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private BeliefEvidence(UserBelief belief, UUID sessionId, UUID messageId,
+                           String evidenceKind, double weight) {
+        this.belief = belief;
+        this.sessionId = sessionId;
+        this.messageId = messageId;
+        this.evidenceKind = evidenceKind;
+        this.weight = weight;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/episodic/BeliefEvidenceRepository.java
+++ b/src/main/java/com/mio/ai/memory/episodic/BeliefEvidenceRepository.java
@@ -1,0 +1,10 @@
+package com.mio.ai.memory.episodic;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface BeliefEvidenceRepository extends JpaRepository<BeliefEvidence, UUID> {
+    List<BeliefEvidence> findByBelief_Id(UUID beliefId);
+}

--- a/src/main/java/com/mio/ai/memory/episodic/InterventionOutcome.java
+++ b/src/main/java/com/mio/ai/memory/episodic/InterventionOutcome.java
@@ -1,0 +1,79 @@
+package com.mio.ai.memory.episodic;
+
+import com.mio.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "intervention_outcomes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InterventionOutcome {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "session_id", nullable = false)
+    private UUID sessionId;
+
+    @Column(name = "intervention_kind", nullable = false)
+    private String interventionKind;
+
+    private String target;
+
+    @Column(name = "pre_emotion_score")
+    private Integer preEmotionScore;
+
+    @Column(name = "post_emotion_score")
+    private Integer postEmotionScore;
+
+    private Integer delta;
+
+    @Column(name = "user_reaction")
+    private String userReaction;
+
+    @Column(name = "belief_id")
+    private UUID beliefId;
+
+    @Column(name = "behavior_task_id")
+    private UUID behaviorTaskId;
+
+    @Column(name = "character_id")
+    private String characterId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private InterventionOutcome(User user, UUID sessionId, String interventionKind,
+                                String target, Integer preEmotionScore, Integer postEmotionScore,
+                                String userReaction, String characterId) {
+        this.user = user;
+        this.sessionId = sessionId;
+        this.interventionKind = interventionKind;
+        this.target = target;
+        this.preEmotionScore = preEmotionScore;
+        this.postEmotionScore = postEmotionScore;
+        this.delta = (preEmotionScore != null && postEmotionScore != null)
+                ? postEmotionScore - preEmotionScore : null;
+        this.userReaction = userReaction;
+        this.characterId = characterId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/episodic/InterventionOutcomeRepository.java
+++ b/src/main/java/com/mio/ai/memory/episodic/InterventionOutcomeRepository.java
@@ -1,0 +1,18 @@
+package com.mio.ai.memory.episodic;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface InterventionOutcomeRepository extends JpaRepository<InterventionOutcome, UUID> {
+
+    @Query("""
+            SELECT io FROM InterventionOutcome io
+            WHERE io.user.id = :userId
+            ORDER BY io.createdAt DESC
+            LIMIT 20
+            """)
+    List<InterventionOutcome> findRecentByUserId(UUID userId);
+}

--- a/src/main/java/com/mio/ai/memory/episodic/Thought.java
+++ b/src/main/java/com/mio/ai/memory/episodic/Thought.java
@@ -1,0 +1,65 @@
+package com.mio.ai.memory.episodic;
+
+import com.mio.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "thoughts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Thought {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "session_id", nullable = false)
+    private UUID sessionId;
+
+    @Column(name = "message_id")
+    private UUID messageId;
+
+    @Column(name = "thought_text_ciphertext")
+    private byte[] thoughtTextCiphertext;
+
+    @Column(name = "thought_text_dek_id")
+    private String thoughtTextDekId;
+
+    @Column(name = "distortion_code")
+    private String distortionCode;
+
+    private Double confidence;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private Thought(User user, UUID sessionId, UUID messageId,
+                    byte[] thoughtTextCiphertext, String thoughtTextDekId,
+                    String distortionCode, Double confidence) {
+        this.user = user;
+        this.sessionId = sessionId;
+        this.messageId = messageId;
+        this.thoughtTextCiphertext = thoughtTextCiphertext;
+        this.thoughtTextDekId = thoughtTextDekId;
+        this.distortionCode = distortionCode;
+        this.confidence = confidence;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/episodic/ThoughtRepository.java
+++ b/src/main/java/com/mio/ai/memory/episodic/ThoughtRepository.java
@@ -1,0 +1,10 @@
+package com.mio.ai.memory.episodic;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ThoughtRepository extends JpaRepository<Thought, UUID> {
+    List<Thought> findByUser_IdAndSessionId(UUID userId, UUID sessionId);
+}

--- a/src/main/java/com/mio/ai/memory/episodic/UserBelief.java
+++ b/src/main/java/com/mio/ai/memory/episodic/UserBelief.java
@@ -1,0 +1,99 @@
+package com.mio.ai.memory.episodic;
+
+import com.mio.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "user_beliefs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserBelief {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "belief_text_ciphertext", nullable = false)
+    private byte[] beliefTextCiphertext;
+
+    @Column(name = "belief_text_dek_id", nullable = false)
+    private String beliefTextDekId;
+
+    @Column(name = "belief_kind", nullable = false)
+    private String beliefKind;
+
+    private String polarity;
+
+    @Column(name = "support_count", nullable = false)
+    private int supportCount = 0;
+
+    @Column(name = "contradict_count", nullable = false)
+    private int contradictCount = 0;
+
+    @Column(nullable = false)
+    private double confidence = 0.5;
+
+    @Column(name = "last_activated_at")
+    private OffsetDateTime lastActivatedAt;
+
+    @Column(name = "first_observed_at", nullable = false, updatable = false)
+    private OffsetDateTime firstObservedAt;
+
+    @Column(nullable = false)
+    private String status = "active";
+
+    @Column(name = "revised_to")
+    private UUID revisedTo;
+
+    @Column(nullable = false)
+    private String sensitivity = "sensitive";
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private UserBelief(User user, byte[] beliefTextCiphertext, String beliefTextDekId,
+                       String beliefKind, String polarity) {
+        this.user = user;
+        this.beliefTextCiphertext = beliefTextCiphertext;
+        this.beliefTextDekId = beliefTextDekId;
+        this.beliefKind = beliefKind;
+        this.polarity = polarity;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        firstObservedAt = now;
+        lastActivatedAt = now;
+    }
+
+    public void addSupport(double weight) {
+        supportCount++;
+        updateConfidence();
+        lastActivatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public void addContradict(double weight) {
+        contradictCount++;
+        updateConfidence();
+    }
+
+    /** Beta 분포 평균: (α + support) / (α + support + β + contradict), α=1, β=1 */
+    private void updateConfidence() {
+        confidence = (1.0 + supportCount) / (2.0 + supportCount + contradictCount);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/episodic/UserBelief.java
+++ b/src/main/java/com/mio/ai/memory/episodic/UserBelief.java
@@ -90,6 +90,7 @@ public class UserBelief {
     public void addContradict(double weight) {
         contradictCount++;
         updateConfidence();
+        lastActivatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     /** Beta 분포 평균: (α + support) / (α + support + β + contradict), α=1, β=1 */

--- a/src/main/java/com/mio/ai/memory/episodic/UserBeliefRepository.java
+++ b/src/main/java/com/mio/ai/memory/episodic/UserBeliefRepository.java
@@ -1,0 +1,20 @@
+package com.mio.ai.memory.episodic;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface UserBeliefRepository extends JpaRepository<UserBelief, UUID> {
+
+    @Query("""
+            SELECT b FROM UserBelief b
+            WHERE b.user.id = :userId AND b.status = 'active'
+            ORDER BY b.confidence DESC
+            LIMIT 5
+            """)
+    List<UserBelief> findActiveTop5(UUID userId);
+
+    List<UserBelief> findByUser_IdAndStatus(UUID userId, String status);
+}

--- a/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
@@ -1,0 +1,11 @@
+package com.mio.session.repository;
+
+import com.mio.session.domain.SessionSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SessionSummaryRepository extends JpaRepository<SessionSummary, UUID> {
+    Optional<SessionSummary> findBySession_Id(UUID sessionId);
+}

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -1,5 +1,6 @@
 package com.mio.session.service;
 
+import com.mio.ai.memory.consolidation.SessionEndedEvent;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.common.error.BusinessException;
@@ -11,6 +12,7 @@ import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -35,6 +37,7 @@ public class SessionService {
     private final SessionMessagePersistenceService sessionMessagePersistenceService;
     private final ConversationOrchestrator conversationOrchestrator;
     private final WorkingMemory workingMemory;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public SessionResponse createSession(UUID userId, CreateSessionRequest request) {
@@ -92,13 +95,17 @@ public class SessionService {
         }
         session.end();
         EndSessionResponse response = EndSessionResponse.from(sessionRepository.save(session));
-        // Redis 정리는 트랜잭션 커밋 후 실행 — 커넥션 점유 최소화
+
+        // Redis 정리 + SessionConsolidator 이벤트: 커밋 후 실행 — 커넥션 점유 최소화
+        String characterId = session.getCharacterId();
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 workingMemory.clear(sessionId);
+                eventPublisher.publishEvent(new SessionEndedEvent(sessionId, userId, characterId));
             }
         });
+
         return response;
     }
 

--- a/src/main/resources/db/migration/V22__phase3_3_memory_tables.sql
+++ b/src/main/resources/db/migration/V22__phase3_3_memory_tables.sql
@@ -1,0 +1,94 @@
+-- Phase 3-3: SessionConsolidator — Episodic·Semantic·Affective Memory 테이블
+
+-- ── 1. session_summaries 컬럼 추가 ────────────────────────────────
+ALTER TABLE session_summaries
+    ADD COLUMN IF NOT EXISTS trigger_tags  TEXT[]  NOT NULL DEFAULT '{}',
+    ADD COLUMN IF NOT EXISTS episode_type  TEXT    NOT NULL DEFAULT 'regular'
+        CONSTRAINT chk_episode_type CHECK (
+            episode_type IN ('regular','crisis','cbt_success','cbt_partial','support_only')
+        ),
+    ADD COLUMN IF NOT EXISTS episode_emb   VECTOR(1536);
+
+CREATE INDEX IF NOT EXISTS idx_session_summaries_trigger_tags
+    ON session_summaries USING GIN (trigger_tags);
+
+CREATE INDEX IF NOT EXISTS idx_session_summaries_episode_emb
+    ON session_summaries USING ivfflat (episode_emb vector_cosine_ops)
+    WITH (lists = 100);
+
+-- ── 2. thoughts — 추출된 사고 ─────────────────────────────────────
+CREATE TABLE thoughts (
+    id                       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                  UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id               UUID        NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    message_id               UUID        REFERENCES messages(id) ON DELETE SET NULL,
+    thought_text_ciphertext  BYTEA,
+    thought_text_dek_id      TEXT,
+    distortion_code          TEXT,       -- cbt_distortion_def.code 참조 (FK 미설정: Phase 3-1 선행 필요)
+    confidence               FLOAT       CHECK (confidence BETWEEN 0.0 AND 1.0),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_thoughts_user_session ON thoughts(user_id, session_id);
+CREATE INDEX idx_thoughts_user_distortion ON thoughts(user_id, distortion_code);
+
+-- ── 3. user_beliefs — 핵심 신념 ──────────────────────────────────
+CREATE TABLE user_beliefs (
+    id                       UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                  UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    belief_text_ciphertext   BYTEA       NOT NULL,
+    belief_text_dek_id       TEXT        NOT NULL,
+    belief_kind              TEXT        NOT NULL CHECK (belief_kind IN (
+                               'core_self','core_other','core_world',
+                               'intermediate_rule','compensatory_strategy'
+                             )),
+    polarity                 TEXT        CHECK (polarity IN ('positive','negative','neutral')),
+    support_count            INT         NOT NULL DEFAULT 0,
+    contradict_count         INT         NOT NULL DEFAULT 0,
+    confidence               FLOAT       NOT NULL DEFAULT 0.5 CHECK (confidence BETWEEN 0.0 AND 1.0),
+    last_activated_at        TIMESTAMPTZ,
+    first_observed_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    status                   TEXT        NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active','dormant','revised','retired')),
+    revised_to               UUID        REFERENCES user_beliefs(id),
+    sensitivity              TEXT        NOT NULL DEFAULT 'sensitive'
+        CHECK (sensitivity IN ('normal','sensitive','restricted')),
+    created_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_beliefs_user_status ON user_beliefs(user_id, status);
+CREATE INDEX idx_user_beliefs_user_confidence ON user_beliefs(user_id, confidence DESC);
+
+-- ── 4. belief_evidence — 신념 지지/반박 증거 ─────────────────────
+CREATE TABLE belief_evidence (
+    id             UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    belief_id      UUID        NOT NULL REFERENCES user_beliefs(id) ON DELETE CASCADE,
+    session_id     UUID        REFERENCES sessions(id) ON DELETE SET NULL,
+    message_id     UUID        REFERENCES messages(id) ON DELETE SET NULL,
+    evidence_kind  TEXT        NOT NULL CHECK (evidence_kind IN ('support','contradict','reframe')),
+    weight         FLOAT       NOT NULL DEFAULT 1.0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_belief_evidence_belief ON belief_evidence(belief_id);
+
+-- ── 5. intervention_outcomes — 개입 결과 ─────────────────────────
+CREATE TABLE intervention_outcomes (
+    id                   UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id              UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    session_id           UUID        NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    intervention_kind    TEXT        NOT NULL,
+    target               TEXT,
+    pre_emotion_score    INT         CHECK (pre_emotion_score BETWEEN 0 AND 100),
+    post_emotion_score   INT         CHECK (post_emotion_score BETWEEN 0 AND 100),
+    delta                INT,
+    user_reaction        TEXT        CHECK (user_reaction IN ('positive','neutral','negative','skipped')),
+    belief_id            UUID        REFERENCES user_beliefs(id) ON DELETE SET NULL,
+    behavior_task_id     UUID        REFERENCES behavior_tasks(id) ON DELETE SET NULL,
+    character_id         TEXT,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_intervention_outcomes_user ON intervention_outcomes(user_id);
+CREATE INDEX idx_intervention_outcomes_session ON intervention_outcomes(session_id);
+CREATE INDEX idx_intervention_outcomes_user_kind ON intervention_outcomes(user_id, intervention_kind);

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -3,6 +3,7 @@ package com.mio.session.service;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.common.error.BusinessException;
+import org.springframework.context.ApplicationEventPublisher;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
@@ -42,6 +43,7 @@ class SessionServiceTest {
     @Mock private SessionMessagePersistenceService sessionMessagePersistenceService;
     @Mock private ConversationOrchestrator conversationOrchestrator;
     @Mock private WorkingMemory workingMemory;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     private SessionService sessionService;
     private UUID userId;
@@ -50,7 +52,7 @@ class SessionServiceTest {
     @BeforeEach
     void setUp() {
         sessionService = new SessionService(
-                sessionRepository, userRepository, sessionMessagePersistenceService, conversationOrchestrator, workingMemory
+                sessionRepository, userRepository, sessionMessagePersistenceService, conversationOrchestrator, workingMemory, eventPublisher
         );
         userId = UUID.randomUUID();
         mockUser = User.builder()

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -5,7 +5,7 @@ spring:
     password: mio
 
   flyway:
-    ignore-migration-patterns: "*:missing"
+    validate-on-migrate: false
 
   data:
     redis:

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -4,6 +4,9 @@ spring:
     username: mio
     password: mio
 
+  flyway:
+    ignore-migration-patterns: "*:missing"
+
   data:
     redis:
       host: localhost


### PR DESCRIPTION
## 요약

세션 종료 시 비동기 Tier 1 워커(SessionConsolidator)가 메시지 요약을 생성하고, 추출된 인지 왜곡·감정·트리거를 Postgres에 응고(consolidate)한다. 이 단계부터 Episodic Memory가 처음으로 축적된다.

## 관련 이슈

- Closes #100
- 의존: #103 (Phase 3-1, OntologyValidator 통합 후 TODO 적용)

## 변경 사항

### DB Migration (V22)
- `session_summaries` 컬럼 추가: `trigger_tags TEXT[]` + GIN 인덱스, `episode_emb VECTOR(1536)` + ivfflat 인덱스, `episode_type TEXT`
- 신규 테이블: `thoughts`, `user_beliefs`, `belief_evidence`, `intervention_outcomes`

### 도메인 엔티티 + Repository
- `UserBelief`, `BeliefEvidence`, `Thought`, `InterventionOutcome`
- `UserBeliefRepository`, `BeliefEvidenceRepository`, `ThoughtRepository`, `InterventionOutcomeRepository`
- `SessionSummaryRepository` (session_id 기준 조회)

### 이벤트 아키텍처
- `SessionEndedEvent`: `SessionService.endSession()` 에서 발행
- `SessionConsolidator`: `@Async @EventListener` — 비동기 처리

### SessionConsolidator 처리 흐름
```
SessionEndedEvent → 메시지 로드 → GPT-4o-mini 요약 생성 → AES-256 암호화 →
ExtractorLLM(GPT-4o-mini) 추출 → session_summaries upsert → cbt_patterns++ →
emotional_states INSERT → Thought 저장 → UserBelief 연결 + BeliefEvidenceAccumulator
```

### 지원 컴포넌트
- `ExtractorLlmClient`: schema-constrained JSON 추출 (thought/distortion/emotion/trigger)
- `BeliefEvidenceAccumulator`: Beta 분포 confidence 재계산 (α=β=1)
- `ExtractorResult`: 추출 결과 record

## 영향 범위

- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] Breaking change가 있습니다.

## 테스트

```bash
./gradlew test
```

모든 단위 테스트 및 통합 테스트 통과. 로컬 테스트 DB에 V21이 선적용된 경우를 위해 `flyway.ignore-migration-patterns: "*:missing"` 설정 추가.

## 중점 리뷰 포인트

- OntologyValidator 통합: Phase 3-1(PR #103) 병합 후 `filterValidThoughts()`와 `filterValidEmotion()` 내 TODO를 교체 예정
- `@Async` 처리 실패 시 로그만 남기고 세션 응답에는 영향 없음
- UserBelief 중복 감지: `beliefKind + polarity` 조합으로 기존 신념 재사용

## 배포 / 롤백

- Rollout: Flyway auto-migrate on startup
- Rollback: V22 파일 제거 + `flyway repair`

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic session consolidation with intelligent memory extraction—generates summaries, identifies emotional triggers, classifies episode types, and extracts cognitive patterns from conversations
  * Enhanced belief tracking system that accumulates evidence over time and calculates confidence scores for user beliefs
  * Intervention outcome recording to capture emotional state changes before and after therapeutic actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->