### PR TITLE
ci: GitHub Actions CD 파이프라인 구축 (EC2 + GHCR + Docker Compose)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,101 @@
+name: CD
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    name: Build & Push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    outputs:
+      image-tag: ${{ steps.meta.outputs.tags }}
+      image-digest: ${{ steps.build.outputs.digest }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,prefix=sha-
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to EC2
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    environment: production
+
+    steps:
+      - name: Checkout (docker-compose.prod.yml만 필요)
+        uses: actions/checkout@v4
+
+      - name: Copy docker-compose.prod.yml to EC2
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          source: docker-compose.prod.yml
+          target: ~/mio/
+
+      - name: Deploy
+        uses: appleboy/ssh-action@v1.0.3
+        env:
+          ENV_FILE: ${{ secrets.ENV_FILE }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_ACTOR: ${{ github.actor }}
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ${{ secrets.EC2_USERNAME }}
+          key: ${{ secrets.EC2_SSH_KEY }}
+          envs: ENV_FILE,GHCR_TOKEN,GHCR_ACTOR
+          script: |
+            cd ~/mio
+
+            # .env 파일 갱신 (환경변수 → 파일, history에 값 미노출)
+            printf '%s' "$ENV_FILE" > .env
+
+            # GHCR 로그인 (stdin으로 전달해 process table 노출 방지)
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+
+            # 최신 이미지 pull + 재시작
+            docker compose -f docker-compose.prod.yml pull
+            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+
+            # 사용하지 않는 이미지 정리
+            docker image prune -f

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-push
     environment: production
+    permissions:
+      packages: read
 
     steps:
       - name: Checkout (docker-compose.prod.yml만 필요)
@@ -77,7 +79,7 @@ jobs:
         uses: appleboy/ssh-action@v1.0.3
         env:
           ENV_FILE: ${{ secrets.ENV_FILE }}
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
         with:
           host: ${{ secrets.EC2_HOST }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM eclipse-temurin:21-jdk-alpine AS builder
+WORKDIR /app
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle settings.gradle ./
+RUN chmod +x gradlew && ./gradlew dependencies --no-daemon
+COPY src src
+RUN ./gradlew bootJar --no-daemon -x test
+
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+RUN addgroup -S app && adduser -S app -G app
+COPY --from=builder /app/build/libs/*.jar app.jar
+USER app
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,48 @@
+services:
+  app:
+    image: ghcr.io/yarr-mio/mio_server:latest
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"
+    env_file:
+      - .env
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+
+  postgres:
+    image: pgvector/pgvector:pg16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-mio}
+      POSTGRES_USER: ${DB_USERNAME}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-mio}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: >
+      redis-server
+      ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -199,7 +199,7 @@ public class WorkingMemory {
         try {
             return objectMapper.readValue(json, WorkingMessage.class);
         } catch (Exception e) {
-            log.warn("WorkingMemory: failed to deserialize message: {}", json, e);
+            log.warn("WorkingMemory: failed to deserialize message len={}", json == null ? 0 : json.length(), e);
             return null;
         }
     }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,2 +1,11 @@
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+
+auth:
+  dev-token-enabled: false
+
 notification:
   test-endpoint-enabled: false


### PR DESCRIPTION
## Summary

- `Dockerfile` 멀티스테이지 빌드 추가 (JDK 21 builder → JRE alpine runtime, non-root 사용자)
- `docker-compose.prod.yml` 프로덕션 스택 구성 (app / postgres-pgvector / redis), 포트를 `127.0.0.1:8080`으로 바인딩해 Nginx 외 직접 접근 차단
- `.github/workflows/cd.yml` — main 머지 시 GHCR 이미지 빌드·푸시 후 EC2 SSH 배포 (`appleboy/ssh-action`), `envs` 옵션으로 시크릿을 env vars로 전달해 process table 노출 방지
- `application-prod.yml` — Swagger·dev-token·테스트 알림 엔드포인트 프로덕션 비활성화
- `WorkingMemory` 로그 개선 — 역직렬화 실패 시 원문 JSON 제거, `len`만 기록

## 필요한 GitHub Secrets 설정

| Secret | 값 |
|--------|-----|
| `EC2_HOST` | EC2 퍼블릭 DNS 또는 IP |
| `EC2_USERNAME` | `ec2-user` |
| `EC2_SSH_KEY` | `mio.pem` 내용 (전체) |
| `ENV_FILE` | 프로덕션 `.env` 파일 내용 (전체) |
| `GHCR_PAT` | `read:packages` 권한 PAT |

> Settings → Secrets and variables → Actions → **production** 환경에 등록

## Test plan

- [ ] GitHub Secrets 5개 등록 확인
- [ ] main 머지 후 Actions 탭에서 CD 워크플로우 성공 확인
- [ ] EC2에서 `docker ps`로 app/postgres/redis 컨테이너 실행 확인
- [ ] `curl http://<EC2-IP>/actuator/health` 또는 `/health` 200 응답 확인
- [ ] Swagger UI 접근 불가 확인 (prod 비활성화)

Closes #131

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Deployment**
  * Added automated continuous integration and deployment pipeline enabling rapid production releases and updates
  * Docker containerization support providing consistent application packaging, deployment, and scaling across environments

* **Configuration**
  * Production environment configured with PostgreSQL database and Redis caching services for improved performance
  * API documentation and development token authentication disabled in production for enhanced security

<!-- end of auto-generated comment: release notes by coderabbit.ai -->