### PR TITLE
feat: summary_status 라이프사이클 도입 (spec v1.3.0)

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -91,6 +91,7 @@ public class SessionConsolidator {
     private final ObjectMapper objectMapper;
     private final OntologyValidator ontologyValidator;
     private final TodoRecommendationService todoRecommendationService;
+    private final SummaryStatusWriter summaryStatusWriter;
 
     // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
     // @Transactional(REQUIRES_NEW): 응고 작업을 독립 트랜잭션으로 실행
@@ -106,13 +107,9 @@ public class SessionConsolidator {
             sessionRepository.updateSummaryStatus(event.sessionId(), SummaryStatus.DONE);
         } catch (Exception e) {
             log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
-            try {
-                jdbcTemplate.update(
-                        "UPDATE sessions SET summary_status = 'failed' WHERE id = ?",
-                        event.sessionId());
-            } catch (Exception ex) {
-                log.error("Failed to mark summary as failed for sessionId={}", event.sessionId(), ex);
-            }
+            // REQUIRES_NEW: 현재 트랜잭션이 rollback-only 또는 DB-aborted 상태일 수 있으므로
+            // 별도 트랜잭션에서 failed 상태를 저장한다.
+            summaryStatusWriter.markFailed(event.sessionId());
         }
     }
 
@@ -257,15 +254,10 @@ public class SessionConsolidator {
 
     private String generateSummary(String conversationText) {
         StringBuilder sb = new StringBuilder();
-        try {
-            llmClient.stream(
-                    LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText),
-                    sb::append
-            );
-        } catch (Exception e) {
-            log.warn("Summary generation failed, using fallback", e);
-            return "세션 요약을 생성할 수 없습니다.";
-        }
+        llmClient.stream(
+                LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText),
+                sb::append
+        );
         return sb.toString().trim();
     }
 

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -14,6 +14,7 @@ import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.session.domain.SessionCheckpoint;
 import com.mio.session.domain.SessionSummary;
+import com.mio.session.domain.SummaryStatus;
 import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
@@ -102,8 +103,16 @@ public class SessionConsolidator {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
         try {
             consolidate(event.sessionId(), event.userId(), event.characterId());
+            sessionRepository.updateSummaryStatus(event.sessionId(), SummaryStatus.DONE);
         } catch (Exception e) {
             log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
+            try {
+                jdbcTemplate.update(
+                        "UPDATE sessions SET summary_status = 'failed' WHERE id = ?",
+                        event.sessionId());
+            } catch (Exception ex) {
+                log.error("Failed to mark summary as failed for sessionId={}", event.sessionId(), ex);
+            }
         }
     }
 

--- a/src/main/java/com/mio/ai/memory/consolidation/SummaryStatusWriter.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SummaryStatusWriter.java
@@ -1,0 +1,28 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.session.domain.SummaryStatus;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SummaryStatusWriter {
+
+    private final SessionRepository sessionRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markFailed(UUID sessionId) {
+        try {
+            sessionRepository.updateSummaryStatus(sessionId, SummaryStatus.FAILED);
+        } catch (Exception e) {
+            log.error("Failed to persist failed status for sessionId={}", sessionId, e);
+        }
+    }
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
     SESSION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "SESSION_ALREADY_ACTIVE", "이미 진행 중인 활성 세션이 있습니다."),
     SESSION_ALREADY_ENDED(HttpStatus.GONE, "GONE", "이미 종료된 세션입니다."),
+    SESSION_SUMMARY_FAILED(HttpStatus.GONE, "GONE", "세션 요약 생성에 실패했습니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 
     // Daily Test

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -27,7 +27,7 @@ public class SessionController {
     public ResponseEntity<ApiResponse<ActiveSessionResponse>> getActiveSession(
             Principal principal) {
         UUID userId = resolveUserId(principal);
-        return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId).orElse(null)));
+        return ResponseEntity.ok(ApiResponse.ok(sessionService.getActiveSession(userId)));
     }
 
     @PostMapping
