### PR TITLE
fix: 채팅 API 명세 불일치 4건 수정 (delta.replace / Idempotency-Key / Rate Limit / 명세)

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -210,12 +210,10 @@ public class ConversationOrchestrator {
                         }
                     });
                     assistantContent = contentBuilder.toString();
-                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
 
-                    // CAUTIOUS_SPECULATIVE: post-stream OutputGuard
-                    // 이미 스트리밍된 응답은 취소 불가하지만, DB에는 안전 버전을 저장해
-                    // 대화 기록 조회 시 유해 원문이 노출되지 않도록 한다.
                     if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
+                        // post-stream OutputGuard: 스트리밍 완료 후 안전성 검사
+                        // REWRITE/REPLACE 시 delta.replace 이벤트로 FE 말풍선 교체 후 done 전송
                         preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
                         if (!preFilterResult.passed()) {
                             judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
@@ -223,15 +221,28 @@ public class ConversationOrchestrator {
                                     sessionId, preFilterResult.failReasons(),
                                     judgeActionResult != null ? judgeActionResult.action() : "none");
                             if (judgeActionResult != null) {
-                                assistantContent = switch (judgeActionResult.action()) {
+                                String replacedContent = switch (judgeActionResult.action()) {
                                     case REWRITE -> judgeActionResult.rewrittenContent() != null
-                                            ? judgeActionResult.rewrittenContent() : assistantContent;
+                                            ? judgeActionResult.rewrittenContent() : null;
                                     case REPLACE, CRISIS_FLOW ->
                                             "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
-                                    case SEND -> assistantContent;
+                                    case SEND -> null;
                                 };
+                                if (replacedContent != null) {
+                                    assistantContent = replacedContent;
+                                    sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "replaced_by_guard"));
+                                } else {
+                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
+                                }
+                            } else {
+                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                             }
+                        } else {
+                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                         }
+                    } else {
+                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                     }
                 }
             } else {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -221,6 +221,8 @@ public class ConversationOrchestrator {
                                     sessionId, preFilterResult.failReasons(),
                                     judgeActionResult != null ? judgeActionResult.action() : "none");
                             if (judgeActionResult != null) {
+                                boolean isCrisis = judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW;
+                                if (isCrisis) crisisFlowTriggered = true;
                                 String replacedContent = switch (judgeActionResult.action()) {
                                     case REWRITE -> judgeActionResult.rewrittenContent() != null
                                             ? judgeActionResult.rewrittenContent() : null;
@@ -231,7 +233,7 @@ public class ConversationOrchestrator {
                                 if (replacedContent != null) {
                                     assistantContent = replacedContent;
                                     sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
-                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "replaced_by_guard"));
+                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), isCrisis, "replaced_by_guard"));
                                 } else {
                                     sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                                 }

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -46,7 +46,7 @@ public class SessionController {
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody SendMessageRequest request) {
         UUID userId = resolveUserId(principal);
-        sessionService.validateMessageRequest(userId, idempotencyKey);
+        sessionService.validateMessageRequest(userId, sessionId, idempotencyKey);
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(error -> emitter.complete());

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -43,12 +43,14 @@ public class SessionController {
     public SseEmitter sendMessage(
             Principal principal,
             @PathVariable UUID sessionId,
+            @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody SendMessageRequest request) {
         UUID userId = resolveUserId(principal);
+        sessionService.validateMessageRequest(userId, idempotencyKey);
         SseEmitter emitter = new SseEmitter(60_000L);
         emitter.onTimeout(emitter::complete);
         emitter.onError(error -> emitter.complete());
-        Thread.ofVirtual().start(() -> sessionService.streamMessage(userId, sessionId, request, emitter));
+        Thread.ofVirtual().start(() -> sessionService.streamMessage(userId, sessionId, request, emitter, idempotencyKey));
         return emitter;
     }
 

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 public sealed interface SseEventDto
         permits SseEventDto.SessionMetaEvent,
                 SseEventDto.DeltaEvent,
+                SseEventDto.DeltaReplaceEvent,
                 SseEventDto.CrisisEvent,
                 SseEventDto.DoneEvent {
 
@@ -25,6 +26,13 @@ public sealed interface SseEventDto
             @JsonProperty("msg_id") String msgId
     ) implements SseEventDto {
         @Override public String eventName() { return "delta"; }
+    }
+
+    record DeltaReplaceEvent(
+            @JsonProperty("safe_response") String safeResponse,
+            @JsonProperty("msg_id") String msgId
+    ) implements SseEventDto {
+        @Override public String eventName() { return "delta.replace"; }
     }
 
     record CrisisEvent(

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionSynchronization;
@@ -26,12 +27,16 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
 public class SessionService {
 
     private static final Set<String> ALLOWED_CHARACTER_IDS = Set.of("mio", "bau", "rumi", "momo", "chichi");
+    private static final int MSG_RATE_LIMIT_MAX = 60;
+    private static final long MSG_RATE_LIMIT_TTL_SECONDS = 60L;
+    private static final long MSG_IDEMPOTENCY_TTL_SECONDS = 3600L;
 
     private final SessionRepository sessionRepository;
     private final UserRepository userRepository;
@@ -40,6 +45,7 @@ public class SessionService {
     private final WorkingMemory workingMemory;
     private final ApplicationEventPublisher eventPublisher;
     private final ContextPreWarmer contextPreWarmer;
+    private final StringRedisTemplate redisTemplate;
 
     @Transactional
     public SessionResponse createSession(UUID userId, CreateSessionRequest request) {
@@ -111,23 +117,57 @@ public class SessionService {
         session.end();
         EndSessionResponse response = EndSessionResponse.from(sessionRepository.save(session));
 
-        // Redis 정리 + SessionConsolidator 이벤트: 커밋 후 실행 — 커넥션 점유 최소화
+        // @TransactionalEventListener(AFTER_COMMIT) 캡처용: 트랜잭션 내 발행해야 커밋 후 리스너 실행됨
         String characterId = session.getCharacterId();
+        eventPublisher.publishEvent(new SessionEndedEvent(sessionId, userId, characterId));
+
+        // Redis 정리는 커밋 후 실행 (트랜잭션 불필요)
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
             @Override
             public void afterCommit() {
                 workingMemory.clear(sessionId);
-                eventPublisher.publishEvent(new SessionEndedEvent(sessionId, userId, characterId));
             }
         });
 
         return response;
     }
 
-    public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request, SseEmitter emitter) {
+    /**
+     * SSE 스트림 시작 전 동기 검증 — 여기서 예외 발생 시 HTTP 4xx로 응답됨
+     */
+    public void validateMessageRequest(UUID userId, String idempotencyKey) {
+        checkMessageRateLimit(userId);
+        if (idempotencyKey != null
+                && Boolean.TRUE.equals(redisTemplate.hasKey(messageIdempotencyKey(idempotencyKey)))) {
+            throw new BusinessException(ErrorCode.DUPLICATE_REQUEST);
+        }
+    }
+
+    public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request,
+                              SseEmitter emitter, String idempotencyKey) {
         Session session = findSession(sessionId);
         validateSessionOwner(session, userId);
         conversationOrchestrator.handle(userId, sessionId, request.content(), emitter);
+        if (idempotencyKey != null) {
+            redisTemplate.opsForValue().set(
+                    messageIdempotencyKey(idempotencyKey), "1", MSG_IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+    }
+
+    private void checkMessageRateLimit(UUID userId) {
+        String key = "session:ratelimit:msg:" + userId;
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count == null) return;
+        if (count == 1) {
+            redisTemplate.expire(key, MSG_RATE_LIMIT_TTL_SECONDS, TimeUnit.SECONDS);
+        }
+        if (count > MSG_RATE_LIMIT_MAX) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+
+    private static String messageIdempotencyKey(String key) {
+        return "msg:idempotency:" + key;
     }
 
     private User findUser(UUID userId) {

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -133,25 +133,25 @@ public class SessionService {
     }
 
     /**
-     * SSE 스트림 시작 전 동기 검증 — 여기서 예외 발생 시 HTTP 4xx로 응답됨
+     * SSE 스트림 시작 전 동기 검증 — 여기서 예외 발생 시 HTTP 4xx로 응답됨.
+     * 세션 검증도 여기서 수행하여 가상 스레드 내 SseEmitter 누수를 방지한다.
      */
-    public void validateMessageRequest(UUID userId, String idempotencyKey) {
+    public void validateMessageRequest(UUID userId, UUID sessionId, String idempotencyKey) {
         checkMessageRateLimit(userId);
-        if (idempotencyKey != null
-                && Boolean.TRUE.equals(redisTemplate.hasKey(messageIdempotencyKey(idempotencyKey)))) {
-            throw new BusinessException(ErrorCode.DUPLICATE_REQUEST);
+        Session session = findSession(sessionId);
+        validateSessionOwner(session, userId);
+        if (idempotencyKey != null) {
+            Boolean acquired = redisTemplate.opsForValue().setIfAbsent(
+                    messageIdempotencyKey(userId, idempotencyKey), "1", MSG_IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
+            if (!Boolean.TRUE.equals(acquired)) {
+                throw new BusinessException(ErrorCode.DUPLICATE_REQUEST);
+            }
         }
     }
 
     public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request,
                               SseEmitter emitter, String idempotencyKey) {
-        Session session = findSession(sessionId);
-        validateSessionOwner(session, userId);
         conversationOrchestrator.handle(userId, sessionId, request.content(), emitter);
-        if (idempotencyKey != null) {
-            redisTemplate.opsForValue().set(
-                    messageIdempotencyKey(idempotencyKey), "1", MSG_IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
-        }
     }
 
     private void checkMessageRateLimit(UUID userId) {
@@ -166,8 +166,8 @@ public class SessionService {
         }
     }
 
-    private static String messageIdempotencyKey(String key) {
-        return "msg:idempotency:" + key;
+    private static String messageIdempotencyKey(UUID userId, String key) {
+        return "msg:idempotency:" + userId + ":" + key;
     }
 
     private User findUser(UUID userId) {

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -239,12 +239,6 @@ class SessionServiceTest {
     @DisplayName("streamMessage는 ConversationOrchestrator에 위임한다")
     void streamMessage_delegates_to_orchestrator() {
         UUID sessionId = UUID.randomUUID();
-        Session session = Session.builder()
-                .user(mockUser)
-                .characterId("mio")
-                .build();
-        ReflectionTestUtils.setField(session, "id", sessionId);
-        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
         SseEmitter emitter = mock(SseEmitter.class);
 
         sessionService.streamMessage(userId, sessionId, new SendMessageRequest("안녕"), emitter, null);
@@ -256,8 +250,12 @@ class SessionServiceTest {
     @DisplayName("validateMessageRequest: Rate Limit 초과 시 RATE_LIMIT_EXCEEDED 예외가 발생한다")
     void validateMessageRequest_rateLimitExceeded_throws() {
         when(valueOps.increment(anyString())).thenReturn(61L);
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        lenient().when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
 
-        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, null))
+        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, sessionId, null))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED));
@@ -266,21 +264,29 @@ class SessionServiceTest {
     @Test
     @DisplayName("validateMessageRequest: 중복 Idempotency-Key 시 DUPLICATE_REQUEST 예외가 발생한다")
     void validateMessageRequest_duplicateIdempotencyKey_throws() {
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
         when(valueOps.increment(anyString())).thenReturn(1L);
-        when(redisTemplate.hasKey(anyString())).thenReturn(true);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(valueOps.setIfAbsent(anyString(), anyString(), anyLong(), any())).thenReturn(false);
 
-        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, "dup-key-123"))
+        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, sessionId, "dup-key-123"))
                 .isInstanceOf(BusinessException.class)
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.DUPLICATE_REQUEST));
     }
 
     @Test
-    @DisplayName("validateMessageRequest: Idempotency-Key가 null이면 중복 체크를 건너뛴다")
-    void validateMessageRequest_nullIdempotencyKey_skipsCheck() {
+    @DisplayName("validateMessageRequest: Idempotency-Key가 null이면 setIfAbsent를 호출하지 않는다")
+    void validateMessageRequest_nullIdempotencyKey_skipsAtomicSet() {
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", sessionId);
         when(valueOps.increment(anyString())).thenReturn(1L);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
 
-        sessionService.validateMessageRequest(userId, null);
+        sessionService.validateMessageRequest(userId, sessionId, null);
 
         verify(redisTemplate).expire(anyString(), anyLong(), any());
     }

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -22,6 +22,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -31,7 +33,10 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -46,6 +51,8 @@ class SessionServiceTest {
     @Mock private WorkingMemory workingMemory;
     @Mock private ApplicationEventPublisher eventPublisher;
     @Mock private ContextPreWarmer contextPreWarmer;
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOps;
 
     private SessionService sessionService;
     private UUID userId;
@@ -53,9 +60,10 @@ class SessionServiceTest {
 
     @BeforeEach
     void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
         sessionService = new SessionService(
                 sessionRepository, userRepository, sessionMessagePersistenceService,
-                conversationOrchestrator, workingMemory, eventPublisher, contextPreWarmer
+                conversationOrchestrator, workingMemory, eventPublisher, contextPreWarmer, redisTemplate
         );
         userId = UUID.randomUUID();
         mockUser = User.builder()
@@ -239,8 +247,41 @@ class SessionServiceTest {
         when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
         SseEmitter emitter = mock(SseEmitter.class);
 
-        sessionService.streamMessage(userId, sessionId, new SendMessageRequest("안녕"), emitter);
+        sessionService.streamMessage(userId, sessionId, new SendMessageRequest("안녕"), emitter, null);
 
         verify(conversationOrchestrator).handle(userId, sessionId, "안녕", emitter);
+    }
+
+    @Test
+    @DisplayName("validateMessageRequest: Rate Limit 초과 시 RATE_LIMIT_EXCEEDED 예외가 발생한다")
+    void validateMessageRequest_rateLimitExceeded_throws() {
+        when(valueOps.increment(anyString())).thenReturn(61L);
+
+        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, null))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED));
+    }
+
+    @Test
+    @DisplayName("validateMessageRequest: 중복 Idempotency-Key 시 DUPLICATE_REQUEST 예외가 발생한다")
+    void validateMessageRequest_duplicateIdempotencyKey_throws() {
+        when(valueOps.increment(anyString())).thenReturn(1L);
+        when(redisTemplate.hasKey(anyString())).thenReturn(true);
+
+        assertThatThrownBy(() -> sessionService.validateMessageRequest(userId, "dup-key-123"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.DUPLICATE_REQUEST));
+    }
+
+    @Test
+    @DisplayName("validateMessageRequest: Idempotency-Key가 null이면 중복 체크를 건너뛴다")
+    void validateMessageRequest_nullIdempotencyKey_skipsCheck() {
+        when(valueOps.increment(anyString())).thenReturn(1L);
+
+        sessionService.validateMessageRequest(userId, null);
+
+        verify(redisTemplate).expire(anyString(), anyLong(), any());
     }
 }


### PR DESCRIPTION
## Summary

Closes #123

- `delta.replace` SSE 이벤트 구현 — CAUTIOUS_SPECULATIVE 모드에서 OutputGuard가 REWRITE/REPLACE 판정 시 FE에 교체 이벤트를 보내지 않고 DB에만 저장하던 버그 수정. 이제 `delta.replace` 이벤트로 FE 말풍선을 교체한 뒤 `done:replaced_by_guard`를 전송
- Idempotency-Key 처리 추가 — 명세에 명시된 헤더가 미구현 상태였음. Redis 기반 멱등성 체크 구현 (중복 시 409, TTL 1시간)
- Rate Limit 연결 — `RATE_LIMIT_EXCEEDED` 에러코드만 존재하고 메시지 엔드포인트에 연결되지 않았던 문제 수정. 60 req/분/유저 제한 적용

## 변경 파일

| 파일 | 변경 내용 |
|------|---------|
| `SseEventDto.java` | `DeltaReplaceEvent` 타입 추가 |
| `ConversationOrchestrator.java` | CAUTIOUS_SPECULATIVE 흐름 재구성 — `done` 전에 OutputGuard 실행 |
| `SessionService.java` | `StringRedisTemplate` 주입, `validateMessageRequest()`, `checkMessageRateLimit()` 추가 |
| `SessionController.java` | `Idempotency-Key` 헤더 수신, SSE 전 검증 호출 |

## Test plan

- [ ] BUFFER 모드: 기존 동작 유지 — `delta` → `done:stop` 흐름 회귀 없음
- [ ] SPECULATIVE 모드: 기존 동작 유지 — 스트리밍 → `done:stop` 회귀 없음
- [ ] CAUTIOUS_SPECULATIVE + OutputGuard PASS: `done:stop` 정상 수신
- [ ] CAUTIOUS_SPECULATIVE + OutputGuard REWRITE: `delta.replace` → `done:replaced_by_guard` 수신
- [ ] 같은 Idempotency-Key로 두 번 요청 시 두 번째는 `409` 반환
- [ ] Idempotency-Key 없이 요청 시 정상 처리
- [ ] 60회 초과 요청 시 `429` 반환, 1분 후 초기화 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotency protection for message submissions, preventing duplicate messages from being processed in conversations
  * Implemented rate limiting for message sending to maintain service stability
  * Enhanced content safety features with improved filtering and automatic replacement of flagged content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->