### PR TITLE
feat: Phase 3 follow-up — OntologyValidator 통합 + trace 필드 실값 전달

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -32,7 +32,9 @@ import java.nio.charset.StandardCharsets;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * Tier 1 Worker — 세션 종료 직후 비동기 실행.
@@ -323,15 +325,23 @@ public class SessionConsolidator {
             List<ExtractorResult.ExtractedThought> thoughts) {
         if (thoughts == null || thoughts.isEmpty()) return List.of();
 
+        // 배치 검증: 중복 제거 후 단일 IN 쿼리로 검증 (N+1 방지, §12.8)
+        Set<String> distinctCodes = thoughts.stream()
+                .map(ExtractorResult.ExtractedThought::distortionCode)
+                .filter(code -> code != null && !code.isBlank())
+                .collect(Collectors.toSet());
+
+        Set<String> validCodes = ontologyValidator.filterValidDistortionCodes(distinctCodes);
+
+        Set<String> invalidCodes = distinctCodes.stream()
+                .filter(code -> !validCodes.contains(code))
+                .collect(Collectors.toSet());
+        if (!invalidCodes.isEmpty()) {
+            log.warn("SessionConsolidator: discarded unknown distortionCodes={}", invalidCodes);
+        }
+
         var result = thoughts.stream()
-                .filter(t -> {
-                    if (t.distortionCode() == null) return true; // distortion 없는 사고는 허용
-                    boolean valid = ontologyValidator.isValidDistortionCode(t.distortionCode());
-                    if (!valid) {
-                        log.warn("SessionConsolidator: discarded unknown distortionCode='{}'", t.distortionCode());
-                    }
-                    return valid;
-                })
+                .filter(t -> t.distortionCode() == null || validCodes.contains(t.distortionCode()))
                 .toList();
 
         int discarded = thoughts.size() - result.size();

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -5,6 +5,7 @@ import com.mio.ai.domain.CbtPattern;
 import com.mio.ai.domain.EmotionalState;
 import com.mio.ai.domain.MemoryEmbedding;
 import com.mio.ai.llm.LlmClient;
+import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.memory.episodic.Thought;
 import com.mio.ai.memory.episodic.ThoughtRepository;
@@ -81,9 +82,7 @@ public class SessionConsolidator {
     private final MessageEncryptor messageEncryptor;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
-
-    // Phase 3-1 (PR #103) 병합 후 OntologyValidator 주입 예정
-    // 현재는 ExtractorLLM 출력을 그대로 수용 (open validation)
+    private final OntologyValidator ontologyValidator;
 
     // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
     // @Transactional(REQUIRES_NEW): 응고 작업을 독립 트랜잭션으로 실행
@@ -318,16 +317,34 @@ public class SessionConsolidator {
         evidenceAccumulator.accumulate(belief, evidenceKind, sessionId, null);
     }
 
-    // ── OntologyValidator 필터 (Phase 3-1 병합 후 적용) ─────────────
+    // ── OntologyValidator 필터 ────────────────────────────────────
 
     private List<ExtractorResult.ExtractedThought> filterValidThoughts(
             List<ExtractorResult.ExtractedThought> thoughts) {
-        // TODO(Phase 3-1): OntologyValidator.filterValidDistortionCodes() 적용
-        return thoughts;
+        if (thoughts == null || thoughts.isEmpty()) return List.of();
+
+        var result = thoughts.stream()
+                .filter(t -> {
+                    if (t.distortionCode() == null) return true; // distortion 없는 사고는 허용
+                    boolean valid = ontologyValidator.isValidDistortionCode(t.distortionCode());
+                    if (!valid) {
+                        log.warn("SessionConsolidator: discarded unknown distortionCode='{}'", t.distortionCode());
+                    }
+                    return valid;
+                })
+                .toList();
+
+        int discarded = thoughts.size() - result.size();
+        if (discarded > 0) {
+            log.info("SessionConsolidator: OntologyValidator filtered {}/{} thoughts", discarded, thoughts.size());
+        }
+        return result;
     }
 
     private String filterValidEmotion(String emotionCode) {
-        // TODO(Phase 3-1): OntologyValidator.isValidEmotionCode() 적용
-        return emotionCode;
+        if (emotionCode == null) return null;
+        if (ontologyValidator.isValidEmotionCode(emotionCode)) return emotionCode;
+        log.warn("SessionConsolidator: discarded unknown emotionCode='{}'", emotionCode);
+        return null;
     }
 }

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -43,13 +43,17 @@ public class AiDecisionLogger {
             boolean crisisFlowTriggered,
             boolean inputJudgeCalled,
             OutputPreFilterResult preFilterResult,
-            OutputJudgeResult outputJudgeResult) {
+            OutputJudgeResult outputJudgeResult,
+            String l1ThresholdSource,
+            boolean safetyProfileCacheHit,
+            boolean memoryCacheHit) {
 
         try {
             Map<String, Object> trace = buildTrace(
                     moderation, l1Result, llmTtftMs, totalPipelineMs,
                     crisisFlowTriggered, decision,
-                    inputJudgeCalled, preFilterResult, outputJudgeResult);
+                    inputJudgeCalled, preFilterResult, outputJudgeResult,
+                    l1ThresholdSource, safetyProfileCacheHit, memoryCacheHit);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -88,7 +92,8 @@ public class AiDecisionLogger {
             boolean crisisFlowTriggered) {
         log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered,
-                false, OutputPreFilterResult.pass(), null);
+                false, OutputPreFilterResult.pass(), null,
+                "default", false, false);
     }
 
     private Map<String, Object> buildTrace(
@@ -100,7 +105,10 @@ public class AiDecisionLogger {
             PolicyDecision decision,
             boolean inputJudgeCalled,
             OutputPreFilterResult preFilterResult,
-            OutputJudgeResult outputJudgeResult) {
+            OutputJudgeResult outputJudgeResult,
+            String l1ThresholdSource,
+            boolean safetyProfileCacheHit,
+            boolean memoryCacheHit) {
 
         Map<String, Object> l1Flags = new LinkedHashMap<>();
         l1Flags.put("crisis_keyword", l1Result.hardCrisis());
@@ -116,11 +124,11 @@ public class AiDecisionLogger {
         trace.put("l0_category_scores", moderation.categoryScores());
         trace.put("l1_flags", l1Flags);
         trace.put("l1_combined_confidence", l1Result.combinedConfidence());
-        trace.put("l1_threshold_source", "default");
+        trace.put("l1_threshold_source", l1ThresholdSource != null ? l1ThresholdSource : "default");
         trace.put("input_judge_called", inputJudgeCalled);
         trace.put("risk_level", decision.riskLevel() != null ? decision.riskLevel().name() : null);
-        trace.put("safety_profile_cache_hit", false);
-        trace.put("memory_cache_hit", false);
+        trace.put("safety_profile_cache_hit", safetyProfileCacheHit);
+        trace.put("memory_cache_hit", memoryCacheHit);
         trace.put("llm_model", "gpt-4o");
         trace.put("llm_ttft_ms", ttftMs);
         trace.put("llm_cost_usd", 0.0);

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -17,6 +17,7 @@ import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.profile.ContextPreWarmer;
+import com.mio.ai.profile.SafetyProfileBuilder.ProfileResult;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.policy.DecisionAction;
@@ -107,7 +108,9 @@ public class ConversationOrchestrator {
                     messagePersistenceService.loadRecentUserSafetyHistory(sessionId, 3);
 
             // 2. Load SafetyProfile (Redis cache HIT → JSON 역직렬화, MISS → buildSync)
-            SafetyProfile profile = safetyProfileBuilder.getOrDefault(sessionId.toString(), userId.toString());
+            ProfileResult profileResult = safetyProfileBuilder.getWithCacheHit(sessionId.toString(), userId.toString());
+            SafetyProfile profile = profileResult.profile();
+            boolean safetyProfileCacheHit = profileResult.cacheHit();
 
             // 3. Safety checks (parallel in production; sequential with virtual threads)
             SecurityAssessment securityAssessment = securityRuleFilter.check(normalized);
@@ -132,11 +135,11 @@ public class ConversationOrchestrator {
 
             // 5. Working Memory (CBT counters) + Memory Context
             SessionDelta sessionDelta = workingMemory.getSessionDelta(sessionId);
-            String memoryContext = contextPreWarmer.getCachedContext(sessionId);
-            // cache MISS → 동기 fallback build (MemoryRetrievalPlanner 활용, §12.4)
-            if (memoryContext == null) {
-                memoryContext = contextPreWarmer.buildContextSync(sessionId, userId, combined, profile);
-            }
+            String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
+            boolean memoryCacheHit = cachedMemory != null;
+            String memoryContext = memoryCacheHit
+                    ? cachedMemory
+                    : contextPreWarmer.buildContextSync(sessionId, userId, combined, profile);
 
             // 6. Policy decision (10-step)
             PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
@@ -244,7 +247,8 @@ public class ConversationOrchestrator {
             long totalMs = System.currentTimeMillis() - startMs;
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
-                    inputJudgeCalled, preFilterResult, judgeActionResult);
+                    inputJudgeCalled, preFilterResult, judgeActionResult,
+                    profile.source(), safetyProfileCacheHit, memoryCacheHit);
 
             emitter.complete();
 

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -61,18 +61,27 @@ public class SafetyProfileBuilder {
      * MISS → buildSync 동기 build.
      */
     public SafetyProfile getOrDefault(String sessionId, String userId) {
+        return getWithCacheHit(sessionId, userId).profile();
+    }
+
+    /**
+     * profile + cache HIT 여부를 함께 반환 — trace 로깅용 (§27.6).
+     */
+    public ProfileResult getWithCacheHit(String sessionId, String userId) {
         try {
             String json = redisTemplate.opsForValue().get(PROFILE_KEY.formatted(sessionId));
             if (json != null) {
-                log.debug("SafetyProfileBuilder: getOrDefault cache HIT sessionId={}", sessionId);
-                return objectMapper.readValue(json, SafetyProfile.class);
+                log.debug("SafetyProfileBuilder: cache HIT sessionId={}", sessionId);
+                SafetyProfile profile = objectMapper.readValue(json, SafetyProfile.class);
+                return new ProfileResult(profile, true);
             }
         } catch (Exception e) {
-            log.warn("SafetyProfileBuilder: getOrDefault cache read failed", e);
+            log.warn("SafetyProfileBuilder: cache read failed", e);
         }
-        // MISS → 동기 build (사실상 세션 시작 직후라 pre-warm이 완료됐어야 함)
-        return buildSync(userId);
+        return new ProfileResult(buildSync(userId), false);
     }
+
+    public record ProfileResult(SafetyProfile profile, boolean cacheHit) {}
 
     /**
      * ContextPreWarmer용 — 세션 시작 시 profile 빌드 후 JSON으로 Redis 캐싱.

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -58,7 +58,10 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 null,
-                null
+                null,
+                "default",
+                false,
+                false
         );
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);


### PR DESCRIPTION
## 요약

Phase 3-3 TODO였던 OntologyValidator 통합을 완료하고, Phase 3에서 추가된 캐시 HIT/personalized 지표를 trace에 실값으로 기록한다.

## 변경 사항

### 1. OntologyValidator 통합 (§12.8)

**SessionConsolidator**
- `OntologyValidator` 빈 주입
- `filterValidThoughts()`: distortionCode 시드 검증 — 미등록 코드 warn 로그 후 폐기
- `filterValidEmotion()`: emotionCode 시드 검증 — 미등록 코드 null 반환
- OntologyValidator 통과율 ≥ 80% 기준 달성 가능

### 2. AiDecisionLogger trace 실값 전달 (§27.6, §27.9)

**SafetyProfileBuilder**
- `getWithCacheHit(sessionId, userId)`: `ProfileResult(profile, cacheHit)` 반환
  - `safety_profile_cache_hit` 측정 가능

**ConversationOrchestrator**
- `safetyProfileCacheHit`: `getWithCacheHit()` Redis HIT 여부
- `memoryCacheHit`: `getCachedContext()` non-null 여부 (context_cache HIT)
- Logger 호출 시 실값 전달

**AiDecisionLogger**
- `log()` 시그니처에 `l1ThresholdSource`, `safetyProfileCacheHit`, `memoryCacheHit` 추가
- trace 필드 실값 적재:
  - `l1_threshold_source`: `profile.source()` ("default" | "personalized")
  - `safety_profile_cache_hit`: Redis HIT 여부 실값
  - `memory_cache_hit`: context cache HIT 여부 실값

## 영향 범위

- [ ] API 스펙 변경 없음
- [ ] DB 스키마 변경 없음

## 완료 후 측정 가능 지표 (§27)

```sql
-- safety_profile HIT율 (목표 ≥ 95%)
SELECT AVG((trace->>'safety_profile_cache_hit')::boolean::int) FROM ai_policy_decisions;

-- context_cache HIT율 (목표 ≥ 80%)
SELECT AVG((trace->>'memory_cache_hit')::boolean::int) FROM ai_policy_decisions;

-- personalized 전환 현황
SELECT trace->>'l1_threshold_source', COUNT(*) FROM ai_policy_decisions GROUP BY 1;
```