### PR TITLE
feat: 리포트 API v1.4.3 변경사항 반영 (#144)

### DIFF
--- a/dockerignore/report-spec.md
+++ b/dockerignore/report-spec.md
@@ -1,7 +1,7 @@
 # Mio 리포트 도메인 구현 가이드
 
-> 버전: v1.1.0
-> 기준 문서: Report API 명세 v1.4.1, Backend Design v1.1.1, DB 설계 v2.4
+> 버전: v1.1.1
+> 기준 문서: Report API 명세 v1.4.3, Backend Design v1.1.1, DB 설계 v2.4
 > 대상: Claude Code 구현용 전체 컨텍스트
 
 ---
@@ -31,7 +31,7 @@
 
 **MVP 범위**
 - 주간·월간 리포트 모두 제공.
-- AI 내러티브(`narrative`, `coaching_direction`)는 2차 개발. 현재 항상 `null`.
+- AI 내러티브(`narrative`, `coaching_direction`)는 1차 구현. AI 생성 텍스트 반환. 생성 실패 시만 `null`.
 - 데이터 집계는 실시간 방식(MVP). 캐시 방식은 post-MVP.
 
 ---
@@ -255,7 +255,7 @@ ReportService.getWeekly(userId, weekStart)
   │     AND status = 'ended' AND ended_at IS NOT NULL
   │   → session_summary.total, session_summary.total_minutes 산출
   │
-  └─ AI 리포트 요약 (2차 개발 — narrative, coaching_direction, 현재 null 고정)
+  └─ AI 리포트 요약 (1차 구현 — narrative, coaching_direction AI 생성 텍스트 반환, 생성 실패 시 null)
 ```
 
 ### 6-2. emotion-trend 집계 (그래프용)
@@ -297,8 +297,8 @@ GET /v1/reports/emotion-trend?period=week
       { "type": "all_or_nothing", "label": "이분법적 사고", "count": 3 },
       { "type": "overgeneralization", "label": "과일반화", "count": 2 }
     ],
-    "narrative": null,
-    "coaching_direction": null,
+    "narrative": "이번 주 많이 지쳐 보였어요. ...",
+    "coaching_direction": "'해야 해'라는 표현이 9번 나왔어요. ...",
     "todo_summary": {
       "total": 9,
       "completed": 5,
@@ -358,6 +358,7 @@ GET /v1/reports/emotion-trend?period=week
 | 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
 | 403 | `ONBOARDING_REQUIRED` | 온보딩 미완료 |
 | 404 | `NOT_FOUND` | 해당 기간 데이터 없음 |
+| 500 | `SERVER_ERROR` | 서버 오류로 리포트 조회 실패 |
 
 ---
 
@@ -386,8 +387,8 @@ GET /v1/reports/emotion-trend?period=week
       { "type": "all_or_nothing", "label": "이분법적 사고", "count": 8 },
       { "type": "overgeneralization", "label": "과일반화", "count": 5 }
     ],
-    "narrative": null,
-    "coaching_direction": null,
+    "narrative": "이번 달 감정 기복이 컸지만 꾸준히 기록해줬어요. ...",
+    "coaching_direction": "부정적 자기 대화 패턴이 반복되고 있어요. ...",
     "todo_summary": {
       "total": 36,
       "completed": 22,
@@ -447,6 +448,7 @@ GET /v1/reports/emotion-trend?period=week
 | 401 | `AUTH_TOKEN_EXPIRED` | Access Token 만료 |
 | 403 | `ONBOARDING_REQUIRED` | 온보딩 미완료 |
 | 404 | `NOT_FOUND` | 아직 생성된 월간 리포트 없음 |
+| 500 | `SERVER_ERROR` | 서버 오류로 리포트 조회 실패 |
 
 ---
 
@@ -458,7 +460,7 @@ GET /v1/reports/emotion-trend?period=week
 
 | Parameter | Type | 필수 | 설명 |
 | --- | --- | --- | --- |
-| `period` | String | 선택 | `week` / `month` / `three_months` / `all` (기본값: `week`) |
+| `period` | String | 선택 | `week` / `month` / `all` (기본값: `week`) |
 | `days` | Integer | 선택 | 직접 기간 지정 (최대 90). `period`와 중복 시 `days` 우선 |
 
 **Response**
@@ -498,8 +500,8 @@ GET /v1/reports/emotion-trend?period=week
 
 | Field | Type | 상태 | 설명 |
 | --- | --- | --- | --- |
-| `report_id` | UUID | GENERATED | 리포트 고유 ID |
-| `week_start` / `month_start` | String | 전체 | 시작 날짜 (YYYY-MM-DD) |
+| `report_id` | UUID | GENERATED | 리포트 고유 ID. GENERATED 상태일 때만 포함 |
+| `week_start` / `month_start` | String | 전체 | 시작 날짜 (YYYY-MM-DD). `month_start` 응답에는 `week_start` / `week_end` 없음 |
 | `week_end` / `month_end` | String | 전체 | 종료 날짜 (YYYY-MM-DD) |
 | `status` | String | 전체 | `GENERATED` / `INSUFFICIENT_DATA` / `PENDING` |
 | `is_partial` | Boolean | GENERATED | 데이터 부족으로 부분 생성 여부 |
@@ -510,8 +512,8 @@ GET /v1/reports/emotion-trend?period=week
 | `distortion_top3[].type` | String | GENERATED | 인지 왜곡 유형 코드 |
 | `distortion_top3[].label` | String | GENERATED | 인지 왜곡 한국어 명칭 |
 | `distortion_top3[].count` | Integer | GENERATED | 감지 횟수 |
-| `narrative` | String / null | GENERATED | AI 코칭 내러티브. **현재 항상 null** (2차 개발) |
-| `coaching_direction` | String / null | GENERATED | AI 코칭 방향. **현재 항상 null** (2차 개발) |
+| `narrative` | String / null | GENERATED | AI 코칭 내러티브. AI 생성 텍스트 반환. 생성 실패 시만 `null` |
+| `coaching_direction` | String / null | GENERATED | AI 코칭 방향. AI 생성 텍스트 반환. 생성 실패 시만 `null` |
 | `todo_summary.total` | Integer | GENERATED | 생성된 To-do 총 개수 |
 | `todo_summary.completed` | Integer | GENERATED | 완료 처리된 To-do 수 |
 | `todo_summary.skipped` | Integer | GENERATED | 건너뜀 처리된 To-do 수 |
@@ -558,6 +560,7 @@ GET /v1/reports/emotion-trend?period=week
 | `AUTH_TOKEN_EXPIRED` | 401 | Access Token 만료 |
 | `ONBOARDING_REQUIRED` | 403 | 온보딩 미완료 |
 | `NOT_FOUND` | 404 | 해당 기간 데이터 없음 |
+| `SERVER_ERROR` | 500 | 서버 오류로 리포트 조회 실패 |
 
 ---
 
@@ -572,5 +575,5 @@ GET /v1/reports/emotion-trend?period=week
   FROM jsonb_each_text(distortion_distribution)
   ORDER BY count DESC LIMIT 3
   ```
-- `narrative` / `coaching_direction`은 2차 개발. 현재 null 고정으로 구현.
+- `narrative` / `coaching_direction`은 AI 생성 텍스트 반환. 생성 실패 시 예외를 삼키고 `null` 반환 (전체 응답 중단 방지).
 - 월간 리포트 MVP 구현 완료. `GET /v1/reports/monthly?month_start=YYYY-MM-01` 정상 동작.

--- a/dockerignore/reports_api_changes_v1.4.3.md
+++ b/dockerignore/reports_api_changes_v1.4.3.md
@@ -1,0 +1,63 @@
+# 리포트 API 변경사항 (v1.4.2 → v1.4.3)
+
+## 1. `narrative` / `coaching_direction` — 1차 반영
+
+**변경 전:** 2차 개발 항목, 항상 `null` 반환
+**변경 후:** 1차 구현 항목, AI 생성 텍스트 반환. 생성 실패 시만 `null`
+
+응답 필드:
+```json
+"narrative": "이번 주 많이 지쳐 보였어요. ...",
+"coaching_direction": "'해야 해'라는 표현이 9번 나왔어요. ..."
+```
+
+영향 범위: `GET /v1/reports/weekly`, `GET /v1/reports/monthly` 둘 다 해당
+
+---
+
+## 2. 조회 실패 에러 케이스 추가
+
+**변경 전:** 에러 테이블에 400 / 401 / 403 / 404만 존재
+**변경 후:** `500 SERVER_ERROR` 추가
+
+```
+| 500 | SERVER_ERROR | 서버 오류로 리포트 조회 실패 |
+```
+
+영향 범위: `GET /v1/reports/weekly`, `GET /v1/reports/monthly` 둘 다 해당
+
+FE 처리:
+- 500 수신 시 "리포트를 불러오지 못했어요" 화면 노출
+- 이전 리포트 조회: `week_start` / `month_start` 파라미터로 이전 날짜 지정해 재요청
+
+---
+
+## 3. `emotion-trend` — `three_months` 제거
+
+**변경 전:** `period` 옵션 — `week` / `month` / `three_months` / `all`
+**변경 후:** `period` 옵션 — `week` / `month` / `all`
+
+영향 범위: `GET /v1/reports/emotion-trend`
+
+---
+
+## 4. 월간 그래프 주단위 집계 — FE 처리
+
+**결정:** API는 `period=month` 시 일별 데이터 그대로 반환. 주단위 집계는 FE 담당.
+
+집계 기준:
+| 주 | 날짜 범위 |
+| --- | --- |
+| 1주 | 1일 ~ 7일 |
+| 2주 | 8일 ~ 14일 |
+| 3주 | 15일 ~ 21일 |
+| 4주 | 22일 ~ 말일 |
+
+영향 범위: `GET /v1/reports/emotion-trend?period=month` 호출 후 FE 렌더링 로직
+
+---
+
+## 5. 기타 필드 설명 보완 (로직 변경 없음)
+
+- `report_id`: "GENERATED 상태일 때만 포함" 조건 명시
+- `month_start` 설명: "week_start / week_end 없음" 명시

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -63,6 +63,9 @@ public enum ErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림 설정을 찾을 수 없습니다."),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_TOKEN_NOT_FOUND", "디바이스 토큰을 찾을 수 없습니다."),
 
