### PR TITLE
feat: APNs .p8 키를 base64 환경변수(APNS_KEY_CONTENT)로 주입 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,8 @@ FCM_CREDENTIALS_JSON=
 
 # Apple APNs — iOS 푸시 알림 (Apple Developer에서 발급)
 # APNS_KEY_CONTENT 우선 사용 (프로덕션 권장): .p8 파일 전체를 base64 인코딩한 값
-# 인코딩 방법: base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
+# 인코딩 방법(macOS): base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
+# 인코딩 방법(Linux): base64 -w 0 AuthKey_XXXXXXXXXX.p8
 APNS_KEY_CONTENT=
 # APNS_KEY_PATH는 폴백 (로컬 개발 시 파일 경로 직접 지정 가능)
 APNS_KEY_PATH=

--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,11 @@ OPENAI_API_KEY=
 FCM_CREDENTIALS_JSON=
 
 # Apple APNs — iOS 푸시 알림 (Apple Developer에서 발급)
-APNS_KEY_PATH=/path/to/AuthKey_XXXXXXXXXX.p8
+# APNS_KEY_CONTENT 우선 사용 (프로덕션 권장): .p8 파일 전체를 base64 인코딩한 값
+# 인코딩 방법: base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
+APNS_KEY_CONTENT=
+# APNS_KEY_PATH는 폴백 (로컬 개발 시 파일 경로 직접 지정 가능)
+APNS_KEY_PATH=
 APNS_KEY_ID=XXXXXXXXXX
 APNS_TEAM_ID=XXXXXXXXXX
 APNS_BUNDLE_ID=com.example.mio

--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -41,6 +41,9 @@ public class PushSender {
     private static final long JWT_TTL_SECONDS = 3000;
     private static final String APNS_TOKEN_PATTERN = "[0-9a-fA-F]{64}";
 
+    @Value("${apns.key-content:}")
+    private String apnsKeyContent;
+
     @Value("${apns.key-path:}")
     private String apnsKeyPath;
 
@@ -77,20 +80,21 @@ public class PushSender {
     }
 
     private void initApns() {
-        if (apnsKeyPath == null || apnsKeyPath.isBlank()) {
-            log.warn("APNs not configured — APNS_KEY_PATH is empty");
-            return;
-        }
         if (apnsKeyId.isBlank() || apnsTeamId.isBlank() || apnsBundleId.isBlank()) {
             log.warn("APNs not configured — APNS_KEY_ID, APNS_TEAM_ID, or APNS_BUNDLE_ID is empty");
             return;
         }
         try {
-            String keyContent = new String(Files.readAllBytes(Paths.get(apnsKeyPath)))
+            String pemContent = resolveApnsPem();
+            if (pemContent == null) {
+                log.warn("APNs not configured — neither APNS_KEY_CONTENT nor APNS_KEY_PATH is set");
+                return;
+            }
+            String stripped = pemContent
                     .replaceAll("-----BEGIN PRIVATE KEY-----", "")
                     .replaceAll("-----END PRIVATE KEY-----", "")
                     .replaceAll("\\s", "");
-            byte[] keyBytes = Base64.getDecoder().decode(keyContent);
+            byte[] keyBytes = Base64.getDecoder().decode(stripped);
             KeyFactory kf = KeyFactory.getInstance("EC");
             apnsPrivateKey = kf.generatePrivate(new PKCS8EncodedKeySpec(keyBytes));
             apnsEnabled = true;
@@ -98,6 +102,16 @@ public class PushSender {
         } catch (Exception e) {
             log.warn("APNs initialization failed: {}", e.getMessage());
         }
+    }
+
+    private String resolveApnsPem() throws Exception {
+        if (apnsKeyContent != null && !apnsKeyContent.isBlank()) {
+            return new String(Base64.getDecoder().decode(apnsKeyContent));
+        }
+        if (apnsKeyPath != null && !apnsKeyPath.isBlank()) {
+            return new String(Files.readAllBytes(Paths.get(apnsKeyPath)));
+        }
+        return null;
     }
 
     private void initFcm() {

--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayInputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -106,10 +107,10 @@ public class PushSender {
 
     private String resolveApnsPem() throws Exception {
         if (apnsKeyContent != null && !apnsKeyContent.isBlank()) {
-            return new String(Base64.getDecoder().decode(apnsKeyContent));
+            return new String(Base64.getMimeDecoder().decode(apnsKeyContent.trim()), StandardCharsets.UTF_8);
         }
         if (apnsKeyPath != null && !apnsKeyPath.isBlank()) {
-            return new String(Files.readAllBytes(Paths.get(apnsKeyPath)));
+            return new String(Files.readAllBytes(Paths.get(apnsKeyPath)), StandardCharsets.UTF_8);
         }
         return null;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,7 @@ apple:
   app-id: ${APPLE_APP_ID}
 
 apns:
+  key-content: ${APNS_KEY_CONTENT:}
   key-path: ${APNS_KEY_PATH:}
   key-id: ${APNS_KEY_ID:}
   team-id: ${APNS_TEAM_ID:}


### PR DESCRIPTION
## Summary
- `APNS_KEY_CONTENT` 환경변수(`.p8` 파일 전체를 base64 인코딩)로 APNs 키 주입 지원
- 기존 `APNS_KEY_PATH`(파일 경로)는 폴백으로 유지 — 로컬 개발 시 그대로 사용 가능
- `application.yml`, `.env.example`에 `APNS_KEY_CONTENT` 추가

## 변경 파일
- `PushSender.java` — `resolveApnsPem()` 메서드로 key-content 우선, key-path 폴백
- `application.yml` — `apns.key-content` 설정 키 추가
- `.env.example` — `APNS_KEY_CONTENT` 사용법 안내 추가

## ENV_FILE에 넣는 방법
```bash
# .p8 파일을 base64로 인코딩
base64 -i AuthKey_XXXXXXXXXX.p8 | tr -d '\n'
# 출력값을 APNS_KEY_CONTENT=<값> 으로 ENV_FILE 시크릿에 추가
```

## Test plan
- [ ] CI 통과 확인
- [ ] `APNS_KEY_CONTENT` 설정 시 APNs 정상 초기화 로그 확인
- [ ] `APNS_KEY_CONTENT` 미설정 + `APNS_KEY_PATH` 설정 시 폴백 동작 확인

Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the APNs private key via base64-encoded content as an alternative to file path, providing greater flexibility in deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->