### PR TITLE
fix: nginx proxy_buffering으로 인한 SSE 스트림 지연 전달 수정

### DIFF
--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -41,10 +42,13 @@ public class SessionController {
 
     @PostMapping(value = "/{sessionId}/messages", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter sendMessage(
+            HttpServletResponse response,
             Principal principal,
             @PathVariable UUID sessionId,
             @RequestHeader(value = "Idempotency-Key", required = false) String idempotencyKey,
             @Valid @RequestBody SendMessageRequest request) {
+        response.setHeader("X-Accel-Buffering", "no");
+        response.setHeader("Cache-Control", "no-cache");
         UUID userId = resolveUserId(principal);
         sessionService.validateMessageRequest(userId, sessionId, idempotencyKey);
         SseEmitter emitter = new SseEmitter(60_000L);


### PR DESCRIPTION
## Summary

- `POST /v1/sessions/{id}/messages` SSE 엔드포인트 응답에 `X-Accel-Buffering: no` 헤더 추가
- `Cache-Control: no-cache` 헤더 추가
- nginx config 변경 없이 per-response 단위로 버퍼링 비활성화

## 문제

nginx `proxy_buffering on`(기본값)이 Spring Boot SSE chunked 스트림 전체를 버퍼링한 뒤 단일 `Identity` 응답으로 재포장하여 클라이언트에 전달.

**증상 (프론트 측정)**
- `transfer-encoding: Identity` (chunked 아님)
- `reader.read()` 요청당 2회 (delta 30+ 개가 단일 ~2KB 청크로 수신)
- TTFB = LLM 전체 생성 시간(~2초)

## 수정

`X-Accel-Buffering: no` — nginx는 upstream 응답에 이 헤더가 있으면 해당 응답에 한해 `proxy_buffering`을 자동 비활성화.

## Test plan

- [ ] 배포 후 `transfer-encoding: chunked` 확인
- [ ] `reader.read()` 호출 횟수가 delta 이벤트 수와 일치하는지 확인 (기존 2회 → 30+)
- [ ] TTFB 대폭 감소 확인 (첫 delta ~100ms 이내)

Closes #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time message delivery by preventing proxy buffering and caching issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->