### PR TITLE
fix: LoginRequest 필드명 camelCase → snake_case 통일 (#161)

### DIFF
--- a/src/main/java/com/mio/auth/dto/LoginRequest.java
+++ b/src/main/java/com/mio/auth/dto/LoginRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public record LoginRequest(
         @NotBlank String provider,
-        @JsonProperty("idToken") String idToken,
-        @JsonProperty("accessToken") String accessToken,
-        @JsonProperty("deviceId") @NotBlank String deviceId
+        @JsonProperty("id_token") String idToken,
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("device_id") @NotBlank String deviceId
 ) {
 }


### PR DESCRIPTION
● ## 요약
  전역 Jackson SNAKE_CASE 제거 후 @JsonProperty 명시적 복원 과정에서
  LoginRequest만 camelCase로 잘못 설정되어 LogoutRequest(snake_case)와 불일치가 발생.
  FE에서 두 요청의 필드명을 각각 다르게 처리해야 하는 문제를 해결합니다.

  ## 관련 이슈
  - Closes #161

  ## 변경 사항
  - `LoginRequest`: `idToken` → `id_token`, `accessToken` → `access_token`, `deviceId` → `device_id`                                                                             

  ## 영향 범위
  - [x] API 스펙 또는 응답 형식이 변경됩니다.
  - [x] Breaking change 가 있습니다.

  ## 테스트
  ### 실행 커맨드
  ```bash
  ./gradlew test

  확인 내용

  - snake_case 필드명으로 로그인 요청 시 정상 응답 확인
  - 기존 camelCase 필드명으로 요청 시 400 반환 확인 (Breaking change)

  중점 리뷰 포인트

  - FE와 동시 배포 필요. 서버만 먼저 배포되면 기존 클라이언트 로그인 전체 차단됨.

  배포 / 롤백

  - Rollout: FE의 로그인 요청 필드명 snake_case 수정과 동시 배포
  - Rollback: @JsonProperty 값을 camelCase로 되돌리고 재배포

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON property naming for authentication request fields to ensure proper API communication and data serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->