### PR TITLE
feat: 온보딩 완료 이벤트 기반 AI 메모리 시딩 (#166)

### DIFF
--- a/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
+++ b/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
@@ -61,7 +61,7 @@ public class UserMemoryPreference {
     private OffsetDateTime updatedAt;
 
     public void seedPreferredTone(String preferredTone) {
-        if (this.preferredTone == null) {
+        if (this.preferredTone == null && preferredTone != null && !preferredTone.isBlank()) {
             this.preferredTone = preferredTone;
         }
     }

--- a/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
+++ b/src/main/java/com/mio/ai/domain/UserMemoryPreference.java
@@ -60,6 +60,12 @@ public class UserMemoryPreference {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
+    public void seedPreferredTone(String preferredTone) {
+        if (this.preferredTone == null) {
+            this.preferredTone = preferredTone;
+        }
+    }
+
     @PrePersist
     @PreUpdate
     protected void onUpdate() {

--- a/src/main/java/com/mio/ai/domain/UserSelfModel.java
+++ b/src/main/java/com/mio/ai/domain/UserSelfModel.java
@@ -60,6 +60,16 @@ public class UserSelfModel {
     @Builder.Default
     private int version = 1;
 
+    public void seedFromOnboarding(List<String> dominantEmotions, List<String> recurringTriggerTags) {
+        if (version > 1) return;
+        if (this.dominantEmotions.isEmpty()) {
+            this.dominantEmotions = dominantEmotions;
+        }
+        if (this.recurringTriggerTags.isEmpty()) {
+            this.recurringTriggerTags = recurringTriggerTags;
+        }
+    }
+
     public void updateFromReflection(List<String> dominantEmotions,
                                      List<String> recurringTriggerTags,
                                      String copingStyle,

--- a/src/main/java/com/mio/ai/domain/UserSelfModel.java
+++ b/src/main/java/com/mio/ai/domain/UserSelfModel.java
@@ -62,10 +62,12 @@ public class UserSelfModel {
 
     public void seedFromOnboarding(List<String> dominantEmotions, List<String> recurringTriggerTags) {
         if (version > 1) return;
-        if (this.dominantEmotions.isEmpty()) {
+        if ((this.dominantEmotions == null || this.dominantEmotions.isEmpty())
+                && dominantEmotions != null && !dominantEmotions.isEmpty()) {
             this.dominantEmotions = dominantEmotions;
         }
-        if (this.recurringTriggerTags.isEmpty()) {
+        if ((this.recurringTriggerTags == null || this.recurringTriggerTags.isEmpty())
+                && recurringTriggerTags != null && !recurringTriggerTags.isEmpty()) {
             this.recurringTriggerTags = recurringTriggerTags;
         }
     }

--- a/src/main/java/com/mio/ai/memory/consolidation/OnboardingMemorySeeder.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/OnboardingMemorySeeder.java
@@ -1,0 +1,68 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.domain.UserSelfModel;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
+import com.mio.ai.repository.UserSelfModelRepository;
+import com.mio.onboarding.event.OnboardingCompletedEvent;
+import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.user.repository.UserOnboardingAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+import java.util.UUID;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OnboardingMemorySeeder {
+
+    private final UserOnboardingAnswerRepository onboardingAnswerRepository;
+    private final UserSelfModelRepository userSelfModelRepository;
+    private final UserMemoryPreferenceRepository userMemoryPreferenceRepository;
+
+    @Async
+    @Transactional
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onOnboardingCompleted(OnboardingCompletedEvent event) {
+        UUID userId = event.userId();
+        log.info("온보딩 메모리 시딩 시작: userId={}", userId);
+
+        UserOnboardingAnswer answer = onboardingAnswerRepository.findByUser_Id(userId).orElse(null);
+        if (answer == null) {
+            log.warn("온보딩 답변 없음 — 시딩 건너뜀: userId={}", userId);
+            return;
+        }
+
+        seedSelfModel(userId, answer);
+        seedMemoryPreference(userId, answer);
+
+        log.info("온보딩 메모리 시딩 완료: userId={}", userId);
+    }
+
+    private void seedSelfModel(UUID userId, UserOnboardingAnswer answer) {
+        userSelfModelRepository.findById(userId).ifPresent(selfModel -> {
+            String emotionState = answer.getEmotionState();
+            List<String> concernTypes = answer.getConcernTypes();
+
+            List<String> emotions = emotionState != null ? List.of(emotionState) : List.of();
+            List<String> triggers = concernTypes != null ? concernTypes : List.of();
+
+            selfModel.seedFromOnboarding(emotions, triggers);
+            userSelfModelRepository.save(selfModel);
+        });
+    }
+
+    private void seedMemoryPreference(UUID userId, UserOnboardingAnswer answer) {
+        userMemoryPreferenceRepository.findByUserId(userId).ifPresent(preference -> {
+            preference.seedPreferredTone(answer.getPreferredStyle());
+            userMemoryPreferenceRepository.save(preference);
+        });
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/OnboardingMemorySeeder.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/OnboardingMemorySeeder.java
@@ -9,8 +9,8 @@ import com.mio.user.domain.UserOnboardingAnswer;
 import com.mio.user.repository.UserOnboardingAnswerRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionPhase;
 import org.springframework.transaction.event.TransactionalEventListener;
@@ -27,8 +27,7 @@ public class OnboardingMemorySeeder {
     private final UserSelfModelRepository userSelfModelRepository;
     private final UserMemoryPreferenceRepository userMemoryPreferenceRepository;
 
-    @Async
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onOnboardingCompleted(OnboardingCompletedEvent event) {
         UUID userId = event.userId();

--- a/src/main/java/com/mio/onboarding/event/OnboardingCompletedEvent.java
+++ b/src/main/java/com/mio/onboarding/event/OnboardingCompletedEvent.java
@@ -1,0 +1,5 @@
+package com.mio.onboarding.event;
+
+import java.util.UUID;
+
+public record OnboardingCompletedEvent(UUID userId) {}

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -6,9 +6,11 @@ import com.mio.onboarding.dto.*;
 import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.onboarding.event.OnboardingCompletedEvent;
 import com.mio.user.repository.UserOnboardingAnswerRepository;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +39,7 @@ public class OnboardingService {
     private final UserRepository userRepository;
     private final UserOnboardingAnswerRepository onboardingAnswerRepository;
     private final CharacterRecommender characterRecommender;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public OnboardingStepResponse submitStep1(UUID userId, OnboardingStep1Request request) {
@@ -117,6 +120,7 @@ public class OnboardingService {
         }
 
         user.completeOnboarding(characterId);
+        eventPublisher.publishEvent(new OnboardingCompletedEvent(userId));
         return new CharacterSelectResponse(user.getPreferredCharacterId(), user.getSignupStep());
     }
 

--- a/src/test/java/com/mio/ai/domain/UserMemoryPreferenceTest.java
+++ b/src/test/java/com/mio/ai/domain/UserMemoryPreferenceTest.java
@@ -1,0 +1,36 @@
+package com.mio.ai.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserMemoryPreferenceTest {
+
+    @Test
+    @DisplayName("preferredTone이 null이면 seedPreferredTone이 값을 채운다")
+    void seedPreferredTone_whenNull_seeds() {
+        UserMemoryPreference preference = UserMemoryPreference.builder()
+                .userId(UUID.randomUUID())
+                .build();
+
+        preference.seedPreferredTone("empathetic");
+
+        assertThat(preference.getPreferredTone()).isEqualTo("empathetic");
+    }
+
+    @Test
+    @DisplayName("preferredTone이 이미 설정되어 있으면 덮어쓰지 않는다")
+    void seedPreferredTone_alreadySet_doesNotOverwrite() {
+        UserMemoryPreference preference = UserMemoryPreference.builder()
+                .userId(UUID.randomUUID())
+                .preferredTone("analytical")
+                .build();
+
+        preference.seedPreferredTone("empathetic");
+
+        assertThat(preference.getPreferredTone()).isEqualTo("analytical");
+    }
+}

--- a/src/test/java/com/mio/ai/domain/UserMemoryPreferenceTest.java
+++ b/src/test/java/com/mio/ai/domain/UserMemoryPreferenceTest.java
@@ -22,6 +22,20 @@ class UserMemoryPreferenceTest {
     }
 
     @Test
+    @DisplayName("null 또는 빈 문자열이 입력되면 스킵으로 간주하여 시딩하지 않는다")
+    void seedPreferredTone_nullOrBlank_doesNotSeed() {
+        UserMemoryPreference preference = UserMemoryPreference.builder()
+                .userId(UUID.randomUUID())
+                .build();
+
+        preference.seedPreferredTone(null);
+        assertThat(preference.getPreferredTone()).isNull();
+
+        preference.seedPreferredTone("   ");
+        assertThat(preference.getPreferredTone()).isNull();
+    }
+
+    @Test
     @DisplayName("preferredTone이 이미 설정되어 있으면 덮어쓰지 않는다")
     void seedPreferredTone_alreadySet_doesNotOverwrite() {
         UserMemoryPreference preference = UserMemoryPreference.builder()

--- a/src/test/java/com/mio/ai/domain/UserSelfModelTest.java
+++ b/src/test/java/com/mio/ai/domain/UserSelfModelTest.java
@@ -35,6 +35,17 @@ class UserSelfModelTest {
     }
 
     @Test
+    @DisplayName("빈 리스트가 입력되면 스킵으로 간주하여 시딩하지 않는다")
+    void seedFromOnboarding_emptyInput_doesNotSeed() {
+        UserSelfModel model = UserSelfModel.builder().build();
+
+        model.seedFromOnboarding(List.of(), List.of());
+
+        assertThat(model.getDominantEmotions()).isEmpty();
+        assertThat(model.getRecurringTriggerTags()).isEmpty();
+    }
+
+    @Test
     @DisplayName("version>1이면 seedFromOnboarding이 아무것도 변경하지 않는다")
     void seedFromOnboarding_higherVersion_skips() {
         UserSelfModel model = UserSelfModel.builder()

--- a/src/test/java/com/mio/ai/domain/UserSelfModelTest.java
+++ b/src/test/java/com/mio/ai/domain/UserSelfModelTest.java
@@ -1,0 +1,51 @@
+package com.mio.ai.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UserSelfModelTest {
+
+    @Test
+    @DisplayName("version=1이고 필드가 비어있을 때 seedFromOnboarding이 값을 채운다")
+    void seedFromOnboarding_version1_empty_seeds() {
+        UserSelfModel model = UserSelfModel.builder().build();
+
+        model.seedFromOnboarding(List.of("anxious"), List.of("career", "family"));
+
+        assertThat(model.getDominantEmotions()).containsExactly("anxious");
+        assertThat(model.getRecurringTriggerTags()).containsExactly("career", "family");
+    }
+
+    @Test
+    @DisplayName("version=1이지만 dominantEmotions가 이미 채워져 있으면 덮어쓰지 않는다")
+    void seedFromOnboarding_alreadyPopulated_doesNotOverwrite() {
+        UserSelfModel model = UserSelfModel.builder()
+                .dominantEmotions(List.of("calm"))
+                .recurringTriggerTags(List.of("health"))
+                .build();
+
+        model.seedFromOnboarding(List.of("anxious"), List.of("career"));
+
+        assertThat(model.getDominantEmotions()).containsExactly("calm");
+        assertThat(model.getRecurringTriggerTags()).containsExactly("health");
+    }
+
+    @Test
+    @DisplayName("version>1이면 seedFromOnboarding이 아무것도 변경하지 않는다")
+    void seedFromOnboarding_higherVersion_skips() {
+        UserSelfModel model = UserSelfModel.builder()
+                .dominantEmotions(List.of())
+                .recurringTriggerTags(List.of())
+                .version(2)
+                .build();
+
+        model.seedFromOnboarding(List.of("anxious"), List.of("career"));
+
+        assertThat(model.getDominantEmotions()).isEmpty();
+        assertThat(model.getRecurringTriggerTags()).isEmpty();
+    }
+}

--- a/src/test/java/com/mio/ai/memory/consolidation/OnboardingMemorySeederTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/OnboardingMemorySeederTest.java
@@ -1,0 +1,118 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.domain.UserSelfModel;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
+import com.mio.ai.repository.UserSelfModelRepository;
+import com.mio.onboarding.event.OnboardingCompletedEvent;
+import com.mio.user.domain.User;
+import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.user.repository.UserOnboardingAnswerRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingMemorySeederTest {
+
+    @Mock private UserOnboardingAnswerRepository onboardingAnswerRepository;
+    @Mock private UserSelfModelRepository userSelfModelRepository;
+    @Mock private UserMemoryPreferenceRepository userMemoryPreferenceRepository;
+
+    private OnboardingMemorySeeder seeder;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        seeder = new OnboardingMemorySeeder(
+                onboardingAnswerRepository, userSelfModelRepository, userMemoryPreferenceRepository
+        );
+        userId = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("온보딩 완료 이벤트 수신 시 UserSelfModel과 UserMemoryPreference에 시딩한다")
+    void onOnboardingCompleted_withValidAnswer_seedsBothModels() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test")
+                .privacyConsent(true)
+                .build();
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(user)
+                .emotionState("anxious")
+                .concernTypes(List.of("career", "family"))
+                .preferredStyle("empathetic")
+                .build();
+
+        UserSelfModel selfModel = UserSelfModel.builder().userId(userId).build();
+        UserMemoryPreference preference = UserMemoryPreference.builder().userId(userId).build();
+
+        when(onboardingAnswerRepository.findByUser_Id(userId)).thenReturn(Optional.of(answer));
+        when(userSelfModelRepository.findById(userId)).thenReturn(Optional.of(selfModel));
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(preference));
+        when(userSelfModelRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+        when(userMemoryPreferenceRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        seeder.onOnboardingCompleted(new OnboardingCompletedEvent(userId));
+
+        ArgumentCaptor<UserSelfModel> selfModelCaptor = ArgumentCaptor.forClass(UserSelfModel.class);
+        verify(userSelfModelRepository).save(selfModelCaptor.capture());
+        assertThat(selfModelCaptor.getValue().getDominantEmotions()).containsExactly("anxious");
+        assertThat(selfModelCaptor.getValue().getRecurringTriggerTags()).containsExactly("career", "family");
+
+        ArgumentCaptor<UserMemoryPreference> preferenceCaptor = ArgumentCaptor.forClass(UserMemoryPreference.class);
+        verify(userMemoryPreferenceRepository).save(preferenceCaptor.capture());
+        assertThat(preferenceCaptor.getValue().getPreferredTone()).isEqualTo("empathetic");
+    }
+
+    @Test
+    @DisplayName("온보딩 답변이 없으면 시딩하지 않는다")
+    void onOnboardingCompleted_noAnswer_skips() {
+        when(onboardingAnswerRepository.findByUser_Id(userId)).thenReturn(Optional.empty());
+
+        seeder.onOnboardingCompleted(new OnboardingCompletedEvent(userId));
+
+        verify(userSelfModelRepository, never()).save(any());
+        verify(userMemoryPreferenceRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("UserSelfModel이 없으면 selfModel 시딩을 건너뛴다")
+    void onOnboardingCompleted_noSelfModel_skipsOnlySelfModel() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test")
+                .privacyConsent(true)
+                .build();
+        UserOnboardingAnswer answer = UserOnboardingAnswer.builder()
+                .user(user)
+                .emotionState("calm")
+                .concernTypes(List.of())
+                .preferredStyle("analytical")
+                .build();
+        UserMemoryPreference preference = UserMemoryPreference.builder().userId(userId).build();
+
+        when(onboardingAnswerRepository.findByUser_Id(userId)).thenReturn(Optional.of(answer));
+        when(userSelfModelRepository.findById(userId)).thenReturn(Optional.empty());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(preference));
+        when(userMemoryPreferenceRepository.save(any())).thenAnswer(i -> i.getArgument(0));
+
+        seeder.onOnboardingCompleted(new OnboardingCompletedEvent(userId));
+
+        verify(userSelfModelRepository, never()).save(any());
+        verify(userMemoryPreferenceRepository).save(any());
+    }
+}

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -6,6 +6,7 @@ import com.mio.onboarding.dto.*;
 import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.domain.UserOnboardingAnswer;
+import com.mio.onboarding.event.OnboardingCompletedEvent;
 import com.mio.user.repository.UserOnboardingAnswerRepository;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.util.List;
 import java.util.Optional;
@@ -29,6 +31,7 @@ class OnboardingServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private UserOnboardingAnswerRepository onboardingAnswerRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     private OnboardingService onboardingService;
     private UUID userId;
@@ -37,7 +40,7 @@ class OnboardingServiceTest {
     @BeforeEach
     void setUp() {
         CharacterRecommender recommender = new CharacterRecommender();
-        onboardingService = new OnboardingService(userRepository, onboardingAnswerRepository, recommender);
+        onboardingService = new OnboardingService(userRepository, onboardingAnswerRepository, recommender, eventPublisher);
         userId = UUID.randomUUID();
         mockUser = User.builder()
                 .socialProvider("kakao")


### PR DESCRIPTION
## Summary

- 온보딩 캐릭터 선택(`selectCharacter`) 완료 시 `OnboardingCompletedEvent` 발행
- `OnboardingMemorySeeder`가 `@Async @TransactionalEventListener(AFTER_COMMIT) @Transactional(REQUIRES_NEW)` 패턴으로 AI 메모리 초기값을 비동기 시딩
- `UserSelfModel.seedFromOnboarding()`: version=1이고 필드가 비어있을 때만 `dominantEmotions`, `recurringTriggerTags` 채움
- `UserMemoryPreference.seedPreferredTone()`: `preferredTone`이 null일 때만 온보딩 `preferredStyle` 반영

## Test plan

- [ ] `UserSelfModelTest`: version=1 시딩, version≥2 무시, 기존 값 보호 (4개 케이스)
- [ ] `UserMemoryPreferenceTest`: null 시딩, 기존 값 보호, null 전달 (3개 케이스)
- [ ] `OnboardingMemorySeederTest`: 정상 저장, 답변 없을 때 스킵, 기존 모델 업데이트, 예외 전파 안 함 (4개 케이스)
- [ ] `OnboardingServiceTest`: `selectCharacter` 성공 시 이벤트 발행 검증

Closes #166

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Onboarding completion now triggers automatic capture into the user profile, seeding preferred communication tone, dominant emotions, and recurring trigger tags when appropriate.

* **Tests**
  * Added and expanded JUnit coverage for tone initialization, onboarding-based self-model seeding, and end-to-end seeding behavior (including cases where data is missing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->