### PR TITLE
fix: FCM 초기화 시 Base64 인코딩된 credentials JSON 디코딩 추가

### DIFF
--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -106,7 +106,7 @@ public class PushSender {
             return;
         }
         try {
-            byte[] credBytes = fcmCredentialsJson.getBytes();
+            byte[] credBytes = Base64.getDecoder().decode(fcmCredentialsJson);
             FirebaseOptions options = FirebaseOptions.builder()
                     .setCredentials(GoogleCredentials.fromStream(new ByteArrayInputStream(credBytes)))
                     .build();


### PR DESCRIPTION
## Summary

- `PushSender.initFcm()`에서 `FCM_CREDENTIALS_JSON` 환경 변수를 Base64 디코딩 후 Firebase SDK에 전달하도록 수정
- 기존: `fcmCredentialsJson.getBytes()` → 수정: `Base64.getDecoder().decode(fcmCredentialsJson)`
- `import java.util.Base64`는 기존 코드에 이미 존재 (추가 import 불필요)

## 배경

`FCM_CREDENTIALS_JSON`은 GitHub Secret에 멀티라인 JSON을 안전하게 담기 위해 Base64 인코딩된 값으로 관리된다. 코드가 이를 디코딩하지 않아 프로덕션에서 `FCM initialization failed: malformed JSON` 경고가 발생하고 Android 푸시가 비활성화되었다.

## Test plan

- [ ] 로컬에서 `./gradlew compileJava` 통과 확인
- [ ] 배포 후 EC2 로그에서 `FCM initialized` 메시지 확인 (기존: `FCM initialization failed`)

Closes #135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed Firebase Cloud Messaging credential initialization to properly handle Base64-encoded credentials format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->