### PR TITLE
feat: sensitive_info 동의 항목 추가 — Apple Guideline 5.1.2(i) 대응 (#153)

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -123,15 +123,16 @@ public class AuthService {
             throw new BusinessException(ErrorCode.SIGNUP_STEP_INVALID);
         }
 
-        boolean hasTerms = false, hasPrivacy = false, hasAgeVerification = false, hasMarketing = false;
+        boolean hasTerms = false, hasPrivacy = false, hasAgeVerification = false, hasMarketing = false, hasSensitiveInfo = false;
         boolean marketingAgreed = false;
         for (ConsentRequest.ConsentItem item : request.consents()) {
             if ("terms".equals(item.type()) && item.agreed()) hasTerms = true;
             if ("privacy".equals(item.type()) && item.agreed()) hasPrivacy = true;
             if ("age_verification".equals(item.type()) && item.agreed()) hasAgeVerification = true;
             if ("marketing".equals(item.type())) { hasMarketing = true; marketingAgreed = item.agreed(); }
+            if ("sensitive_info".equals(item.type()) && item.agreed()) hasSensitiveInfo = true;
         }
-        if (!hasTerms || !hasPrivacy || !hasAgeVerification || !hasMarketing) {
+        if (!hasTerms || !hasPrivacy || !hasAgeVerification || !hasMarketing || !hasSensitiveInfo) {
             throw new BusinessException(ErrorCode.CONSENT_REQUIRED);
         }
 

--- a/src/main/resources/db/migration/V29__add_sensitive_info_consent_type.sql
+++ b/src/main/resources/db/migration/V29__add_sensitive_info_consent_type.sql
@@ -1,0 +1,5 @@
+-- Apple App Store Guideline 5.1.2(i) 대응: sensitive_info 동의 항목 추가
+ALTER TABLE user_consents
+    DROP CONSTRAINT user_consents_consent_type_check,
+    ADD CONSTRAINT user_consents_consent_type_check
+        CHECK (consent_type IN ('terms','privacy','age_verification','marketing','sensitive_info'));

--- a/src/test/java/com/mio/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/mio/auth/AuthIntegrationTest.java
@@ -290,7 +290,8 @@ class AuthIntegrationTest {
                                       {"type": "terms",            "agreed": true,  "version": "v1"},
                                       {"type": "privacy",          "agreed": true,  "version": "v1"},
                                       {"type": "age_verification", "agreed": true,  "version": "v1"},
-                                      {"type": "marketing",        "agreed": false, "version": "v1"}
+                                      {"type": "marketing",        "agreed": false, "version": "v1"},
+                                      {"type": "sensitive_info",   "agreed": true,  "version": "v1"}
                                     ]}
                                     """))
                     .andExpect(status().isOk())
@@ -345,7 +346,8 @@ class AuthIntegrationTest {
                       {"type": "terms",            "agreed": true,  "version": "v1"},
                       {"type": "privacy",          "agreed": true,  "version": "v1"},
                       {"type": "age_verification", "agreed": true,  "version": "v1"},
-                      {"type": "marketing",        "agreed": false, "version": "v1"}
+                      {"type": "marketing",        "agreed": false, "version": "v1"},
+                      {"type": "sensitive_info",   "agreed": true,  "version": "v1"}
                     ]}
                     """;
 

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -157,7 +157,8 @@ class AuthServiceTest {
                 new ConsentRequest.ConsentItem("terms", true, "v1"),
                 new ConsentRequest.ConsentItem("privacy", true, "v1"),
                 new ConsentRequest.ConsentItem("age_verification", true, "v1"),
-                new ConsentRequest.ConsentItem("marketing", false, "v1")
+                new ConsentRequest.ConsentItem("marketing", false, "v1"),
+                new ConsentRequest.ConsentItem("sensitive_info", true, "v1")
         ));
 
         ConsentResponse response = authService.agreeConsent(USER_ID, request);
@@ -178,7 +179,8 @@ class AuthServiceTest {
                 new ConsentRequest.ConsentItem("terms", true, "v1"),
                 new ConsentRequest.ConsentItem("privacy", true, "v1"),
                 new ConsentRequest.ConsentItem("age_verification", true, "v1"),
-                new ConsentRequest.ConsentItem("marketing", true, "v1")
+                new ConsentRequest.ConsentItem("marketing", true, "v1"),
+                new ConsentRequest.ConsentItem("sensitive_info", true, "v1")
         ));
 
         authService.agreeConsent(USER_ID, request);


### PR DESCRIPTION
 ## 요약
  Apple App Store Guideline 5.1.2(i) 2025년 11월 개정 대응으로 추가된 `sensitive_info` 동의 항목이
  서버에 반영되지 않아 발생하던 500 에러를 수정합니다.
  
  ## 관련 이슈
  - Closes #153

  ## 변경 사항
  - `V29__add_sensitive_info_consent_type.sql`: `user_consents` CHECK 제약에 `sensitive_info` 추가
  - `AuthService.agreeConsent()`: `sensitive_info` 필수 동의 검증 로직 추가

  ## 영향 범위
  - [x] API 스펙 또는 응답 형식이 변경됩니다.
  - [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
  - [x] Breaking change 가 있습니다.

  ## 테스트
  ### 실행 커맨드
  ```bash
  ./gradlew test

  확인 내용

  - sensitive_info 포함 5개 항목 전송 시 200 응답 및 CONSENT_AGREED 반환 확인
  - sensitive_info 누락 시 400 CONSENT_REQUIRED 반환 확인
  - sensitive_info agreed: false 시 400 CONSENT_REQUIRED 반환 확인
  - 기존 4개 항목(terms, privacy, age_verification, marketing)만 전송 시 400 반환 확인

  중점 리뷰 포인트

  - sensitive_info가 필수(agreed: true)로 강제되어 있어 기존 클라이언트(v1.2.0 이하)와 Breaking change 발생. 클라이언트 배포와 동시 릴리즈 필요.

  배포 / 롤백

  - Rollout: 클라이언트(iOS) sensitive_info 항목 추가 배포와 동시에 서버 배포
  - Rollback: V29 마이그레이션 롤백 (DROP CONSTRAINT → ADD CONSTRAINT 이전 값으로 복원) 및 AuthService 검증 조건 이전 코드로 복원

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
