### PR TITLE
feat: 온보딩 단계 건너뛰기 API 추가

### DIFF
--- a/src/main/java/com/mio/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/mio/onboarding/controller/OnboardingController.java
@@ -41,6 +41,13 @@ public class OnboardingController {
         return ResponseEntity.ok(ApiResponse.ok(onboardingService.submitStep3(resolveUserId(principal), request)));
     }
 
+    @PostMapping("/step/{stepNumber}/skip")
+    public ResponseEntity<ApiResponse<OnboardingStepResponse>> skipStep(
+            Principal principal,
+            @PathVariable int stepNumber) {
+        return ResponseEntity.ok(ApiResponse.ok(onboardingService.skipStep(resolveUserId(principal), stepNumber)));
+    }
+
     @PostMapping("/character")
     public ResponseEntity<ApiResponse<CharacterSelectResponse>> selectCharacter(
             Principal principal,

--- a/src/main/java/com/mio/onboarding/service/CharacterRecommender.java
+++ b/src/main/java/com/mio/onboarding/service/CharacterRecommender.java
@@ -94,8 +94,8 @@ public class CharacterRecommender {
     }
 
     private Scored score(CharacterProfile p, String emotion, List<String> concerns, String style) {
-        double styleScore = p.styleScores().getOrDefault(style, 0.3);
-        double emotionScore = p.emotionScores().getOrDefault(emotion, 0.5);
+        double styleScore = style != null ? p.styleScores().getOrDefault(style, 0.3) : 0.3;
+        double emotionScore = emotion != null ? p.emotionScores().getOrDefault(emotion, 0.5) : 0.5;
         double concernScore = concerns.stream()
                 .mapToDouble(c -> p.concernScores().getOrDefault(c, 0.5))
                 .max()

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -127,6 +127,9 @@ public class OnboardingService {
         }
 
         User user = findUser(userId);
+        if (user.getOnboardingStep() >= stepNumber) {
+            return new OnboardingStepResponse(user.getOnboardingStep());
+        }
         if (stepNumber > 1 && user.getOnboardingStep() < stepNumber - 1) {
             throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
         }

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -120,6 +120,39 @@ public class OnboardingService {
         return new CharacterSelectResponse(user.getPreferredCharacterId(), user.getSignupStep());
     }
 
+    @Transactional
+    public OnboardingStepResponse skipStep(UUID userId, int stepNumber) {
+        if (stepNumber < 1 || stepNumber > 3) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        User user = findUser(userId);
+        if (stepNumber > 1 && user.getOnboardingStep() < stepNumber - 1) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
+        if (stepNumber == 1 && user.getSignupStep().ordinal() < SignupStep.PROFILE_COMPLETED.ordinal()) {
+            throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
+        }
+
+        UserOnboardingAnswer answer = findOrCreateAnswer(user);
+        switch (stepNumber) {
+            case 1 -> answer.updateStep1(null, toJson(List.of()));
+            case 2 -> answer.updateStep2(toJson(List.of()), toJson(List.of()));
+            case 3 -> {
+                List<String> concernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
+                if (concernTypes == null) concernTypes = List.of();
+                List<CharacterRecommendationDto> recommendations = characterRecommender.recommend(
+                        answer.getEmotionState(), concernTypes, null
+                );
+                answer.updateStep3(null, toJson(recommendations), toJson(List.of()));
+            }
+        }
+        user.updateOnboardingStep(stepNumber);
+
+        onboardingAnswerRepository.save(answer);
+        return new OnboardingStepResponse(stepNumber);
+    }
+
     @Transactional(readOnly = true)
     public OnboardingStatusResponse getStatus(UUID userId) {
         User user = findUser(userId);

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -136,15 +136,14 @@ public class OnboardingService {
 
         UserOnboardingAnswer answer = findOrCreateAnswer(user);
         switch (stepNumber) {
-            case 1 -> answer.updateStep1(null, toJson(List.of()));
-            case 2 -> answer.updateStep2(toJson(List.of()), toJson(List.of()));
+            case 1 -> answer.updateStep1(null, List.of());
+            case 2 -> answer.updateStep2(List.of(), List.of());
             case 3 -> {
-                List<String> concernTypes = fromJson(answer.getConcernTypes(), new TypeReference<>() {});
-                if (concernTypes == null) concernTypes = List.of();
+                List<String> concernTypes = answer.getConcernTypes() != null ? answer.getConcernTypes() : List.of();
                 List<CharacterRecommendationDto> recommendations = characterRecommender.recommend(
                         answer.getEmotionState(), concernTypes, null
                 );
-                answer.updateStep3(null, toJson(recommendations), toJson(List.of()));
+                answer.updateStep3(null, recommendations, List.of());
             }
         }
         user.updateOnboardingStep(stepNumber);

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -97,7 +97,9 @@ public class User {
     private OffsetDateTime deletedAt;
 
     public void updateOnboardingStep(int step) {
-        this.onboardingStep = step;
+        if (step > this.onboardingStep) {
+            this.onboardingStep = step;
+        }
     }
 
     public void completeOnboarding(String characterId) {

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -321,10 +321,10 @@ class OnboardingServiceTest {
         when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
 
         onboardingService.skipStep(userId, 2);
-        assertThat(answer.getConcernTypes()).isEqualTo("[]");
+        assertThat(answer.getConcernTypes()).isEmpty();
 
         onboardingService.submitStep2(userId, new OnboardingStep2Request(List.of("career"), List.of()));
-        assertThat(answer.getConcernTypes()).isEqualTo("[\"career\"]");
+        assertThat(answer.getConcernTypes()).containsExactly("career");
         assertThat(mockUser.getOnboardingStep()).isEqualTo(2);
     }
 
@@ -335,7 +335,7 @@ class OnboardingServiceTest {
         UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
                 .user(mockUser)
                 .emotionState("anxious")
-                .concernTypes("[\"relationship\"]")
+                .concernTypes(List.of("relationship"))
                 .build();
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -366,4 +366,17 @@ class OnboardingServiceTest {
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.INVALID_INPUT));
     }
+
+    @Test
+    @DisplayName("이미 완료한 단계를 다시 skip해도 데이터를 덮어쓰지 않고 현재 상태를 반환한다")
+    void skipStep_alreadyCompleted_returnsCurrentStateWithoutOverwrite() {
+        mockUser.updateOnboardingStep(1);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        OnboardingStepResponse response = onboardingService.skipStep(userId, 1);
+
+        assertThat(response.onboardingStep()).isEqualTo(1);
+        verify(onboardingAnswerRepository, never()).save(any());
+        verify(onboardingAnswerRepository, never()).findByUser_Id(any());
+    }
 }

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -266,4 +266,104 @@ class OnboardingServiceTest {
                 .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
                         .isEqualTo(ErrorCode.USER_NOT_FOUND));
     }
+
+    @Test
+    @DisplayName("이미 완료한 단계를 다시 제출해도 onboarding_step은 낮아지지 않는다")
+    void submitStep1_resubmit_doesNotRegressStep() {
+        mockUser.completeProfile("테스트", null, null);
+        mockUser.updateOnboardingStep(2);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        onboardingService.submitStep1(userId, new OnboardingStep1Request("happy", List.of()));
+
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("step 1 skip 성공 시 onboarding_step이 1을 반환한다")
+    void skipStep1_success_returnsStep1() {
+        mockUser.completeProfile("테스트", null, null);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStepResponse response = onboardingService.skipStep(userId, 1);
+
+        assertThat(response.onboardingStep()).isEqualTo(1);
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("step 2 skip 성공 시 onboarding_step이 2를 반환한다")
+    void skipStep2_success_returnsStep2() {
+        mockUser.updateOnboardingStep(1);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStepResponse response = onboardingService.skipStep(userId, 2);
+
+        assertThat(response.onboardingStep()).isEqualTo(2);
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("step 2 skip 후 step 2 정식 제출 시 concern_types가 업데이트된다")
+    void skipStep2_thenSubmitStep2_updatesData() {
+        mockUser.updateOnboardingStep(1);
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(mockUser)
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        onboardingService.skipStep(userId, 2);
+        assertThat(answer.getConcernTypes()).isEqualTo("[]");
+
+        onboardingService.submitStep2(userId, new OnboardingStep2Request(List.of("career"), List.of()));
+        assertThat(answer.getConcernTypes()).isEqualTo("[\"career\"]");
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("step 3 skip 성공 시 character_recommendations 3개를 반환한다")
+    void skipStep3_success_returnsRecommendations() {
+        mockUser.updateOnboardingStep(2);
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(mockUser)
+                .emotionState("anxious")
+                .concernTypes("[\"relationship\"]")
+                .build();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.of(answer));
+        when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        OnboardingStepResponse response = onboardingService.skipStep(userId, 3);
+
+        assertThat(response.onboardingStep()).isEqualTo(3);
+        assertThat(mockUser.getOnboardingStep()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("1단계 미완료 상태에서 step 2 skip 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
+    void skipStep2_step1NotCompleted_throws() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.skipStep(userId, 2))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 stepNumber는 INVALID_INPUT 예외를 발생시킨다")
+    void skipStep_invalidStepNumber_throws() {
+        assertThatThrownBy(() -> onboardingService.skipStep(userId, 4))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
 }


### PR DESCRIPTION
## Summary

- `POST /v1/onboarding/step/{stepNumber}/skip` 엔드포인트 추가
- step 1~3 건너뛰기만 허용, 캐릭터 선택(step 4)은 skip 불가 (INVALID_INPUT)
- 이전 단계 미완료 상태에서 skip 시도 시 ONBOARDING_STEP_NOT_COMPLETED
- step 3 skip 시 기존 emotionState/concernTypes 기반으로 캐릭터 자동 추천
- `User.updateOnboardingStep()` 단조증가 보장 (퇴보 방지 regression fix)
- `CharacterRecommender` null guard 추가 (skip 시 emotion/style null 허용)

## Test plan

- [ ] `OnboardingServiceTest` 22개 테스트 모두 통과 확인
- [ ] step 1 skip → onboardingStep = 1 반환
- [ ] step 2 skip → onboardingStep = 2 반환
- [ ] step 3 skip → characterRecommendations 3개 반환
- [ ] step 2 skip 후 정식 제출 시 concernTypes 덮어쓰기 동작 확인
- [ ] 이전 단계 미완료 skip → ONBOARDING_STEP_NOT_COMPLETED
- [ ] stepNumber = 4 (캐릭터 선택) skip 시도 → INVALID_INPUT

Closes #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an onboarding “skip step” action that lets users bypass a specific step. Skipped step data is cleared and, when applicable, character recommendations are refreshed to reflect the updated inputs.
* **Bug Fixes**
  * Improved onboarding progression so step status only moves forward (including when resubmitting earlier steps).
  * Enhanced character recommendation scoring to handle missing style/emotion inputs safely.
* **Tests**
  * Expanded unit tests for skipping steps, resubmission behavior, and validation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->