### PR TITLE
refactor: 전역 Jackson SNAKE_CASE 제거 및 @JsonProperty 명시적 복원 (#141)

### DIFF
--- a/src/main/java/com/mio/auth/dto/ConsentResponse.java
+++ b/src/main/java/com/mio/auth/dto/ConsentResponse.java
@@ -1,7 +1,8 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record ConsentResponse(
-        SignupStep signupStep
+        @JsonProperty("signup_step") SignupStep signupStep
 ) {}

--- a/src/main/java/com/mio/auth/dto/DevTokenRequest.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenRequest.java
@@ -1,10 +1,11 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 
 import java.util.UUID;
 
 public record DevTokenRequest(
-        @NotNull UUID userId
+        @NotNull @JsonProperty("user_id") UUID userId
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/DevTokenResponse.java
+++ b/src/main/java/com/mio/auth/dto/DevTokenResponse.java
@@ -1,7 +1,9 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record DevTokenResponse(
-        String accessToken,
-        int expiresIn
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") int expiresIn
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/LoginRequest.java
+++ b/src/main/java/com/mio/auth/dto/LoginRequest.java
@@ -1,11 +1,12 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank String provider,
-        String idToken,
-        String accessToken,
-        @NotBlank String deviceId
+        @JsonProperty("idToken") String idToken,
+        @JsonProperty("accessToken") String accessToken,
+        @JsonProperty("deviceId") @NotBlank String deviceId
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/LoginResponse.java
+++ b/src/main/java/com/mio/auth/dto/LoginResponse.java
@@ -1,26 +1,27 @@
 package com.mio.auth.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginResponse(
-        String accessToken,
-        String refreshToken,
-        int expiresIn,
-        boolean isNewUser,
-        boolean isNewDevice,
-        SignupStep signupStep,
-        int onboardingStep,
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("refresh_token") String refreshToken,
+        @JsonProperty("expires_in") int expiresIn,
+        @JsonProperty("is_new_user") boolean isNewUser,
+        @JsonProperty("is_new_device") boolean isNewDevice,
+        @JsonProperty("signup_step") SignupStep signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep,
         UserInfo user
 ) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record UserInfo(
             String id,
             String nickname,
-            String preferredCharacterId,
-            boolean isMinor,
-            boolean isPremium,
+            @JsonProperty("preferred_character_id") String preferredCharacterId,
+            @JsonProperty("is_minor") boolean isMinor,
+            @JsonProperty("is_premium") boolean isPremium,
             String status
     ) {
     }

--- a/src/main/java/com/mio/auth/dto/LogoutRequest.java
+++ b/src/main/java/com/mio/auth/dto/LogoutRequest.java
@@ -1,8 +1,9 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record LogoutRequest(
-        @NotBlank String deviceId
+        @JsonProperty("device_id") @NotBlank String deviceId
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteResponse.java
@@ -1,9 +1,11 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupCompleteResponse(
-        SignupStep signupStep,
-        int onboardingStep,
+        @JsonProperty("signup_step") SignupStep signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep,
         String nickname
-) {}
+) {
+}

--- a/src/main/java/com/mio/auth/dto/SignupFinalizeResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupFinalizeResponse.java
@@ -1,8 +1,9 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupFinalizeResponse(
-        SignupStep signupStep,
+        @JsonProperty("signup_step") SignupStep signupStep,
         String status
 ) {}

--- a/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
+++ b/src/main/java/com/mio/auth/dto/SignupStatusResponse.java
@@ -1,8 +1,10 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record SignupStatusResponse(
-        SignupStep signupStep,
-        int onboardingStep
-) {}
+        @JsonProperty("signup_step") SignupStep signupStep,
+        @JsonProperty("onboarding_step") int onboardingStep
+) {
+}

--- a/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshRequest.java
@@ -1,8 +1,9 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record TokenRefreshRequest(
-        @NotBlank String refreshToken
+        @JsonProperty("refresh_token") @NotBlank String refreshToken
 ) {
 }

--- a/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
+++ b/src/main/java/com/mio/auth/dto/TokenRefreshResponse.java
@@ -1,6 +1,9 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record TokenRefreshResponse(
-        String accessToken,
-        int expiresIn
-) {}
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("expires_in") int expiresIn
+) {
+}

--- a/src/main/java/com/mio/auth/dto/WithdrawResponse.java
+++ b/src/main/java/com/mio/auth/dto/WithdrawResponse.java
@@ -1,11 +1,13 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.OffsetDateTime;
 
 public record WithdrawResponse(
         boolean success,
-        OffsetDateTime withdrawnAt,
-        OffsetDateTime hardDeleteScheduledAt
+        @JsonProperty("withdrawn_at") OffsetDateTime withdrawnAt,
+        @JsonProperty("hard_delete_scheduled_at") OffsetDateTime hardDeleteScheduledAt
 ) {
     public WithdrawResponse(OffsetDateTime withdrawnAt) {
         this(true, withdrawnAt, withdrawnAt != null ? withdrawnAt.plusDays(30) : null);

--- a/src/main/java/com/mio/character/dto/CharacterChangeRequest.java
+++ b/src/main/java/com/mio/character/dto/CharacterChangeRequest.java
@@ -1,7 +1,8 @@
 package com.mio.character.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 public record CharacterChangeRequest(
-        @NotBlank String characterId
+        @JsonProperty("character_id") @NotBlank String characterId
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterChangeResponse.java
+++ b/src/main/java/com/mio/character/dto/CharacterChangeResponse.java
@@ -1,8 +1,10 @@
 package com.mio.character.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record CharacterChangeResponse(
-        String characterId,
+        @JsonProperty("character_id") String characterId,
         String name,
         boolean changed,
-        String greetingMessage
+        @JsonProperty("greeting_message") String greetingMessage
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterItemDto.java
+++ b/src/main/java/com/mio/character/dto/CharacterItemDto.java
@@ -1,12 +1,14 @@
 package com.mio.character.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record CharacterItemDto(
-        String characterId,
+        @JsonProperty("character_id") String characterId,
         String name,
         String animal,
         String description,
         List<String> tags,
-        boolean isCurrent
+        @JsonProperty("is_current") boolean isCurrent
 ) {}

--- a/src/main/java/com/mio/character/dto/CharacterListResponse.java
+++ b/src/main/java/com/mio/character/dto/CharacterListResponse.java
@@ -1,8 +1,10 @@
 package com.mio.character.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record CharacterListResponse(
-        String currentCharacterId,
+        @JsonProperty("current_character_id") String currentCharacterId,
         List<CharacterItemDto> characters
 ) {}

--- a/src/main/java/com/mio/character/dto/UserCharacterResponse.java
+++ b/src/main/java/com/mio/character/dto/UserCharacterResponse.java
@@ -1,7 +1,9 @@
 package com.mio.character.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record UserCharacterResponse(
-        String characterId,
+        @JsonProperty("character_id") String characterId,
         String name,
         String animal
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinCreateResponse.java
@@ -1,17 +1,18 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinCreateResponse(
-        UUID checkinId,
-        String timeOfDay,
-        String emotionType,
-        int conditionScore,
+        @JsonProperty("checkin_id") UUID checkinId,
+        @JsonProperty("time_of_day") String timeOfDay,
+        @JsonProperty("emotion_type") String emotionType,
+        @JsonProperty("condition_score") int conditionScore,
         String memo,
-        String aiResponse,
-        OffsetDateTime createdAt
+        @JsonProperty("ai_response") String aiResponse,
+        @JsonProperty("created_at") OffsetDateTime createdAt
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinRequest.java
@@ -1,10 +1,11 @@
 package com.mio.checkin.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.*;
 
 public record CheckinRequest(
-        @NotBlank String timeOfDay,
-        @NotBlank String emotionType,
-        @NotNull @Min(1) @Max(5) Integer conditionScore,
+        @NotBlank @JsonProperty("time_of_day") String timeOfDay,
+        @NotBlank @JsonProperty("emotion_type") String emotionType,
+        @NotNull @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
         @Size(max = 200) String memo
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinResponse.java
@@ -1,18 +1,19 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinResponse(
-        UUID checkinId,
-        String timeOfDay,
-        String emotionType,
-        int conditionScore,
+        @JsonProperty("checkin_id") UUID checkinId,
+        @JsonProperty("time_of_day") String timeOfDay,
+        @JsonProperty("emotion_type") String emotionType,
+        @JsonProperty("condition_score") int conditionScore,
         String memo,
-        String aiResponse,
-        OffsetDateTime createdAt,
-        OffsetDateTime updatedAt
+        @JsonProperty("ai_response") String aiResponse,
+        @JsonProperty("created_at") OffsetDateTime createdAt,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinTodayResponse.java
@@ -1,11 +1,13 @@
 package com.mio.checkin.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.LocalDate;
 import java.util.List;
 
 public record CheckinTodayResponse(
         LocalDate date,
         List<CheckinResponse> checkins,
-        List<String> completedSlots,
-        List<String> availableSlots
+        @JsonProperty("completed_slots") List<String> completedSlots,
+        @JsonProperty("available_slots") List<String> availableSlots
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateRequest.java
@@ -1,11 +1,12 @@
 package com.mio.checkin.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.Size;
 
 public record CheckinUpdateRequest(
-        String emotionType,
-        @Min(1) @Max(5) Integer conditionScore,
+        @JsonProperty("emotion_type") String emotionType,
+        @Min(1) @Max(5) @JsonProperty("condition_score") Integer conditionScore,
         @Size(max = 200) String memo
 ) {}

--- a/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
+++ b/src/main/java/com/mio/checkin/dto/CheckinUpdateResponse.java
@@ -1,17 +1,18 @@
 package com.mio.checkin.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record CheckinUpdateResponse(
-        UUID checkinId,
-        String timeOfDay,
-        String emotionType,
-        int conditionScore,
+        @JsonProperty("checkin_id") UUID checkinId,
+        @JsonProperty("time_of_day") String timeOfDay,
+        @JsonProperty("emotion_type") String emotionType,
+        @JsonProperty("condition_score") int conditionScore,
         String memo,
-        String aiResponse,
-        OffsetDateTime updatedAt
+        @JsonProperty("ai_response") String aiResponse,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/common/error/ErrorResponse.java
+++ b/src/main/java/com/mio/common/error/ErrorResponse.java
@@ -1,5 +1,6 @@
 package com.mio.common.error;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -16,6 +17,6 @@ public record ErrorResponse(ErrorDetail error) {
     public record ErrorDetail(
             String code,
             String message,
-            String traceId
+            @JsonProperty("trace_id") String traceId
     ) {}
 }

--- a/src/main/java/com/mio/common/response/ApiResponse.java
+++ b/src/main/java/com/mio/common/response/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.mio.common.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Builder;
 
@@ -27,9 +28,9 @@ public record ApiResponse<T>(
     }
 
 public record Meta(
-            String traceId,
-            String nextCursor,
-            Boolean hasMore
+            @JsonProperty("trace_id") String traceId,
+            @JsonProperty("next_cursor") String nextCursor,
+            @JsonProperty("has_more") Boolean hasMore
     ) {
         public static Meta trace(String traceId) {
             return new Meta(traceId, null, null);

--- a/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestResultResponse.java
@@ -1,16 +1,18 @@
 package com.mio.dailytest.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.OffsetDateTime;
 import java.util.List;
 
 public record DailyTestResultResponse(
         ResultDto result,
-        OffsetDateTime completedAt
+        @JsonProperty("completed_at") OffsetDateTime completedAt
 ) {
     public record ResultDto(
             String summary,
             String description,
             List<String> tags,
-            String characterComment
+            @JsonProperty("character_comment") String characterComment
     ) {}
 }

--- a/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
+++ b/src/main/java/com/mio/dailytest/dto/DailyTestTodayResponse.java
@@ -1,30 +1,31 @@
 package com.mio.dailytest.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record DailyTestTodayResponse(
-        boolean completedToday,
-        UUID testId,
+        @JsonProperty("completed_today") boolean completedToday,
+        @JsonProperty("test_id") UUID testId,
         String title,
-        Integer estimatedMinutes,
+        @JsonProperty("estimated_minutes") Integer estimatedMinutes,
         List<QuestionDto> questions,
         ResultDto result
 ) {
     public record ResultDto(String summary, List<String> tags) {}
 
     public record QuestionDto(
-            String questionId,
+            @JsonProperty("question_id") String questionId,
             int order,
             String text,
             List<OptionDto> options
     ) {}
 
     public record OptionDto(
-            String optionId,
+            @JsonProperty("option_id") String optionId,
             String text
     ) {}
 

--- a/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
+++ b/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
@@ -1,32 +1,34 @@
 package com.mio.mypage.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 import java.util.UUID;
 
 public record UserProfileResponse(
-        UUID userId,
+        @JsonProperty("user_id") UUID userId,
         String nickname,
-        String ageRange,
-        PreferredCharacterDto preferredCharacter,
+        @JsonProperty("age_range") String ageRange,
+        @JsonProperty("preferred_character") PreferredCharacterDto preferredCharacter,
         UserStatsDto stats,
-        List<EmotionDistributionDto> monthlyEmotionDistribution,
-        String signupStep
+        @JsonProperty("monthly_emotion_distribution") List<EmotionDistributionDto> monthlyEmotionDistribution,
+        @JsonProperty("signup_step") String signupStep
 ) {
     public record PreferredCharacterDto(
-            String characterId,
+            @JsonProperty("character_id") String characterId,
             String name,
             String animal,
             String description
     ) {}
 
     public record UserStatsDto(
-            long totalCheckins,
-            int consecutiveDays,
-            long todoCompleted
+            @JsonProperty("total_checkins") long totalCheckins,
+            @JsonProperty("consecutive_days") int consecutiveDays,
+            @JsonProperty("todo_completed") long todoCompleted
     ) {}
 
     public record EmotionDistributionDto(
-            String emotionType,
+            @JsonProperty("emotion_type") String emotionType,
             String label,
             int percentage
     ) {}

--- a/src/main/java/com/mio/mypage/dto/UserProfileUpdateResponse.java
+++ b/src/main/java/com/mio/mypage/dto/UserProfileUpdateResponse.java
@@ -1,11 +1,13 @@
 package com.mio.mypage.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record UserProfileUpdateResponse(
-        UUID userId,
+        @JsonProperty("user_id") UUID userId,
         String nickname,
-        String ageRange,
-        OffsetDateTime updatedAt
+        @JsonProperty("age_range") String ageRange,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
 ) {}

--- a/src/main/java/com/mio/notification/dto/DeviceTokenRegisterRequest.java
+++ b/src/main/java/com/mio/notification/dto/DeviceTokenRegisterRequest.java
@@ -1,11 +1,12 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
 public record DeviceTokenRegisterRequest(
-        @NotBlank String deviceId,
-        @NotBlank String pushToken,
+        @JsonProperty("device_id") @NotBlank String deviceId,
+        @JsonProperty("push_token") @NotBlank String pushToken,
         @NotBlank @Pattern(regexp = "ios|android", message = "platform must be 'ios' or 'android'") String platform,
-        @NotBlank String appVersion
+        @JsonProperty("app_version") @NotBlank String appVersion
 ) {}

--- a/src/main/java/com/mio/notification/dto/DeviceTokenResponse.java
+++ b/src/main/java/com/mio/notification/dto/DeviceTokenResponse.java
@@ -1,10 +1,11 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.DeviceToken;
 
 public record DeviceTokenResponse(
         boolean success,
-        String deviceId,
+        @JsonProperty("device_id") String deviceId,
         String platform
 ) {
 

--- a/src/main/java/com/mio/notification/dto/NotificationHistoryItemResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationHistoryItemResponse.java
@@ -1,5 +1,6 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.ProactiveCareLog;
 import com.mio.notification.service.NotificationMessageMapper;
 
@@ -7,13 +8,13 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record NotificationHistoryItemResponse(
-        UUID notificationId,
-        String triggerCode,
+        @JsonProperty("notification_id") UUID notificationId,
+        @JsonProperty("trigger_code") String triggerCode,
         String title,
         String body,
-        String notificationStatus,
-        OffsetDateTime sentAt,
-        OffsetDateTime respondedAt
+        @JsonProperty("notification_status") String notificationStatus,
+        @JsonProperty("sent_at") OffsetDateTime sentAt,
+        @JsonProperty("responded_at") OffsetDateTime respondedAt
 ) {
 
     public static NotificationHistoryItemResponse from(

--- a/src/main/java/com/mio/notification/dto/NotificationReadResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationReadResponse.java
@@ -1,10 +1,12 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record NotificationReadResponse(
-        UUID notificationId,
-        String notificationStatus,
-        OffsetDateTime respondedAt
+        @JsonProperty("notification_id") UUID notificationId,
+        @JsonProperty("notification_status") String notificationStatus,
+        @JsonProperty("responded_at") OffsetDateTime respondedAt
 ) {}

--- a/src/main/java/com/mio/notification/dto/NotificationSettingResponse.java
+++ b/src/main/java/com/mio/notification/dto/NotificationSettingResponse.java
@@ -1,15 +1,16 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.notification.domain.NotificationSetting;
 
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 public record NotificationSettingResponse(
-        boolean checkinEnabled,
-        NotificationCheckinTimeResponse checkinTime,
-        boolean characterEnabled,
-        boolean reportEnabled
+        @JsonProperty("checkin_enabled") boolean checkinEnabled,
+        @JsonProperty("checkin_time") NotificationCheckinTimeResponse checkinTime,
+        @JsonProperty("character_enabled") boolean characterEnabled,
+        @JsonProperty("report_enabled") boolean reportEnabled
 ) {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 

--- a/src/main/java/com/mio/notification/dto/NotificationSettingUpdateRequest.java
+++ b/src/main/java/com/mio/notification/dto/NotificationSettingUpdateRequest.java
@@ -1,10 +1,11 @@
 package com.mio.notification.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 
 public record NotificationSettingUpdateRequest(
-        Boolean checkinEnabled,
-        @Valid NotificationCheckinTimeUpdateRequest checkinTime,
-        Boolean characterEnabled,
-        Boolean reportEnabled
+        @JsonProperty("checkin_enabled") Boolean checkinEnabled,
+        @Valid @JsonProperty("checkin_time") NotificationCheckinTimeUpdateRequest checkinTime,
+        @JsonProperty("character_enabled") Boolean characterEnabled,
+        @JsonProperty("report_enabled") Boolean reportEnabled
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterRecommendationDto.java
@@ -1,8 +1,10 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record CharacterRecommendationDto(
-        String characterId,
+        @JsonProperty("character_id") String characterId,
         String name,
-        double matchScore,
+        @JsonProperty("match_score") double matchScore,
         String reason
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectRequest.java
@@ -1,5 +1,7 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record CharacterSelectRequest(
-        String characterId
+        @JsonProperty("character_id") String characterId
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/CharacterSelectResponse.java
@@ -1,8 +1,9 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 public record CharacterSelectResponse(
-        String preferredCharacterId,
-        SignupStep signupStep
+        @JsonProperty("preferred_character_id") String preferredCharacterId,
+        @JsonProperty("signup_step") SignupStep signupStep
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStatusResponse.java
@@ -1,11 +1,12 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
 import java.util.List;
 
 public record OnboardingStatusResponse(
-        int onboardingStep,
-        SignupStep signupStep,
-        List<CharacterRecommendationDto> characterRecommendations
+        @JsonProperty("onboarding_step") int onboardingStep,
+        @JsonProperty("signup_step") SignupStep signupStep,
+        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep1Request.java
@@ -1,10 +1,11 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
 public record OnboardingStep1Request(
-        @NotBlank String emotionState,
+        @JsonProperty("emotion_state") @NotBlank String emotionState,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep2Request.java
@@ -1,10 +1,11 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotEmpty;
 
 import java.util.List;
 
 public record OnboardingStep2Request(
-        @NotEmpty List<String> concernTypes,
+        @JsonProperty("concern_types") @NotEmpty List<String> concernTypes,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Request.java
@@ -1,10 +1,11 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.List;
 
 public record OnboardingStep3Request(
-        @NotBlank String preferredStyle,
+        @JsonProperty("preferred_style") @NotBlank String preferredStyle,
         List<QuestionResponse> responses
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStep3Response.java
@@ -1,8 +1,10 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.List;
 
 public record OnboardingStep3Response(
-        int onboardingStep,
-        List<CharacterRecommendationDto> characterRecommendations
+        @JsonProperty("onboarding_step") int onboardingStep,
+        @JsonProperty("character_recommendations") List<CharacterRecommendationDto> characterRecommendations
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/OnboardingStepResponse.java
@@ -1,5 +1,7 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record OnboardingStepResponse(
-        int onboardingStep
+        @JsonProperty("onboarding_step") int onboardingStep
 ) {}

--- a/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
+++ b/src/main/java/com/mio/onboarding/dto/QuestionResponse.java
@@ -1,6 +1,8 @@
 package com.mio.onboarding.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record QuestionResponse(
-        String questionId,
+        @JsonProperty("question_id") String questionId,
         String answer
 ) {}

--- a/src/main/java/com/mio/report/dto/EmotionTrendResponse.java
+++ b/src/main/java/com/mio/report/dto/EmotionTrendResponse.java
@@ -1,19 +1,20 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
 import java.util.List;
 
 public record EmotionTrendResponse(
-        LocalDate periodStart,
-        LocalDate periodEnd,
+        @JsonProperty("period_start") LocalDate periodStart,
+        @JsonProperty("period_end") LocalDate periodEnd,
         List<TrendPointDto> points
 ) {
     public record TrendPointDto(
             LocalDate date,
             @JsonInclude(JsonInclude.Include.ALWAYS)
-            Double avgConditionScore,
-            int checkinCount
+            @JsonProperty("avg_condition_score") Double avgConditionScore,
+            @JsonProperty("checkin_count") int checkinCount
     ) {}
 }

--- a/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
@@ -1,6 +1,7 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.report.dto.ReportCommonDto.DistortionDto;
 import com.mio.report.dto.ReportCommonDto.SessionSummaryDto;
 import com.mio.report.dto.ReportCommonDto.TodoSummaryDto;
@@ -12,20 +13,20 @@ import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record MonthlyReportResponse(
-        UUID reportId,
-        LocalDate monthStart,
-        LocalDate monthEnd,
+        @JsonProperty("report_id") UUID reportId,
+        @JsonProperty("month_start") LocalDate monthStart,
+        @JsonProperty("month_end") LocalDate monthEnd,
         String status,
-        Boolean isPartial,
-        Integer checkinCount,
-        Integer requiredCount,
-        Double avgEmotionScore,
-        List<DistortionDto> distortionTop3,
+        @JsonProperty("is_partial") Boolean isPartial,
+        @JsonProperty("checkin_count") Integer checkinCount,
+        @JsonProperty("required_count") Integer requiredCount,
+        @JsonProperty("avg_emotion_score") Double avgEmotionScore,
+        @JsonProperty("distortion_top3") List<DistortionDto> distortionTop3,
         String narrative,
-        String coachingDirection,
-        TodoSummaryDto todoSummary,
-        SessionSummaryDto sessionSummary,
-        OffsetDateTime generatedAt,
+        @JsonProperty("coaching_direction") String coachingDirection,
+        @JsonProperty("todo_summary") TodoSummaryDto todoSummary,
+        @JsonProperty("session_summary") SessionSummaryDto sessionSummary,
+        @JsonProperty("generated_at") OffsetDateTime generatedAt,
         String message
 ) {
     public static MonthlyReportResponse insufficientData(LocalDate monthStart, LocalDate monthEnd, int checkinCount) {

--- a/src/main/java/com/mio/report/dto/ReportCommonDto.java
+++ b/src/main/java/com/mio/report/dto/ReportCommonDto.java
@@ -1,5 +1,7 @@
 package com.mio.report.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.util.Map;
 
 public class ReportCommonDto {
@@ -11,13 +13,13 @@ public class ReportCommonDto {
             int completed,
             int skipped,
             int expired,
-            double completionRate,
-            Map<String, Integer> categoryDistribution
+            @JsonProperty("completion_rate") double completionRate,
+            @JsonProperty("category_distribution") Map<String, Integer> categoryDistribution
     ) {}
 
     public record SessionSummaryDto(
             int total,
-            long totalMinutes
+            @JsonProperty("total_minutes") long totalMinutes
     ) {}
 
     private ReportCommonDto() {}

--- a/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
@@ -1,6 +1,7 @@
 package com.mio.report.dto;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.report.dto.ReportCommonDto.DistortionDto;
 import com.mio.report.dto.ReportCommonDto.SessionSummaryDto;
 import com.mio.report.dto.ReportCommonDto.TodoSummaryDto;
@@ -12,20 +13,20 @@ import java.util.UUID;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record WeeklyReportResponse(
-        UUID reportId,
-        LocalDate weekStart,
-        LocalDate weekEnd,
+        @JsonProperty("report_id") UUID reportId,
+        @JsonProperty("week_start") LocalDate weekStart,
+        @JsonProperty("week_end") LocalDate weekEnd,
         String status,
-        Boolean isPartial,
-        Integer checkinCount,
-        Integer requiredCount,
-        Double avgEmotionScore,
-        List<DistortionDto> distortionTop3,
+        @JsonProperty("is_partial") Boolean isPartial,
+        @JsonProperty("checkin_count") Integer checkinCount,
+        @JsonProperty("required_count") Integer requiredCount,
+        @JsonProperty("avg_emotion_score") Double avgEmotionScore,
+        @JsonProperty("distortion_top3") List<DistortionDto> distortionTop3,
         String narrative,
-        String coachingDirection,
-        TodoSummaryDto todoSummary,
-        SessionSummaryDto sessionSummary,
-        OffsetDateTime generatedAt,
+        @JsonProperty("coaching_direction") String coachingDirection,
+        @JsonProperty("todo_summary") TodoSummaryDto todoSummary,
+        @JsonProperty("session_summary") SessionSummaryDto sessionSummary,
+        @JsonProperty("generated_at") OffsetDateTime generatedAt,
         String message
 ) {
     public static WeeklyReportResponse insufficientData(LocalDate weekStart, LocalDate weekEnd, int checkinCount) {

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -1,19 +1,20 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record ActiveSessionResponse(
-        UUID sessionId,
-        String characterId,
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("character_id") String characterId,
         String status,
-        OffsetDateTime startedAt,
-        OffsetDateTime lastMessageAt,
-        Integer messageCount,
-        String lastSummaryStatus,
-        UUID lastEndedSessionId
+        @JsonProperty("started_at") OffsetDateTime startedAt,
+        @JsonProperty("last_message_at") OffsetDateTime lastMessageAt,
+        @JsonProperty("message_count") Integer messageCount,
+        @JsonProperty("last_summary_status") String lastSummaryStatus,
+        @JsonProperty("last_ended_session_id") UUID lastEndedSessionId
 ) {
     public static ActiveSessionResponse fromActive(Session session) {
         return new ActiveSessionResponse(

--- a/src/main/java/com/mio/session/dto/CreateSessionRequest.java
+++ b/src/main/java/com/mio/session/dto/CreateSessionRequest.java
@@ -1,9 +1,10 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.Size;
 
 public record CreateSessionRequest(
         @Size(max = 50, message = "character_id는 50자를 초과할 수 없습니다.")
-        String characterId
+        @JsonProperty("character_id") String characterId
 ) {
 }

--- a/src/main/java/com/mio/session/dto/EndSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/EndSessionResponse.java
@@ -1,17 +1,18 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record EndSessionResponse(
-        UUID sessionId,
+        @JsonProperty("session_id") UUID sessionId,
         String status,
-        OffsetDateTime endedAt,
-        int messageCount,
-        long durationSeconds,
-        String summaryStatus
+        @JsonProperty("ended_at") OffsetDateTime endedAt,
+        @JsonProperty("message_count") int messageCount,
+        @JsonProperty("duration_seconds") long durationSeconds,
+        @JsonProperty("summary_status") String summaryStatus
 ) {
     public static EndSessionResponse from(Session session) {
         if (session.getEndedAt() == null) {

--- a/src/main/java/com/mio/session/dto/SessionResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionResponse.java
@@ -1,15 +1,16 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record SessionResponse(
-        UUID sessionId,
-        String characterId,
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("character_id") String characterId,
         String status,
-        OffsetDateTime startedAt
+        @JsonProperty("started_at") OffsetDateTime startedAt
 ) {
     public static SessionResponse from(Session session) {
         return new SessionResponse(

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -1,5 +1,6 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionSummary;
 
@@ -7,15 +8,15 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record SessionSummaryResponse(
-        UUID sessionId,
-        String summaryStatus,
-        OffsetDateTime endedAt,
-        long durationSeconds,
-        int messageCount,
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("summary_status") String summaryStatus,
+        @JsonProperty("ended_at") OffsetDateTime endedAt,
+        @JsonProperty("duration_seconds") long durationSeconds,
+        @JsonProperty("message_count") int messageCount,
         String summary,
-        Integer avgEmotionScore,
-        String biasTypesDetected,
-        Boolean cbtIntervened
+        @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
+        @JsonProperty("bias_types_detected") String biasTypesDetected,
+        @JsonProperty("cbt_intervened") Boolean cbtIntervened
 ) {
     public static SessionSummaryResponse pending(Session session) {
         return new SessionSummaryResponse(

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -1,5 +1,7 @@
 package com.mio.session.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import java.time.OffsetDateTime;
 import java.util.List;
 
@@ -13,29 +15,29 @@ public sealed interface SseEventDto
     String eventName();
 
     record SessionMetaEvent(
-            String messageId,
-            OffsetDateTime receivedAt
+            @JsonProperty("message_id") String messageId,
+            @JsonProperty("received_at") OffsetDateTime receivedAt
     ) implements SseEventDto {
         @Override public String eventName() { return "session_meta"; }
     }
 
     record DeltaEvent(
             String chunk,
-            String msgId
+            @JsonProperty("msg_id") String msgId
     ) implements SseEventDto {
         @Override public String eventName() { return "delta"; }
     }
 
     record DeltaReplaceEvent(
-            String safeResponse,
-            String msgId
+            @JsonProperty("safe_response") String safeResponse,
+            @JsonProperty("msg_id") String msgId
     ) implements SseEventDto {
         @Override public String eventName() { return "delta.replace"; }
     }
 
     record CrisisEvent(
             int severity,
-            String fixedResponse,
+            @JsonProperty("fixed_response") String fixedResponse,
             Resources resources
     ) implements SseEventDto {
         @Override public String eventName() { return "crisis"; }
@@ -45,10 +47,10 @@ public sealed interface SseEventDto
     }
 
     record DoneEvent(
-            String msgId,
-            Integer emotionScore,
-            boolean isCrisisFlagged,
-            String finishedReason
+            @JsonProperty("msg_id") String msgId,
+            @JsonProperty("emotion_score") Integer emotionScore,
+            @JsonProperty("is_crisis_flagged") boolean isCrisisFlagged,
+            @JsonProperty("finished_reason") String finishedReason
     ) implements SseEventDto {
         @Override public String eventName() { return "done"; }
     }

--- a/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
@@ -1,5 +1,6 @@
 package com.mio.todo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -8,8 +9,10 @@ public record TodoCheckinRequest(
         @Pattern(regexp = "completed|skipped", message = "status는 completed 또는 skipped 이어야 합니다.")
         String status,
 
+        @JsonProperty("before_emotion")
         Integer beforeEmotion,
 
+        @JsonProperty("after_emotion")
         Integer afterEmotion,
 
         String feedback

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -1,15 +1,19 @@
 package com.mio.todo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 
 public record TodoCheckinResponse(
         String status,
 
+        @JsonProperty("before_emotion")
         Integer beforeEmotion,
 
+        @JsonProperty("after_emotion")
         Integer afterEmotion,
 
+        @JsonProperty("character_reaction")
         String characterReaction
 ) {
     private static final String REACTION_COMPLETED = "잘했어! 작은 것부터 하나씩 해나가는 게 진짜 대단한 거야 🎉";

--- a/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoGenerateRequest.java
@@ -1,5 +1,6 @@
 package com.mio.todo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -10,5 +11,6 @@ public record TodoGenerateRequest(
         @Pattern(regexp = "checkin|chat", message = "source는 checkin 또는 chat 이어야 합니다.")
         String source,
 
+        @JsonProperty("source_id")
         UUID sourceId
 ) {}

--- a/src/main/java/com/mio/todo/dto/TodoResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoResponse.java
@@ -1,5 +1,6 @@
 package com.mio.todo.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 
@@ -7,19 +8,24 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public record TodoResponse(
+        @JsonProperty("todo_id")
         UUID todoId,
 
+        @JsonProperty("action_text")
         String actionText,
 
         String category,
         Integer difficulty,
 
+        @JsonProperty("estimated_minutes")
         Integer estimatedMinutes,
 
         String status,
 
+        @JsonProperty("created_at")
         OffsetDateTime createdAt,
 
+        @JsonProperty("character_comment")
         String characterComment
 ) {
     private static final String MOCK_CHARACTER_COMMENT = "미오가 응원해요!";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,6 @@ spring:
       timeout: 2000ms
 
   jackson:
-    property-naming-strategy: SNAKE_CASE
     time-zone: Asia/Seoul
     serialization:
       write-dates-as-timestamps: false


### PR DESCRIPTION
## 배경

PR #129에서 전역 `spring.jackson.property-naming-strategy: SNAKE_CASE` 설정 추가 및 59개 DTO `@JsonProperty` 일괄 제거.

이로 인해 `LoginRequest`가 camelCase 명세(`idToken`, `accessToken`, `deviceId`)임에도 snake_case 입력만 수용하게 되어 **프론트엔드 로그인 요청 400 오류** 발생.

근본 원인은 전역 설정의 "숨겨진 동작" — `@JsonProperty` 없는 DTO가 안전해 보이지만, 전역 설정 변경 시 의도치 않게 동작이 바뀌는 함정.

## 변경 사항

- `application.yml`에서 `spring.jackson.property-naming-strategy: SNAKE_CASE` 제거
- PR #129에서 제거된 59개 DTO의 `@JsonProperty` 복원 (git revert)
- `LoginRequest`에 camelCase 명세 기준으로 `@JsonProperty` 명시 추가 (기존 명세 유지)

## 이유

- **예측 가능성**: 클래스 열면 JSON key가 코드에서 바로 확인 가능
- **안전성**: 전역 설정 한 줄 변경이 전체 API에 사이드 이펙트 주는 구조 제거
- **명세 일치**: `LoginRequest`는 기존 camelCase 명세대로 동작 복구

## 영향 범위

- [x] API 스펙 또는 응답 형식이 변경됩니다 (LoginRequest: snake_case → camelCase 복구)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다
- [ ] Breaking change가 있습니다 (로그인은 오히려 camelCase 명세로 복구)

## 테스트

```bash
./gradlew compileJava  # 컴파일 확인 완료
```

로그인 curl 테스트 (배포 후):
```bash
# camelCase — 명세 기준, 정상 동작해야 함
curl -X POST https://mio.io.kr/v1/auth/login \
  -H "Content-Type: application/json" \
  -d '{"provider":"kakao","accessToken":"test","deviceId":"device-1"}'
# 기대: 401 OAUTH_VERIFICATION_FAILED (바인딩 성공, 토큰 검증 단계)
```

## 관련

- Closes #141
- 관련 PR #129 (전역 SNAKE_CASE 도입, 이 PR로 되돌림)
- 관련 PR #140 (임시 patch, close 처리됨)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Infrastructure & APIs
* Standardized JSON field naming conventions across all API endpoints and responses to consistently use snake_case formatting for improved consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->