### PR TITLE
fix: Apple 로그인 번들 ID 다중 허용으로 dev/prod 동시 지원 (#149)

### DIFF
--- a/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
+++ b/src/main/java/com/mio/auth/provider/AppleAuthProvider.java
@@ -19,6 +19,7 @@ import java.security.KeyFactory;
 import java.security.interfaces.RSAPublicKey;
 import java.security.spec.RSAPublicKeySpec;
 import java.util.Base64;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -28,7 +29,7 @@ public class AppleAuthProvider implements SocialAuthProvider {
     private String appleJwksUrl;
 
     @Value("${apple.app-id}")
-    private String appleAppId;
+    private List<String> appleAppIds;
 
     private final AppleJwksRedisRepository jwksRepository;
     private final ObjectMapper objectMapper;
@@ -130,7 +131,7 @@ public class AppleAuthProvider implements SocialAuthProvider {
         if (!"https://appleid.apple.com".equals(claims.getIssuer())) {
             throw new BusinessException(ErrorCode.OAUTH_FAILED);
         }
-        if (!claims.getAudience().contains(appleAppId)) {
+        if (appleAppIds.stream().noneMatch(id -> claims.getAudience().contains(id))) {
             throw new BusinessException(ErrorCode.OAUTH_FAILED);
         }
     }


### PR DESCRIPTION
● ## 요약
  Apple 로그인 시 단일 번들 ID만 허용하던 구조를 개선하여,
  콤마 구분 환경변수로 dev/prod 번들 ID를 동시에 허용할 수 있도록 수정합니다.
  
  ## 관련 이슈
  - Closes #149

  ## 변경 사항
  - `AppleAuthProvider`: `appleAppId` 필드를 `String` → `List<String>`으로 변경
  - `validateClaims()`: 단일 비교 → 리스트 중 하나라도 일치하면 통과하도록 수정
  - 환경변수 `APPLE_APP_ID`에 콤마 구분으로 복수 번들 ID 설정 가능

  ## 영향 범위
  - [x] 환경 변수 또는 외부 설정 변경이 필요합니다.

  ## 테스트
  ### 실행 커맨드
  ```bash
  ./gradlew test

  확인 내용

  - com.mio.yarr 번들 ID로 발급된 Apple ID 토큰 → 로그인 성공
  - com.mio.yarr.dev 번들 ID로 발급된 Apple ID 토큰 → 로그인 성공
  - 허용되지 않은 번들 ID 토큰 → OAUTH_FAILED 반환 확인

  중점 리뷰 포인트

  - @Value로 주입한 List<String>이 콤마 구분 환경변수를 올바르게 파싱하는지 확인

  배포 / 롤백

  - Rollout: GitHub Secrets ENV_FILE의 APPLE_APP_ID 값을 com.mio.yarr,com.mio.yarr.dev로 변경
  후 재배포
  - Rollback: APPLE_APP_ID=com.mio.yarr 단일 값으로 되돌리고 재배포

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple authentication now supports validation against multiple configured app IDs, allowing tokens with any of the registered IDs to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->