### PR TITLE
fix: LoginRequest에 snake_case JsonProperty 추가 (#139)

### DIFF
--- a/src/main/java/com/mio/auth/dto/LoginRequest.java
+++ b/src/main/java/com/mio/auth/dto/LoginRequest.java
@@ -1,11 +1,12 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank String provider,
-        String idToken,
-        String accessToken,
-        @NotBlank String deviceId
+        @JsonProperty("id_token") String idToken,
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("device_id") @NotBlank String deviceId
 ) {
 }


### PR DESCRIPTION
 POST /v1/auth/login의 LoginRequest만 다른 Request DTO와 달리 @JsonProperty("snake_case")
  어노테이션이 빠져 있어, camelCase(idToken/accessToken/deviceId) 요청만 바인딩되고 운영에서
  실제로 쓰이는 snake_case(id_token/access_token/device_id) 요청은 deviceId 누락으로 400
  처리되던 문제를 수정합니다.

  관련 이슈

  - Closes #139

  변경 사항

  - LoginRequest.idToken → @JsonProperty("id_token") 추가
  - LoginRequest.accessToken → @JsonProperty("access_token") 추가
  - LoginRequest.deviceId → @JsonProperty("device_id") 추가 (@NotBlank 유지)

  영향 범위

  - [x] API 스펙 또는 응답 형식이 변경됩니다.
  - [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
  - [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
  - [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
  - [ ] 로깅 / 모니터링 포인트가 변경됩니다.
  - [x] Breaking change 가 있습니다.

  ▎ develop 기준으로는 camelCase 요청이 더 이상 바인딩되지 않게 되는 breaking change지만,
  ▎ 운영 서버(mio.io.kr)는 이미 snake_case만 받고 있고 프론트도 이미 snake_case로 호출
  ▎ 중이므로 실서비스 영향은 없음 — develop을 운영 실제 동작에 맞추는 변경입니다.

  테스트

  실행 커맨드

  ./gradlew test --tests "com.mio.auth.dto.LoginRequestJsonTest"  # 임시 @JsonTest, 검증 후
  제거

  확인 내용

  - @JsonTest로 LoginRequest 바인딩 확인
    - {"id_token":..,"access_token":..,"device_id":..} → 정상 바인딩 (수정 후)
    - {"idToken":..,"accessToken":..,"deviceId":..} → 전부 null (수정 후, @NotBlank deviceId
  위반 시 400)
  - 운영 서버(https://mio.io.kr/v1/auth/login)에 직접 curl로 현재 동작 재확인
    - camelCase → 400 VALIDATION_ERROR "must not be blank"
    - snake_case → 401 OAUTH_VERIFICATION_FAILED (검증 통과, 토큰 검증 단계까지 진행)
    - 위 결과가 수정 후 코드의 snake_case 바인딩 결과와 일치
  - AuthIntegrationTest는 로컬 Postgres(5432)/Redis(6379) 미기동으로 컨텍스트 로딩 단계에서
  9건 모두 실패 — 본 변경과 무관한 환경 문제 (직렬화/역직렬화가 동일 ObjectMapper를
  사용하므로 라운드트립 자체는 영향 없음)

  중점 리뷰 포인트

  - 현재 develop(camelCase 전용) 기준으로 요청을 보내는 클라이언트/테스트가 또 있는지 확인
  필요 — 확인된 바로는 프론트/운영은 이미 snake_case
  - auth-api-spec.md의 POST /v1/auth/login 요청 필드(snake_case) 문서 갱신은 별도로 처리 예정
  (이 PR에는 미포함)

  배포 / 롤백

  - Rollout: 일반 배포. DB/설정 변경 없음, 운영은 이미 snake_case로 동작 중이라 배포 즉시
  영향 없음
  - Rollback: 커밋 되돌리면 즉시 원복 (단, 되돌릴 경우 develop이 다시 운영과 불일치 상태로
  회귀)

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. (기존 AuthIntegrationTest의
  로그인 헬퍼가 동일 ObjectMapper로 직렬화/역직렬화하는 경로를 그대로 검증하므로 별도 단위
  테스트 추가 안 함)
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (스펙 문서
  갱신은 별도 작업으로 진행)
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved login request validation to require device ID for better authentication tracking.

* **Updates**
  * Standardized JSON property naming in login requests for clearer API integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->