### PR TITLE
feat: Phase 3-5 SafetyProfile Personalized — 개인화 안전 프로파일 완성

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisDetectedEvent.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisDetectedEvent.java
@@ -1,0 +1,12 @@
+package com.mio.ai.crisis;
+
+import java.util.UUID;
+
+/**
+ * Crisis flow 발동 시 발행. SafetyProfileBuilder가 즉시 profile 캐시를 invalidate (§17.8).
+ */
+public record CrisisDetectedEvent(
+        UUID sessionId,
+        UUID userId,
+        int severity
+) {}

--- a/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
@@ -7,6 +7,7 @@ import com.mio.session.dto.SseEventDto;
 import com.mio.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -19,6 +20,7 @@ import java.util.List;
 public class CrisisFlowService {
 
     private final CrisisEventRepository crisisEventRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private static final List<String> SEVERITY_3_KEYWORDS = List.of(
             "자살", "자해", "죽고싶다", "죽을거야", "목숨을끊", "자살하고싶", "자해하고싶"
@@ -66,6 +68,8 @@ public class CrisisFlowService {
         }
 
         persistCrisisEvent(user, session, severity, triggerType);
+        // SafetyProfile 즉시 invalidate (§17.8)
+        eventPublisher.publishEvent(new CrisisDetectedEvent(session.getId(), user.getId(), severity));
 
         return new CrisisHandleResult(fixedResponse, severity);
     }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -106,8 +106,8 @@ public class ConversationOrchestrator {
             List<SafetyL1HistoryMessage> recentUserMessages =
                     messagePersistenceService.loadRecentUserSafetyHistory(sessionId, 3);
 
-            // 2. Load SafetyProfile
-            SafetyProfile profile = safetyProfileBuilder.getOrDefault(userId.toString());
+            // 2. Load SafetyProfile (Redis cache HIT → JSON 역직렬화, MISS → buildSync)
+            SafetyProfile profile = safetyProfileBuilder.getOrDefault(sessionId.toString(), userId.toString());
 
             // 3. Safety checks (parallel in production; sequential with virtual threads)
             SecurityAssessment securityAssessment = securityRuleFilter.check(normalized);

--- a/src/main/java/com/mio/ai/profile/SafetyProfile.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfile.java
@@ -3,19 +3,47 @@ package com.mio.ai.profile;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * Memory Layer의 durable artifacts를 얇은 구조화 JSON으로 사전 계산한 프로파일 (§17).
+ * 원문 belief text 없음 — 구조화 필드만.
+ */
 public record SafetyProfile(
         String userId,
-        String source,
+        String source,                          // "default" | "personalized"
         Map<String, Double> dynamicThresholds,
         List<String> effectiveInterventions,
         List<String> ineffectiveInterventions,
         List<String> policyFlags,
         double riskPriorScore,
         int recentCrisisSeverityMax,
-        List<String> commonDistortionCodes
+        List<String> commonDistortionCodes,
+
+        // Phase 3-5 추가 필드 (§17.2)
+        int activeNegativeBeliefCount,
+        String copingStyle,                     // "avoidance" | "approach" | null
+        List<String> dominantTriggerKinds,
+        String sensitivityCap                   // "normal" | "sensitive" | "restricted"
 ) {
-    public static final String SOURCE_DEFAULT = "default";
+    public static final String SOURCE_DEFAULT      = "default";
     public static final String SOURCE_PERSONALIZED = "personalized";
+
+    /** 기존 생성자와의 하위 호환 (13개 인자 → 기본값 채움) */
+    public SafetyProfile(
+            String userId, String source,
+            Map<String, Double> dynamicThresholds,
+            List<String> effectiveInterventions,
+            List<String> ineffectiveInterventions,
+            List<String> policyFlags,
+            double riskPriorScore,
+            int recentCrisisSeverityMax,
+            List<String> commonDistortionCodes) {
+        this(userId, source, dynamicThresholds,
+                effectiveInterventions, ineffectiveInterventions, policyFlags,
+                riskPriorScore, recentCrisisSeverityMax, commonDistortionCodes,
+                0, null, List.of(), "sensitive");
+    }
+
+    // ── threshold accessors ──────────────────────────────────────
 
     public double emotionDropThreshold() {
         return dynamicThresholds.getOrDefault("emotion_drop_threshold", 30.0);
@@ -35,5 +63,9 @@ public record SafetyProfile(
 
     public boolean hasForceJudge() {
         return policyFlags != null && policyFlags.contains("force_judge");
+    }
+
+    public boolean isPersonalized() {
+        return SOURCE_PERSONALIZED.equals(source);
     }
 }

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -1,18 +1,30 @@
 package com.mio.ai.profile;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.crisis.CrisisDetectedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 /**
- * SafetyProfile 빌더.
- * Phase 3-4: Redis 캐싱 + buildAndCache 추가.
- * Phase 3-5: personalized build 완성.
+ * SafetyProfile 빌더 — Phase 3-5 완성 (§17).
+ * - 5개 쿼리 병렬 ~25ms
+ * - risk_prior_score 기반 dynamic_thresholds 계산
+ * - 7일/10세션 이후 personalized 전환
+ * - CrisisDetectedEvent 시 즉시 invalidate
  */
 @Component
 @RequiredArgsConstructor
@@ -22,6 +34,7 @@ public class SafetyProfileBuilder {
     private static final String PROFILE_KEY = "session:%s:safety_profile";
     private static final Duration PROFILE_TTL = Duration.ofMinutes(90);
 
+    // 보수적 default — 신규 사용자 (모든 임계값을 민감한 쪽으로)
     private static final Map<String, Double> DEFAULT_THRESHOLDS = Map.of(
             "emotion_drop_threshold", 30.0,
             "repetitive_negative_count", 3.0,
@@ -30,61 +43,62 @@ public class SafetyProfileBuilder {
     );
 
     private final StringRedisTemplate redisTemplate;
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
 
-    public SafetyProfile buildDefault(String userId) {
-        return new SafetyProfile(
-                userId,
-                SafetyProfile.SOURCE_DEFAULT,
-                DEFAULT_THRESHOLDS,
-                List.of(),
-                List.of(),
-                List.of(),
-                0.0,
-                0,
-                List.of()
-        );
-    }
+    private final Executor profileBuildPool = Executors.newVirtualThreadPerTaskExecutor();
 
-    /**
-     * Phase 3-4: Redis 캐시 우선 조회 → 없으면 default 빌드 후 캐싱.
-     * Phase 3-5에서 personalized build로 교체 예정.
-     */
+    // ── 진입점 ────────────────────────────────────────────────────
+
+    /** 하위 호환 — sessionId 없는 경우 default만 반환 */
     public SafetyProfile getOrDefault(String userId) {
         return buildDefault(userId);
     }
 
     /**
-     * ContextPreWarmer 호출용 — 세션 시작 시 profile 빌드 후 Redis 캐싱.
+     * ConversationOrchestrator가 매 메시지마다 호출.
+     * Redis cache HIT → JSON 역직렬화 즉시 반환 (0.5ms).
+     * MISS → buildSync 동기 build.
+     */
+    public SafetyProfile getOrDefault(String sessionId, String userId) {
+        try {
+            String json = redisTemplate.opsForValue().get(PROFILE_KEY.formatted(sessionId));
+            if (json != null) {
+                log.debug("SafetyProfileBuilder: getOrDefault cache HIT sessionId={}", sessionId);
+                return objectMapper.readValue(json, SafetyProfile.class);
+            }
+        } catch (Exception e) {
+            log.warn("SafetyProfileBuilder: getOrDefault cache read failed", e);
+        }
+        // MISS → 동기 build (사실상 세션 시작 직후라 pre-warm이 완료됐어야 함)
+        return buildSync(userId);
+    }
+
+    /**
+     * ContextPreWarmer용 — 세션 시작 시 profile 빌드 후 JSON으로 Redis 캐싱.
      */
     public SafetyProfile buildAndCache(String sessionId, String userId) {
         String key = PROFILE_KEY.formatted(sessionId);
         try {
             String cached = redisTemplate.opsForValue().get(key);
             if (cached != null) {
-                log.debug("SafetyProfileBuilder: cache HIT for sessionId={}", sessionId);
-                return buildDefault(userId);
+                log.debug("SafetyProfileBuilder: buildAndCache HIT for sessionId={}", sessionId);
+                return objectMapper.readValue(cached, SafetyProfile.class);
             }
         } catch (Exception e) {
-            log.warn("SafetyProfileBuilder: Redis get failed, building default", e);
+            log.warn("SafetyProfileBuilder: Redis read failed, building fresh", e);
         }
 
-        SafetyProfile profile = buildDefault(userId);
-
-        try {
-            // Phase 3-5에서 직렬화 개선 예정. 현재는 userId 마커만 저장.
-            redisTemplate.opsForValue().set(key, userId, PROFILE_TTL);
-        } catch (Exception e) {
-            log.warn("SafetyProfileBuilder: Redis set failed for sessionId={}", sessionId, e);
-        }
-
+        SafetyProfile profile = buildSync(userId);
+        cacheProfile(key, profile);
         return profile;
     }
 
     public SafetyProfile getFromCache(String sessionId, String userId) {
         try {
-            String cached = redisTemplate.opsForValue().get(PROFILE_KEY.formatted(sessionId));
-            if (cached != null) {
-                return buildDefault(userId);
+            String json = redisTemplate.opsForValue().get(PROFILE_KEY.formatted(sessionId));
+            if (json != null) {
+                return objectMapper.readValue(json, SafetyProfile.class);
             }
         } catch (Exception e) {
             log.warn("SafetyProfileBuilder: cache read failed, using default", e);
@@ -92,11 +106,233 @@ public class SafetyProfileBuilder {
         return buildDefault(userId);
     }
 
+    private void cacheProfile(String key, SafetyProfile profile) {
+        try {
+            String json = objectMapper.writeValueAsString(profile);
+            redisTemplate.opsForValue().set(key, json, PROFILE_TTL);
+        } catch (Exception e) {
+            log.warn("SafetyProfileBuilder: Redis set failed for key={}", key, e);
+        }
+    }
+
     public void invalidate(String sessionId) {
         try {
             redisTemplate.delete(PROFILE_KEY.formatted(sessionId));
+            log.debug("SafetyProfileBuilder: invalidated profile for sessionId={}", sessionId);
         } catch (Exception e) {
             log.warn("SafetyProfileBuilder.invalidate failed for sessionId={}", sessionId, e);
         }
     }
+
+    @EventListener
+    public void onCrisisDetected(CrisisDetectedEvent event) {
+        invalidate(event.sessionId().toString());
+    }
+
+    // ── 빌드 로직 ────────────────────────────────────────────────
+
+    SafetyProfile buildDefault(String userId) {
+        return new SafetyProfile(
+                userId, SafetyProfile.SOURCE_DEFAULT,
+                DEFAULT_THRESHOLDS,
+                List.of(), List.of(), List.of(),
+                0.0, 0, List.of()
+        );
+    }
+
+    /**
+     * 5개 쿼리 병렬 빌드 (~25ms).
+     * 데이터 부족 시 default 반환.
+     */
+    SafetyProfile buildSync(String userId) {
+        UUID userUUID;
+        try {
+            userUUID = UUID.fromString(userId);
+        } catch (IllegalArgumentException e) {
+            return buildDefault(userId);
+        }
+
+        try {
+            // 5개 병렬 쿼리
+            var beliefsF   = CompletableFuture.supplyAsync(() -> queryActiveBeliefs(userUUID), profileBuildPool);
+            var crisisF    = CompletableFuture.supplyAsync(() -> queryRecentCrisis(userUUID), profileBuildPool);
+            var patternsF  = CompletableFuture.supplyAsync(() -> queryCbtPatterns(userUUID), profileBuildPool);
+            var outcomesF  = CompletableFuture.supplyAsync(() -> queryInterventionOutcomes(userUUID), profileBuildPool);
+            var sessionMF  = CompletableFuture.supplyAsync(() -> querySessionMeta(userUUID), profileBuildPool);
+
+            CompletableFuture.allOf(beliefsF, crisisF, patternsF, outcomesF, sessionMF).join();
+
+            var beliefs     = beliefsF.join();
+            var crisisMax   = crisisF.join();
+            var patterns    = patternsF.join();
+            var outcomes    = outcomesF.join();
+            var sessionMeta = sessionMF.join();
+
+            // 데이터 없으면 default
+            if (!beliefs.hasData() && patterns.topDistortionCodes().isEmpty()) {
+                return buildDefault(userId);
+            }
+
+            // personalized 전환 조건: 7일 이상 사용 OR 10세션 이상
+            boolean personalized = sessionMeta.daysSinceFirst() >= 7 || sessionMeta.totalSessions() >= 10;
+            String source = personalized ? SafetyProfile.SOURCE_PERSONALIZED : SafetyProfile.SOURCE_DEFAULT;
+
+            // risk_prior_score 계산
+            double riskPrior = Math.min(1.0,
+                    (crisisMax * 0.3) + (beliefs.negativeCount() * 0.1));
+
+            // dynamic_thresholds — high-prior 사용자는 민감하게
+            Map<String, Double> thresholds = computeThresholds(riskPrior);
+
+            List<String> policyFlags = new ArrayList<>();
+            if (riskPrior > 0.5) policyFlags.add("dependency_caution");
+            if (crisisMax >= 2)  policyFlags.add("force_judge");
+
+            return new SafetyProfile(
+                    userId, source, thresholds,
+                    outcomes.effectiveKinds(),
+                    outcomes.ineffectiveKinds(),
+                    policyFlags,
+                    riskPrior, crisisMax,
+                    patterns.topDistortionCodes(),
+                    beliefs.negativeCount(),
+                    beliefs.copingStyle(),
+                    patterns.triggerKinds(),
+                    "sensitive"
+            );
+        } catch (Exception e) {
+            log.warn("SafetyProfileBuilder.buildSync failed for userId={}, falling back to default", userId, e);
+            return buildDefault(userId);
+        }
+    }
+
+    // ── DB 쿼리 ──────────────────────────────────────────────────
+
+    private BeliefSummary queryActiveBeliefs(UUID userId) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    """
+                    SELECT belief_kind, polarity, confidence
+                    FROM user_beliefs
+                    WHERE user_id = ? AND status = 'active'
+                    ORDER BY confidence DESC LIMIT 10
+                    """, userId
+            );
+            int negCount = (int) rows.stream()
+                    .filter(r -> "negative".equals(r.get("polarity"))).count();
+            String coping = negCount > 2 ? "avoidance" : null;
+            return new BeliefSummary(negCount, coping, !rows.isEmpty());
+        } catch (Exception e) {
+            log.warn("queryActiveBeliefs failed", e);
+            return new BeliefSummary(0, null, false);
+        }
+    }
+
+    private int queryRecentCrisis(UUID userId) {
+        try {
+            Integer max = jdbcTemplate.queryForObject(
+                    """
+                    SELECT COALESCE(MAX(severity), 0)
+                    FROM crisis_events
+                    WHERE user_id = ?
+                      AND created_at > NOW() - INTERVAL '14 days'
+                    """, Integer.class, userId
+            );
+            return max != null ? max : 0;
+        } catch (Exception e) {
+            log.warn("queryRecentCrisis failed", e);
+            return 0;
+        }
+    }
+
+    private PatternSummary queryCbtPatterns(UUID userId) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    """
+                    SELECT pattern_type, recurrence_count
+                    FROM cbt_patterns
+                    WHERE user_id = ?
+                    ORDER BY recurrence_count DESC LIMIT 5
+                    """, userId
+            );
+            List<String> codes = rows.stream()
+                    .map(r -> (String) r.get("pattern_type"))
+                    .toList();
+            List<String> triggers = codes.stream().limit(2).toList();
+            return new PatternSummary(codes, triggers);
+        } catch (Exception e) {
+            log.warn("queryCbtPatterns failed", e);
+            return new PatternSummary(List.of(), List.of());
+        }
+    }
+
+    private OutcomeSummary queryInterventionOutcomes(UUID userId) {
+        try {
+            var rows = jdbcTemplate.queryForList(
+                    """
+                    SELECT intervention_kind, AVG(delta) AS avg_delta, COUNT(*) AS cnt
+                    FROM intervention_outcomes
+                    WHERE user_id = ?
+                      AND created_at > NOW() - INTERVAL '30 days'
+                    GROUP BY intervention_kind
+                    HAVING COUNT(*) >= 2
+                    ORDER BY AVG(delta) DESC
+                    LIMIT 10
+                    """, userId
+            );
+            List<String> effective = new ArrayList<>();
+            List<String> ineffective = new ArrayList<>();
+            for (var row : rows) {
+                String kind = (String) row.get("intervention_kind");
+                // AVG(delta)는 PostgreSQL numeric → BigDecimal 반환 가능, Number로 안전 캐스트
+                Number avgNum = (Number) row.get("avg_delta");
+                Double avg = avgNum != null ? avgNum.doubleValue() : null;
+                if (avg != null && avg > 5) effective.add(kind);
+                else if (avg != null && avg < -3) ineffective.add(kind);
+            }
+            return new OutcomeSummary(effective, ineffective);
+        } catch (Exception e) {
+            log.warn("queryInterventionOutcomes failed", e);
+            return new OutcomeSummary(List.of(), List.of());
+        }
+    }
+
+    private SessionMeta querySessionMeta(UUID userId) {
+        try {
+            var row = jdbcTemplate.queryForMap(
+                    """
+                    SELECT COUNT(*) AS total_sessions,
+                           EXTRACT(DAY FROM NOW() - MIN(started_at)) AS days_since_first
+                    FROM sessions WHERE user_id = ?
+                    """, userId
+            );
+            long total = ((Number) row.get("total_sessions")).longValue();
+            double days = row.get("days_since_first") != null
+                    ? ((Number) row.get("days_since_first")).doubleValue() : 0;
+            return new SessionMeta((int) total, (int) days);
+        } catch (Exception e) {
+            log.warn("querySessionMeta failed", e);
+            return new SessionMeta(0, 0);
+        }
+    }
+
+    // ── threshold 계산 ────────────────────────────────────────────
+
+    private Map<String, Double> computeThresholds(double riskPrior) {
+        Map<String, Double> t = new HashMap<>(DEFAULT_THRESHOLDS);
+        if (riskPrior > 0.4) {
+            // high-prior → 더 민감하게 (낮은 임계값)
+            t.put("emotion_drop_threshold", 25.0);
+            t.put("repetitive_negative_count", 2.0);
+            t.put("message_burst_count", 8.0);
+        }
+        return Map.copyOf(t);
+    }
+
+    // ── 내부 DTO ──────────────────────────────────────────────────
+
+    private record BeliefSummary(int negativeCount, String copingStyle, boolean hasData) {}
+    private record PatternSummary(List<String> topDistortionCodes, List<String> triggerKinds) {}
+    private record OutcomeSummary(List<String> effectiveKinds, List<String> ineffectiveKinds) {}
+    private record SessionMeta(int totalSessions, int daysSinceFirst) {}
 }


### PR DESCRIPTION
## 요약

Phase 3-3으로 축적된 메모리(user_beliefs, cbt_patterns, crisis_events, intervention_outcomes)를 기반으로 SafetyProfile을 개인화한다. 7일 경과 또는 10세션 달성 시 default → personalized로 전환하며, crisis 발생 시 Redis 캐시를 즉시 invalidate한다.

## 관련 이슈

- Closes #102

## 변경 사항

### SafetyProfile 확장 (§17.2)
- `activeNegativeBeliefCount`, `copingStyle`, `dominantTriggerKinds`, `sensitivityCap` 필드 추가
- 하위호환 생성자 추가 (기존 9인자 호출 코드 무변경)

### SafetyProfileBuilder 완전 구현 (§17.3)
- `buildSync()`: 5개 쿼리 VirtualThread 병렬 (~25ms)
  - active_beliefs, recent_crisis_14d, cbt_patterns, intervention_outcomes_30d, session_meta
- `risk_prior_score` 계산 → dynamic_thresholds 자동 조정
  - riskPrior > 0.4: emotion_drop 30→25, repetition_count 3→2, burst 10→8
- 개인화 전환: 7일 경과 OR 10세션 → `source = "personalized"`
- 빌드 실패 시 default fallback (≤ 1% 목표, §27.9)

### CrisisDetectedEvent + invalidate (§17.8)
- `CrisisDetectedEvent`: crisis flow 발동 시 Spring 이벤트
- `CrisisFlowService`: persistCrisisEvent 후 이벤트 발행
- `SafetyProfileBuilder.onCrisisDetected`: @EventListener → Redis 즉시 삭제

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] Breaking change가 있습니다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.