### PR TITLE
feat: CAUTIOUS_SPECULATIVE OutputJudge 병렬 실행 (§14.5)

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -58,6 +58,8 @@ import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -93,6 +95,7 @@ public class ConversationOrchestrator {
     private final UserRepository userRepository;
     private final UserMessageSignalAnalyzer userMessageSignalAnalyzer;
     private final ObjectMapper objectMapper;
+    private final Executor outputJudgeExecutor;
 
     public void handle(UUID userId, UUID sessionId, String userMessage, SseEmitter emitter) {
         long startMs = System.currentTimeMillis();
@@ -231,7 +234,7 @@ public class ConversationOrchestrator {
                                     final String capturedSnapshot = snapshot;
                                     final OutputPreFilterResult capturedCheck = earlyCheck;
                                     earlyJudgeFutureRef.set(CompletableFuture.supplyAsync(
-                                            () -> outputJudge.judge(capturedSnapshot, capturedCheck)));
+                                            () -> outputJudge.judge(capturedSnapshot, capturedCheck), outputJudgeExecutor));
                                     return;
                                 }
                             }
@@ -261,13 +264,13 @@ public class ConversationOrchestrator {
                             final String fullContent = assistantContent;
                             final OutputPreFilterResult fullFilter = preFilterResult;
                             judgeFuture = CompletableFuture.supplyAsync(
-                                    () -> outputJudge.judge(fullContent, fullFilter));
+                                    () -> outputJudge.judge(fullContent, fullFilter), outputJudgeExecutor);
                         }
                     }
 
                     if (judgeFuture != null) {
                         try {
-                            judgeActionResult = judgeFuture.join();
+                            judgeActionResult = judgeFuture.orTimeout(5, TimeUnit.SECONDS).join();
                         } catch (Exception e) {
                             log.warn("OutputJudge async failed, defaulting to REPLACE: {}", e.getMessage());
                             judgeActionResult = OutputJudgeResult.replace();
@@ -280,7 +283,8 @@ public class ConversationOrchestrator {
 
                         String replacedContent = switch (judgeActionResult.action()) {
                             case REWRITE -> judgeActionResult.rewrittenContent() != null
-                                    ? judgeActionResult.rewrittenContent() : null;
+                                    ? judgeActionResult.rewrittenContent()
+                                    : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
                             case REPLACE, CRISIS_FLOW -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
                             case SEND -> null;
                         };

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -57,6 +57,10 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Service
 @RequiredArgsConstructor
@@ -64,6 +68,7 @@ import java.util.UUID;
 public class ConversationOrchestrator {
 
     private static final String LLM_MODEL = "gpt-4o";
+    private static final int EARLY_PREFILTER_THRESHOLD = 200;
 
     private final InputNormalizer inputNormalizer;
     private final SecurityRuleFilter securityRuleFilter;
@@ -199,8 +204,108 @@ public class ConversationOrchestrator {
                         sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
                     }
 
+                } else if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
+                    // CAUTIOUS_SPECULATIVE: stream immediately + parallel OutputJudge
+                    // Pre-filter runs every EARLY_PREFILTER_THRESHOLD chars during stream.
+                    // If a violation is detected early, delta SSEs stop immediately and
+                    // OutputJudge starts async on the partial snapshot.
+                    AtomicBoolean stopSendingDeltas = new AtomicBoolean(false);
+                    AtomicInteger lastCheckedLength = new AtomicInteger(0);
+                    AtomicReference<OutputPreFilterResult> earlyFilterRef = new AtomicReference<>();
+                    AtomicReference<CompletableFuture<OutputJudgeResult>> earlyJudgeFutureRef = new AtomicReference<>();
+
+                    llmTtftMs = llmClient.stream(llmRequest, chunk -> {
+                        contentBuilder.append(chunk);
+                        if (!stopSendingDeltas.get()) {
+                            int currentLen = contentBuilder.length();
+                            if (currentLen - lastCheckedLength.get() >= EARLY_PREFILTER_THRESHOLD) {
+                                lastCheckedLength.set(currentLen);
+                                String snapshot = contentBuilder.toString();
+                                OutputPreFilterResult earlyCheck =
+                                        outputPreFilter.checkWithCrisisContext(snapshot, inputHadRiskSignal);
+                                if (!earlyCheck.passed()) {
+                                    stopSendingDeltas.set(true);
+                                    earlyFilterRef.set(earlyCheck);
+                                    log.warn("OutputGuard early-stop during stream: session={} reasons={}",
+                                            sessionId, earlyCheck.failReasons());
+                                    final String capturedSnapshot = snapshot;
+                                    final OutputPreFilterResult capturedCheck = earlyCheck;
+                                    earlyJudgeFutureRef.set(CompletableFuture.supplyAsync(
+                                            () -> outputJudge.judge(capturedSnapshot, capturedCheck)));
+                                    return;
+                                }
+                            }
+                            try {
+                                sendEvent(emitter, new SseEventDto.DeltaEvent(chunk, outboundMsgId));
+                            } catch (IOException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    });
+
+                    assistantContent = contentBuilder.toString();
+
+                    CompletableFuture<OutputJudgeResult> judgeFuture = earlyJudgeFutureRef.get();
+                    OutputPreFilterResult earlyFilter = earlyFilterRef.get();
+
+                    if (earlyFilter != null) {
+                        preFilterResult = earlyFilter;
+                    }
+
+                    if (judgeFuture == null) {
+                        // No early stop — run post-stream pre-filter check
+                        preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
+                        if (!preFilterResult.passed()) {
+                            log.warn("OutputGuard post-stream: session={} reasons={}",
+                                    sessionId, preFilterResult.failReasons());
+                            final String fullContent = assistantContent;
+                            final OutputPreFilterResult fullFilter = preFilterResult;
+                            judgeFuture = CompletableFuture.supplyAsync(
+                                    () -> outputJudge.judge(fullContent, fullFilter));
+                        }
+                    }
+
+                    if (judgeFuture != null) {
+                        try {
+                            judgeActionResult = judgeFuture.join();
+                        } catch (Exception e) {
+                            log.warn("OutputJudge async failed, defaulting to REPLACE: {}", e.getMessage());
+                            judgeActionResult = OutputJudgeResult.replace();
+                        }
+                        log.warn("OutputGuard action: session={} action={}", sessionId,
+                                judgeActionResult.action());
+
+                        boolean isCrisis = judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW;
+                        if (isCrisis) crisisFlowTriggered = true;
+
+                        String replacedContent = switch (judgeActionResult.action()) {
+                            case REWRITE -> judgeActionResult.rewrittenContent() != null
+                                    ? judgeActionResult.rewrittenContent() : null;
+                            case REPLACE, CRISIS_FLOW -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+                            case SEND -> null;
+                        };
+
+                        if (replacedContent != null) {
+                            assistantContent = replacedContent;
+                            sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                    userSignal.emotionScore(), isCrisis, "replaced_by_guard"));
+                        } else if (stopSendingDeltas.get()) {
+                            // Stopped mid-stream but content is safe — restore via delta.replace
+                            sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                    userSignal.emotionScore(), false, "stop"));
+                        } else {
+                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                    userSignal.emotionScore(), false, "stop"));
+                        }
+                    } else {
+                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                userSignal.emotionScore(), false, "stop"));
+                    }
+
                 } else {
-                    // SPECULATIVE / CAUTIOUS_SPECULATIVE: stream immediately
+                    // SPECULATIVE: stream immediately, no post-guard
                     llmTtftMs = llmClient.stream(llmRequest, chunk -> {
                         contentBuilder.append(chunk);
                         try {
@@ -210,42 +315,8 @@ public class ConversationOrchestrator {
                         }
                     });
                     assistantContent = contentBuilder.toString();
-
-                    if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
-                        // post-stream OutputGuard: 스트리밍 완료 후 안전성 검사
-                        // REWRITE/REPLACE 시 delta.replace 이벤트로 FE 말풍선 교체 후 done 전송
-                        preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
-                        if (!preFilterResult.passed()) {
-                            judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
-                            log.warn("OutputGuard FAIL post-stream: session={} reasons={} action={}",
-                                    sessionId, preFilterResult.failReasons(),
-                                    judgeActionResult != null ? judgeActionResult.action() : "none");
-                            if (judgeActionResult != null) {
-                                boolean isCrisis = judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW;
-                                if (isCrisis) crisisFlowTriggered = true;
-                                String replacedContent = switch (judgeActionResult.action()) {
-                                    case REWRITE -> judgeActionResult.rewrittenContent() != null
-                                            ? judgeActionResult.rewrittenContent() : null;
-                                    case REPLACE, CRISIS_FLOW ->
-                                            "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
-                                    case SEND -> null;
-                                };
-                                if (replacedContent != null) {
-                                    assistantContent = replacedContent;
-                                    sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
-                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), isCrisis, "replaced_by_guard"));
-                                } else {
-                                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
-                                }
-                            } else {
-                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
-                            }
-                        } else {
-                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
-                        }
-                    } else {
-                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
-                    }
+                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                            userSignal.emotionScore(), false, "stop"));
                 }
             } else {
                 // FALLBACK 또는 미지원 action — 안전 응답 반환

--- a/src/main/java/com/mio/config/AiConfig.java
+++ b/src/main/java/com/mio/config/AiConfig.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import java.net.http.HttpClient;
 import java.time.Duration;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
 
 @Configuration
 @EnableAsync
@@ -18,6 +19,11 @@ public class AiConfig {
         return HttpClient.newBuilder()
                 .connectTimeout(Duration.ofSeconds(10))
                 .build();
+    }
+
+    @Bean(name = "outputJudgeExecutor")
+    public Executor outputJudgeExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
     }
 
     @Bean(name = "aiDecisionLoggerExecutor")


