### PR TITLE
refactor: 전역 Jackson SNAKE_CASE 설정 전환 및 @JsonProperty 일괄 제거

### DIFF
--- a/src/main/java/com/mio/auth/dto/ConsentResponse.java
+++ b/src/main/java/com/mio/auth/dto/ConsentResponse.java
@@ -1,8 +1,7 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record ConsentResponse(
-        @JsonProperty("signup_step") SignupStep signupStep
+        SignupStep signupStep
 ) {}

--- a/src/main/java/com/mio/auth/dto/DevTokenRequest.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenRequest.java
@@ -1,11 +1,10 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
 public record DevTokenRequest(
-        @NotNull @JsonProperty("user_id") UUID userId
+        @NotNull UUID userId
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/DevTokenResponse.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenResponse.java
@@ -1,9 +1,7 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record DevTokenResponse(
-        @JsonProperty("access_token") String accessToken,
-        @JsonProperty("expires_in") int expiresIn
+        String accessToken,
+        int expiresIn
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/LoginResponse.java
+++ b/src/main/java/com/mio/auth/dto/LoginResponse.java
@@ -1,27 +1,26 @@
 package com.mio.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginResponse(
-        @JsonProperty("access_token") String accessToken,
-        @JsonProperty("refresh_token") String refreshToken,
-        @JsonProperty("expires_in") int expiresIn,
-        @JsonProperty("is_new_user") boolean isNewUser,
-        @JsonProperty("is_new_device") boolean isNewDevice,
-        @JsonProperty("signup_step") SignupStep signupStep,
-        @JsonProperty("onboarding_step") int onboardingStep,
+        String accessToken,
+        String refreshToken,
+        int expiresIn,
+        boolean isNewUser,
+        boolean isNewDevice,
+        SignupStep signupStep,
+        int onboardingStep,
         UserInfo user
 ) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record UserInfo(
             String id,
             String nickname,
-            @JsonProperty("preferred_character_id") String preferredCharacterId,
-            @JsonProperty("is_minor") boolean isMinor,
-            @JsonProperty("is_premium") boolean isPremium,
+            String preferredCharacterId,
+            boolean isMinor,
+            boolean isPremium,
             String status
     ) {
     }

--- a/src/main/java/com/mio/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/mio/auth/dto/LogoutRequest.java
@@ -1,9 +1,8 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record LogoutRequest(
-        @JsonProperty("device_id") @NotBlank String deviceId
+        @NotBlank String deviceId
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
@@ -1,11 +1,9 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupCompleteResponse(
-        @JsonProperty("signup_step") SignupStep signupStep,
-        @JsonProperty("onboarding_step") int onboardingStep,
+        SignupStep signupStep,
+        int onboardingStep,
         String nickname
-) {
-}
+) {}

--- a/src/main/java/com/mio/auth/dto/SignupFinalizeResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupFinalizeResponse.java
@@ -1,9 +1,8 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupFinalizeResponse(
-        @JsonProperty("signup_step") SignupStep signupStep,
+        SignupStep signupStep,
         String status
 ) {}

--- a/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
@@ -1,10 +1,8 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupStatusResponse(
-        @JsonProperty("signup_step") SignupStep signupStep,
-        @JsonProperty("onboarding_step") int onboardingStep
-) {
-}
+        SignupStep signupStep,
+        int onboardingStep
+) {}

--- a/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
@@ -1,9 +1,8 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record TokenRefreshRequest(
-        @JsonProperty("refresh_token") @NotBlank String refreshToken
+        @NotBlank String refreshToken
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
@@ -1,9 +1,6 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record TokenRefreshResponse(
-        @JsonProperty("access_token") String accessToken,
-        @JsonProperty("expires_in") int expiresIn
-) {
-}
+        String accessToken,
+        int expiresIn
+) {}

--- a/src/main/java/com/mio/auth/dto/WithdrawResponse.java
+++ b/src/main/java/com/mio/auth/dto/WithdrawResponse.java
@@ -1,13 +1,11 @@
 package com.mio.auth.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
 
 public record WithdrawResponse(
         boolean success,
-        @JsonProperty("withdrawn_at") OffsetDateTime withdrawnAt,
-        @JsonProperty("hard_delete_scheduled_at") OffsetDateTime hardDeleteScheduledAt
+        OffsetDateTime withdrawnAt,
+        OffsetDateTime hardDeleteScheduledAt
 ) {
     public WithdrawResponse(OffsetDateTime withdrawnAt) {
         this(true, withdrawnAt, withdrawnAt != null ? withdrawnAt.plusDays(30) : null);

--- a/src/main/java/com/mio/character/dto/CharacterChangeRequest.java
+++ b/src/main/java/com/mio/character/dto/CharacterChangeRequest.java
@@ -1,8 +1,7 @@
 package com.mio.character.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record CharacterChangeRequest(
-        @JsonProperty("character_id") @NotBlank String characterId
+        @NotBlank String characterId
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterChangeResponse.java
+++ b/src/main/java/com/mio/character/dto/CharacterChangeResponse.java
@@ -1,10 +1,8 @@
 package com.mio.character.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record CharacterChangeResponse(
-        @JsonProperty("character_id") String characterId,
+        String characterId,
         String name,
         boolean changed,
-        @JsonProperty("greeting_message") String greetingMessage
+        String greetingMessage
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterItemDto.java
+++ b/src/main/java/com/mio/character/dto/CharacterItemDto.java
@@ -1,14 +1,12 @@
 package com.mio.character.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record CharacterItemDto(
-        @JsonProperty("character_id") String characterId,
+        String characterId,
         String name,
         String animal,
         String description,
         List<String> tags,
-        @JsonProperty("is_current") boolean isCurrent
+        boolean isCurrent
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterListResponse.java
+++ b/src/main/java/com/mio/character/dto/CharacterListResponse.java
@@ -1,10 +1,8 @@
 package com.mio.character.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record CharacterListResponse(
-        @JsonProperty("current_character_id") String currentCharacterId,
+        String currentCharacterId,
         List<CharacterItemDto> characters
 ) {}

--- a/src/main/java/com/mio/character/dto/UserCharacterResponse.java
+++ b/src/main/java/com/mio/character/dto/UserCharacterResponse.java
@@ -1,9 +1,7 @@
 package com.mio.character.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record UserCharacterResponse(
-        @JsonProperty("character_id") String characterId,
+        String characterId,
         String name,
         String animal
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
@@ -1,18 +1,17 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinCreateResponse(
-        @JsonProperty("checkin_id") UUID checkinId,
-        @JsonProperty("time_of_day") String timeOfDay,
-        @JsonProperty("emotion_type") String emotionType,
-        @JsonProperty("condition_score") int conditionScore,
+        UUID checkinId,
+        String timeOfDay,
+        String emotionType,
+        int conditionScore,
         String memo,
-        @JsonProperty("ai_response") String aiResponse,
-        @JsonProperty("created_at") OffsetDateTime createdAt
+        String aiResponse,
+        OffsetDateTime createdAt
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinRequest.java
@@ -1,11 +1,10 @@
 package com.mio.checkin.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.*;
 
 public record CheckinRequest(
-        @NotBlank @JsonProperty("time_of_day") String timeOfDay,
-        @NotBlank @JsonProperty("emotion_type") String emotionType,
-        @NotNull @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
+        @NotBlank String timeOfDay,
+        @NotBlank String emotionType,
+        @NotNull @Min(1) @Max(5) Integer conditionScore,
         @Size(max = 200) String memo
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinResponse.java
@@ -1,19 +1,18 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinResponse(
-        @JsonProperty("checkin_id") UUID checkinId,
-        @JsonProperty("time_of_day") String timeOfDay,
-        @JsonProperty("emotion_type") String emotionType,
-        @JsonProperty("condition_score") int conditionScore,
+        UUID checkinId,
+        String timeOfDay,
+        String emotionType,
+        int conditionScore,
         String memo,
-        @JsonProperty("ai_response") String aiResponse,
-        @JsonProperty("created_at") OffsetDateTime createdAt,
-        @JsonProperty("updated_at") OffsetDateTime updatedAt
+        String aiResponse,
+        OffsetDateTime createdAt,
+        OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
@@ -1,13 +1,11 @@
 package com.mio.checkin.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.LocalDate;
 import java.util.List;
 
 public record CheckinTodayResponse(
         LocalDate date,
         List<CheckinResponse> checkins,
-        @JsonProperty("completed_slots") List<String> completedSlots,
-        @JsonProperty("available_slots") List<String> availableSlots
+        List<String> completedSlots,
+        List<String> availableSlots
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
@@ -1,12 +1,11 @@
 package com.mio.checkin.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record CheckinUpdateRequest(
-        @JsonProperty("emotion_type") String emotionType,
-        @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
+        String emotionType,
+        @Min(1) @Max(5) Integer conditionScore,
         @Size(max = 200) String memo
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
@@ -1,18 +1,17 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinUpdateResponse(
-        @JsonProperty("checkin_id") UUID checkinId,
-        @JsonProperty("time_of_day") String timeOfDay,
-        @JsonProperty("emotion_type") String emotionType,
-        @JsonProperty("condition_score") int conditionScore,
+        UUID checkinId,
+        String timeOfDay,
+        String emotionType,
+        int conditionScore,
         String memo,
-        @JsonProperty("ai_response") String aiResponse,
-        @JsonProperty("updated_at") OffsetDateTime updatedAt
+        String aiResponse,
+        OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/common/error/ErrorResponse.java
+++ b/src/main/java/com/mio/common/error/ErrorResponse.java
@@ -1,6 +1,5 @@
 package com.mio.common.error;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -17,6 +16,6 @@ public record ErrorResponse(ErrorDetail error) {
     public record ErrorDetail(
             String code,
             String message,
-            @JsonProperty("trace_id") String traceId
+            String traceId
     ) {}
 }

--- a/src/main/java/com/mio/common/response/ApiResponse.java
+++ b/src/main/java/com/mio/common/response/ApiResponse.java
@@ -1,6 +1,5 @@
 package com.mio.common.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -28,9 +27,9 @@ public record ApiResponse<T>(
     }
 
 public record Meta(
-            @JsonProperty("trace_id") String traceId,
-            @JsonProperty("next_cursor") String nextCursor,
-            @JsonProperty("has_more") Boolean hasMore
+            String traceId,
+            String nextCursor,
+            Boolean hasMore
     ) {
         public static Meta trace(String traceId) {
             return new Meta(traceId, null, null);

--- a/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
@@ -1,18 +1,16 @@
 package com.mio.dailytest.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 
 public record DailyTestResultResponse(
         ResultDto result,
-        @JsonProperty("completed_at") OffsetDateTime completedAt
+        OffsetDateTime completedAt
 ) {
     public record ResultDto(
             String summary,
             String description,
             List<String> tags,
-            @JsonProperty("character_comment") String characterComment
+            String characterComment
     ) {}
 }

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,31 +1,30 @@
 package com.mio.dailytest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DailyTestTodayResponse(
-        @JsonProperty("completed_today") boolean completedToday,
-        @JsonProperty("test_id") UUID testId,
+        boolean completedToday,
+        UUID testId,
         String title,
-        @JsonProperty("estimated_minutes") Integer estimatedMinutes,
+        Integer estimatedMinutes,
         List<QuestionDto> questions,
         ResultDto result
 ) {
     public record ResultDto(String summary, List<String> tags) {}
 
     public record QuestionDto(
-            @JsonProperty("question_id") String questionId,
+            String questionId,
             int order,
             String text,
             List<OptionDto> options
     ) {}
 
     public record OptionDto(
-            @JsonProperty("option_id") String optionId,
+            String optionId,
             String text
     ) {}
 

--- a/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
+++ b/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
@@ -1,34 +1,32 @@
 package com.mio.mypage.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 import java.util.UUID;
 
 public record UserProfileResponse(
-        @JsonProperty("user_id") UUID userId,
+        UUID userId,
         String nickname,
-        @JsonProperty("age_range") String ageRange,
-        @JsonProperty("preferred_character") PreferredCharacterDto preferredCharacter,
+        String ageRange,
+        PreferredCharacterDto preferredCharacter,
         UserStatsDto stats,
-        @JsonProperty("monthly_emotion_distribution") List<EmotionDistributionDto> monthlyEmotionDistribution,
-        @JsonProperty("signup_step") String signupStep
+        List<EmotionDistributionDto> monthlyEmotionDistribution,
+        String signupStep
 ) {
     public record PreferredCharacterDto(
-            @JsonProperty("character_id") String characterId,
+            String characterId,
             String name,
             String animal,
             String description
     ) {}
 
     public record UserStatsDto(
-            @JsonProperty("total_checkins") long totalCheckins,
-            @JsonProperty("consecutive_days") int consecutiveDays,
-            @JsonProperty("todo_completed") long todoCompleted
+            long totalCheckins,
+            int consecutiveDays,
+            long todoCompleted
     ) {}
 
     public record EmotionDistributionDto(
-            @JsonProperty("emotion_type") String emotionType,
+            String emotionType,
             String label,
             int percentage
     ) {}

--- a/src/main/java/com/mio/mypage/dto/UserProfileUpdateResponse.java
+++ b/src/main/java/com/mio/mypage/dto/UserProfileUpdateResponse.java
@@ -1,13 +1,11 @@
 package com.mio.mypage.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record UserProfileUpdateResponse(
-        @JsonProperty("user_id") UUID userId,
+        UUID userId,
         String nickname,
-        @JsonProperty("age_range") String ageRange,
-        @JsonProperty("updated_at") OffsetDateTime updatedAt
+        String ageRange,
+        OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/notification/dto/DeviceTokenRegisterRequest.java
+++ b/src/main/java/com/mio/notification/dto/DeviceTokenRegisterRequest.java
@@ -1,12 +1,11 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record DeviceTokenRegisterRequest(
-        @JsonProperty("device_id") @NotBlank String deviceId,
-        @JsonProperty("push_token") @NotBlank String pushToken,
+        @NotBlank String deviceId,
+        @NotBlank String pushToken,
         @NotBlank @Pattern(regexp = "ios|android", message = "platform must be 'ios' or 'android'") String platform,
-        @JsonProperty("app_version") @NotBlank String appVersion
+        @NotBlank String appVersion
 ) {}

--- a/src/main/java/com/mio/notification/dto/DeviceTokenResponse.java
+++ b/src/main/java/com/mio/notification/dto/DeviceTokenResponse.java
@@ -1,11 +1,10 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.DeviceToken;
 
 public record DeviceTokenResponse(
         boolean success,
-        @JsonProperty("device_id") String deviceId,
+        String deviceId,
         String platform
 ) {
 

--- a/src/main/java/com/mio/notification/dto/NotificationHistoryItemResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationHistoryItemResponse.java
@@ -1,6 +1,5 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.ProactiveCareLog;
 import com.mio.notification.service.NotificationMessageMapper;
 
@@ -8,13 +7,13 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record NotificationHistoryItemResponse(
-        @JsonProperty("notification_id") UUID notificationId,
-        @JsonProperty("trigger_code") String triggerCode,
+        UUID notificationId,
+        String triggerCode,
         String title,
         String body,
-        @JsonProperty("notification_status") String notificationStatus,
-        @JsonProperty("sent_at") OffsetDateTime sentAt,
-        @JsonProperty("responded_at") OffsetDateTime respondedAt
+        String notificationStatus,
+        OffsetDateTime sentAt,
+        OffsetDateTime respondedAt
 ) {
 
     public static NotificationHistoryItemResponse from(

--- a/src/main/java/com/mio/notification/dto/NotificationReadResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationReadResponse.java
@@ -1,12 +1,10 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record NotificationReadResponse(
-        @JsonProperty("notification_id") UUID notificationId,
-        @JsonProperty("notification_status") String notificationStatus,
-        @JsonProperty("responded_at") OffsetDateTime respondedAt
+        UUID notificationId,
+        String notificationStatus,
+        OffsetDateTime respondedAt
 ) {}

--- a/src/main/java/com/mio/notification/dto/NotificationSettingResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationSettingResponse.java
@@ -1,16 +1,15 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.NotificationSetting;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 public record NotificationSettingResponse(
-        @JsonProperty("checkin_enabled") boolean checkinEnabled,
-        @JsonProperty("checkin_time") NotificationCheckinTimeResponse checkinTime,
-        @JsonProperty("character_enabled") boolean characterEnabled,
-        @JsonProperty("report_enabled") boolean reportEnabled
+        boolean checkinEnabled,
+        NotificationCheckinTimeResponse checkinTime,
+        boolean characterEnabled,
+        boolean reportEnabled
 ) {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 

--- a/src/main/java/com/mio/notification/dto/NotificationSettingUpdateRequest.java
+++ b/src/main/java/com/mio/notification/dto/NotificationSettingUpdateRequest.java
@@ -1,11 +1,10 @@
 package com.mio.notification.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 
 public record NotificationSettingUpdateRequest(
-        @JsonProperty("checkin_enabled") Boolean checkinEnabled,
-        @Valid @JsonProperty("checkin_time") NotificationCheckinTimeUpdateRequest checkinTime,
-        @JsonProperty("character_enabled") Boolean characterEnabled,
-        @JsonProperty("report_enabled") Boolean reportEnabled
+        Boolean checkinEnabled,
+        @Valid NotificationCheckinTimeUpdateRequest checkinTime,
+        Boolean characterEnabled,
+        Boolean reportEnabled
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
@@ -1,10 +1,8 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record CharacterRecommendationDto(
-        @JsonProperty("character_id") String characterId,
+        String characterId,
         String name,
-        @JsonProperty("match_score") double matchScore,
+        double matchScore,
         String reason
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
@@ -1,7 +1,5 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record CharacterSelectRequest(
-        @JsonProperty("character_id") String characterId
+        String characterId
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
@@ -1,9 +1,8 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record CharacterSelectResponse(
-        @JsonProperty("preferred_character_id") String preferredCharacterId,
-        @JsonProperty("signup_step") SignupStep signupStep
+        String preferredCharacterId,
+        SignupStep signupStep
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
@@ -1,12 +1,11 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 import java.util.List;
 
 public record OnboardingStatusResponse(
-        @JsonProperty("onboarding_step") int onboardingStep,
-        @JsonProperty("signup_step") SignupStep signupStep,
-        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
+        int onboardingStep,
+        SignupStep signupStep,
+        List<CharacterRecommendationDto> characterRecommendations
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
@@ -1,11 +1,10 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
 public record OnboardingStep1Request(
-        @JsonProperty("emotion_state") @NotBlank String emotionState,
+        @NotBlank String emotionState,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
@@ -1,11 +1,10 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record OnboardingStep2Request(
-        @JsonProperty("concern_types") @NotEmpty List<String> concernTypes,
+        @NotEmpty List<String> concernTypes,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
@@ -1,11 +1,10 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
 public record OnboardingStep3Request(
-        @JsonProperty("preferred_style") @NotBlank String preferredStyle,
+        @NotBlank String preferredStyle,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
@@ -1,10 +1,8 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.List;
 
 public record OnboardingStep3Response(
-        @JsonProperty("onboarding_step") int onboardingStep,
-        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
+        int onboardingStep,
+        List<CharacterRecommendationDto> characterRecommendations
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
@@ -1,7 +1,5 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record OnboardingStepResponse(
-        @JsonProperty("onboarding_step") int onboardingStep
+        int onboardingStep
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
@@ -1,8 +1,6 @@
 package com.mio.onboarding.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 public record QuestionResponse(
-        @JsonProperty("question_id") String questionId,
+        String questionId,
         String answer
 ) {}

--- a/src/main/java/com/mio/report/dto/EmotionTrendResponse.java
+++ b/src/main/java/com/mio/report/dto/EmotionTrendResponse.java
@@ -1,20 +1,19 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record EmotionTrendResponse(
-        @JsonProperty("period_start") LocalDate periodStart,
-        @JsonProperty("period_end") LocalDate periodEnd,
+        LocalDate periodStart,
+        LocalDate periodEnd,
         List<TrendPointDto> points
 ) {
     public record TrendPointDto(
             LocalDate date,
             @JsonInclude(JsonInclude.Include.ALWAYS)
-            @JsonProperty("avg_condition_score") Double avgConditionScore,
-            @JsonProperty("checkin_count") int checkinCount
+            Double avgConditionScore,
+            int checkinCount
     ) {}
 }

--- a/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
@@ -1,7 +1,6 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.report.dto.ReportCommonDto.DistortionDto;
 import com.mio.report.dto.ReportCommonDto.SessionSummaryDto;
 import com.mio.report.dto.ReportCommonDto.TodoSummaryDto;
@@ -13,20 +12,20 @@ import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MonthlyReportResponse(
-        @JsonProperty("report_id") UUID reportId,
-        @JsonProperty("month_start") LocalDate monthStart,
-        @JsonProperty("month_end") LocalDate monthEnd,
+        UUID reportId,
+        LocalDate monthStart,
+        LocalDate monthEnd,
         String status,
-        @JsonProperty("is_partial") Boolean isPartial,
-        @JsonProperty("checkin_count") Integer checkinCount,
-        @JsonProperty("required_count") Integer requiredCount,
-        @JsonProperty("avg_emotion_score") Double avgEmotionScore,
-        @JsonProperty("distortion_top3") List<DistortionDto> distortionTop3,
+        Boolean isPartial,
+        Integer checkinCount,
+        Integer requiredCount,
+        Double avgEmotionScore,
+        List<DistortionDto> distortionTop3,
         String narrative,
-        @JsonProperty("coaching_direction") String coachingDirection,
-        @JsonProperty("todo_summary") TodoSummaryDto todoSummary,
-        @JsonProperty("session_summary") SessionSummaryDto sessionSummary,
-        @JsonProperty("generated_at") OffsetDateTime generatedAt,
+        String coachingDirection,
+        TodoSummaryDto todoSummary,
+        SessionSummaryDto sessionSummary,
+        OffsetDateTime generatedAt,
         String message
 ) {
     public static MonthlyReportResponse insufficientData(LocalDate monthStart, LocalDate monthEnd, int checkinCount) {

--- a/src/main/java/com/mio/report/dto/ReportCommonDto.java
+++ b/src/main/java/com/mio/report/dto/ReportCommonDto.java
@@ -1,7 +1,5 @@
 package com.mio.report.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.Map;
 
 public class ReportCommonDto {
@@ -13,13 +11,13 @@ public class ReportCommonDto {
             int completed,
             int skipped,
             int expired,
-            @JsonProperty("completion_rate") double completionRate,
-            @JsonProperty("category_distribution") Map<String, Integer> categoryDistribution
+            double completionRate,
+            Map<String, Integer> categoryDistribution
     ) {}
 
     public record SessionSummaryDto(
             int total,
-            @JsonProperty("total_minutes") long totalMinutes
+            long totalMinutes
     ) {}
 
     private ReportCommonDto() {}

--- a/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
@@ -1,7 +1,6 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.report.dto.ReportCommonDto.DistortionDto;
 import com.mio.report.dto.ReportCommonDto.SessionSummaryDto;
 import com.mio.report.dto.ReportCommonDto.TodoSummaryDto;
@@ -13,20 +12,20 @@ import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record WeeklyReportResponse(
-        @JsonProperty("report_id") UUID reportId,
-        @JsonProperty("week_start") LocalDate weekStart,
-        @JsonProperty("week_end") LocalDate weekEnd,
+        UUID reportId,
+        LocalDate weekStart,
+        LocalDate weekEnd,
         String status,
-        @JsonProperty("is_partial") Boolean isPartial,
-        @JsonProperty("checkin_count") Integer checkinCount,
-        @JsonProperty("required_count") Integer requiredCount,
-        @JsonProperty("avg_emotion_score") Double avgEmotionScore,
-        @JsonProperty("distortion_top3") List<DistortionDto> distortionTop3,
+        Boolean isPartial,
+        Integer checkinCount,
+        Integer requiredCount,
+        Double avgEmotionScore,
+        List<DistortionDto> distortionTop3,
         String narrative,
-        @JsonProperty("coaching_direction") String coachingDirection,
-        @JsonProperty("todo_summary") TodoSummaryDto todoSummary,
-        @JsonProperty("session_summary") SessionSummaryDto sessionSummary,
-        @JsonProperty("generated_at") OffsetDateTime generatedAt,
+        String coachingDirection,
+        TodoSummaryDto todoSummary,
+        SessionSummaryDto sessionSummary,
+        OffsetDateTime generatedAt,
         String message
 ) {
     public static WeeklyReportResponse insufficientData(LocalDate weekStart, LocalDate weekEnd, int checkinCount) {

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -1,20 +1,19 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record ActiveSessionResponse(
-        @JsonProperty("session_id") UUID sessionId,
-        @JsonProperty("character_id") String characterId,
+        UUID sessionId,
+        String characterId,
         String status,
-        @JsonProperty("started_at") OffsetDateTime startedAt,
-        @JsonProperty("last_message_at") OffsetDateTime lastMessageAt,
-        @JsonProperty("message_count") Integer messageCount,
-        @JsonProperty("last_summary_status") String lastSummaryStatus,
-        @JsonProperty("last_ended_session_id") UUID lastEndedSessionId
+        OffsetDateTime startedAt,
+        OffsetDateTime lastMessageAt,
+        Integer messageCount,
+        String lastSummaryStatus,
+        UUID lastEndedSessionId
 ) {
     public static ActiveSessionResponse fromActive(Session session) {
         return new ActiveSessionResponse(

--- a/src/main/java/com/mio/session/dto/CreateSessionRequest.java
+++ b/src/main/java/com/mio/session/dto/CreateSessionRequest.java
@@ -1,10 +1,9 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 
 public record CreateSessionRequest(
         @Size(max = 50, message = "character_id는 50자를 초과할 수 없습니다.")
-        @JsonProperty("character_id") String characterId
+        String characterId
 ) {
 }

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -1,18 +1,17 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record EndSessionResponse(
-        @JsonProperty("session_id") UUID sessionId,
+        UUID sessionId,
         String status,
-        @JsonProperty("ended_at") OffsetDateTime endedAt,
-        @JsonProperty("message_count") int messageCount,
-        @JsonProperty("duration_seconds") long durationSeconds,
-        @JsonProperty("summary_status") String summaryStatus
+        OffsetDateTime endedAt,
+        int messageCount,
+        long durationSeconds,
+        String summaryStatus
 ) {
     public static EndSessionResponse from(Session session) {
         if (session.getEndedAt() == null) {

--- a/src/main/java/com/mio/session/dto/SessionResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionResponse.java
@@ -1,16 +1,15 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record SessionResponse(
-        @JsonProperty("session_id") UUID sessionId,
-        @JsonProperty("character_id") String characterId,
+        UUID sessionId,
+        String characterId,
         String status,
-        @JsonProperty("started_at") OffsetDateTime startedAt
+        OffsetDateTime startedAt
 ) {
     public static SessionResponse from(Session session) {
         return new SessionResponse(

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionSummary;
 
@@ -8,15 +7,15 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record SessionSummaryResponse(
-        @JsonProperty("session_id") UUID sessionId,
-        @JsonProperty("summary_status") String summaryStatus,
-        @JsonProperty("ended_at") OffsetDateTime endedAt,
-        @JsonProperty("duration_seconds") long durationSeconds,
-        @JsonProperty("message_count") int messageCount,
+        UUID sessionId,
+        String summaryStatus,
+        OffsetDateTime endedAt,
+        long durationSeconds,
+        int messageCount,
         String summary,
-        @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
-        @JsonProperty("bias_types_detected") String biasTypesDetected,
-        @JsonProperty("cbt_intervened") Boolean cbtIntervened
+        Integer avgEmotionScore,
+        String biasTypesDetected,
+        Boolean cbtIntervened
 ) {
     public static SessionSummaryResponse pending(Session session) {
         return new SessionSummaryResponse(

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -1,7 +1,5 @@
 package com.mio.session.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -15,29 +13,29 @@ public sealed interface SseEventDto
     String eventName();
 
     record SessionMetaEvent(
-            @JsonProperty("message_id") String messageId,
-            @JsonProperty("received_at") OffsetDateTime receivedAt
+            String messageId,
+            OffsetDateTime receivedAt
     ) implements SseEventDto {
         @Override public String eventName() { return "session_meta"; }
     }
 
     record DeltaEvent(
             String chunk,
-            @JsonProperty("msg_id") String msgId
+            String msgId
     ) implements SseEventDto {
         @Override public String eventName() { return "delta"; }
     }
 
     record DeltaReplaceEvent(
-            @JsonProperty("safe_response") String safeResponse,
-            @JsonProperty("msg_id") String msgId
+            String safeResponse,
+            String msgId
     ) implements SseEventDto {
         @Override public String eventName() { return "delta.replace"; }
     }
 
     record CrisisEvent(
             int severity,
-            @JsonProperty("fixed_response") String fixedResponse,
+            String fixedResponse,
             Resources resources
     ) implements SseEventDto {
         @Override public String eventName() { return "crisis"; }
@@ -47,10 +45,10 @@ public sealed interface SseEventDto
     }
 
     record DoneEvent(
-            @JsonProperty("msg_id") String msgId,
-            @JsonProperty("emotion_score") Integer emotionScore,
-            @JsonProperty("is_crisis_flagged") boolean isCrisisFlagged,
-            @JsonProperty("finished_reason") String finishedReason
+            String msgId,
+            Integer emotionScore,
+            boolean isCrisisFlagged,
+            String finishedReason
     ) implements SseEventDto {
         @Override public String eventName() { return "done"; }
     }

--- a/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
@@ -1,6 +1,5 @@
 package com.mio.todo.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -9,10 +8,8 @@ public record TodoCheckinRequest(
         @Pattern(regexp = "completed|skipped", message = "status는 completed 또는 skipped 이어야 합니다.")
         String status,
 
-        @JsonProperty("before_emotion")
         Integer beforeEmotion,
 
-        @JsonProperty("after_emotion")
         Integer afterEmotion,
 
         String feedback

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -1,19 +1,15 @@
 package com.mio.todo.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 
 public record TodoCheckinResponse(
         String status,
 
-        @JsonProperty("before_emotion")
         Integer beforeEmotion,
 
-        @JsonProperty("after_emotion")
         Integer afterEmotion,
 
-        @JsonProperty("character_reaction")
         String characterReaction
 ) {
     private static final String REACTION_COMPLETED = "잘했어! 작은 것부터 하나씩 해나가는 게 진짜 대단한 거야 🎉";

--- a/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
@@ -1,6 +1,5 @@
 package com.mio.todo.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -11,6 +10,5 @@ public record TodoGenerateRequest(
         @Pattern(regexp = "checkin|chat", message = "source는 checkin 또는 chat 이어야 합니다.")
         String source,
 
-        @JsonProperty("source_id")
         UUID sourceId
 ) {}

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -1,6 +1,5 @@
 package com.mio.todo.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 
@@ -8,24 +7,19 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record TodoResponse(
-        @JsonProperty("todo_id")
         UUID todoId,
 
-        @JsonProperty("action_text")
         String actionText,
 
         String category,
         Integer difficulty,
 
-        @JsonProperty("estimated_minutes")
         Integer estimatedMinutes,
 
         String status,
 
-        @JsonProperty("created_at")
         OffsetDateTime createdAt,
 
-        @JsonProperty("character_comment")
         String characterComment
 ) {
     private static final String MOCK_CHARACTER_COMMENT = "미오가 응원해요!";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,7 @@ spring:
       timeout: 2000ms
 
   jackson:
+    property-naming-strategy: SNAKE_CASE
     time-zone: Asia/Seoul
     serialization:
       write-dates-as-timestamps: false


### PR DESCRIPTION
## Summary

- `application.yml`에 `spring.jackson.property-naming-strategy: SNAKE_CASE` 전역 설정 추가
- 59개 DTO 파일에서 camelCase→snake_case 변환 목적의 `@JsonProperty` 어노테이션 전량 제거
- 불필요한 `JsonProperty` import 함께 제거 (총 59 파일, -90 lines)

## 변경 범위

| 도메인 | 파일 수 |
|--------|---------|
| auth | 11 |
| character | 5 |
| checkin | 6 |
| common (error, response) | 2 |
| dailytest | 2 |
| mypage | 2 |
| notification | 5 |
| onboarding | 8 |
| report | 4 |
| session | 6 |
| todo | 4 |

## 주의사항

- JSON 필드명을 **재정의**한 `@JsonProperty` (필드명 snake_case와 다른 경우)는 없었음 — 전량 제거
- 직렬화/역직렬화 동작은 전역 설정으로 동일하게 유지됨

## Test plan

- [ ] `./gradlew compileJava` 통과 확인 ✅
- [ ] 각 도메인 API 엔드포인트의 응답 JSON 필드명 snake_case 확인
- [ ] 인증(auth), 세션(session), 알림(notification) 통합 테스트

Closes #66

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized JSON serialization configuration across data transfer objects by removing explicit field-level property mappings and implementing a centralized naming strategy for consistent API response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->