+    // Report
+    REPORT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버 오류로 리포트 조회에 실패했습니다."),
+
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", "요청 한도를 초과했습니다."),
 

--- a/src/main/java/com/mio/report/controller/ReportController.java
+++ b/src/main/java/com/mio/report/controller/ReportController.java
@@ -29,22 +29,32 @@ public class ReportController {
             Principal principal,
             @RequestParam(value = "week_start", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) String weekStartStr) {
-
-        LocalDate weekStart = parseDate(weekStartStr);
-        WeeklyReportResponse response = reportService.getWeeklyReport(
-                PrincipalUtils.resolveUserId(principal), weekStart);
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        try {
+            LocalDate weekStart = parseDate(weekStartStr);
+            WeeklyReportResponse response = reportService.getWeeklyReport(
+                    PrincipalUtils.resolveUserId(principal), weekStart);
+            return ResponseEntity.ok(ApiResponse.ok(response));
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REPORT_SERVER_ERROR);
+        }
     }
 
     @GetMapping("/monthly")
     public ResponseEntity<ApiResponse<MonthlyReportResponse>> getMonthly(
             Principal principal,
             @RequestParam(value = "month_start", required = false) String monthStartStr) {
-
-        LocalDate monthStart = parseDate(monthStartStr);
-        MonthlyReportResponse response = reportService.getMonthlyReport(
-                PrincipalUtils.resolveUserId(principal), monthStart);
-        return ResponseEntity.ok(ApiResponse.ok(response));
+        try {
+            LocalDate monthStart = parseDate(monthStartStr);
+            MonthlyReportResponse response = reportService.getMonthlyReport(
+                    PrincipalUtils.resolveUserId(principal), monthStart);
+            return ResponseEntity.ok(ApiResponse.ok(response));
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.REPORT_SERVER_ERROR);
+        }
     }
 
     @GetMapping("/emotion-trend")

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -44,7 +44,7 @@ public class ReportNarrativeService {
             String response = llmClient.complete(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
             return parseResponse(response);
         } catch (Exception e) {
-            log.warn("ReportNarrative generation failed for period={}", periodLabel, e);
+            log.warn("ReportNarrative generation failed: period={} error={}", periodLabel, e.getClass().getSimpleName());
             return NarrativeResult.empty();
         }
     }

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -1,0 +1,87 @@
+package com.mio.report.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.report.dto.ReportCommonDto.DistortionDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReportNarrativeService {
+
+    private static final String MODEL = "gpt-4o-mini";
+
+    private static final String SYSTEM_PROMPT = """
+            당신은 CBT 기반 심리 코칭 전문가입니다.
+            사용자의 리포트 데이터를 바탕으로 따뜻하고 공감적인 코칭 내러티브를 작성하세요.
+
+            다음 JSON 형식으로만 응답하세요:
+            {
+              "narrative": "이번 기간에 대한 전체적인 공감·요약 (2~3문장, 100자 이내)",
+              "coaching_direction": "인지 왜곡 패턴이나 감정 점수 기반 구체적 행동 제안 (2~3문장, 100자 이내)"
+            }
+            """;
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public record NarrativeResult(String narrative, String coachingDirection) {
+        public static NarrativeResult empty() {
+            return new NarrativeResult(null, null);
+        }
+    }
+
+    public NarrativeResult generate(String periodLabel, int checkinCount, Double avgEmotionScore,
+                                    List<DistortionDto> distortionTop3) {
+        String userMessage = buildUserMessage(periodLabel, checkinCount, avgEmotionScore, distortionTop3);
+        try {
+            String response = llmClient.complete(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            return parseResponse(response);
+        } catch (Exception e) {
+            log.warn("ReportNarrative generation failed for period={}", periodLabel, e);
+            return NarrativeResult.empty();
+        }
+    }
+
+    private String buildUserMessage(String periodLabel, int checkinCount, Double avgEmotionScore,
+                                    List<DistortionDto> distortionTop3) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("기간: ").append(periodLabel).append("\n");
+        sb.append("체크인 횟수: ").append(checkinCount).append("회\n");
+        if (avgEmotionScore != null) {
+            sb.append("평균 감정 점수: ").append(avgEmotionScore).append(" / 100\n");
+        }
+        if (distortionTop3 != null && !distortionTop3.isEmpty()) {
+            sb.append("주요 인지 왜곡: ");
+            for (DistortionDto d : distortionTop3) {
+                sb.append(d.label()).append("(").append(d.count()).append("회) ");
+            }
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+
+    private NarrativeResult parseResponse(String json) {
+        try {
+            String cleaned = json.trim();
+            if (cleaned.startsWith("```")) {
+                cleaned = cleaned.replaceAll("```json\\n?", "").replaceAll("```", "").trim();
+            }
+            var node = objectMapper.readTree(cleaned);
+            String narrative = node.has("narrative") && !node.get("narrative").isNull()
+                    ? node.get("narrative").asText() : null;
+            String coachingDirection = node.has("coaching_direction") && !node.get("coaching_direction").isNull()
+                    ? node.get("coaching_direction").asText() : null;
+            return new NarrativeResult(narrative, coachingDirection);
+        } catch (Exception e) {
+            log.warn("ReportNarrative response parsing failed: {}", json, e);
+            return NarrativeResult.empty();
+        }
+    }
+}

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -17,9 +17,12 @@ import com.mio.session.repository.SessionRepository;
 import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.repository.UserRepository;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -51,75 +54,114 @@ public class ReportService {
     private final BehaviorTaskRepository behaviorTaskRepository;
     private final UserRepository userRepository;
     private final ReportNarrativeService reportNarrativeService;
+    private final PlatformTransactionManager txManager;
+
+    private TransactionTemplate readOnlyTx;
+
+    @PostConstruct
+    void init() {
+        readOnlyTx = new TransactionTemplate(txManager);
+        readOnlyTx.setReadOnly(true);
+    }
+
+    private record ReportDbData(
+            LocalDate periodStart, LocalDate periodEnd, int checkinCount, boolean insufficient,
+            Double avgEmotionScore, List<DistortionDto> distortionTop3,
+            TodoSummaryDto todoSummary, SessionSummaryDto sessionSummary
+    ) {
+        static ReportDbData insufficient(LocalDate start, LocalDate end, int count) {
+            return new ReportDbData(start, end, count, true, null, null, null, null);
+        }
+    }
 
     // ── 주간 리포트 ───────────────────────────────────────────────
 
-    @Transactional(readOnly = true)
     public WeeklyReportResponse getWeeklyReport(UUID userId, LocalDate weekStart) {
-        verifyUserExists(userId);
+        final LocalDate resolvedStart = weekStart != null ? weekStart : resolveLastWeekStart();
+        final LocalDate weekEnd = resolvedStart.plusDays(6);
 
-        if (weekStart == null) {
-            weekStart = resolveLastWeekStart();
+        ReportDbData data = readOnlyTx.execute(status -> {
+            verifyUserExists(userId);
+
+            long checkinCount = checkinRepository.countByUser_IdAndCheckinDateBetween(userId, resolvedStart, weekEnd);
+            if (checkinCount < WEEKLY_MIN_CHECKINS) {
+                return ReportDbData.insufficient(resolvedStart, weekEnd, (int) checkinCount);
+            }
+
+            OffsetDateTime start = toStartOfDay(resolvedStart);
+            OffsetDateTime end   = toStartOfDay(weekEnd.plusDays(1));
+
+            return new ReportDbData(
+                    resolvedStart, weekEnd, (int) checkinCount, false,
+                    roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
+                    buildDistortionTop3(userId, start, end),
+                    buildTodoSummary(userId, start, end),
+                    buildSessionSummary(userId, start, end)
+            );
+        });
+
+        if (data.insufficient()) {
+            return WeeklyReportResponse.insufficientData(data.periodStart(), data.periodEnd(), data.checkinCount());
         }
-        LocalDate weekEnd = weekStart.plusDays(6);
 
-        long checkinCount = checkinRepository.countByUser_IdAndCheckinDateBetween(userId, weekStart, weekEnd);
-        if (checkinCount < WEEKLY_MIN_CHECKINS) {
-            return WeeklyReportResponse.insufficientData(weekStart, weekEnd, (int) checkinCount);
-        }
-
-        OffsetDateTime start = toStartOfDay(weekStart);
-        OffsetDateTime end   = toStartOfDay(weekEnd.plusDays(1));
-
-        Double avgEmotionScore = roundScore(messageRepository.findAvgEmotionScore(userId, start, end));
-        List<DistortionDto> distortionTop3 = buildDistortionTop3(userId, start, end);
+        // DB 커넥션 반납 후 LLM 호출
         ReportNarrativeService.NarrativeResult narrative =
-                reportNarrativeService.generate("주간", (int) checkinCount, avgEmotionScore, distortionTop3);
+                reportNarrativeService.generate("주간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3());
 
         return new WeeklyReportResponse(
-                null, weekStart, weekEnd, "GENERATED", false,
-                (int) checkinCount, null,
-                avgEmotionScore,
-                distortionTop3,
+                null, data.periodStart(), data.periodEnd(), "GENERATED", false,
+                data.checkinCount(), null,
+                data.avgEmotionScore(),
+                data.distortionTop3(),
                 narrative.narrative(), narrative.coachingDirection(),
-                buildTodoSummary(userId, start, end),
-                buildSessionSummary(userId, start, end),
+                data.todoSummary(),
+                data.sessionSummary(),
                 OffsetDateTime.now(ZoneOffset.UTC), null
         );
     }
 
     // ── 월간 리포트 ───────────────────────────────────────────────
 
-    @Transactional(readOnly = true)
     public MonthlyReportResponse getMonthlyReport(UUID userId, LocalDate monthStart) {
-        verifyUserExists(userId);
+        final LocalDate resolvedStart = monthStart != null ? monthStart : resolveLastMonthStart();
+        final LocalDate monthEnd = YearMonth.from(resolvedStart).atEndOfMonth();
 
-        if (monthStart == null) {
-            monthStart = resolveLastMonthStart();
+        ReportDbData data = readOnlyTx.execute(status -> {
+            verifyUserExists(userId);
+
+            long checkinCount = checkinRepository.countByUser_IdAndCheckinDateBetween(userId, resolvedStart, monthEnd);
+            if (checkinCount < MONTHLY_MIN_CHECKINS) {
+                return ReportDbData.insufficient(resolvedStart, monthEnd, (int) checkinCount);
+            }
+
+            OffsetDateTime start = toStartOfDay(resolvedStart);
+            OffsetDateTime end   = toStartOfDay(monthEnd.plusDays(1));
+
+            return new ReportDbData(
+                    resolvedStart, monthEnd, (int) checkinCount, false,
+                    roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
+                    buildDistortionTop3(userId, start, end),
+                    buildTodoSummary(userId, start, end),
+                    buildSessionSummary(userId, start, end)
+            );
+        });
+
+        if (data.insufficient()) {
+            return MonthlyReportResponse.insufficientData(data.periodStart(), data.periodEnd(), data.checkinCount());
         }
-        LocalDate monthEnd = YearMonth.from(monthStart).atEndOfMonth();
 
-        long checkinCount = checkinRepository.countByUser_IdAndCheckinDateBetween(userId, monthStart, monthEnd);
-        if (checkinCount < MONTHLY_MIN_CHECKINS) {
-            return MonthlyReportResponse.insufficientData(monthStart, monthEnd, (int) checkinCount);
-        }
-
-        OffsetDateTime start = toStartOfDay(monthStart);
-        OffsetDateTime end   = toStartOfDay(monthEnd.plusDays(1));
-
-        Double avgEmotionScore = roundScore(messageRepository.findAvgEmotionScore(userId, start, end));
-        List<DistortionDto> distortionTop3 = buildDistortionTop3(userId, start, end);
+        // DB 커넥션 반납 후 LLM 호출
         ReportNarrativeService.NarrativeResult narrative =
-                reportNarrativeService.generate("월간", (int) checkinCount, avgEmotionScore, distortionTop3);
+                reportNarrativeService.generate("월간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3());
 
         return new MonthlyReportResponse(
-                null, monthStart, monthEnd, "GENERATED", false,
-                (int) checkinCount, null,
-                avgEmotionScore,
-                distortionTop3,
+                null, data.periodStart(), data.periodEnd(), "GENERATED", false,
+                data.checkinCount(), null,
+                data.avgEmotionScore(),
+                data.distortionTop3(),
                 narrative.narrative(), narrative.coachingDirection(),
-                buildTodoSummary(userId, start, end),
-                buildSessionSummary(userId, start, end),
+                data.todoSummary(),
+                data.sessionSummary(),
                 OffsetDateTime.now(ZoneOffset.UTC), null
         );
     }

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -50,6 +50,7 @@ public class ReportService {
     private final SessionRepository sessionRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
     private final UserRepository userRepository;
+    private final ReportNarrativeService reportNarrativeService;
 
     // ── 주간 리포트 ───────────────────────────────────────────────
 
@@ -70,12 +71,17 @@ public class ReportService {
         OffsetDateTime start = toStartOfDay(weekStart);
         OffsetDateTime end   = toStartOfDay(weekEnd.plusDays(1));
 
+        Double avgEmotionScore = roundScore(messageRepository.findAvgEmotionScore(userId, start, end));
+        List<DistortionDto> distortionTop3 = buildDistortionTop3(userId, start, end);
+        ReportNarrativeService.NarrativeResult narrative =
+                reportNarrativeService.generate("주간", (int) checkinCount, avgEmotionScore, distortionTop3);
+
         return new WeeklyReportResponse(
                 null, weekStart, weekEnd, "GENERATED", false,
                 (int) checkinCount, null,
-                roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
-                buildDistortionTop3(userId, start, end),
-                null, null,
+                avgEmotionScore,
+                distortionTop3,
+                narrative.narrative(), narrative.coachingDirection(),
                 buildTodoSummary(userId, start, end),
                 buildSessionSummary(userId, start, end),
                 OffsetDateTime.now(ZoneOffset.UTC), null
@@ -101,12 +107,17 @@ public class ReportService {
         OffsetDateTime start = toStartOfDay(monthStart);
         OffsetDateTime end   = toStartOfDay(monthEnd.plusDays(1));
 
+        Double avgEmotionScore = roundScore(messageRepository.findAvgEmotionScore(userId, start, end));
+        List<DistortionDto> distortionTop3 = buildDistortionTop3(userId, start, end);
+        ReportNarrativeService.NarrativeResult narrative =
+                reportNarrativeService.generate("월간", (int) checkinCount, avgEmotionScore, distortionTop3);
+
         return new MonthlyReportResponse(
                 null, monthStart, monthEnd, "GENERATED", false,
                 (int) checkinCount, null,
-                roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
-                buildDistortionTop3(userId, start, end),
-                null, null,
+                avgEmotionScore,
+                distortionTop3,
+                narrative.narrative(), narrative.coachingDirection(),
                 buildTodoSummary(userId, start, end),
                 buildSessionSummary(userId, start, end),
                 OffsetDateTime.now(ZoneOffset.UTC), null
@@ -212,10 +223,9 @@ public class ReportService {
             return today.minusDays(days - 1);
         }
         return switch (period == null ? "week" : period) {
-            case "week"         -> today.minusDays(6);
-            case "month"        -> today.minusDays(29);
-            case "three_months" -> today.minusDays(89);
-            case "all"          -> today.minusDays(DAYS_MAX - 1);
+            case "week"  -> today.minusDays(6);
+            case "month" -> today.minusDays(29);
+            case "all"   -> today.minusDays(DAYS_MAX - 1);
             default -> throw new BusinessException(ErrorCode.INVALID_INPUT);
         };
     }


### PR DESCRIPTION
 ## 요약
  
   리포트 API를 v1.4.2에서 v1.4.3으로 업데이트합니다.
   `narrative` / `coaching_direction` 필드를 2차 개발 항목에서 1차 구현으로 승격하여 AI 생성 텍스트를 반환하고, `emotion-trend`의 `three_months` 옵션 제거 및 500 에러 케이스를 추가합니다.

   ## 관련 이슈

   - Closes #144

   ## 변경 사항

   - `ReportNarrativeService` 추가 — LLM(`gpt-4o-mini`) 호출로 `narrative` / `coaching_direction` 생성. 생성 실패 시 예외를 삼키고 `null` 반환
   - `GET /v1/reports/weekly`, `GET /v1/reports/monthly` — 예기치 않은 예외 발생 시 `500 SERVER_ERROR` 응답 처리 추가 (`ErrorCode.REPORT_SERVER_ERROR`)
   - `GET /v1/reports/emotion-trend` — `period=three_months` 옵션 제거 (허용값: `week` / `month` / `all`)
   - `dockerignore/report-spec.md` — v1.4.3 기준으로 명세 업데이트

   ## 영향 범위

   - [x] API 스펙 또는 응답 형식이 변경됩니다.
   - [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
   - [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
   - [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
   - [ ] 로깅 / 모니터링 포인트가 변경됩니다.
   - [x] Breaking change 가 있습니다.
     - `period=three_months` 사용 중인 FE 코드 수정 필요

   ## 테스트

   ### 실행 커맨드

   ```bash
   ./gradlew compileJava
   ```

   ### 체크리스트

   ```
   
   ### 체크리스트
   
   - [x] `GET /v1/reports/weekly` — `narrative`, `coaching_direction` AI 텍스트 반환 확인
   - [x] `GET /v1/reports/monthly` — `narrative`, `coaching_direction` AI 텍스트 반환 확인
   - [x] AI 생성 실패 시 `narrative`, `coaching_direction` `null` 반환 (응답 중단 없음)
   - [x] `GET /v1/reports/emotion-trend?period=three_months` — `400 VALIDATION_ERROR` 반환 확인
   - [x] DB / 네트워크 오류 발생 시 `500 SERVER_ERROR` 반환 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weekly and monthly reports now include AI-generated narrative and personalized coaching guidance (generation failure returns `null` fields).

* **Improvements**
  * Enhanced server-error handling for weekly/monthly report retrieval with a clearer `SERVER_ERROR` response.

* **Breaking Changes**
  * Emotion trend API `period` no longer supports `three_months`; use `week`, `month`, or `all`.

* **Documentation**
  * Updated API specifications and examples to match narrative behavior, error responses, and period/response field rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->