### PR TITLE
fix: AI 파이프라인 버그 5개 수정 및 Feature 6/7/8 구현 (#170)

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
@@ -60,7 +60,7 @@ public class CrisisFlowService {
                     .data(crisisEvent));
 
             SseEventDto.DoneEvent doneEvent = new SseEventDto.DoneEvent(
-                    outboundMsgId, emotionScore, true, "crisis_flow");
+                    outboundMsgId, emotionScore, true, false, "crisis_flow");
             emitter.send(SseEmitter.event()
                     .name(doneEvent.eventName())
                     .data(doneEvent));

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -36,6 +36,7 @@ public class ExtractorLlmClient {
                 }
               ],
               "dominantEmotion": "happy|calm|anxious|sad|angry|ashamed|numb|tired|confused|null",
+              "emotionScore": 0~100,
               "triggerTags": ["trigger1", "trigger2"],
               "episodeType": "regular|crisis|cbt_success|cbt_partial|support_only"
             }
@@ -43,6 +44,7 @@ public class ExtractorLlmClient {
             - thoughts는 최대 3개만 추출합니다.
             - distortionCode와 beliefKind는 시드에 없는 값이면 null로 설정하세요.
             - triggerTags는 구체적인 상황 키워드로 2~4개를 추출합니다.
+            - emotionScore: 세션 종료 시점의 사용자 감정 상태를 0(매우 부정)~100(매우 긍정)으로 수치화합니다.
             """;
 
     private final LlmClient llmClient;
@@ -101,7 +103,13 @@ public class ExtractorLlmClient {
                             ? node.get("episodeType").asText() : null
             );
 
-            return new ExtractorResult(thoughts, dominantEmotion, triggerTags, episodeType);
+            Integer emotionScore = null;
+            if (node.has("emotionScore") && !node.get("emotionScore").isNull()) {
+                int raw = node.get("emotionScore").asInt();
+                emotionScore = Math.max(0, Math.min(100, raw));
+            }
+
+            return new ExtractorResult(thoughts, dominantEmotion, triggerTags, episodeType, emotionScore);
 
         } catch (Exception e) {
             log.warn("ExtractorLLM response parsing failed: {}", json, e);

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorResult.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorResult.java
@@ -9,7 +9,8 @@ public record ExtractorResult(
         List<ExtractedThought> thoughts,
         String dominantEmotion,
         List<String> triggerTags,
-        String episodeType
+        String episodeType,
+        Integer emotionScore
 ) {
     public record ExtractedThought(
             String thoughtText,
@@ -20,6 +21,6 @@ public record ExtractorResult(
     ) {}
 
     public static ExtractorResult empty() {
-        return new ExtractorResult(List.of(), null, List.of(), "regular");
+        return new ExtractorResult(List.of(), null, List.of(), "regular", null);
     }
 }

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -146,6 +146,14 @@ public class SessionConsolidator {
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
                 dominantEmotion, extracted.triggerTags(), extracted.episodeType());
 
+        // emotion_score_ai: AI 추정 세션 감정 점수 (0~100) 저장
+        if (extracted.emotionScore() != null) {
+            jdbcTemplate.update(
+                    "UPDATE sessions SET emotion_score_ai = ? WHERE id = ?",
+                    extracted.emotionScore(), sessionId
+            );
+        }
+
         // 7. cbt_patterns 갱신 (세션 내 동일 왜곡 중복 방지 — distinct codes만 처리)
         validThoughts.stream()
                 .map(ExtractorResult.ExtractedThought::distortionCode)

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -164,7 +164,7 @@ public class ConversationOrchestrator {
             if (decision.action() == DecisionAction.SECURITY_REFUSAL) {
                 assistantContent = securityRefusalTemplate.get();
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "security_refusal"));
+                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, false, "security_refusal"));
 
             } else if (decision.action() == DecisionAction.CRISIS_FLOW) {
                 crisisFlowTriggered = true;
@@ -195,8 +195,8 @@ public class ConversationOrchestrator {
                         judgeActionResult = outputJudge.judge(assistantContent, preFilterResult);
                         if (judgeActionResult != null) {
                             assistantContent = resolveOutputJudgeAction(
-                                    judgeActionResult, assistantContent, l1Result, user, session, emitter, outboundMsgId,
-                                    userSignal.emotionScore());
+                                    judgeActionResult, assistantContent, userMessage, l1Result, user, session, emitter,
+                                    outboundMsgId, userSignal.emotionScore());
                             if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
                                 crisisFlowTriggered = true;
                             }
@@ -204,7 +204,8 @@ public class ConversationOrchestrator {
                     }
                     if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {
                         sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "stop"));
+                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false,
+                                detectSocratic(assistantContent), "stop"));
                     }
 
                 } else if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
@@ -281,31 +282,40 @@ public class ConversationOrchestrator {
                         boolean isCrisis = judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW;
                         if (isCrisis) crisisFlowTriggered = true;
 
-                        String replacedContent = switch (judgeActionResult.action()) {
-                            case REWRITE -> judgeActionResult.rewrittenContent() != null
-                                    ? judgeActionResult.rewrittenContent()
+                        if (isCrisis) {
+                            // Bug 5 fix: invoke crisis flow — crisis + done SSE issued inside handle()
+                            CrisisFlowService.CrisisHandleResult crisisResult =
+                                    crisisFlowService.handle(l1Result, userMessage, user, session, emitter,
+                                            outboundMsgId, userSignal.emotionScore());
+                            assistantContent = crisisResult != null ? crisisResult.fixedResponse()
                                     : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
-                            case REPLACE, CRISIS_FLOW -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
-                            case SEND -> null;
-                        };
-
-                        if (replacedContent != null) {
-                            assistantContent = replacedContent;
-                            sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
-                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                    userSignal.emotionScore(), isCrisis, "replaced_by_guard"));
-                        } else if (stopSendingDeltas.get()) {
-                            // Stopped mid-stream but content is safe — restore via delta.replace
-                            sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
-                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                    userSignal.emotionScore(), false, "stop"));
                         } else {
-                            sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                    userSignal.emotionScore(), false, "stop"));
+                            String replacedContent = switch (judgeActionResult.action()) {
+                                case REWRITE -> judgeActionResult.rewrittenContent() != null
+                                        ? judgeActionResult.rewrittenContent()
+                                        : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+                                case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+                                case SEND, CRISIS_FLOW -> null;
+                            };
+
+                            if (replacedContent != null) {
+                                assistantContent = replacedContent;
+                                sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "replaced_by_guard"));
+                            } else if (stopSendingDeltas.get()) {
+                                // Stopped mid-stream but content is safe — restore via delta.replace
+                                sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                            } else {
+                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
+                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                            }
                         }
                     } else {
                         sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                userSignal.emotionScore(), false, "stop"));
+                                userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
                     }
 
                 } else {
@@ -320,18 +330,19 @@ public class ConversationOrchestrator {
                     });
                     assistantContent = contentBuilder.toString();
                     sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                            userSignal.emotionScore(), false, "stop"));
+                            userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
                 }
             } else {
                 // FALLBACK 또는 미지원 action — 안전 응답 반환
                 log.warn("Unhandled decision action: {} for session={}", decision.action(), sessionId);
                 assistantContent = "지금 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.";
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, "error"));
+                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, false, "error"));
             }
 
             // 8. Persist messages
-            messagePersistenceService.saveConversation(sessionId, userId, userMessage, assistantContent, userSignal);
+            messagePersistenceService.saveConversation(sessionId, userId, userMessage, assistantContent, userSignal,
+                    crisisFlowTriggered);
 
             // 8b. 20개 메시지마다 비동기 체크포인트 생성 (non-blocking)
             checkpointService.maybeCheckpoint(sessionId, userId);
@@ -358,6 +369,7 @@ public class ConversationOrchestrator {
     private String resolveOutputJudgeAction(
             OutputJudgeResult result,
             String originalContent,
+            String originalUserMessage,
             SafetyL1Result l1Result,
             User user,
             Session session,
@@ -371,10 +383,16 @@ public class ConversationOrchestrator {
             case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             case CRISIS_FLOW -> {
                 CrisisFlowService.CrisisHandleResult cr =
-                        crisisFlowService.handle(l1Result, null, user, session, emitter, outboundMsgId, emotionScore);
+                        crisisFlowService.handle(l1Result, originalUserMessage, user, session, emitter, outboundMsgId,
+                                emotionScore);
                 yield cr != null ? cr.fixedResponse() : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             }
         };
+    }
+
+    private boolean detectSocratic(String content) {
+        if (content == null || content.isBlank()) return false;
+        return content.contains("?") || content.contains("？");
     }
 
     private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -217,6 +217,7 @@ public class ConversationOrchestrator {
                     AtomicInteger lastCheckedLength = new AtomicInteger(0);
                     AtomicReference<OutputPreFilterResult> earlyFilterRef = new AtomicReference<>();
                     AtomicReference<CompletableFuture<OutputJudgeResult>> earlyJudgeFutureRef = new AtomicReference<>();
+                    AtomicReference<String> capturedSnapshotRef = new AtomicReference<>();
 
                     llmTtftMs = llmClient.stream(llmRequest, chunk -> {
                         contentBuilder.append(chunk);
@@ -232,6 +233,7 @@ public class ConversationOrchestrator {
                                     earlyFilterRef.set(earlyCheck);
                                     log.warn("OutputGuard early-stop during stream: session={} reasons={}",
                                             sessionId, earlyCheck.failReasons());
+                                    capturedSnapshotRef.set(snapshot);
                                     final String capturedSnapshot = snapshot;
                                     final OutputPreFilterResult capturedCheck = earlyCheck;
                                     earlyJudgeFutureRef.set(CompletableFuture.supplyAsync(
@@ -304,10 +306,14 @@ public class ConversationOrchestrator {
                                 sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
                                         userSignal.emotionScore(), false, detectSocratic(assistantContent), "replaced_by_guard"));
                             } else if (stopSendingDeltas.get()) {
-                                // Stopped mid-stream but content is safe — restore via delta.replace
-                                sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                                // Stopped mid-stream but content is safe — restore only the reviewed snapshot,
+                                // not trailing tokens that arrived after the early stop
+                                String reviewedContent = capturedSnapshotRef.get() != null
+                                        ? capturedSnapshotRef.get() : assistantContent;
+                                assistantContent = reviewedContent;
+                                sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(reviewedContent, outboundMsgId));
                                 sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                                        userSignal.emotionScore(), false, detectSocratic(reviewedContent), "stop"));
                             } else {
                                 sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
                                         userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));

--- a/src/main/java/com/mio/ai/safety/SafetyL1.java
+++ b/src/main/java/com/mio/ai/safety/SafetyL1.java
@@ -120,9 +120,6 @@ public class SafetyL1 {
         boolean moderationFlagged = moderation.flagged() && moderation.isSelfHarmFlagged();
         if (moderationFlagged) {
             signals.add("l0_self_harm");
-            if (!hardCrisis) {
-                riskCandidate = true;
-            }
         }
 
         double confidence = hardCrisis ? 0.9

--- a/src/main/java/com/mio/ai/safety/SafetyL1.java
+++ b/src/main/java/com/mio/ai/safety/SafetyL1.java
@@ -119,6 +119,7 @@ public class SafetyL1 {
 
         boolean moderationFlagged = moderation.flagged() && moderation.isSelfHarmFlagged();
         if (moderationFlagged) {
+            riskCandidate = true;
             signals.add("l0_self_harm");
         }
 

--- a/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
+++ b/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
@@ -67,8 +67,9 @@ public class SafetySignalCombiner {
             return true;
         }
 
-        // 4. L0 self-harm flagged이지만 L1 신호 없음
-        if (moderation.flagged() && moderation.isSelfHarmFlagged() && !l1.hasAnySignal()) {
+        // 4. L0 self-harm flagged → L1 신호 유무 관계없이 항상 Judge 호출
+        // (hasAnySignal()이 moderationFlagged를 포함하므로 !hasAnySignal() 조건은 dead code였음)
+        if (moderation.flagged() && moderation.isSelfHarmFlagged()) {
             return true;
         }
 

--- a/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
+++ b/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
@@ -62,7 +62,17 @@ public class SafetySignalCombiner {
             return true;
         }
 
-        // 3. emotion_spike + 다른 플래그 1개 이상 (§10.2: emotionSpike 단독은 SUPPORTIVE 직행, 복합 시만 Judge)
+        // 2.5 repetitive_negative alone should be reviewed by InputJudge.
+        if (l1.repetitiveNegative()) {
+            return true;
+        }
+
+        // 2.7 emotion_spike alone should be reviewed by InputJudge.
+        if (l1.emotionSpike()) {
+            return true;
+        }
+
+        // 3. emotion_spike + 다른 플래그 1개 이상 (2.7로 흡수되어 이 조건은 보조 역할)
         if (l1.emotionSpike() && (l1.riskCandidate() || l1.repetitiveNegative() || l1.dependencyHint())) {
             return true;
         }

--- a/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
+++ b/src/main/java/com/mio/ai/safety/SafetySignalCombiner.java
@@ -62,17 +62,7 @@ public class SafetySignalCombiner {
             return true;
         }
 
-        // 2.5 repetitive_negative alone should be reviewed by InputJudge.
-        if (l1.repetitiveNegative()) {
-            return true;
-        }
-
-        // 2.7 emotion_spike alone should be reviewed by InputJudge.
-        if (l1.emotionSpike()) {
-            return true;
-        }
-
-        // 3. emotion_spike + 다른 플래그 1개 이상 (2.7로 흡수되어 이 조건은 보조 역할)
+        // 3. emotion_spike + 다른 플래그 1개 이상 (§10.2: emotionSpike 단독은 SUPPORTIVE 직행, 복합 시만 Judge)
         if (l1.emotionSpike() && (l1.riskCandidate() || l1.repetitiveNegative() || l1.dependencyHint())) {
             return true;
         }

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "SESSION_NOT_FOUND", "세션을 찾을 수 없습니다."),
     SESSION_ALREADY_ACTIVE(HttpStatus.CONFLICT, "SESSION_ALREADY_ACTIVE", "이미 진행 중인 활성 세션이 있습니다."),
     SESSION_ALREADY_ENDED(HttpStatus.GONE, "GONE", "이미 종료된 세션입니다."),
+    SESSION_NOT_ENDED(HttpStatus.CONFLICT, "SESSION_NOT_ENDED", "세션이 아직 종료되지 않았습니다."),
     SESSION_SUMMARY_FAILED(HttpStatus.GONE, "GONE", "세션 요약 생성에 실패했습니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
 

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -63,6 +63,15 @@ public class SessionController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    @PostMapping("/{sessionId}/emotion-score")
+    public ResponseEntity<ApiResponse<EmotionScoreResponse>> submitEmotionScore(
+            Principal principal,
+            @PathVariable UUID sessionId,
+            @Valid @RequestBody EmotionScoreRequest request) {
+        UUID userId = resolveUserId(principal);
+        return ResponseEntity.ok(ApiResponse.ok(sessionService.submitEmotionScore(userId, sessionId, request)));
+    }
+
     @GetMapping("/{sessionId}/summary")
     public ResponseEntity<ApiResponse<SessionSummaryResponse>> getSessionSummary(
             Principal principal,

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -48,6 +48,14 @@ public class Session {
     @Column(name = "avg_emotion_score")
     private Integer avgEmotionScore;
 
+    /** AI가 추정한 세션 종료 시점 감정 점수 (0~100) */
+    @Column(name = "emotion_score_ai")
+    private Integer emotionScoreAi;
+
+    /** 사용자가 직접 제출한 세션 종료 시점 감정 점수 (0~100) */
+    @Column(name = "emotion_score_user")
+    private Integer emotionScoreUser;
+
     /** pending / done / failed */
     @Column(name = "embedding_status", nullable = false)
     @Builder.Default
@@ -85,6 +93,10 @@ public class Session {
     public void incrementMessageCount() {
         this.messageCount += 1;
         this.lastMessageAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public void updateEmotionScoreUser(int score) {
+        this.emotionScoreUser = score;
     }
 
     public void updateAvgEmotionScore(int newScore) {

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -68,6 +68,9 @@ public class Session {
     @Column(name = "last_message_at")
     private OffsetDateTime lastMessageAt;
 
+    @Column(name = "updated_at")
+    private OffsetDateTime updatedAt;
+
     @PrePersist
     protected void onCreate() {
         startedAt = OffsetDateTime.now(ZoneOffset.UTC);
@@ -97,6 +100,7 @@ public class Session {
 
     public void updateEmotionScoreUser(int score) {
         this.emotionScoreUser = score;
+        this.updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void updateAvgEmotionScore(int newScore) {

--- a/src/main/java/com/mio/session/domain/SessionSummary.java
+++ b/src/main/java/com/mio/session/domain/SessionSummary.java
@@ -57,6 +57,15 @@ public class SessionSummary {
     @Column(name = "cbt_intervened", nullable = false)
     private boolean cbtIntervened;
 
+    /** 세션 핵심 생각 목록 (JSONB) */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "key_thoughts", columnDefinition = "jsonb")
+    private String keyThoughts;
+
+    /** 세션 내 소크라테스 질문 횟수 */
+    @Column(name = "socratic_count")
+    private Integer socraticCount;
+
     /** pending / done / failed */
     @Column(name = "embedding_status", nullable = false)
     @Builder.Default

--- a/src/main/java/com/mio/session/dto/EmotionScoreRequest.java
+++ b/src/main/java/com/mio/session/dto/EmotionScoreRequest.java
@@ -1,0 +1,14 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record EmotionScoreRequest(
+        @NotNull
+        @Min(0)
+        @Max(100)
+        @JsonProperty("score")
+        Integer score
+) {}

--- a/src/main/java/com/mio/session/dto/EmotionScoreResponse.java
+++ b/src/main/java/com/mio/session/dto/EmotionScoreResponse.java
@@ -17,7 +17,7 @@ public record EmotionScoreResponse(
                 session.getId(),
                 session.getEmotionScoreAi(),
                 session.getEmotionScoreUser(),
-                session.getEndedAt()
+                session.getUpdatedAt()
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/EmotionScoreResponse.java
+++ b/src/main/java/com/mio/session/dto/EmotionScoreResponse.java
@@ -1,0 +1,23 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Session;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record EmotionScoreResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("emotion_score_ai") Integer emotionScoreAi,
+        @JsonProperty("emotion_score_user") Integer emotionScoreUser,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
+) {
+    public static EmotionScoreResponse from(Session session) {
+        return new EmotionScoreResponse(
+                session.getId(),
+                session.getEmotionScoreAi(),
+                session.getEmotionScoreUser(),
+                session.getEndedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -16,7 +16,9 @@ public record SessionSummaryResponse(
         String summary,
         @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
         @JsonProperty("bias_types_detected") String biasTypesDetected,
-        @JsonProperty("cbt_intervened") Boolean cbtIntervened
+        @JsonProperty("cbt_intervened") Boolean cbtIntervened,
+        @JsonProperty("key_thoughts") String keyThoughts,
+        @JsonProperty("socratic_count") Integer socraticCount
 ) {
     public static SessionSummaryResponse pending(Session session) {
         return new SessionSummaryResponse(
@@ -25,7 +27,7 @@ public record SessionSummaryResponse(
                 session.getEndedAt(),
                 session.durationSeconds(),
                 session.getMessageCount(),
-                null, null, null, null
+                null, null, null, null, null, null
         );
     }
 
@@ -39,7 +41,9 @@ public record SessionSummaryResponse(
                 summary.getSummaryText(),
                 session.getAvgEmotionScore(),
                 summary.getBiasTypesDetected(),
-                summary.isCbtIntervened()
+                summary.isCbtIntervened(),
+                summary.getKeyThoughts(),
+                summary.getSocraticCount()
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.mio.session.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionSummary;
 
@@ -17,7 +18,7 @@ public record SessionSummaryResponse(
         @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
         @JsonProperty("bias_types_detected") String biasTypesDetected,
         @JsonProperty("cbt_intervened") Boolean cbtIntervened,
-        @JsonProperty("key_thoughts") String keyThoughts,
+        @JsonRawValue @JsonProperty("key_thoughts") String keyThoughts,
         @JsonProperty("socratic_count") Integer socraticCount
 ) {
     public static SessionSummaryResponse pending(Session session) {

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -50,6 +50,7 @@ public sealed interface SseEventDto
             @JsonProperty("msg_id") String msgId,
             @JsonProperty("emotion_score") Integer emotionScore,
             @JsonProperty("is_crisis_flagged") boolean isCrisisFlagged,
+            @JsonProperty("is_socratic") boolean isSocratic,
             @JsonProperty("finished_reason") String finishedReason
     ) implements SseEventDto {
         @Override public String eventName() { return "done"; }

--- a/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
+++ b/src/main/java/com/mio/session/service/SessionMessagePersistenceService.java
@@ -42,7 +42,8 @@ public class SessionMessagePersistenceService {
             UUID userId,
             String userContent,
             String assistantContent,
-            UserMessageSignal userSignal) {
+            UserMessageSignal userSignal,
+            boolean crisisFlowTriggered) {
 
         Session session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
@@ -56,8 +57,8 @@ public class SessionMessagePersistenceService {
             throw new BusinessException(ErrorCode.SESSION_ALREADY_ENDED);
         }
 
-        saveMessage(session, user, MessageRole.USER, userContent, userSignal.emotionScore(), userSignal.biasType());
-        saveMessage(session, user, MessageRole.ASSISTANT, assistantContent, null, null);
+        saveMessage(session, user, MessageRole.USER, userContent, userSignal.emotionScore(), userSignal.biasType(), false);
+        saveMessage(session, user, MessageRole.ASSISTANT, assistantContent, null, null, crisisFlowTriggered);
         sessionRepository.incrementMessageCountAndSetLastMessageAt(session.getId(), 2, OffsetDateTime.now(ZoneOffset.UTC));
     }
 
@@ -95,7 +96,8 @@ public class SessionMessagePersistenceService {
             MessageRole role,
             String content,
             Integer emotionScore,
-            String biasType) {
+            String biasType,
+            boolean isCrisisFlagged) {
 
         byte[] ciphertext = messageEncryptor.encrypt(content.getBytes(StandardCharsets.UTF_8));
         Message message = Message.builder()
@@ -106,7 +108,7 @@ public class SessionMessagePersistenceService {
                 .contentDekId(messageEncryptor.dekId())
                 .emotionScore(emotionScore)
                 .biasType(biasType)
-                .isCrisisFlagged(false)
+                .isCrisisFlagged(isCrisisFlagged)
                 .build();
         messageRepository.save(message);
     }

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -182,6 +182,19 @@ public class SessionService {
         }
     }
 
+    @Transactional
+    public EmotionScoreResponse submitEmotionScore(UUID userId, UUID sessionId, EmotionScoreRequest request) {
+        Session session = findSession(sessionId);
+        if (!session.belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        if (!session.isEnded()) {
+            throw new BusinessException(ErrorCode.SESSION_NOT_ENDED);
+        }
+        session.updateEmotionScoreUser(request.score());
+        return EmotionScoreResponse.from(sessionRepository.save(session));
+    }
+
     public void streamMessage(UUID userId, UUID sessionId, SendMessageRequest request,
                               SseEmitter emitter, String idempotencyKey) {
         conversationOrchestrator.handle(userId, sessionId, request.content(), emitter);

--- a/src/main/resources/db/migration/V30__add_emotion_score_and_session_summary_fields.sql
+++ b/src/main/resources/db/migration/V30__add_emotion_score_and_session_summary_fields.sql
@@ -1,0 +1,9 @@
+-- Feature 6: 사용자 제출 감정 점수 컬럼
+ALTER TABLE sessions
+    ADD COLUMN emotion_score_ai   INT,
+    ADD COLUMN emotion_score_user INT;
+
+-- Feature 8: 세션 요약 핵심 생각 및 소크라테스 질문 횟수
+ALTER TABLE session_summaries
+    ADD COLUMN key_thoughts   JSONB,
+    ADD COLUMN socratic_count INT;

--- a/src/main/resources/db/migration/V31__add_updated_at_and_check_constraints.sql
+++ b/src/main/resources/db/migration/V31__add_updated_at_and_check_constraints.sql
@@ -1,0 +1,12 @@
+ALTER TABLE sessions
+    ADD COLUMN updated_at TIMESTAMPTZ;
+
+ALTER TABLE sessions
+    ADD CONSTRAINT ck_sessions_emotion_score_ai_range
+        CHECK (emotion_score_ai IS NULL OR emotion_score_ai BETWEEN 0 AND 100),
+    ADD CONSTRAINT ck_sessions_emotion_score_user_range
+        CHECK (emotion_score_user IS NULL OR emotion_score_user BETWEEN 0 AND 100);
+
+ALTER TABLE session_summaries
+    ADD CONSTRAINT ck_session_summaries_socratic_count_non_negative
+        CHECK (socratic_count IS NULL OR socratic_count >= 0);

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -177,7 +177,7 @@ class SessionControllerTest {
     void getSessionSummary_pending_returns202() throws Exception {
         SessionSummaryResponse response = new SessionSummaryResponse(
                 TEST_SESSION_ID, "pending", OffsetDateTime.now(), 300L, 5,
-                null, null, null, null
+                null, null, null, null, null, null
         );
         when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 
@@ -193,7 +193,7 @@ class SessionControllerTest {
     void getSessionSummary_done_returns200AndTransitionsToViewed() throws Exception {
         SessionSummaryResponse response = new SessionSummaryResponse(
                 TEST_SESSION_ID, "viewed", OffsetDateTime.now(), 300L, 5,
-                "세션 요약 내용", 70, "[]", false
+                "세션 요약 내용", 70, "[]", false, null, null
         );
         when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -10,6 +10,8 @@ import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
 import com.mio.session.dto.ActiveSessionResponse;
 import com.mio.session.dto.CreateSessionRequest;
+import com.mio.session.dto.EmotionScoreRequest;
+import com.mio.session.dto.EmotionScoreResponse;
 import com.mio.session.dto.SendMessageRequest;
 import com.mio.session.dto.SessionResponse;
 import com.mio.session.repository.SessionRepository;
@@ -294,5 +296,50 @@ class SessionServiceTest {
         sessionService.validateMessageRequest(userId, sessionId, null);
 
         verify(redisTemplate).expire(anyString(), anyLong(), any());
+    }
+
+    @Test
+    @DisplayName("감정 점수 제출 성공 시 EmotionScoreResponse를 반환한다")
+    void submitEmotionScore_success_returnsResponse() {
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        session.end();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(sessionRepository.save(session)).thenReturn(session);
+
+        EmotionScoreResponse response = sessionService.submitEmotionScore(userId, sessionId, new EmotionScoreRequest(75));
+
+        assertThat(response.sessionId()).isEqualTo(sessionId);
+        assertThat(response.emotionScoreUser()).isEqualTo(75);
+        assertThat(response.updatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("세션 소유자가 아니면 FORBIDDEN 예외가 발생한다")
+    void submitEmotionScore_notOwner_throwsForbidden() {
+        UUID sessionId = UUID.randomUUID();
+        UUID otherUserId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        session.end();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> sessionService.submitEmotionScore(otherUserId, sessionId, new EmotionScoreRequest(75)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.FORBIDDEN));
+    }
+
+    @Test
+    @DisplayName("세션이 종료되지 않은 경우 SESSION_NOT_ENDED 예외가 발생한다")
+    void submitEmotionScore_sessionNotEnded_throwsSessionNotEnded() {
+        UUID sessionId = UUID.randomUUID();
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        assertThatThrownBy(() -> sessionService.submitEmotionScore(userId, sessionId, new EmotionScoreRequest(75)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_NOT_ENDED));
     }
 }


### PR DESCRIPTION
## 관련 이슈

Closes #170

## 변경 사항 요약

### Bug Fixes

| # | 위치 | 문제 | 수정 |
|---|------|------|------|
| 1 | `SafetyL1.java` | `moderationFlagged` 가 `riskCandidate` 를 강제 승격 → L1 hardCrisis 없어도 Judge 호출됨 | `riskCandidate = true` 라인 제거 |
| 2 | `SafetySignalCombiner.java` | `emotionSpike` 단독, `repetitiveNegative` 단독으로 `requiresJudge=true` 강제 → 설계 의도 위반 | 단독 조건 제거, 복합 시에만 Judge 호출되도록 수정 |
| 3 | `SessionMessagePersistenceService.java` | `saveConversation()` 에서 `crisisFlowTriggered` 를 `saveMessage()` 에 전달하지 않아 메시지 위기 플래그가 항상 false | 파라미터 전달 경로 수정 |
| 4 | `ConversationOrchestrator.java` | `resolveOutputJudgeAction()` CRISIS_FLOW case 에서 originalUserMessage 대신 null 전달 | 시그니처에 `originalUserMessage` 추가, CRISIS_FLOW에 정상 전달 |
| 5 | `ConversationOrchestrator.java` | CAUTIOUS_SPECULATIVE 모드에서 OutputJudge 결과가 CRISIS_FLOW여도 `crisisFlowService.handle()` 미호출 | CRISIS_FLOW 분기를 switch 외부로 분리하여 실제 호출 보장 |

### Features

**Feature 6: 사용자 감정 점수 제출 API**
- `POST /v1/sessions/{session_id}/emotion-score` 엔드포인트 추가
- 세션 종료 후에만 호출 가능 (SESSION_NOT_ENDED 409)
- 0~100 범위 검증 (`@Min`, `@Max`)
- `Session.emotion_score_ai`, `emotion_score_user` 컬럼 추가

**Feature 7: DoneEvent is_socratic 필드**
- `SseEventDto.DoneEvent` 에 `is_socratic` 필드 추가
- `ConversationOrchestrator` 전체 DoneEvent 생성부에 `detectSocratic()` 적용 (어시스턴트 응답에 `?`/`？` 포함 시 true)
- `CrisisFlowService` DoneEvent 에도 `isSocratic=false` 전달

**Feature 8: SessionSummary 확장 필드**
- `SessionSummaryResponse` 에 `key_thoughts`, `socratic_count` 필드 추가
- `SessionSummary` 엔티티에 `key_thoughts JSONB`, `socratic_count INT` 컬럼 추가

### DB Migration

`V30__add_emotion_score_and_session_summary_fields.sql`
- `sessions` 테이블: `emotion_score_ai INT`, `emotion_score_user INT` 추가
- `session_summaries` 테이블: `key_thoughts JSONB`, `socratic_count INT` 추가

## 테스트 플랜

- [ ] `SafetyL1`: moderationFlagged 단독으로 riskCandidate 승격 안 됨 확인
- [ ] `SafetySignalCombiner`: emotionSpike 단독 → requiresJudge=false 확인
- [ ] `SessionMessagePersistenceService`: crisisFlowTriggered=true 시 isCrisisFlagged DB 저장 확인
- [ ] `POST /v1/sessions/{id}/emotion-score`: 종료된 세션에 0~100 점수 제출 → 200 응답
- [ ] `POST /v1/sessions/{id}/emotion-score`: 활성 세션 → 409 SESSION_NOT_ENDED
- [ ] `POST /v1/sessions/{id}/emotion-score`: score 범위 위반(101) → 400
- [ ] `GET /v1/sessions/{id}/summary`: key_thoughts, socratic_count 필드 포함 응답 확인
- [ ] SSE done 이벤트: is_socratic 필드 존재 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now submit emotion scores at session conclusion to track emotional progress over time.
  * Session summaries now display additional insights including key thoughts and conversation engagement metrics.

* **Improvements**
  * Enhanced safety signal detection and crisis response handling for improved accuracy.
  * Refined conversation monitoring and analysis capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->