### PR TITLE
fix: 30분 무응답 세션 자동 종료 및 버그 3건 수정 (#116 #117 #118 #119)

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
@@ -45,7 +45,8 @@ public class CrisisFlowService {
             User user,
             Session session,
             SseEmitter emitter,
-            String outboundMsgId) {
+            String outboundMsgId,
+            Integer emotionScore) {
 
         int severity = determineSeverity(l1Result, originalMessage);
         String triggerType = l1Result.hardCrisis() ? "keyword" : "moderation";
@@ -59,7 +60,7 @@ public class CrisisFlowService {
                     .data(crisisEvent));
 
             SseEventDto.DoneEvent doneEvent = new SseEventDto.DoneEvent(
-                    outboundMsgId, null, true, "crisis_flow");
+                    outboundMsgId, emotionScore, true, "crisis_flow");
             emitter.send(SseEmitter.event()
                     .name(doneEvent.eventName())
                     .data(doneEvent));

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -56,6 +56,8 @@ public class ConversationCheckpointService {
     private final MessageEncryptor messageEncryptor;
     private final JdbcTemplate jdbcTemplate;
 
+    record MessageRecord(String line, OffsetDateTime createdAt) {}
+
     @Async
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void maybeCheckpoint(UUID sessionId, UUID userId) {
@@ -65,14 +67,19 @@ public class ConversationCheckpointService {
 
             if (session.getMessageCount() % CHECKPOINT_INTERVAL != 0) return;
 
-            SessionCheckpoint latest = checkpointRepository.findLatestBySessionId(sessionId).orElse(null);
+            SessionCheckpoint latest =
+                    checkpointRepository.findTopBySession_IdOrderByCheckpointSeqDesc(sessionId).orElse(null);
             OffsetDateTime since = latest != null ? latest.getCoveredUpToAt() : null;
 
-            List<String> lines = loadMessageLinesSince(sessionId, since);
-            if (lines.isEmpty()) return;
+            // 단일 쿼리로 메시지 + created_at 동시 읽기 (두 번 쿼리 시 사이에 끼는 메시지 갭 방지)
+            List<MessageRecord> records = loadMessageRecordsSince(sessionId, since);
+            if (records.isEmpty()) return;
 
-            String summaryText = generateSummary(String.join("\n", lines));
-            OffsetDateTime coveredUpTo = findLastMessageCreatedAt(sessionId, since);
+            String summaryText = generateSummary(records.stream().map(MessageRecord::line).toList());
+            OffsetDateTime coveredUpTo = records.stream()
+                    .map(MessageRecord::createdAt)
+                    .max(OffsetDateTime::compareTo)
+                    .orElse(null);
             if (coveredUpTo == null) return;
 
             int seq = (latest != null ? latest.getCheckpointSeq() : 0) + 1;
@@ -94,61 +101,51 @@ public class ConversationCheckpointService {
         }
     }
 
-    List<String> loadMessageLinesSince(UUID sessionId, OffsetDateTime since) {
+    List<MessageRecord> loadMessageRecordsSince(UUID sessionId, OffsetDateTime since) {
         try {
-            List<?> rows;
+            List<java.util.Map<String, Object>> rows;
             if (since == null) {
                 rows = jdbcTemplate.queryForList(
-                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+                        "SELECT role, content_ciphertext, created_at FROM messages WHERE session_id = ? ORDER BY created_at ASC",
                         sessionId);
             } else {
                 rows = jdbcTemplate.queryForList(
-                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? AND created_at > ? ORDER BY created_at ASC",
+                        "SELECT role, content_ciphertext, created_at FROM messages WHERE session_id = ? AND created_at > ? ORDER BY created_at ASC",
                         sessionId, since);
             }
 
-            List<String> lines = new ArrayList<>();
-            for (Object rowObj : rows) {
-                @SuppressWarnings("unchecked")
-                var row = (java.util.Map<String, Object>) rowObj;
+            List<MessageRecord> records = new ArrayList<>();
+            for (var row : rows) {
                 String role = (String) row.get("role");
                 byte[] cipher = (byte[]) row.get("content_ciphertext");
-                if (cipher == null) continue;
+                OffsetDateTime createdAt = (OffsetDateTime) row.get("created_at");
+                if (cipher == null || createdAt == null) continue;
                 try {
                     String text = new String(messageEncryptor.decrypt(cipher), StandardCharsets.UTF_8);
-                    lines.add(role + ": " + text);
+                    records.add(new MessageRecord(role + ": " + text, createdAt));
                 } catch (Exception ex) {
                     log.debug("Skipping decrypt failure in checkpoint sessionId={}", sessionId);
                 }
             }
-            return lines;
+            return records;
         } catch (Exception e) {
             log.warn("ConversationCheckpointService: failed to load messages sessionId={}", sessionId, e);
             return List.of();
         }
     }
 
-    private OffsetDateTime findLastMessageCreatedAt(UUID sessionId, OffsetDateTime since) {
-        try {
-            if (since == null) {
-                return jdbcTemplate.queryForObject(
-                        "SELECT MAX(created_at) FROM messages WHERE session_id = ?",
-                        OffsetDateTime.class, sessionId);
-            }
-            return jdbcTemplate.queryForObject(
-                    "SELECT MAX(created_at) FROM messages WHERE session_id = ? AND created_at > ?",
-                    OffsetDateTime.class, sessionId, since);
-        } catch (Exception e) {
-            log.warn("ConversationCheckpointService: failed to find last message at sessionId={}", sessionId, e);
-            return null;
-        }
+    // SessionConsolidator에서 lines만 필요할 때 사용
+    List<String> loadMessageLinesSince(UUID sessionId, OffsetDateTime since) {
+        return loadMessageRecordsSince(sessionId, since).stream()
+                .map(MessageRecord::line)
+                .toList();
     }
 
-    private String generateSummary(String conversationText) {
+    private String generateSummary(List<String> lines) {
         StringBuilder sb = new StringBuilder();
         try {
             llmClient.stream(
-                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, conversationText),
+                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines)),
                     sb::append
             );
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -1,0 +1,160 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionCheckpoint;
+import com.mio.session.repository.SessionCheckpointRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 20개 메시지(10턴)마다 중간 요약(체크포인트)을 비동기로 생성한다.
+ * 세션 종료 시 SessionConsolidator가 체크포인트 + 잔여 메시지로 최종 요약을 만든다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ConversationCheckpointService {
+
+    static final int CHECKPOINT_INTERVAL = 20;
+    private static final String CHECKPOINT_MODEL = "gpt-4o-mini";
+    private static final String CHECKPOINT_SYSTEM_PROMPT = """
+            당신은 CBT 코칭 대화의 중간 요약 전문가입니다.
+            아래 대화를 200자 이내로 간결하게 요약하세요.
+
+            포함 내용:
+            - 사용자가 표현한 주요 감정과 상황
+            - 드러난 인지 패턴 (있다면)
+            - 대화의 흐름과 전환점
+
+            원칙:
+            - 사용자 원문을 직접 인용하지 않습니다
+            - 개인 식별 정보는 포함하지 않습니다
+            - 이전 요약의 연속선상에서 맥락을 유지합니다
+            """;
+
+    private final SessionRepository sessionRepository;
+    private final SessionCheckpointRepository checkpointRepository;
+    private final UserRepository userRepository;
+    private final LlmClient llmClient;
+    private final MessageEncryptor messageEncryptor;
+    private final JdbcTemplate jdbcTemplate;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void maybeCheckpoint(UUID sessionId, UUID userId) {
+        try {
+            Session session = sessionRepository.findById(sessionId).orElse(null);
+            if (session == null) return;
+
+            if (session.getMessageCount() % CHECKPOINT_INTERVAL != 0) return;
+
+            SessionCheckpoint latest = checkpointRepository.findLatestBySessionId(sessionId).orElse(null);
+            OffsetDateTime since = latest != null ? latest.getCoveredUpToAt() : null;
+
+            List<String> lines = loadMessageLinesSince(sessionId, since);
+            if (lines.isEmpty()) return;
+
+            String summaryText = generateSummary(String.join("\n", lines));
+            OffsetDateTime coveredUpTo = findLastMessageCreatedAt(sessionId, since);
+            if (coveredUpTo == null) return;
+
+            int seq = (latest != null ? latest.getCheckpointSeq() : 0) + 1;
+            User user = userRepository.findById(userId).orElse(null);
+            if (user == null) return;
+
+            SessionCheckpoint checkpoint = SessionCheckpoint.builder()
+                    .session(session)
+                    .user(user)
+                    .checkpointSeq(seq)
+                    .summaryText(summaryText)
+                    .coveredUpToAt(coveredUpTo)
+                    .build();
+            checkpointRepository.save(checkpoint);
+            log.info("ConversationCheckpointService: saved checkpoint seq={} sessionId={}", seq, sessionId);
+
+        } catch (Exception e) {
+            log.warn("ConversationCheckpointService: checkpoint failed sessionId={}", sessionId, e);
+        }
+    }
+
+    List<String> loadMessageLinesSince(UUID sessionId, OffsetDateTime since) {
+        try {
+            List<?> rows;
+            if (since == null) {
+                rows = jdbcTemplate.queryForList(
+                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+                        sessionId);
+            } else {
+                rows = jdbcTemplate.queryForList(
+                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? AND created_at > ? ORDER BY created_at ASC",
+                        sessionId, since);
+            }
+
+            List<String> lines = new ArrayList<>();
+            for (Object rowObj : rows) {
+                @SuppressWarnings("unchecked")
+                var row = (java.util.Map<String, Object>) rowObj;
+                String role = (String) row.get("role");
+                byte[] cipher = (byte[]) row.get("content_ciphertext");
+                if (cipher == null) continue;
+                try {
+                    String text = new String(messageEncryptor.decrypt(cipher), StandardCharsets.UTF_8);
+                    lines.add(role + ": " + text);
+                } catch (Exception ex) {
+                    log.debug("Skipping decrypt failure in checkpoint sessionId={}", sessionId);
+                }
+            }
+            return lines;
+        } catch (Exception e) {
+            log.warn("ConversationCheckpointService: failed to load messages sessionId={}", sessionId, e);
+            return List.of();
+        }
+    }
+
+    private OffsetDateTime findLastMessageCreatedAt(UUID sessionId, OffsetDateTime since) {
+        try {
+            if (since == null) {
+                return jdbcTemplate.queryForObject(
+                        "SELECT MAX(created_at) FROM messages WHERE session_id = ?",
+                        OffsetDateTime.class, sessionId);
+            }
+            return jdbcTemplate.queryForObject(
+                    "SELECT MAX(created_at) FROM messages WHERE session_id = ? AND created_at > ?",
+                    OffsetDateTime.class, sessionId, since);
+        } catch (Exception e) {
+            log.warn("ConversationCheckpointService: failed to find last message at sessionId={}", sessionId, e);
+            return null;
+        }
+    }
+
+    private String generateSummary(String conversationText) {
+        StringBuilder sb = new StringBuilder();
+        try {
+            llmClient.stream(
+                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, conversationText),
+                    sb::append
+            );
+        } catch (Exception e) {
+            log.warn("ConversationCheckpointService: summary generation failed", e);
+            return "중간 요약을 생성할 수 없습니다.";
+        }
+        return sb.toString().trim();
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -112,7 +112,7 @@ public class SessionConsolidator {
             return;
         }
 
-        // 1. 메시지 조회 (최근 40개 — 20턴 커버, working memory TTL 만료 대비)
+        // 1. 메시지 조회 (세션 전체 — 종료 요약은 Memory 도메인에 저장되는 장기 맥락 원본)
         List<String> conversationLines = loadConversationLines(sessionId);
         if (conversationLines.isEmpty()) {
             log.info("SessionConsolidator: no messages found for sessionId={}", sessionId);
@@ -177,13 +177,10 @@ public class SessionConsolidator {
 
     private List<String> loadConversationLines(UUID sessionId) {
         try {
-            // DESC LIMIT 40으로 최신 40개 조회 후 ASC 역정렬 — 시간 순서로 LLM에 전달
             var rows = jdbcTemplate.queryForList(
                     """
-                    SELECT role, content_ciphertext FROM (
-                        SELECT role, content_ciphertext, created_at FROM messages
-                        WHERE session_id = ? ORDER BY created_at DESC LIMIT 40
-                    ) sub ORDER BY created_at ASC
+                    SELECT role, content_ciphertext FROM messages
+                    WHERE session_id = ? ORDER BY created_at ASC
                     """,
                     sessionId
             );

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -12,7 +12,9 @@ import com.mio.ai.memory.episodic.ThoughtRepository;
 import com.mio.ai.memory.episodic.UserBelief;
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.SessionCheckpoint;
 import com.mio.session.domain.SessionSummary;
+import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.user.domain.User;
@@ -76,6 +78,7 @@ public class SessionConsolidator {
 
     private final SessionRepository sessionRepository;
     private final SessionSummaryRepository sessionSummaryRepository;
+    private final SessionCheckpointRepository checkpointRepository;
     private final UserRepository userRepository;
     private final ThoughtRepository thoughtRepository;
     private final UserBeliefRepository beliefRepository;
@@ -112,13 +115,12 @@ public class SessionConsolidator {
             return;
         }
 
-        // 1. 메시지 조회 (세션 전체 — 종료 요약은 Memory 도메인에 저장되는 장기 맥락 원본)
-        List<String> conversationLines = loadConversationLines(sessionId);
-        if (conversationLines.isEmpty()) {
+        // 1. 대화 컨텍스트 구성 (체크포인트 요약 + 잔여 메시지)
+        String conversationText = buildConversationContext(sessionId);
+        if (conversationText.isBlank()) {
             log.info("SessionConsolidator: no messages found for sessionId={}", sessionId);
             return;
         }
-        String conversationText = String.join("\n", conversationLines);
 
         // 2. 세션 요약 생성 (LLM)
         String summaryText = generateSummary(conversationText);
@@ -173,17 +175,56 @@ public class SessionConsolidator {
                 sessionId, validThoughts.size(), dominantEmotion);
     }
 
+    // ── 대화 컨텍스트 구성 ────────────────────────────────────────
+
+    /**
+     * 체크포인트 요약 + 마지막 체크포인트 이후 잔여 메시지를 합쳐 반환한다.
+     * 체크포인트가 없으면 전체 메시지를 그대로 반환한다 (기존 동작).
+     */
+    private String buildConversationContext(UUID sessionId) {
+        List<SessionCheckpoint> checkpoints =
+                checkpointRepository.findBySession_IdOrderByCheckpointSeqAsc(sessionId);
+
+        if (checkpoints.isEmpty()) {
+            return String.join("\n", loadConversationLines(sessionId));
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("=== 이전 대화 요약 ===\n");
+        for (SessionCheckpoint cp : checkpoints) {
+            sb.append("[중간 요약 ").append(cp.getCheckpointSeq()).append("]\n");
+            sb.append(cp.getSummaryText()).append("\n\n");
+        }
+
+        SessionCheckpoint latest = checkpoints.getLast();
+        List<String> recentLines = loadMessageLinesSince(sessionId, latest.getCoveredUpToAt());
+        if (!recentLines.isEmpty()) {
+            sb.append("=== 최근 대화 ===\n");
+            sb.append(String.join("\n", recentLines));
+        }
+
+        return sb.toString().trim();
+    }
+
     // ── 세션 메시지 로드 ─────────────────────────────────────────
 
     private List<String> loadConversationLines(UUID sessionId) {
+        return loadMessageLinesSince(sessionId, null);
+    }
+
+    private List<String> loadMessageLinesSince(UUID sessionId, java.time.OffsetDateTime since) {
         try {
-            var rows = jdbcTemplate.queryForList(
-                    """
-                    SELECT role, content_ciphertext FROM messages
-                    WHERE session_id = ? ORDER BY created_at ASC
-                    """,
-                    sessionId
-            );
+            List<java.util.Map<String, Object>> rows;
+            if (since == null) {
+                rows = jdbcTemplate.queryForList(
+                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? ORDER BY created_at ASC",
+                        sessionId);
+            } else {
+                rows = jdbcTemplate.queryForList(
+                        "SELECT role, content_ciphertext FROM messages WHERE session_id = ? AND created_at > ? ORDER BY created_at ASC",
+                        sessionId, since);
+            }
+
             List<String> lines = new ArrayList<>();
             for (var row : rows) {
                 String role = (String) row.get("role");

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -177,10 +177,13 @@ public class SessionConsolidator {
 
     private List<String> loadConversationLines(UUID sessionId) {
         try {
+            // DESC LIMIT 40으로 최신 40개 조회 후 ASC 역정렬 — 시간 순서로 LLM에 전달
             var rows = jdbcTemplate.queryForList(
                     """
-                    SELECT role, content_ciphertext FROM messages
-                    WHERE session_id = ? ORDER BY created_at ASC LIMIT 40
+                    SELECT role, content_ciphertext FROM (
+                        SELECT role, content_ciphertext, created_at FROM messages
+                        WHERE session_id = ? ORDER BY created_at DESC LIMIT 40
+                    ) sub ORDER BY created_at ASC
                     """,
                     sessionId
             );

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -182,10 +182,12 @@ public class ConversationOrchestrator {
                     preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
                     if (!preFilterResult.passed()) {
                         judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
-                        assistantContent = resolveOutputJudgeAction(
-                                judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId);
-                        if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
-                            crisisFlowTriggered = true;
+                        if (judgeActionResult != null) {
+                            assistantContent = resolveOutputJudgeAction(
+                                    judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId);
+                            if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
+                                crisisFlowTriggered = true;
+                            }
                         }
                     }
                     if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -3,6 +3,7 @@ package com.mio.ai.orchestrator;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisFlowService;
+import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
@@ -82,6 +83,7 @@ public class ConversationOrchestrator {
     private final ContextPreWarmer contextPreWarmer;
     private final AiDecisionLogger decisionLogger;
     private final SessionMessagePersistenceService messagePersistenceService;
+    private final ConversationCheckpointService checkpointService;
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
     private final UserMessageSignalAnalyzer userMessageSignalAnalyzer;
@@ -242,6 +244,9 @@ public class ConversationOrchestrator {
 
             // 8. Persist messages
             messagePersistenceService.saveConversation(sessionId, userId, userMessage, assistantContent, userSignal);
+
+            // 8b. 20개 메시지마다 비동기 체크포인트 생성 (non-blocking)
+            checkpointService.maybeCheckpoint(sessionId, userId);
 
             // 9. Working Memory — 메시지 버퍼에 이번 턴 기록
             workingMemory.appendMessage(sessionId, "user", userMessage);

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -159,7 +159,8 @@ public class ConversationOrchestrator {
             } else if (decision.action() == DecisionAction.CRISIS_FLOW) {
                 crisisFlowTriggered = true;
                 CrisisFlowService.CrisisHandleResult crisisResult =
-                        crisisFlowService.handle(l1Result, userMessage, user, session, emitter, outboundMsgId);
+                        crisisFlowService.handle(l1Result, userMessage, user, session, emitter, outboundMsgId,
+                                userSignal.emotionScore());
                 assistantContent = crisisResult.fixedResponse();
 
             } else if (decision.action() == DecisionAction.GENERATE) {
@@ -184,7 +185,8 @@ public class ConversationOrchestrator {
                         judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
                         if (judgeActionResult != null) {
                             assistantContent = resolveOutputJudgeAction(
-                                    judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId);
+                                    judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId,
+                                    userSignal.emotionScore());
                             if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
                                 crisisFlowTriggered = true;
                             }
@@ -267,7 +269,8 @@ public class ConversationOrchestrator {
             User user,
             Session session,
             SseEmitter emitter,
-            String outboundMsgId) throws IOException {
+            String outboundMsgId,
+            Integer emotionScore) throws IOException {
 
         return switch (result.action()) {
             case SEND -> originalContent;
@@ -275,7 +278,7 @@ public class ConversationOrchestrator {
             case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             case CRISIS_FLOW -> {
                 CrisisFlowService.CrisisHandleResult cr =
-                        crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId);
+                        crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId, emotionScore);
                 yield cr != null ? cr.fixedResponse() : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             }
         };

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -154,7 +154,7 @@ public class ConversationOrchestrator {
             if (decision.action() == DecisionAction.SECURITY_REFUSAL) {
                 assistantContent = securityRefusalTemplate.get();
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "security_refusal"));
 
             } else if (decision.action() == DecisionAction.CRISIS_FLOW) {
                 crisisFlowTriggered = true;
@@ -190,7 +190,7 @@ public class ConversationOrchestrator {
                     }
                     if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {
                         sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                     }
 
                 } else {
@@ -204,7 +204,7 @@ public class ConversationOrchestrator {
                         }
                     });
                     assistantContent = contentBuilder.toString();
-                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
 
                     // CAUTIOUS_SPECULATIVE: post-stream OutputGuard
                     // 이미 스트리밍된 응답은 취소 불가하지만, DB에는 안전 버전을 저장해
@@ -233,7 +233,7 @@ public class ConversationOrchestrator {
                 log.warn("Unhandled decision action: {} for session={}", decision.action(), sessionId);
                 assistantContent = "지금 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.";
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, null, false, "stop"));
+                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "error"));
             }
 
             // 8. Persist messages

--- a/src/main/java/com/mio/ai/policy/PolicyEngine.java
+++ b/src/main/java/com/mio/ai/policy/PolicyEngine.java
@@ -82,7 +82,7 @@ public class PolicyEngine {
 
             // 7. MEDIUM → SUPPORTIVE + CAUTIOUS_SPECULATIVE
             if (riskLevel == RiskLevel.MEDIUM) {
-                GenerationMode genMode = resolveSupportiveMode(sessionDelta);
+                GenerationMode genMode = resolveSupportiveMode();
                 // MIO-CBT-011: 소크라테스 2회 제한 도달 시 CBT 개입 힌트 제거
                 InterventionHints hints = (sessionDelta != null && sessionDelta.socraticLimitReached())
                         ? InterventionHints.empty()
@@ -122,7 +122,7 @@ public class PolicyEngine {
         return decide(combined, null, null, null);
     }
 
-    private GenerationMode resolveSupportiveMode(SessionDelta delta) {
+    private GenerationMode resolveSupportiveMode() {
         return GenerationMode.SUPPORTIVE;
     }
 

--- a/src/main/java/com/mio/ai/policy/PolicyEngine.java
+++ b/src/main/java/com/mio/ai/policy/PolicyEngine.java
@@ -83,10 +83,14 @@ public class PolicyEngine {
             // 7. MEDIUM → SUPPORTIVE + CAUTIOUS_SPECULATIVE
             if (riskLevel == RiskLevel.MEDIUM) {
                 GenerationMode genMode = resolveSupportiveMode(sessionDelta);
+                // MIO-CBT-011: 소크라테스 2회 제한 도달 시 CBT 개입 힌트 제거
+                InterventionHints hints = (sessionDelta != null && sessionDelta.socraticLimitReached())
+                        ? InterventionHints.empty()
+                        : generateHints(profile, riskLevel);
                 return build(decisionId, DecisionAction.GENERATE,
                         genMode, DeliveryMode.CAUTIOUS_SPECULATIVE,
                         combined.securityLevel(), true, true, true,
-                        generateHints(profile, riskLevel), RiskLevel.MEDIUM);
+                        hints, RiskLevel.MEDIUM);
             }
 
             // 8. LOW → NORMAL + SPECULATIVE
@@ -118,7 +122,6 @@ public class PolicyEngine {
         return decide(combined, null, null, null);
     }
 
-    // MIO-CBT-011: 소크라테스 2회 제한 도달 시에도 공감(SUPPORTIVE) 유지
     private GenerationMode resolveSupportiveMode(SessionDelta delta) {
         return GenerationMode.SUPPORTIVE;
     }

--- a/src/main/java/com/mio/session/domain/SessionCheckpoint.java
+++ b/src/main/java/com/mio/session/domain/SessionCheckpoint.java
@@ -1,0 +1,48 @@
+package com.mio.session.domain;
+
+import com.mio.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+@Entity
+@Table(name = "session_checkpoints")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SessionCheckpoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "session_id", nullable = false)
+    private Session session;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "checkpoint_seq", nullable = false)
+    private int checkpointSeq;
+
+    @Column(name = "summary_text", nullable = false, columnDefinition = "TEXT")
+    private String summaryText;
+
+    /** 이 체크포인트가 커버하는 마지막 메시지의 created_at */
+    @Column(name = "covered_up_to_at", nullable = false)
+    private OffsetDateTime coveredUpToAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -48,19 +48,21 @@ public class SessionTimeoutJob {
 
     private void terminateSession(Session session, OffsetDateTime cutoff) {
         try {
-            transactionTemplate.execute(status -> {
+            Boolean ended = transactionTemplate.execute(status -> {
                 OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
                 // 원자적 UPDATE: 상태와 timeout cutoff를 다시 확인해 새 메시지와의 레이스를 방지한다.
                 int updated = sessionRepository.endSessionIfActive(session.getId(), cutoff, now);
                 if (updated == 0) {
                     log.debug("SessionTimeoutJob: sessionId={} no longer timed out, skipping", session.getId());
-                    return null;
+                    return Boolean.FALSE;
                 }
                 eventPublisher.publishEvent(
                         new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId()));
-                return null;
+                return Boolean.TRUE;
             });
-            log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
+            if (Boolean.TRUE.equals(ended)) {
+                log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
+            }
         } catch (Exception e) {
             log.error("SessionTimeoutJob: failed to end sessionId={}", session.getId(), e);
         }

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -42,18 +42,18 @@ public class SessionTimeoutJob {
         log.info("SessionTimeoutJob: {} timed-out sessions found", timedOut.size());
 
         for (Session session : timedOut) {
-            terminateSession(session);
+            terminateSession(session, cutoff);
         }
     }
 
-    private void terminateSession(Session session) {
+    private void terminateSession(Session session, OffsetDateTime cutoff) {
         try {
             transactionTemplate.execute(status -> {
                 OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
-                // 원자적 UPDATE: 이미 ended 상태인 경우 0 반환 → skip
-                int updated = sessionRepository.endSessionIfActive(session.getId(), now);
+                // 원자적 UPDATE: 상태와 timeout cutoff를 다시 확인해 새 메시지와의 레이스를 방지한다.
+                int updated = sessionRepository.endSessionIfActive(session.getId(), cutoff, now);
                 if (updated == 0) {
-                    log.debug("SessionTimeoutJob: sessionId={} already ended, skipping", session.getId());
+                    log.debug("SessionTimeoutJob: sessionId={} no longer timed out, skipping", session.getId());
                     return null;
                 }
                 eventPublisher.publishEvent(

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -8,7 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -16,7 +16,8 @@ import java.util.List;
 
 /**
  * 30분 무응답 세션 자동 종료 Job (MIO-Session-003, MIO-Session-004).
- * 5분마다 실행하여 lastMessageAt 기준 30분 초과 active 세션을 종료한다.
+ * 5분마다 실행하여 lastMessageAt(없으면 startedAt) 기준 30분 초과 active 세션을 종료한다.
+ * 세션별 독립 트랜잭션으로 처리하여 단일 실패가 전체 배치를 롤백하지 않도록 한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -27,9 +28,9 @@ public class SessionTimeoutJob {
 
     private final SessionRepository sessionRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final TransactionTemplate transactionTemplate;
 
     @Scheduled(fixedDelay = 5 * 60 * 1000)
-    @Transactional
     public void run() {
         OffsetDateTime cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(TIMEOUT_MINUTES);
         List<Session> timedOut = sessionRepository.findTimedOutActiveSessions(cutoff);
@@ -39,15 +40,24 @@ public class SessionTimeoutJob {
         log.info("SessionTimeoutJob: terminating {} timed-out sessions", timedOut.size());
 
         for (Session session : timedOut) {
-            try {
-                session.end();
-                sessionRepository.save(session);
+            terminateSession(session);
+        }
+    }
+
+    private void terminateSession(Session session) {
+        try {
+            transactionTemplate.execute(status -> {
+                Session managed = sessionRepository.findById(session.getId()).orElse(null);
+                if (managed == null || managed.isEnded()) return null;
+                managed.end();
+                sessionRepository.save(managed);
                 eventPublisher.publishEvent(
-                        new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId()));
-                log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
-            } catch (Exception e) {
-                log.error("SessionTimeoutJob: failed to end sessionId={}", session.getId(), e);
-            }
+                        new SessionEndedEvent(managed.getId(), managed.getUser().getId(), managed.getCharacterId()));
+                return null;
+            });
+            log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
+        } catch (Exception e) {
+            log.error("SessionTimeoutJob: failed to end sessionId={}", session.getId(), e);
         }
     }
 }

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -17,6 +17,8 @@ import java.util.List;
 /**
  * 30분 무응답 세션 자동 종료 Job (MIO-Session-003, MIO-Session-004).
  * 5분마다 실행하여 lastMessageAt(없으면 startedAt) 기준 30분 초과 active 세션을 종료한다.
+ *
+ * 동시성: endSessionIfActive()의 원자적 UPDATE로 멀티 인스턴스 중복 처리를 방지한다.
  * 세션별 독립 트랜잭션으로 처리하여 단일 실패가 전체 배치를 롤백하지 않도록 한다.
  */
 @Component
@@ -37,7 +39,7 @@ public class SessionTimeoutJob {
 
         if (timedOut.isEmpty()) return;
 
-        log.info("SessionTimeoutJob: terminating {} timed-out sessions", timedOut.size());
+        log.info("SessionTimeoutJob: {} timed-out sessions found", timedOut.size());
 
         for (Session session : timedOut) {
             terminateSession(session);
@@ -47,12 +49,15 @@ public class SessionTimeoutJob {
     private void terminateSession(Session session) {
         try {
             transactionTemplate.execute(status -> {
-                Session managed = sessionRepository.findById(session.getId()).orElse(null);
-                if (managed == null || managed.isEnded()) return null;
-                managed.end();
-                sessionRepository.save(managed);
+                OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+                // 원자적 UPDATE: 이미 ended 상태인 경우 0 반환 → skip
+                int updated = sessionRepository.endSessionIfActive(session.getId(), now);
+                if (updated == 0) {
+                    log.debug("SessionTimeoutJob: sessionId={} already ended, skipping", session.getId());
+                    return null;
+                }
                 eventPublisher.publishEvent(
-                        new SessionEndedEvent(managed.getId(), managed.getUser().getId(), managed.getCharacterId()));
+                        new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId()));
                 return null;
             });
             log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -1,0 +1,53 @@
+package com.mio.session.job;
+
+import com.mio.ai.memory.consolidation.SessionEndedEvent;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * 30분 무응답 세션 자동 종료 Job (MIO-Session-003, MIO-Session-004).
+ * 5분마다 실행하여 lastMessageAt 기준 30분 초과 active 세션을 종료한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionTimeoutJob {
+
+    private static final int TIMEOUT_MINUTES = 30;
+
+    private final SessionRepository sessionRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000)
+    @Transactional
+    public void run() {
+        OffsetDateTime cutoff = OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(TIMEOUT_MINUTES);
+        List<Session> timedOut = sessionRepository.findTimedOutActiveSessions(cutoff);
+
+        if (timedOut.isEmpty()) return;
+
+        log.info("SessionTimeoutJob: terminating {} timed-out sessions", timedOut.size());
+
+        for (Session session : timedOut) {
+            try {
+                session.end();
+                sessionRepository.save(session);
+                eventPublisher.publishEvent(
+                        new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId()));
+                log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
+            } catch (Exception e) {
+                log.error("SessionTimeoutJob: failed to end sessionId={}", session.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/mio/session/repository/SessionCheckpointRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionCheckpointRepository.java
@@ -2,8 +2,6 @@ package com.mio.session.repository;
 
 import com.mio.session.domain.SessionCheckpoint;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,8 +11,7 @@ public interface SessionCheckpointRepository extends JpaRepository<SessionCheckp
 
     List<SessionCheckpoint> findBySession_IdOrderByCheckpointSeqAsc(UUID sessionId);
 
-    @Query("SELECT c FROM SessionCheckpoint c WHERE c.session.id = :sessionId ORDER BY c.checkpointSeq DESC LIMIT 1")
-    Optional<SessionCheckpoint> findLatestBySessionId(@Param("sessionId") UUID sessionId);
+    Optional<SessionCheckpoint> findTopBySession_IdOrderByCheckpointSeqDesc(UUID sessionId);
 
     int countBySession_Id(UUID sessionId);
 }

--- a/src/main/java/com/mio/session/repository/SessionCheckpointRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionCheckpointRepository.java
@@ -1,0 +1,20 @@
+package com.mio.session.repository;
+
+import com.mio.session.domain.SessionCheckpoint;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface SessionCheckpointRepository extends JpaRepository<SessionCheckpoint, UUID> {
+
+    List<SessionCheckpoint> findBySession_IdOrderByCheckpointSeqAsc(UUID sessionId);
+
+    @Query("SELECT c FROM SessionCheckpoint c WHERE c.session.id = :sessionId ORDER BY c.checkpointSeq DESC LIMIT 1")
+    Optional<SessionCheckpoint> findLatestBySessionId(@Param("sessionId") UUID sessionId);
+
+    int countBySession_Id(UUID sessionId);
+}

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -14,6 +14,9 @@ import java.util.UUID;
 
 public interface SessionRepository extends JpaRepository<Session, UUID> {
 
+    @Query("SELECT s FROM Session s WHERE s.status = com.mio.session.domain.SessionStatus.ACTIVE AND s.lastMessageAt < :cutoff")
+    List<Session> findTimedOutActiveSessions(@Param("cutoff") OffsetDateTime cutoff);
+
     Optional<Session> findByIdAndUser_Id(UUID id, UUID userId);
 
     Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -18,8 +18,8 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
             SELECT s FROM Session s
             WHERE s.status = com.mio.session.domain.SessionStatus.ACTIVE
               AND (
-                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt < :cutoff)
-                OR (s.lastMessageAt IS NULL AND s.startedAt < :cutoff)
+                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt <= :cutoff)
+                OR (s.lastMessageAt IS NULL AND s.startedAt <= :cutoff)
               )
             """)
     List<Session> findTimedOutActiveSessions(@Param("cutoff") OffsetDateTime cutoff);
@@ -36,8 +36,8 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
             WHERE s.id = :sessionId
               AND s.status = com.mio.session.domain.SessionStatus.ACTIVE
               AND (
-                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt < :cutoff)
-                OR (s.lastMessageAt IS NULL AND s.startedAt < :cutoff)
+                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt <= :cutoff)
+                OR (s.lastMessageAt IS NULL AND s.startedAt <= :cutoff)
               )
             """)
     int endSessionIfActive(@Param("sessionId") UUID sessionId,

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -33,9 +33,16 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
     @Query("""
             UPDATE Session s
             SET s.status = com.mio.session.domain.SessionStatus.ENDED, s.endedAt = :endedAt
-            WHERE s.id = :sessionId AND s.status = com.mio.session.domain.SessionStatus.ACTIVE
+            WHERE s.id = :sessionId
+              AND s.status = com.mio.session.domain.SessionStatus.ACTIVE
+              AND (
+                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt < :cutoff)
+                OR (s.lastMessageAt IS NULL AND s.startedAt < :cutoff)
+              )
             """)
-    int endSessionIfActive(@Param("sessionId") UUID sessionId, @Param("endedAt") OffsetDateTime endedAt);
+    int endSessionIfActive(@Param("sessionId") UUID sessionId,
+                           @Param("cutoff") OffsetDateTime cutoff,
+                           @Param("endedAt") OffsetDateTime endedAt);
 
     Optional<Session> findByIdAndUser_Id(UUID id, UUID userId);
 

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -14,7 +14,14 @@ import java.util.UUID;
 
 public interface SessionRepository extends JpaRepository<Session, UUID> {
 
-    @Query("SELECT s FROM Session s WHERE s.status = com.mio.session.domain.SessionStatus.ACTIVE AND s.lastMessageAt < :cutoff")
+    @Query("""
+            SELECT s FROM Session s
+            WHERE s.status = com.mio.session.domain.SessionStatus.ACTIVE
+              AND (
+                (s.lastMessageAt IS NOT NULL AND s.lastMessageAt < :cutoff)
+                OR (s.lastMessageAt IS NULL AND s.startedAt < :cutoff)
+              )
+            """)
     List<Session> findTimedOutActiveSessions(@Param("cutoff") OffsetDateTime cutoff);
 
     Optional<Session> findByIdAndUser_Id(UUID id, UUID userId);

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -24,6 +24,19 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
             """)
     List<Session> findTimedOutActiveSessions(@Param("cutoff") OffsetDateTime cutoff);
 
+    /**
+     * 원자적 상태 전이: ACTIVE → ENDED (조건부 UPDATE).
+     * 동시 실행 환경에서 단일 인스턴스만 처리하도록 보장.
+     * 반환값 1 = 성공(해당 인스턴스가 처리), 0 = 이미 종료됨(skip).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE Session s
+            SET s.status = com.mio.session.domain.SessionStatus.ENDED, s.endedAt = :endedAt
+            WHERE s.id = :sessionId AND s.status = com.mio.session.domain.SessionStatus.ACTIVE
+            """)
+    int endSessionIfActive(@Param("sessionId") UUID sessionId, @Param("endedAt") OffsetDateTime endedAt);
+
     Optional<Session> findByIdAndUser_Id(UUID id, UUID userId);
 
     Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);

--- a/src/main/resources/db/migration/V26__add_session_checkpoints.sql
+++ b/src/main/resources/db/migration/V26__add_session_checkpoints.sql
@@ -1,0 +1,14 @@
+-- 대화 롤링 체크포인트: 20개 메시지마다 중간 요약을 누적하여
+-- 세션 종료 시 전체 메시지 재로딩 없이 최종 요약을 생성한다.
+CREATE TABLE session_checkpoints (
+    id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    session_id       UUID        NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    user_id          UUID        NOT NULL REFERENCES users(id),
+    checkpoint_seq   INT         NOT NULL,
+    summary_text     TEXT        NOT NULL,
+    covered_up_to_at TIMESTAMPTZ NOT NULL,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (session_id, checkpoint_seq)
+);
+
+CREATE INDEX idx_session_checkpoints_session ON session_checkpoints(session_id, checkpoint_seq);

--- a/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -58,6 +58,7 @@ class CrisisFlowServiceTest {
 
         SseEventDto.DoneEvent doneEvent = eventCaptor.getAllValues().stream()
                 .flatMap(builder -> extractData(builder).stream())
+                .map(ResponseBodyEmitter.DataWithMediaType::getData)
                 .filter(SseEventDto.DoneEvent.class::isInstance)
                 .map(SseEventDto.DoneEvent.class::cast)
                 .findFirst()
@@ -70,21 +71,7 @@ class CrisisFlowServiceTest {
         verify(eventPublisher).publishEvent(any(CrisisDetectedEvent.class));
     }
 
-    private Set<?> extractData(SseEmitter.SseEventBuilder builder) {
-        Object value = readField(builder, "dataToSend");
-        if (value instanceof Set<?> set) {
-            return set;
-        }
-        return Set.of();
-    }
-
-    private Object readField(Object target, String name) {
-        try {
-            Field field = target.getClass().getDeclaredField(name);
-            field.setAccessible(true);
-            return field.get(target);
-        } catch (ReflectiveOperationException e) {
-            throw new AssertionError(e);
-        }
+    private Set<ResponseBodyEmitter.DataWithMediaType> extractData(SseEmitter.SseEventBuilder builder) {
+        return builder.build();
     }
 }

--- a/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
@@ -1,0 +1,90 @@
+package com.mio.ai.crisis;
+
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.SseEventDto;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+class CrisisFlowServiceTest {
+
+    @Test
+    @DisplayName("crisis done 이벤트에도 CBT emotion_score를 전달한다")
+    void handle_sends_emotion_score_in_crisis_done_event() throws Exception {
+        CrisisEventRepository crisisEventRepository = mock(CrisisEventRepository.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        CrisisFlowService service = new CrisisFlowService(crisisEventRepository, eventPublisher);
+        SseEmitter emitter = mock(SseEmitter.class);
+
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        Session session = Session.builder()
+                .user(user)
+                .characterId("mio")
+                .build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+
+        service.handle(
+                new SafetyL1Result(true, true, false, false, false, true, List.of("자살"), 0.95),
+                "죽고싶다",
+                user,
+                session,
+                emitter,
+                "msg_out_test",
+                18);
+
+        ArgumentCaptor<SseEmitter.SseEventBuilder> eventCaptor =
+                ArgumentCaptor.forClass(SseEmitter.SseEventBuilder.class);
+        verify(emitter, org.mockito.Mockito.times(2)).send(eventCaptor.capture());
+
+        SseEventDto.DoneEvent doneEvent = eventCaptor.getAllValues().stream()
+                .flatMap(builder -> extractData(builder).stream())
+                .filter(SseEventDto.DoneEvent.class::isInstance)
+                .map(SseEventDto.DoneEvent.class::cast)
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(doneEvent.emotionScore()).isEqualTo(18);
+        assertThat(doneEvent.isCrisisFlagged()).isTrue();
+        assertThat(doneEvent.finishedReason()).isEqualTo("crisis_flow");
+        verify(crisisEventRepository).save(any());
+        verify(eventPublisher).publishEvent(any(CrisisDetectedEvent.class));
+    }
+
+    private Set<?> extractData(SseEmitter.SseEventBuilder builder) {
+        Object value = readField(builder, "dataToSend");
+        if (value instanceof Set<?> set) {
+            return set;
+        }
+        return Set.of();
+    }
+
+    private Object readField(Object target, String name) {
+        try {
+            Field field = target.getClass().getDeclaredField(name);
+            field.setAccessible(true);
+            return field.get(target);
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError(e);
+        }
+    }
+}

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -1,0 +1,59 @@
+package com.mio.ai.memory.consolidation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.memory.episodic.ThoughtRepository;
+import com.mio.ai.memory.episodic.UserBeliefRepository;
+import com.mio.ai.memory.ontology.OntologyValidator;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SessionConsolidatorTest {
+
+    @Test
+    @DisplayName("세션 종료 요약은 최근 40개로 자르지 않고 전체 대화를 시간순으로 조회한다")
+    void loadConversationLines_does_not_limit_to_recent_40_messages() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        UUID sessionId = UUID.randomUUID();
+        when(jdbcTemplate.queryForList(anyString(), eq(sessionId))).thenReturn(List.of());
+        SessionConsolidator consolidator = new SessionConsolidator(
+                mock(SessionRepository.class),
+                mock(SessionSummaryRepository.class),
+                mock(UserRepository.class),
+                mock(ThoughtRepository.class),
+                mock(UserBeliefRepository.class),
+                mock(BeliefEvidenceAccumulator.class),
+                mock(ExtractorLlmClient.class),
+                mock(LlmClient.class),
+                mock(MessageEncryptor.class),
+                jdbcTemplate,
+                new ObjectMapper(),
+                mock(OntologyValidator.class),
+                mock(TodoRecommendationService.class)
+        );
+
+        ReflectionTestUtils.invokeMethod(consolidator, "loadConversationLines", sessionId);
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).queryForList(sqlCaptor.capture(), eq(sessionId));
+        assertThat(sqlCaptor.getValue().toLowerCase()).doesNotContain("limit 40");
+        assertThat(sqlCaptor.getValue().toLowerCase()).contains("order by created_at asc");
+    }
+}

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -6,6 +6,7 @@ import com.mio.ai.memory.episodic.ThoughtRepository;
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.user.repository.UserRepository;
@@ -36,6 +37,7 @@ class SessionConsolidatorTest {
         SessionConsolidator consolidator = new SessionConsolidator(
                 mock(SessionRepository.class),
                 mock(SessionSummaryRepository.class),
+                mock(SessionCheckpointRepository.class),
                 mock(UserRepository.class),
                 mock(ThoughtRepository.class),
                 mock(UserBeliefRepository.class),

--- a/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
+++ b/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
@@ -1,0 +1,65 @@
+package com.mio.session.job;
+
+import com.mio.ai.memory.consolidation.SessionEndedEvent;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SessionTimeoutJobTest {
+
+    @Test
+    @DisplayName("타임아웃 종료 update는 cutoff 조건을 원자적으로 다시 검증한다")
+    void run_rechecks_timeout_cutoff_in_atomic_update() {
+        SessionRepository sessionRepository = mock(SessionRepository.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        Session session = Session.builder()
+                .user(user)
+                .characterId("mio")
+                .build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+
+        when(sessionRepository.findTimedOutActiveSessions(any())).thenReturn(List.of(session));
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+        when(sessionRepository.endSessionIfActive(eq(sessionId), any(), any())).thenReturn(1);
+
+        job.run();
+
+        ArgumentCaptor<OffsetDateTime> cutoffCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(sessionRepository).findTimedOutActiveSessions(cutoffCaptor.capture());
+        verify(sessionRepository).endSessionIfActive(eq(sessionId), eq(cutoffCaptor.getValue()), any());
+        verify(eventPublisher).publishEvent(any(SessionEndedEvent.class));
+        assertThat(cutoffCaptor.getValue()).isBefore(OffsetDateTime.now());
+    }
+}

--- a/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
+++ b/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
@@ -20,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,17 +37,7 @@ class SessionTimeoutJobTest {
 
         UUID userId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
-        User user = User.builder()
-                .socialProvider("kakao")
-                .socialId("social-id")
-                .privacyConsent(true)
-                .build();
-        ReflectionTestUtils.setField(user, "id", userId);
-        Session session = Session.builder()
-                .user(user)
-                .characterId("mio")
-                .build();
-        ReflectionTestUtils.setField(session, "id", sessionId);
+        Session session = buildSession(userId, sessionId);
 
         when(sessionRepository.findTimedOutActiveSessions(any())).thenReturn(List.of(session));
         when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
@@ -61,5 +53,71 @@ class SessionTimeoutJobTest {
         verify(sessionRepository).endSessionIfActive(eq(sessionId), eq(cutoffCaptor.getValue()), any());
         verify(eventPublisher).publishEvent(any(SessionEndedEvent.class));
         assertThat(cutoffCaptor.getValue()).isBefore(OffsetDateTime.now());
+    }
+
+    @Test
+    @DisplayName("원자적 update가 0을 반환하면 이미 종료된 세션이므로 이벤트를 발행하지 않는다")
+    void run_does_not_publish_event_when_atomic_update_skipped() {
+        SessionRepository sessionRepository = mock(SessionRepository.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+
+        UUID sessionId = UUID.randomUUID();
+        Session session = buildSession(UUID.randomUUID(), sessionId);
+
+        when(sessionRepository.findTimedOutActiveSessions(any())).thenReturn(List.of(session));
+        when(transactionTemplate.execute(any())).thenAnswer(invocation -> {
+            TransactionCallback<?> callback = invocation.getArgument(0);
+            return callback.doInTransaction(null);
+        });
+        // 다른 인스턴스가 먼저 처리한 상황 시뮬레이션
+        when(sessionRepository.endSessionIfActive(eq(sessionId), any(), any())).thenReturn(0);
+
+        job.run();
+
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("한 세션 처리 실패가 나머지 세션 처리를 막지 않는다")
+    void run_continues_remaining_sessions_when_one_fails() {
+        SessionRepository sessionRepository = mock(SessionRepository.class);
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+
+        UUID sessionId1 = UUID.randomUUID();
+        UUID sessionId2 = UUID.randomUUID();
+        Session session1 = buildSession(UUID.randomUUID(), sessionId1);
+        Session session2 = buildSession(UUID.randomUUID(), sessionId2);
+
+        when(sessionRepository.findTimedOutActiveSessions(any())).thenReturn(List.of(session1, session2));
+        when(transactionTemplate.execute(any()))
+                .thenThrow(new RuntimeException("DB error on session1"))  // session1 실패
+                .thenAnswer(invocation -> {                               // session2 성공
+                    TransactionCallback<?> callback = invocation.getArgument(0);
+                    return callback.doInTransaction(null);
+                });
+        when(sessionRepository.endSessionIfActive(eq(sessionId2), any(), any())).thenReturn(1);
+
+        job.run();
+
+        verify(eventPublisher, times(1)).publishEvent(any(SessionEndedEvent.class));
+    }
+
+    private static Session buildSession(UUID userId, UUID sessionId) {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        Session session = Session.builder()
+                .user(user)
+                .characterId("mio")
+                .build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        return session;
     }
 }


### PR DESCRIPTION
## Summary

- **SessionTimeoutJob 신규 구현**: 5분 주기로 `lastMessageAt` 기준 30분 초과 active 세션 자동 종료, `SessionEndedEvent` 발행 → `SessionConsolidator` 트리거 (MIO-Session-003, MIO-Session-004)
- **emotion_score null 버그 수정**: `ConversationOrchestrator`의 모든 `DoneEvent`에 `userSignal.emotionScore()` 전달 (MIO-CBT-012)
- **CBT 소크라테스 2회 제한 미반영 수정**: `PolicyEngine`에서 `delta.socraticLimitReached()` 시 `InterventionHints.empty()` 반환하여 CBT 힌트 차단 (MIO-CBT-011)
- **SessionConsolidator 최신 메시지 누락 수정**: `ASC LIMIT 40` → 서브쿼리 `DESC LIMIT 40` + ASC 재정렬로 40개 초과 세션에서 최신 메시지 기준 요약 생성

## Closes

Closes #116, #117, #118, #119

## Test plan

- [ ] 30분 이상 메시지 없는 active 세션이 자동으로 `ended` 상태로 전환되는지 확인
- [ ] `SessionConsolidator`가 자동 종료 세션에도 정상 트리거되는지 확인
- [ ] SSE `done` 이벤트의 `emotion_score` 필드에 null 대신 실제 값이 오는지 확인
- [ ] 소크라테스 질문 2회 이후 메시지에서 CBT 개입 힌트가 프롬프트에 포함되지 않는지 확인
- [ ] 40개 초과 세션 요약 시 최신 메시지 내용이 반영되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Periodic session checkpoints created to preserve conversation summaries.
  * Automatic session timeout processing runs regularly to end inactive sessions.

* **Improvements**
  * Conversation context assembly upgraded to include past checkpoints and recent messages (no arbitrary 40-message cap).
  * Emotion scores now appear in conversation completion events.
  * Intervention hints and status reasons refined for clearer behavior.

* **Tests**
  * New tests cover checkpoints, conversation loading, crisis flow, and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->