### PR TITLE
fix: JwtAuthenticationFilter WHITELIST에 /actuator/health 누락 수정

### DIFF
--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -34,7 +34,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "POST /v1/auth/login",
             "POST /v1/auth/refresh",
             "POST /v1/auth/dev/token",
-            "GET /v1/health"
+            "GET /actuator/health"
     );
 
     private final JwtTokenService jwtTokenService;


### PR DESCRIPTION
 요약

  SecurityConfig.PUBLIC_ENDPOINTS에는 /actuator/health가 공개 엔드포인트로 설정되어 있으나, JwtAuthenticationFilter.WHITELIST에는 누락되어 있어 GET /actuator/health 요청이 항상 401을 반환하는 버그를
  수정한다.

  관련 이슈

  - Closes #134

  변경 사항

  - JwtAuthenticationFilter.WHITELIST에 "GET /actuator/health" 추가
  - 컨트롤러가 존재하지 않는 죽은 코드 "GET /v1/health" 제거

  영향 범위

  - [ ] API 스펙 또는 응답 형식이 변경됩니다.
  - [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
  - [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
  - [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
  - [ ] 로깅 / 모니터링 포인트가 변경됩니다.
  - [ ] Breaking change 가 있습니다.

  (해당 없음 — /actuator/health는 기존에 SecurityConfig에서 이미 공개 처리되어 있던 경로이며, 이번 수정으로 JWT 필터 단계의 화이트리스트만 일치시킴)

  테스트

  실행 커맨드

  ./gradlew test --tests "com.mio.auth.filter.JwtAuthenticationFilterTest"

  확인 내용

  - 기존 JwtAuthenticationFilterTest 2건 통과 확인 (devTokenEndpointSkipsJwtFilter, errorDispatchSkipsJwtFilter)
  - 코드 검토로 동작 흐름 확인: GET /actuator/health → shouldNotFilter()가 true 반환 → JWT 필터 통과 → SecurityConfig.PUBLIC_ENDPOINTS의 permitAll() 규칙에 의해 인증 없이 200 응답
  - "GET /v1/health"는 코드/테스트 어디에서도 참조되지 않음을 grep으로 확인 (제거해도 영향 없음)
  - 별도 회귀 테스트는 추가하지 않음 (단순 상수 값 수정이며, shouldNotFilter 매커니즘 자체는 기존 테스트로 커버됨)

  중점 리뷰 포인트

  - "GET /v1/health" 제거가 의도대로 죽은 코드인지(다른 모듈/배포 설정에서 헬스체크용으로 참조하지 않는지) 한 번 더 확인 부탁드립니다.

  배포 / 롤백

  - Rollout: 일반 배포 절차로 머지 후 배포. 별도 설정 변경 불필요.
  - Rollback: 코드 변경분만 revert하면 원복 가능 (DB/설정 변경 없음).

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (해당 없음)
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the health-check endpoint configuration to use the latest monitoring endpoint for service status verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->