@@ -61,6 +61,16 @@ public class SessionController {
         UUID userId = resolveUserId(principal);
         EndSessionResponse response = sessionService.endSession(userId, sessionId);
         return ResponseEntity.ok(ApiResponse.ok(response));
+    }
+
+    @GetMapping("/{sessionId}/summary")
+    public ResponseEntity<ApiResponse<SessionSummaryResponse>> getSessionSummary(
+            Principal principal,
+            @PathVariable UUID sessionId) {
+        UUID userId = resolveUserId(principal);
+        SessionSummaryResponse response = sessionService.getSessionSummary(userId, sessionId);
+        HttpStatus status = "pending".equals(response.summaryStatus()) ? HttpStatus.ACCEPTED : HttpStatus.OK;
+        return ResponseEntity.status(status).body(ApiResponse.ok(response));
     }
 
     private UUID resolveUserId(Principal principal) {

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -53,6 +53,10 @@ public class Session {
     @Builder.Default
     private String embeddingStatus = "pending";
 
+    @Column(name = "summary_status", nullable = false)
+    @Builder.Default
+    private SummaryStatus summaryStatus = SummaryStatus.PENDING;
+
     @Column(name = "last_message_at")
     private OffsetDateTime lastMessageAt;
 
@@ -89,6 +93,18 @@ public class Session {
         } else {
             this.avgEmotionScore = (this.avgEmotionScore * (this.messageCount - 1) + newScore) / this.messageCount;
         }
+    }
+
+    public void markSummaryDone() {
+        this.summaryStatus = SummaryStatus.DONE;
+    }
+
+    public void markSummaryViewed() {
+        this.summaryStatus = SummaryStatus.VIEWED;
+    }
+
+    public void markSummaryFailed() {
+        this.summaryStatus = SummaryStatus.FAILED;
     }
 
     public long durationSeconds() {

--- a/src/main/java/com/mio/session/domain/SummaryStatus.java
+++ b/src/main/java/com/mio/session/domain/SummaryStatus.java
@@ -1,0 +1,27 @@
+package com.mio.session.domain;
+
+import java.util.Arrays;
+
+public enum SummaryStatus {
+    PENDING("pending"),
+    DONE("done"),
+    VIEWED("viewed"),
+    FAILED("failed");
+
+    private final String value;
+
+    SummaryStatus(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static SummaryStatus fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(s -> s.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown summary status: " + value));
+    }
+}

--- a/src/main/java/com/mio/session/domain/SummaryStatusConverter.java
+++ b/src/main/java/com/mio/session/domain/SummaryStatusConverter.java
@@ -1,0 +1,18 @@
+package com.mio.session.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class SummaryStatusConverter implements AttributeConverter<SummaryStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SummaryStatus attribute) {
+        return attribute == null ? null : attribute.value();
+    }
+
+    @Override
+    public SummaryStatus convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : SummaryStatus.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -12,16 +12,28 @@ public record ActiveSessionResponse(
         String status,
         @JsonProperty("started_at") OffsetDateTime startedAt,
         @JsonProperty("last_message_at") OffsetDateTime lastMessageAt,
-        @JsonProperty("message_count") int messageCount
+        @JsonProperty("message_count") Integer messageCount,
+        @JsonProperty("last_summary_status") String lastSummaryStatus,
+        @JsonProperty("last_ended_session_id") UUID lastEndedSessionId
 ) {
-    public static ActiveSessionResponse from(Session session) {
+    public static ActiveSessionResponse fromActive(Session session) {
         return new ActiveSessionResponse(
                 session.getId(),
                 session.getCharacterId(),
                 session.getStatus().value(),
                 session.getStartedAt(),
                 session.getLastMessageAt(),
-                session.getMessageCount()
+                session.getMessageCount(),
+                null,
+                null
+        );
+    }
+
+    public static ActiveSessionResponse noActiveSession(Session lastEndedSession) {
+        return new ActiveSessionResponse(
+                null, null, null, null, null, null,
+                lastEndedSession == null ? null : lastEndedSession.getSummaryStatus().value(),
+                lastEndedSession == null ? null : lastEndedSession.getId()
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -24,7 +24,7 @@ public record EndSessionResponse(
                 session.getEndedAt(),
                 session.getMessageCount(),
                 session.durationSeconds(),
-                "pending"
+                session.getSummaryStatus().value()
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -1,0 +1,45 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionSummary;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record SessionSummaryResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("summary_status") String summaryStatus,
+        @JsonProperty("ended_at") OffsetDateTime endedAt,
+        @JsonProperty("duration_seconds") long durationSeconds,
+        @JsonProperty("message_count") int messageCount,
+        String summary,
+        @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
+        @JsonProperty("bias_types_detected") String biasTypesDetected,
+        @JsonProperty("cbt_intervened") Boolean cbtIntervened
+) {
+    public static SessionSummaryResponse pending(Session session) {
+        return new SessionSummaryResponse(
+                session.getId(),
+                "pending",
+                session.getEndedAt(),
+                session.durationSeconds(),
+                session.getMessageCount(),
+                null, null, null, null
+        );
+    }
+
+    public static SessionSummaryResponse from(Session session, SessionSummary summary) {
+        return new SessionSummaryResponse(
+                session.getId(),
+                session.getSummaryStatus().value(),
+                session.getEndedAt(),
+                session.durationSeconds(),
+                session.getMessageCount(),
+                summary.getSummaryText(),
+                session.getAvgEmotionScore(),
+                summary.getBiasTypesDetected(),
+                summary.isCbtIntervened()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -2,6 +2,7 @@ package com.mio.session.repository;
 
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
+import com.mio.session.domain.SummaryStatus;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -48,7 +49,13 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
 
     Optional<Session> findByUser_IdAndStatus(UUID userId, SessionStatus status);
 
+    Optional<Session> findTopByUser_IdAndStatusOrderByEndedAtDesc(UUID userId, SessionStatus status);
+
     boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE Session s SET s.summaryStatus = :status WHERE s.id = :sessionId")
+    void updateSummaryStatus(@Param("sessionId") UUID sessionId, @Param("status") SummaryStatus status);
 
     @Query("SELECT s FROM Session s WHERE s.user.id = :userId AND s.startedAt >= :start AND s.startedAt < :end AND s.status = com.mio.session.domain.SessionStatus.ENDED AND s.endedAt IS NOT NULL")
     List<Session> findEndedSessionsByUserAndPeriod(@Param("userId") UUID userId,

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -146,6 +146,9 @@ public class SessionService {
         if (!session.belongsTo(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
+        if (!session.isEnded()) {
+            throw new BusinessException(ErrorCode.SESSION_NOT_FOUND);
+        }
         SummaryStatus status = session.getSummaryStatus();
         if (status == SummaryStatus.FAILED) {
             throw new BusinessException(ErrorCode.SESSION_SUMMARY_FAILED);

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -8,8 +8,10 @@ import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
+import com.mio.session.domain.SummaryStatus;
 import com.mio.session.dto.*;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +26,6 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -39,6 +40,7 @@ public class SessionService {
     private static final long MSG_IDEMPOTENCY_TTL_SECONDS = 3600L;
 
     private final SessionRepository sessionRepository;
+    private final SessionSummaryRepository sessionSummaryRepository;
     private final UserRepository userRepository;
     private final SessionMessagePersistenceService sessionMessagePersistenceService;
     private final ConversationOrchestrator conversationOrchestrator;
@@ -96,13 +98,19 @@ public class SessionService {
     }
 
     @Transactional(readOnly = true)
-    public Optional<ActiveSessionResponse> getActiveSession(UUID userId) {
+    public ActiveSessionResponse getActiveSession(UUID userId) {
         User user = findUser(userId);
         if (!user.getSignupStep().isOnboardingComplete()) {
             throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
         }
         return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)
-                .map(ActiveSessionResponse::from);
+                .map(ActiveSessionResponse::fromActive)
+                .orElseGet(() -> {
+                    Session lastEnded = sessionRepository
+                            .findTopByUser_IdAndStatusOrderByEndedAtDesc(userId, SessionStatus.ENDED)
+                            .orElse(null);
+                    return ActiveSessionResponse.noActiveSession(lastEnded);
+                });
     }
 
     @Transactional
@@ -130,6 +138,28 @@ public class SessionService {
         });
 
         return response;
+    }
+
+    @Transactional
+    public SessionSummaryResponse getSessionSummary(UUID userId, UUID sessionId) {
+        Session session = findSession(sessionId);
+        if (!session.belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        SummaryStatus status = session.getSummaryStatus();
+        if (status == SummaryStatus.FAILED) {
+            throw new BusinessException(ErrorCode.SESSION_SUMMARY_FAILED);
+        }
+        if (status == SummaryStatus.PENDING) {
+            return SessionSummaryResponse.pending(session);
+        }
+        if (status == SummaryStatus.DONE) {
+            session.markSummaryViewed();
+            sessionRepository.save(session);
+        }
+        var summary = sessionSummaryRepository.findBySession_Id(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        return SessionSummaryResponse.from(session, summary);
     }
 
     /**

--- a/src/main/resources/db/migration/V28__add_session_summary_status.sql
+++ b/src/main/resources/db/migration/V28__add_session_summary_status.sql
@@ -1,0 +1,3 @@
+ALTER TABLE sessions
+    ADD COLUMN summary_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (summary_status IN ('pending', 'done', 'viewed', 'failed'));

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -48,7 +48,8 @@ class SessionConsolidatorTest {
                 jdbcTemplate,
                 new ObjectMapper(),
                 mock(OntologyValidator.class),
-                mock(TodoRecommendationService.class)
+                mock(TodoRecommendationService.class),
+                mock(SummaryStatusWriter.class)
         );
 
         ReflectionTestUtils.invokeMethod(consolidator, "loadConversationLines", sessionId);

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -215,4 +215,16 @@ class SessionControllerTest {
                 .andExpect(status().isGone())
                 .andExpect(jsonPath("$.error.code").value("GONE"));
     }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/summary - 활성 세션 요약 조회 시 404 반환")
+    void getSessionSummary_activeSession_returns404() throws Exception {
+        when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID)))
+                .thenThrow(new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        mockMvc.perform(get("/v1/sessions/{id}/summary", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.error.code").value("SESSION_NOT_FOUND"));
+    }
 }

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -22,7 +22,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
-import java.util.Optional;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -50,23 +49,25 @@ class SessionControllerTest {
     private static final UUID TEST_SESSION_ID = UUID.randomUUID();
 
     @Test
-    @DisplayName("GET /v1/sessions/active - 활성 세션 없으면 data: null 반환")
-    void getActiveSession_noSession_returnsNullData() throws Exception {
-        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.empty());
+    @DisplayName("GET /v1/sessions/active - 활성 세션 없고 이전 종료 세션도 없으면 session_id: null 반환")
+    void getActiveSession_noSession_returnsNullSessionId() throws Exception {
+        when(sessionService.getActiveSession(TEST_USER_ID))
+                .thenReturn(ActiveSessionResponse.noActiveSession(null));
 
         mockMvc.perform(get("/v1/sessions/active")
                         .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data").doesNotExist());
+                .andExpect(jsonPath("$.data.session_id").doesNotExist())
+                .andExpect(jsonPath("$.data.last_summary_status").doesNotExist());
     }
 
     @Test
     @DisplayName("GET /v1/sessions/active - 활성 세션 있으면 세션 정보 반환")
     void getActiveSession_hasSession_returnsSession() throws Exception {
         ActiveSessionResponse response = new ActiveSessionResponse(
-                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 0
+                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 0, null, null
         );
-        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(Optional.of(response));
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
 
         mockMvc.perform(get("/v1/sessions/active")
                         .principal(() -> TEST_USER_ID.toString()))
@@ -74,6 +75,22 @@ class SessionControllerTest {
                 .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
                 .andExpect(jsonPath("$.data.character_id").value("mio"))
                 .andExpect(jsonPath("$.data.status").value("active"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/active - 활성 세션 없고 마지막 종료 세션 요약이 done 이면 last_summary_status 반환")
+    void getActiveSession_noActiveSession_returnsLastSummaryStatus() throws Exception {
+        ActiveSessionResponse response = new ActiveSessionResponse(
+                null, null, null, null, null, null, "done", TEST_SESSION_ID
+        );
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/sessions/active")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.session_id").doesNotExist())
+                .andExpect(jsonPath("$.data.last_summary_status").value("done"))
+                .andExpect(jsonPath("$.data.last_ended_session_id").value(TEST_SESSION_ID.toString()));
     }
 
     @Test
@@ -150,6 +167,50 @@ class SessionControllerTest {
                 .thenThrow(new BusinessException(ErrorCode.SESSION_ALREADY_ENDED));
 
         mockMvc.perform(post("/v1/sessions/{id}/end", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isGone())
+                .andExpect(jsonPath("$.error.code").value("GONE"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/summary - 요약 pending 상태면 202 반환")
+    void getSessionSummary_pending_returns202() throws Exception {
+        SessionSummaryResponse response = new SessionSummaryResponse(
+                TEST_SESSION_ID, "pending", OffsetDateTime.now(), 300L, 5,
+                null, null, null, null
+        );
+        when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
+
+        mockMvc.perform(get("/v1/sessions/{id}/summary", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.data.summary_status").value("pending"))
+                .andExpect(jsonPath("$.data.summary").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/summary - 요약 done→viewed 전환 시 200 반환")
+    void getSessionSummary_done_returns200AndTransitionsToViewed() throws Exception {
+        SessionSummaryResponse response = new SessionSummaryResponse(
+                TEST_SESSION_ID, "viewed", OffsetDateTime.now(), 300L, 5,
+                "세션 요약 내용", 70, "[]", false
+        );
+        when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
+
+        mockMvc.perform(get("/v1/sessions/{id}/summary", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.summary_status").value("viewed"))
+                .andExpect(jsonPath("$.data.summary").value("세션 요약 내용"));
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/summary - 요약 생성 실패 시 410 반환")
+    void getSessionSummary_failed_returns410() throws Exception {
+        when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID)))
+                .thenThrow(new BusinessException(ErrorCode.SESSION_SUMMARY_FAILED));
+
+        mockMvc.perform(get("/v1/sessions/{id}/summary", TEST_SESSION_ID)
                         .principal(() -> TEST_USER_ID.toString()))
                 .andExpect(status().isGone())
                 .andExpect(jsonPath("$.error.code").value("GONE"));

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -13,6 +13,7 @@ import com.mio.session.dto.CreateSessionRequest;
 import com.mio.session.dto.SendMessageRequest;
 import com.mio.session.dto.SessionResponse;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.when;
 class SessionServiceTest {
 
     @Mock private SessionRepository sessionRepository;
+    @Mock private SessionSummaryRepository sessionSummaryRepository;
     @Mock private UserRepository userRepository;
     @Mock private SessionMessagePersistenceService sessionMessagePersistenceService;
     @Mock private ConversationOrchestrator conversationOrchestrator;
@@ -62,8 +64,9 @@ class SessionServiceTest {
     void setUp() {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
         sessionService = new SessionService(
-                sessionRepository, userRepository, sessionMessagePersistenceService,
-                conversationOrchestrator, workingMemory, eventPublisher, contextPreWarmer, redisTemplate
+                sessionRepository, sessionSummaryRepository, userRepository,
+                sessionMessagePersistenceService, conversationOrchestrator, workingMemory,
+                eventPublisher, contextPreWarmer, redisTemplate
         );
         userId = UUID.randomUUID();
         mockUser = User.builder()
@@ -163,14 +166,17 @@ class SessionServiceTest {
     }
 
     @Test
-    @DisplayName("활성 세션이 없으면 getActiveSession은 Optional.empty를 반환한다")
-    void getActiveSession_noSession_returnsNull() {
+    @DisplayName("활성 세션이 없으면 getActiveSession은 session_id가 null인 응답을 반환한다")
+    void getActiveSession_noSession_returnsNullSessionId() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(Optional.empty());
+        when(sessionRepository.findTopByUser_IdAndStatusOrderByEndedAtDesc(userId, SessionStatus.ENDED))
+                .thenReturn(Optional.empty());
 
-        Optional<ActiveSessionResponse> response = sessionService.getActiveSession(userId);
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
 
-        assertThat(response).isEmpty();
+        assertThat(response.sessionId()).isNull();
+        assertThat(response.lastSummaryStatus()).isNull();
     }
 
     @Test
@@ -183,11 +189,10 @@ class SessionServiceTest {
                 .build();
         when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(Optional.of(session));
 
-        Optional<ActiveSessionResponse> response = sessionService.getActiveSession(userId);
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
 
-        assertThat(response).isPresent();
-        assertThat(response.orElseThrow().characterId()).isEqualTo("mio");
-        assertThat(response.orElseThrow().status()).isEqualTo("active");
+        assertThat(response.characterId()).isEqualTo("mio");
+        assertThat(response.status()).isEqualTo("active");
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `sessions` 테이블에 `summary_status` 컬럼 추가 (`pending` / `done` / `viewed` / `failed`)
- `GET /v1/sessions/active` 응답에 `last_summary_status`, `last_ended_session_id` 포함 (활성 세션 없을 때)
- `GET /v1/sessions/{id}/summary` 신규 엔드포인트 추가 — 202(pending) / 200(done→viewed) / 410(failed)
- `SessionConsolidator`: 성공 시 `DONE`, 실패 시 `FAILED` 마킹 (jdbcTemplate fallback)

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `V28__add_session_summary_status.sql` | `sessions.summary_status` 컬럼 추가 |
| `SummaryStatus.java` | 4-state enum 신규 |
| `SummaryStatusConverter.java` | JPA `@Converter(autoApply=true)` 신규 |
| `Session.java` | `summaryStatus` 필드 + `mark*` 메서드 추가 |
| `SessionRepository.java` | `findTopByUser_IdAndStatusOrderByEndedAtDesc`, `updateSummaryStatus` 추가 |
| `ActiveSessionResponse.java` | `noActiveSession()` 팩토리 + 2 필드 추가 |
| `SessionSummaryResponse.java` | 신규 DTO |
| `SessionService.java` | `getActiveSession()` 반환 타입 변경, `getSessionSummary()` 추가 |
| `SessionController.java` | `/active` 수정, `/{id}/summary` 엔드포인트 추가 |
| `SessionConsolidator.java` | DONE/FAILED 상태 마킹 추가 |

## Test plan

- [x] `SessionControllerTest` — `/active` 수정 + `/summary` 3케이스 (202/200/410) 추가
- [x] `SessionServiceTest` — `getActiveSession` 반환 타입 수정, `SessionSummaryRepository` 주입 추가
- [x] `./gradlew test --tests "com.mio.session.*"` 전체 통과 확인

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added session summary retrieval endpoint with persisted summary states (pending, done, viewed, failed)
  * Active session view now includes message count and last-ended-session summary status/id

* **Bug Fixes**
  * Improved failure handling for summary generation: failures are surfaced and recorded as failed, with appropriate HTTP response for summary-failure cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->