### PR TITLE
fix: 온보딩 step1 500 에러 및 trace_id null 수정

### DIFF
--- a/src/main/java/com/mio/common/trace/TraceIdFilter.java
+++ b/src/main/java/com/mio/common/trace/TraceIdFilter.java
@@ -1,0 +1,42 @@
+package com.mio.common.trace;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class TraceIdFilter extends OncePerRequestFilter {
+
+    private static final String TRACE_ID_HEADER = "X-Request-ID";
+    private static final String TRACE_ID_ATTR = "traceId";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String traceId = request.getHeader(TRACE_ID_HEADER);
+        if (traceId == null || traceId.isBlank()) {
+            traceId = UUID.randomUUID().toString();
+        }
+
+        request.setAttribute(TRACE_ID_ATTR, traceId);
+        response.setHeader(TRACE_ID_HEADER, traceId);
+        MDC.put(TRACE_ID_ATTR, traceId);
+
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            MDC.remove(TRACE_ID_ATTR);
+        }
+    }
+}

--- a/src/main/java/com/mio/common/trace/TraceIdFilter.java
+++ b/src/main/java/com/mio/common/trace/TraceIdFilter.java
@@ -25,7 +25,7 @@ public class TraceIdFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String traceId = request.getHeader(TRACE_ID_HEADER);
-        if (traceId == null || traceId.isBlank()) {
+        if (traceId == null || !traceId.matches("^[a-zA-Z0-9\\-]{1,50}$")) {
             traceId = UUID.randomUUID().toString();
         }
 

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -1,8 +1,5 @@
 package com.mio.onboarding.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.onboarding.dto.*;
@@ -40,7 +37,6 @@ public class OnboardingService {
     private final UserRepository userRepository;
     private final UserOnboardingAnswerRepository onboardingAnswerRepository;
     private final CharacterRecommender characterRecommender;
-    private final ObjectMapper objectMapper;
 
     @Transactional
     public OnboardingStepResponse submitStep1(UUID userId, OnboardingStep1Request request) {
@@ -53,7 +49,7 @@ public class OnboardingService {
             throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
         }
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
-        answer.updateStep1(request.emotionState(), toJson(request.responses()));
+        answer.updateStep1(request.emotionState(), request.responses());
         user.updateOnboardingStep(1);
 
         onboardingAnswerRepository.save(answer);
@@ -74,7 +70,7 @@ public class OnboardingService {
         }
 
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
-        answer.updateStep2(toJson(request.concernTypes()), toJson(request.responses()));
+        answer.updateStep2(request.concernTypes(), request.responses());
         user.updateOnboardingStep(2);
 
         onboardingAnswerRepository.save(answer);
@@ -93,13 +89,12 @@ public class OnboardingService {
         }
 
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
-        List<String> rawConcernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
-        List<String> concernTypes = rawConcernTypes != null ? rawConcernTypes : List.of();
+        List<String> concernTypes = answer.getConcernTypes() != null ? answer.getConcernTypes() : List.of();
         List<CharacterRecommendationDto> recommendations = characterRecommender.recommend(
                 answer.getEmotionState(), concernTypes, request.preferredStyle()
         );
 
-        answer.updateStep3(request.preferredStyle(), toJson(recommendations), toJson(request.responses()));
+        answer.updateStep3(request.preferredStyle(), recommendations, request.responses());
         user.updateOnboardingStep(3);
 
         onboardingAnswerRepository.save(answer);
@@ -132,7 +127,7 @@ public class OnboardingService {
 
         if (user.getOnboardingStep() >= 3) {
             recommendations = onboardingAnswerRepository.findByUser_Id(userId)
-                    .map(a -> fromJson(a.getCharacterRecommendations(), new TypeReference<List<CharacterRecommendationDto>>() {}))
+                    .map(UserOnboardingAnswer::getCharacterRecommendations)
                     .orElse(null);
         }
 
@@ -147,23 +142,5 @@ public class OnboardingService {
     private UserOnboardingAnswer findOrCreateAnswer(User user) {
         return onboardingAnswerRepository.findByUser_Id(user.getId())
                 .orElseGet(() -> UserOnboardingAnswer.builder().user(user).build());
-    }
-
-    private String toJson(Object value) {
-        if (value == null) return "[]";
-        try {
-            return objectMapper.writeValueAsString(value);
-        } catch (JsonProcessingException e) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    private <T> T fromJson(String json, TypeReference<T> type) {
-        if (json == null || json.isBlank()) return null;
-        try {
-            return objectMapper.readValue(json, type);
-        } catch (JsonProcessingException e) {
-            throw new BusinessException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
     }
 }

--- a/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
+++ b/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
@@ -2,6 +2,8 @@ package com.mio.user.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -28,6 +30,7 @@ public class UserOnboardingAnswer {
     private String emotionState;
 
     /** step 2 완료 시 저장 */
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "concern_types", columnDefinition = "jsonb")
     @Builder.Default
     private String concernTypes = "[]";
@@ -37,11 +40,13 @@ public class UserOnboardingAnswer {
     private String preferredStyle;
 
     /** step 3 완료 시 AI 추천 결과 저장 */
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "character_recommendations", columnDefinition = "jsonb")
     @Builder.Default
     private String characterRecommendations = "[]";
 
     /** 개별 질문 답변 목록 */
+    @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "responses", columnDefinition = "jsonb")
     @Builder.Default
     private String responses = "[]";

--- a/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
+++ b/src/main/java/com/mio/user/domain/UserOnboardingAnswer.java
@@ -1,5 +1,7 @@
 package com.mio.user.domain;
 
+import com.mio.onboarding.dto.CharacterRecommendationDto;
+import com.mio.onboarding.dto.QuestionResponse;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
@@ -7,6 +9,8 @@ import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -33,7 +37,7 @@ public class UserOnboardingAnswer {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "concern_types", columnDefinition = "jsonb")
     @Builder.Default
-    private String concernTypes = "[]";
+    private List<String> concernTypes = new ArrayList<>();
 
     /** step 3 완료 시 저장: empathetic/analytical/solution/balanced */
     @Column(name = "preferred_style")
@@ -43,32 +47,32 @@ public class UserOnboardingAnswer {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "character_recommendations", columnDefinition = "jsonb")
     @Builder.Default
-    private String characterRecommendations = "[]";
+    private List<CharacterRecommendationDto> characterRecommendations = new ArrayList<>();
 
     /** 개별 질문 답변 목록 */
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "responses", columnDefinition = "jsonb")
     @Builder.Default
-    private String responses = "[]";
+    private List<QuestionResponse> responses = new ArrayList<>();
 
     /** step 3 완료 시점 */
     @Column(name = "submitted_at")
     private OffsetDateTime submittedAt;
 
-    public void updateStep1(String emotionState, String responsesJson) {
+    public void updateStep1(String emotionState, List<QuestionResponse> responses) {
         this.emotionState = emotionState;
-        this.responses = responsesJson;
+        this.responses = responses != null ? responses : List.of();
     }
 
-    public void updateStep2(String concernTypesJson, String responsesJson) {
-        this.concernTypes = concernTypesJson;
-        this.responses = responsesJson;
+    public void updateStep2(List<String> concernTypes, List<QuestionResponse> responses) {
+        this.concernTypes = concernTypes != null ? concernTypes : List.of();
+        this.responses = responses != null ? responses : List.of();
     }
 
-    public void updateStep3(String preferredStyle, String characterRecommendationsJson, String responsesJson) {
+    public void updateStep3(String preferredStyle, List<CharacterRecommendationDto> characterRecommendations, List<QuestionResponse> responses) {
         this.preferredStyle = preferredStyle;
-        this.characterRecommendations = characterRecommendationsJson;
-        this.responses = responsesJson;
+        this.characterRecommendations = characterRecommendations != null ? characterRecommendations : List.of();
+        this.responses = responses != null ? responses : List.of();
         this.submittedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 }

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -1,6 +1,5 @@
 package com.mio.onboarding.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.onboarding.dto.*;
@@ -38,8 +37,7 @@ class OnboardingServiceTest {
     @BeforeEach
     void setUp() {
         CharacterRecommender recommender = new CharacterRecommender();
-        ObjectMapper objectMapper = new ObjectMapper();
-        onboardingService = new OnboardingService(userRepository, onboardingAnswerRepository, recommender, objectMapper);
+        onboardingService = new OnboardingService(userRepository, onboardingAnswerRepository, recommender);
         userId = UUID.randomUUID();
         mockUser = User.builder()
                 .socialProvider("kakao")
@@ -135,7 +133,7 @@ class OnboardingServiceTest {
         UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
                 .user(mockUser)
                 .emotionState("anxious")
-                .concernTypes("[\"relationship\"]")
+                .concernTypes(List.of("relationship"))
                 .build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
@@ -171,13 +169,13 @@ class OnboardingServiceTest {
     }
 
     @Test
-    @DisplayName("3단계 concernTypes가 빈 문자열이어도 NPE 없이 추천 결과를 반환한다")
+    @DisplayName("3단계 concernTypes가 빈 리스트여도 NPE 없이 추천 결과를 반환한다")
     void submitStep3_concernTypesBlank_doesNotThrow() {
         mockUser.updateOnboardingStep(2);
         UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
                 .user(mockUser)
                 .emotionState("anxious")
-                .concernTypes("")
+                .concernTypes(List.of())
                 .build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));


### PR DESCRIPTION
## Summary

- `UserOnboardingAnswer` JSONB 컬럼 3개에 `@JdbcTypeCode(SqlTypes.JSON)` 추가 — Hibernate 6의 VARCHAR 바인딩으로 인한 PostgreSQL INSERT 거부 문제 해결
- `TraceIdFilter` 신규 추가 — 모든 요청에 traceId를 request attribute/응답 헤더/MDC에 설정

## 원인 상세

### 500 에러
Hibernate 6에서 `@Column(columnDefinition = "jsonb")`은 **DDL 생성에만** 영향을 준다. 런타임 JDBC 바인딩은 여전히 `setString()` (VARCHAR)으로 처리되고, PostgreSQL은 `character varying → jsonb` 암시적 캐스팅을 거부한다:
```
ERROR: column "responses" is of type jsonb but expression is of type character varying
```
→ `DataIntegrityViolationException` → `GlobalExceptionHandler` catch → 500

단위 테스트는 Repository를 mock 처리해 실제 DB를 타지 않아 이 버그가 테스트에서 잡히지 않았다.

### trace_id null
`GlobalExceptionHandler.getTraceId()`가 `request.getAttribute("traceId")`를 읽지만 이 속성을 설정하는 필터가 없었다.

## 변경 파일

| 파일 | 변경 내용 |
|------|----------|
| `UserOnboardingAnswer.java` | `concern_types`, `character_recommendations`, `responses` 컬럼에 `@JdbcTypeCode(SqlTypes.JSON)` 추가 |
| `TraceIdFilter.java` (신규) | `X-Request-ID` 헤더 or UUID → request attribute + 응답 헤더 + MDC 설정 |

## Test plan

- [ ] `POST /v1/onboarding/step/1` 호출 시 200 응답 확인 (실제 DB 연결 환경)
- [ ] 에러 응답 시 `trace_id`가 null이 아닌 UUID 값으로 내려오는지 확인
- [ ] `X-Request-ID` 헤더를 보내면 동일한 값이 응답 헤더와 trace_id에 반영되는지 확인

Closes #158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented request tracing to enable better debugging and error tracking across the application.

* **Chores**
  * Improved data persistence configuration for enhanced data storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->