### PR DESCRIPTION
## Summary

- `CAUTIOUS_SPECULATIVE` 모드에서 LLM 스트리밍 **도중** `OutputPreFilter`를 매 200자(`EARLY_PREFILTER_THRESHOLD`)마다 실행해 위반 감지 시 즉시 delta SSE 전송을 중단
- `OutputJudge`를 `CompletableFuture.supplyAsync()`로 비동기 실행 — 스트림 완료를 기다리지 않고 병렬로 판정 시작
- 스트림 완료 후 `judgeFuture.join()`으로 판정 결과 수신 (virtual threads 환경이므로 blocking join 허용)
- 판정 결과별 처리:
  - `REWRITE/REPLACE/CRISIS_FLOW` → `delta.replace` + `done(replaced_by_guard)` 이벤트 전송
  - `SEND` + 조기 중단 있었음 → `delta.replace`로 전체 콘텐츠 복원 후 `done`
  - `SEND` + 조기 중단 없음 → `done` 정상 전송
- `SPECULATIVE` 모드는 OutputGuard 없이 기존 동작 유지

## Test plan

- [ ] `CAUTIOUS_SPECULATIVE` 모드에서 정상 응답 시 delta 이벤트가 모두 전달되고 `done`이 전송되는지 확인
- [ ] 위반 콘텐츠 스트리밍 시 200자 도달 후 delta 전송 중단되고 `delta.replace` + `done(replaced_by_guard)` 이벤트 수신 확인
- [ ] 조기 중단 후 OutputJudge가 SEND 반환 시 `delta.replace`로 전체 콘텐츠가 복원되는지 확인
- [ ] `SPECULATIVE` 모드는 OutputGuard 없이 기존과 동일하게 동작하는지 확인
- [ ] `./gradlew build` 통과 확인

Closes #94