### PR TITLE
feat: CBT 개입 완료 후 감정 점수 입력 흐름 구현

### DIFF
--- a/src/main/java/com/mio/ai/judge/CbtInterventionState.java
+++ b/src/main/java/com/mio/ai/judge/CbtInterventionState.java
@@ -1,0 +1,33 @@
+package com.mio.ai.judge;
+
+import java.util.Locale;
+
+public enum CbtInterventionState {
+    NONE("none"),
+    SOCRATIC_ASKED("socratic_asked"),
+    FOLLOWUP_NEEDED("followup_needed"),
+    COMPLETED("completed");
+
+    private final String wireValue;
+
+    CbtInterventionState(String wireValue) {
+        this.wireValue = wireValue;
+    }
+
+    public String wireValue() {
+        return wireValue;
+    }
+
+    public static CbtInterventionState fromWireValue(String value) {
+        if (value == null || value.isBlank()) {
+            return NONE;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        for (CbtInterventionState state : values()) {
+            if (state.wireValue.equals(normalized)) {
+                return state;
+            }
+        }
+        return NONE;
+    }
+}

--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -115,7 +115,7 @@ public class CbtMetadataClassifier {
     }
 
     private CbtMetadataResult parse(String json, UserMessageSignal userSignal) throws Exception {
-        JsonNode root = objectMapper.readTree(json);
+        JsonNode root = objectMapper.readTree(sanitizeJson(json));
         CbtInterventionState state = CbtInterventionState.fromWireValue(
                 root.path("cbt_intervention_state").asText("none"));
         String completionReason = textOrNull(root, "completion_reason");
@@ -147,5 +147,17 @@ public class CbtMetadataClassifier {
         }
         String value = node.asText();
         return value == null || value.isBlank() ? null : value;
+    }
+
+    private String sanitizeJson(String json) {
+        if (json == null) {
+            return "{}";
+        }
+        String sanitized = json.trim();
+        if (sanitized.startsWith("```")) {
+            sanitized = sanitized.replaceFirst("^```(?:json)?\\s*", "");
+            sanitized = sanitized.replaceFirst("\\s*```$", "");
+        }
+        return sanitized.trim();
     }
 }

--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -1,0 +1,151 @@
+package com.mio.ai.judge;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.memory.working.WorkingMessage;
+import com.mio.ai.safety.UserMessageSignal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CbtMetadataClassifier {
+
+    private static final String MODEL = "gpt-4o-mini";
+
+    private static final String SYSTEM_PROMPT = """
+            You classify CBT Socratic intervention state for a mental health coaching chat.
+            Return ONLY valid JSON with this exact schema:
+            {
+              "cbt_intervention_state": "none|socratic_asked|followup_needed|completed",
+              "completion_reason": null or "user_reframed_thought|user_declined|max_questions_reached|stabilized|not_applicable",
+              "requires_emotion_score": false,
+              "is_socratic": false,
+              "bias_type": null or "overgeneralization|catastrophizing|mind_reading|all_or_nothing|self_blame|emotional_reasoning",
+              "reconstructed_thought": null or "short user-facing reconstructed thought"
+            }
+
+            Rules:
+            - Do not infer completion from keywords alone. Use the conversation state and semantic meaning.
+            - socratic_asked: assistant asks a Socratic CBT question and waits for the user.
+            - followup_needed: user answered but the answer is not enough to form a reframe; another Socratic question is needed.
+            - completed: user answered the Socratic flow enough to produce a reframe, declined to continue, stabilized, or max questions is reached.
+            - requires_emotion_score is true only when state is completed and this is not a crisis/safety flow.
+            - If completed requires an emotion score, bias_type must be one of the allowed values.
+            - If uncertain, return none with requires_emotion_score=false.
+            """;
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    public CbtMetadataResult classify(
+            String previousState,
+            List<WorkingMessage> recentMessages,
+            String userMessage,
+            String assistantResponse,
+            UserMessageSignal userSignal,
+            int socraticQuestionsUsed,
+            boolean crisisFlowTriggered) {
+
+        if (crisisFlowTriggered || assistantResponse == null || assistantResponse.isBlank()) {
+            return CbtMetadataResult.none();
+        }
+
+        try {
+            LlmRequest request = LlmRequest.of(MODEL, SYSTEM_PROMPT, buildPrompt(
+                    previousState,
+                    recentMessages,
+                    userMessage,
+                    assistantResponse,
+                    userSignal,
+                    socraticQuestionsUsed));
+            String responseJson = llmClient.complete(request);
+            return parse(responseJson, userSignal);
+        } catch (Exception e) {
+            log.warn("CBT metadata classifier failed, defaulting to none: {}", e.getMessage());
+            return CbtMetadataResult.none();
+        }
+    }
+
+    private String buildPrompt(
+            String previousState,
+            List<WorkingMessage> recentMessages,
+            String userMessage,
+            String assistantResponse,
+            UserMessageSignal userSignal,
+            int socraticQuestionsUsed) {
+
+        String lastAssistant = recentMessages.stream()
+                .filter(message -> "assistant".equals(message.role()))
+                .reduce((first, second) -> second)
+                .map(WorkingMessage::content)
+                .orElse("");
+
+        return """
+                [Previous CBT State]
+                %s
+
+                [Last Assistant Message Before Current User Reply]
+                %s
+
+                [Current User Message]
+                %s
+
+                [Current Assistant Response]
+                %s
+
+                [Server Signal]
+                emotion_score=%s
+                bias_type=%s
+                socratic_questions_used=%d
+                """.formatted(
+                previousState == null ? "none" : previousState,
+                lastAssistant,
+                userMessage,
+                assistantResponse,
+                userSignal == null ? null : userSignal.emotionScore(),
+                userSignal == null ? null : userSignal.biasType(),
+                socraticQuestionsUsed);
+    }
+
+    private CbtMetadataResult parse(String json, UserMessageSignal userSignal) throws Exception {
+        JsonNode root = objectMapper.readTree(json);
+        CbtInterventionState state = CbtInterventionState.fromWireValue(
+                root.path("cbt_intervention_state").asText("none"));
+        String completionReason = textOrNull(root, "completion_reason");
+        boolean requiresEmotionScore = root.path("requires_emotion_score").asBoolean(false);
+        boolean isSocratic = root.path("is_socratic").asBoolean(false);
+        String biasType = textOrNull(root, "bias_type");
+        if (!CbtMetadataResult.isAllowedBiasType(biasType) && userSignal != null) {
+            biasType = userSignal.biasType();
+        }
+        if (!CbtMetadataResult.isAllowedBiasType(biasType)) {
+            biasType = null;
+            requiresEmotionScore = false;
+        }
+        String reconstructedThought = textOrNull(root, "reconstructed_thought");
+        return new CbtMetadataResult(
+                state,
+                completionReason,
+                state == CbtInterventionState.COMPLETED && requiresEmotionScore,
+                isSocratic,
+                biasType,
+                reconstructedThought
+        );
+    }
+
+    private String textOrNull(JsonNode root, String fieldName) {
+        JsonNode node = root.path(fieldName);
+        if (node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        String value = node.asText();
+        return value == null || value.isBlank() ? null : value;
+    }
+}

--- a/src/main/java/com/mio/ai/judge/CbtMetadataResult.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataResult.java
@@ -1,0 +1,35 @@
+package com.mio.ai.judge;
+
+import java.util.Set;
+
+public record CbtMetadataResult(
+        CbtInterventionState state,
+        String completionReason,
+        boolean requiresEmotionScore,
+        boolean socratic,
+        String biasType,
+        String reconstructedThought
+) {
+    private static final Set<String> ALLOWED_BIAS_TYPES = Set.of(
+            "overgeneralization",
+            "catastrophizing",
+            "mind_reading",
+            "all_or_nothing",
+            "self_blame",
+            "emotional_reasoning"
+    );
+
+    public static CbtMetadataResult none() {
+        return new CbtMetadataResult(CbtInterventionState.NONE, null, false, false, null, null);
+    }
+
+    public boolean shouldCreateEmotionScoreTarget() {
+        return state == CbtInterventionState.COMPLETED
+                && requiresEmotionScore
+                && isAllowedBiasType(biasType);
+    }
+
+    public static boolean isAllowedBiasType(String biasType) {
+        return biasType != null && ALLOWED_BIAS_TYPES.contains(biasType);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/working/SessionDelta.java
+++ b/src/main/java/com/mio/ai/memory/working/SessionDelta.java
@@ -5,13 +5,14 @@ import java.util.Set;
 
 public record SessionDelta(
         int socraticQuestionsUsed,
+        String cbtInterventionState,
         Map<String, Integer> distortionCounts,
         int sessionRiskAccumulation,
         Set<String> activatedBeliefIds,
         Set<String> currentSessionTriggers
 ) {
     public static SessionDelta empty() {
-        return new SessionDelta(0, Map.of(), 0, Set.of(), Set.of());
+        return new SessionDelta(0, "none", Map.of(), 0, Set.of(), Set.of());
     }
 
     public boolean socraticLimitReached() {

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -21,7 +21,7 @@ import java.util.UUID;
  *
  * 키 구조:
  *   session:{id}:messages  → List (최근 10턴 = 20개, LPUSH 최신 우선)
- *   session:{id}:working   → Hash (socratic_count, distortion:*, risk_accumulation)
+ *   session:{id}:working   → Hash (socratic_count, cbt_intervention_state, distortion:*, risk_accumulation)
  *   session:{id}:beliefs   → Set  (activatedBeliefIds)
  *   session:{id}:triggers  → Set  (currentSessionTriggers)
  */
@@ -38,6 +38,7 @@ public class WorkingMemory {
     private static final String TRIGGERS_KEY  = "session:%s:triggers";
 
     private static final String FIELD_SOCRATIC_COUNT    = "socratic_count";
+    private static final String FIELD_CBT_STATE         = "cbt_intervention_state";
     private static final String FIELD_RISK_ACCUMULATION = "risk_accumulation";
     private static final String FIELD_DISTORTION_PREFIX = "distortion:";
 
@@ -94,6 +95,12 @@ public class WorkingMemory {
         redisTemplate.expire(k, SESSION_TTL);
     }
 
+    public void updateCbtInterventionState(UUID sessionId, String state) {
+        String k = workingKey(sessionId);
+        redisTemplate.opsForHash().put(k, FIELD_CBT_STATE, state == null || state.isBlank() ? "none" : state);
+        redisTemplate.expire(k, SESSION_TTL);
+    }
+
     public int getDistortionCount(UUID sessionId, String distortionCode) {
         String value = (String) redisTemplate.opsForHash()
                 .get(workingKey(sessionId), FIELD_DISTORTION_PREFIX + distortionCode);
@@ -137,6 +144,7 @@ public class WorkingMemory {
 
         int socraticCount = 0;
         int riskAccumulation = 0;
+        String cbtInterventionState = "none";
         Map<String, Integer> distortionCounts = new HashMap<>();
 
         for (Map.Entry<Object, Object> entry : workingEntries.entrySet()) {
@@ -145,6 +153,8 @@ public class WorkingMemory {
 
             if (FIELD_SOCRATIC_COUNT.equals(field)) {
                 socraticCount = parseIntSafe(value);
+            } else if (FIELD_CBT_STATE.equals(field)) {
+                cbtInterventionState = value == null || value.isBlank() ? "none" : value;
             } else if (FIELD_RISK_ACCUMULATION.equals(field)) {
                 riskAccumulation = parseIntSafe(value);
             } else if (field.startsWith(FIELD_DISTORTION_PREFIX)) {
@@ -155,6 +165,7 @@ public class WorkingMemory {
 
         return new SessionDelta(
                 socraticCount,
+                cbtInterventionState,
                 distortionCounts,
                 riskAccumulation,
                 beliefIds != null ? beliefIds : Set.of(),

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -7,6 +7,9 @@ import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
+import com.mio.ai.judge.CbtInterventionState;
+import com.mio.ai.judge.CbtMetadataClassifier;
+import com.mio.ai.judge.CbtMetadataResult;
 import com.mio.ai.judge.InputJudgeResult;
 import com.mio.ai.judge.OutputJudge;
 import com.mio.ai.judge.OutputJudgeAction;
@@ -17,6 +20,7 @@ import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
+import com.mio.ai.memory.working.WorkingMessage;
 import com.mio.ai.profile.ContextPreWarmer;
 import com.mio.ai.profile.SafetyProfileBuilder.ProfileResult;
 import com.mio.ai.moderation.ModerationResult;
@@ -43,6 +47,7 @@ import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
 import com.mio.session.dto.SseEventDto;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.service.CbtReconstructionService;
 import com.mio.session.service.SessionMessagePersistenceService;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -79,6 +84,7 @@ public class ConversationOrchestrator {
     private final SafetySignalCombiner signalCombiner;
     private final SafetyProfileBuilder safetyProfileBuilder;
     private final InputJudge inputJudge;
+    private final CbtMetadataClassifier cbtMetadataClassifier;
     private final OutputPreFilter outputPreFilter;
     private final OutputJudge outputJudge;
     private final PolicyEngine policyEngine;
@@ -89,6 +95,7 @@ public class ConversationOrchestrator {
     private final WorkingMemory workingMemory;
     private final ContextPreWarmer contextPreWarmer;
     private final AiDecisionLogger decisionLogger;
+    private final CbtReconstructionService cbtReconstructionService;
     private final SessionMessagePersistenceService messagePersistenceService;
     private final ConversationCheckpointService checkpointService;
     private final SessionRepository sessionRepository;
@@ -145,6 +152,7 @@ public class ConversationOrchestrator {
 
             // 5. Working Memory (CBT counters) + Memory Context
             SessionDelta sessionDelta = workingMemory.getSessionDelta(sessionId);
+            List<WorkingMessage> recentWorkingMessages = workingMemory.getRecentMessages(sessionId);
             String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
             boolean memoryCacheHit = cachedMemory != null;
             String memoryContext = memoryCacheHit
@@ -164,7 +172,9 @@ public class ConversationOrchestrator {
             if (decision.action() == DecisionAction.SECURITY_REFUSAL) {
                 assistantContent = securityRefusalTemplate.get();
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, false, "security_refusal"));
+                sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                        userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                        "security_refusal", false);
 
             } else if (decision.action() == DecisionAction.CRISIS_FLOW) {
                 crisisFlowTriggered = true;
@@ -204,8 +214,9 @@ public class ConversationOrchestrator {
                     }
                     if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {
                         sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false,
-                                detectSocratic(assistantContent), "stop"));
+                        sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                                userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                                "stop", true);
                     }
 
                 } else if (deliveryMode == DeliveryMode.CAUTIOUS_SPECULATIVE) {
@@ -303,8 +314,9 @@ public class ConversationOrchestrator {
                             if (replacedContent != null) {
                                 assistantContent = replacedContent;
                                 sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
-                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "replaced_by_guard"));
+                                sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                                        userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                                        "replaced_by_guard", false);
                             } else if (stopSendingDeltas.get()) {
                                 // Stopped mid-stream but content is safe — restore only the reviewed snapshot,
                                 // not trailing tokens that arrived after the early stop
@@ -312,16 +324,19 @@ public class ConversationOrchestrator {
                                         ? capturedSnapshotRef.get() : assistantContent;
                                 assistantContent = reviewedContent;
                                 sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(reviewedContent, outboundMsgId));
-                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                        userSignal.emotionScore(), false, detectSocratic(reviewedContent), "stop"));
+                                sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                                        userMessage, reviewedContent, userSignal, sessionDelta, recentWorkingMessages,
+                                        "stop", true);
                             } else {
-                                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                        userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                                sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                                        userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                                        "stop", true);
                             }
                         }
                     } else {
-                        sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                                userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                        sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                                userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                                "stop", true);
                     }
 
                 } else {
@@ -335,15 +350,18 @@ public class ConversationOrchestrator {
                         }
                     });
                     assistantContent = contentBuilder.toString();
-                    sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId,
-                            userSignal.emotionScore(), false, detectSocratic(assistantContent), "stop"));
+                    sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                            userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                            "stop", true);
                 }
             } else {
                 // FALLBACK 또는 미지원 action — 안전 응답 반환
                 log.warn("Unhandled decision action: {} for session={}", decision.action(), sessionId);
                 assistantContent = "지금 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.";
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
-                sendEvent(emitter, new SseEventDto.DoneEvent(outboundMsgId, userSignal.emotionScore(), false, false, "error"));
+                sendDoneEvent(emitter, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
+                        userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
+                        "error", false);
             }
 
             // 8. Persist messages
@@ -396,9 +414,65 @@ public class ConversationOrchestrator {
         };
     }
 
-    private boolean detectSocratic(String content) {
-        if (content == null || content.isBlank()) return false;
-        return content.contains("?") || content.contains("？");
+    private void sendDoneEvent(
+            SseEmitter emitter,
+            UUID userId,
+            UUID sessionId,
+            String outboundMsgId,
+            Integer emotionScore,
+            boolean isCrisisFlagged,
+            String userMessage,
+            String assistantContent,
+            UserMessageSignal userSignal,
+            SessionDelta sessionDelta,
+            List<WorkingMessage> recentWorkingMessages,
+            String finishedReason,
+            boolean classifyCbt) throws IOException {
+
+        CbtMetadataResult metadata = classifyCbt
+                ? cbtMetadataClassifier.classify(
+                        sessionDelta.cbtInterventionState(),
+                        recentWorkingMessages,
+                        userMessage,
+                        assistantContent,
+                        userSignal,
+                        sessionDelta.socraticQuestionsUsed(),
+                        isCrisisFlagged)
+                : CbtMetadataResult.none();
+
+        UUID emotionScoreTargetId = null;
+        if (metadata.shouldCreateEmotionScoreTarget()) {
+            emotionScoreTargetId = cbtReconstructionService.createEmotionScoreTarget(
+                    userId,
+                    sessionId,
+                    userMessage,
+                    assistantContent,
+                    metadata,
+                    emotionScore
+            ).getId();
+        }
+
+        if (classifyCbt) {
+            workingMemory.updateCbtInterventionState(sessionId, metadata.state().wireValue());
+            if (metadata.state() == CbtInterventionState.SOCRATIC_ASKED) {
+                workingMemory.incrementSocraticQuestionCount(sessionId);
+            }
+        }
+
+        boolean isSocratic = metadata.socratic() || metadata.state() == CbtInterventionState.SOCRATIC_ASKED;
+
+        sendEvent(emitter, new SseEventDto.DoneEvent(
+                outboundMsgId,
+                emotionScore,
+                isCrisisFlagged,
+                isSocratic,
+                metadata.state().wireValue(),
+                metadata.completionReason(),
+                emotionScoreTargetId != null,
+                emotionScoreTargetId,
+                emotionScoreTargetId != null ? "after" : null,
+                finishedReason
+        ));
     }
 
     private void sendEvent(SseEmitter emitter, SseEventDto event) throws IOException {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -442,14 +442,19 @@ public class ConversationOrchestrator {
 
         UUID emotionScoreTargetId = null;
         if (metadata.shouldCreateEmotionScoreTarget()) {
-            emotionScoreTargetId = cbtReconstructionService.createEmotionScoreTarget(
-                    userId,
-                    sessionId,
-                    userMessage,
-                    assistantContent,
-                    metadata,
-                    emotionScore
-            ).getId();
+            try {
+                emotionScoreTargetId = cbtReconstructionService.createEmotionScoreTarget(
+                        userId,
+                        sessionId,
+                        userMessage,
+                        assistantContent,
+                        metadata,
+                        emotionScore
+                ).getId();
+            } catch (Exception e) {
+                log.warn("Failed to create CBT emotion-score target for sessionId={} — continuing without target",
+                        sessionId, e);
+            }
         }
 
         if (classifyCbt) {

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -42,6 +42,8 @@ public enum ErrorCode {
     SESSION_NOT_ENDED(HttpStatus.CONFLICT, "SESSION_NOT_ENDED", "세션이 아직 종료되지 않았습니다."),
     SESSION_SUMMARY_FAILED(HttpStatus.GONE, "GONE", "세션 요약 생성에 실패했습니다."),
     LOCKED_BY_SAFETY(HttpStatus.LOCKED, "LOCKED_BY_SAFETY", "보안 정책에 의해 차단된 요청입니다."),
+    CBT_RECONSTRUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "CBT_RECONSTRUCTION_NOT_FOUND", "CBT 재구성 기록을 찾을 수 없습니다."),
+    CBT_SCORE_NOT_REQUIRED(HttpStatus.CONFLICT, "CBT_SCORE_NOT_REQUIRED", "해당 CBT 재구성은 감정 점수 입력 대상이 아닙니다."),
 
     // Daily Test
     DAILY_TEST_NOT_FOUND(HttpStatus.NOT_FOUND, "DAILY_TEST_NOT_FOUND", "오늘의 데일리 테스트가 없습니다."),

--- a/src/main/java/com/mio/session/controller/CbtReconstructionController.java
+++ b/src/main/java/com/mio/session/controller/CbtReconstructionController.java
@@ -1,7 +1,6 @@
 package com.mio.session.controller;
 
-import com.mio.common.error.BusinessException;
-import com.mio.common.error.ErrorCode;
+import com.mio.common.PrincipalUtils;
 import com.mio.common.response.ApiResponse;
 import com.mio.session.dto.CbtEmotionScoreResponse;
 import com.mio.session.dto.EmotionScoreRequest;
@@ -30,19 +29,8 @@ public class CbtReconstructionController {
             Principal principal,
             @PathVariable UUID reconstructionId,
             @Valid @RequestBody EmotionScoreRequest request) {
-        UUID userId = resolveUserId(principal);
+        var userId = PrincipalUtils.resolveUserId(principal);
         return ResponseEntity.ok(ApiResponse.ok(
                 cbtReconstructionService.submitEmotionScore(userId, reconstructionId, request)));
-    }
-
-    private UUID resolveUserId(Principal principal) {
-        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED);
-        }
-        try {
-            return UUID.fromString(principal.getName());
-        } catch (IllegalArgumentException e) {
-            throw new BusinessException(ErrorCode.UNAUTHORIZED, "유효한 사용자 식별자가 필요합니다.");
-        }
     }
 }

--- a/src/main/java/com/mio/session/controller/CbtReconstructionController.java
+++ b/src/main/java/com/mio/session/controller/CbtReconstructionController.java
@@ -1,0 +1,48 @@
+package com.mio.session.controller;
+
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import com.mio.session.dto.CbtEmotionScoreResponse;
+import com.mio.session.dto.EmotionScoreRequest;
+import com.mio.session.service.CbtReconstructionService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/v1/cbt/reconstructions")
+@RequiredArgsConstructor
+public class CbtReconstructionController {
+
+    private final CbtReconstructionService cbtReconstructionService;
+
+    @PostMapping("/{reconstructionId}/emotion-score")
+    public ResponseEntity<ApiResponse<CbtEmotionScoreResponse>> submitEmotionScore(
+            Principal principal,
+            @PathVariable UUID reconstructionId,
+            @Valid @RequestBody EmotionScoreRequest request) {
+        UUID userId = resolveUserId(principal);
+        return ResponseEntity.ok(ApiResponse.ok(
+                cbtReconstructionService.submitEmotionScore(userId, reconstructionId, request)));
+    }
+
+    private UUID resolveUserId(Principal principal) {
+        if (principal == null || principal.getName() == null || principal.getName().isBlank()) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED);
+        }
+        try {
+            return UUID.fromString(principal.getName());
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.UNAUTHORIZED, "유효한 사용자 식별자가 필요합니다.");
+        }
+    }
+}

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -67,15 +67,6 @@ public class SessionController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    @PostMapping("/{sessionId}/emotion-score")
-    public ResponseEntity<ApiResponse<EmotionScoreResponse>> submitEmotionScore(
-            Principal principal,
-            @PathVariable UUID sessionId,
-            @Valid @RequestBody EmotionScoreRequest request) {
-        UUID userId = resolveUserId(principal);
-        return ResponseEntity.ok(ApiResponse.ok(sessionService.submitEmotionScore(userId, sessionId, request)));
-    }
-
     @GetMapping("/{sessionId}/summary")
     public ResponseEntity<ApiResponse<SessionSummaryResponse>> getSessionSummary(
             Principal principal,

--- a/src/main/java/com/mio/session/domain/CbtReconstruction.java
+++ b/src/main/java/com/mio/session/domain/CbtReconstruction.java
@@ -69,19 +69,32 @@ public class CbtReconstruction {
     @Column(name = "reconstructed_thought_dek_id")
     private String reconstructedThoughtDekId;
 
-    /** CBT 측정용 0~100 (재구성 전) */
+    /** CBT 개입 직전 내부 기준값 0~100 */
     @Column(name = "emotion_score_before")
     private Integer emotionScoreBefore;
 
-    /** CBT 측정용 0~100 (재구성 후) */
+    /** CBT 개입 완료 후 사용자 입력값 0~100 */
     @Column(name = "emotion_score_after")
     private Integer emotionScoreAfter;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
+    @Column(name = "updated_at", nullable = false)
+    private OffsetDateTime updatedAt;
+
+    public void submitEmotionScoreAfter(int score) {
+        if (score < 0 || score > 100) {
+            throw new IllegalArgumentException("emotion score must be between 0 and 100");
+        }
+        this.emotionScoreAfter = score;
+        this.updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        createdAt = now;
+        updatedAt = now;
     }
 }

--- a/src/main/java/com/mio/session/dto/CbtEmotionScoreResponse.java
+++ b/src/main/java/com/mio/session/dto/CbtEmotionScoreResponse.java
@@ -1,0 +1,21 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.CbtReconstruction;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public record CbtEmotionScoreResponse(
+        @JsonProperty("reconstruction_id") UUID reconstructionId,
+        @JsonProperty("emotion_score_after") Integer emotionScoreAfter,
+        @JsonProperty("updated_at") OffsetDateTime updatedAt
+) {
+    public static CbtEmotionScoreResponse from(CbtReconstruction reconstruction) {
+        return new CbtEmotionScoreResponse(
+                reconstruction.getId(),
+                reconstruction.getEmotionScoreAfter(),
+                reconstruction.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/SseEventDto.java
+++ b/src/main/java/com/mio/session/dto/SseEventDto.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.UUID;
 
 public sealed interface SseEventDto
         permits SseEventDto.SessionMetaEvent,
@@ -51,8 +52,24 @@ public sealed interface SseEventDto
             @JsonProperty("emotion_score") Integer emotionScore,
             @JsonProperty("is_crisis_flagged") boolean isCrisisFlagged,
             @JsonProperty("is_socratic") boolean isSocratic,
+            @JsonProperty("cbt_intervention_state") String cbtInterventionState,
+            @JsonProperty("completion_reason") String completionReason,
+            @JsonProperty("requires_emotion_score") boolean requiresEmotionScore,
+            @JsonProperty("emotion_score_target_id") UUID emotionScoreTargetId,
+            @JsonProperty("emotion_score_phase") String emotionScorePhase,
             @JsonProperty("finished_reason") String finishedReason
     ) implements SseEventDto {
+        public DoneEvent(
+                String msgId,
+                Integer emotionScore,
+                boolean isCrisisFlagged,
+                boolean isSocratic,
+                String finishedReason
+        ) {
+            this(msgId, emotionScore, isCrisisFlagged, isSocratic,
+                    "none", null, false, null, null, finishedReason);
+        }
+
         @Override public String eventName() { return "done"; }
     }
 }

--- a/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
+++ b/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
@@ -2,8 +2,27 @@ package com.mio.session.repository;
 
 import com.mio.session.domain.CbtReconstruction;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public interface CbtReconstructionRepository extends JpaRepository<CbtReconstruction, UUID> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE CbtReconstruction c
+            SET c.emotionScoreAfter = :score,
+                c.updatedAt = :updatedAt
+            WHERE c.id = :reconstructionId
+              AND c.session.user.id = :userId
+              AND c.emotionScoreAfter IS NULL
+            """)
+    int submitEmotionScoreAfterIfPending(
+            @Param("reconstructionId") UUID reconstructionId,
+            @Param("userId") UUID userId,
+            @Param("score") Integer score,
+            @Param("updatedAt") OffsetDateTime updatedAt);
 }

--- a/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
+++ b/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
@@ -1,0 +1,9 @@
+package com.mio.session.repository;
+
+import com.mio.session.domain.CbtReconstruction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CbtReconstructionRepository extends JpaRepository<CbtReconstruction, UUID> {
+}

--- a/src/main/java/com/mio/session/service/CbtReconstructionService.java
+++ b/src/main/java/com/mio/session/service/CbtReconstructionService.java
@@ -1,0 +1,90 @@
+package com.mio.session.service;
+
+import com.mio.ai.judge.CbtMetadataResult;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.CbtReconstruction;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.CbtEmotionScoreResponse;
+import com.mio.session.dto.EmotionScoreRequest;
+import com.mio.session.repository.CbtReconstructionRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class CbtReconstructionService {
+
+    private final CbtReconstructionRepository cbtReconstructionRepository;
+    private final SessionRepository sessionRepository;
+    private final UserRepository userRepository;
+    private final MessageEncryptor messageEncryptor;
+
+    @Transactional
+    public CbtReconstruction createEmotionScoreTarget(
+            UUID userId,
+            UUID sessionId,
+            String distortedThought,
+            String assistantResponse,
+            CbtMetadataResult metadata,
+            Integer emotionScoreBefore) {
+
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        if (!session.belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String reconstructedThought = metadata.reconstructedThought() != null
+                ? metadata.reconstructedThought()
+                : assistantResponse;
+
+        CbtReconstruction reconstruction = CbtReconstruction.builder()
+                .user(user)
+                .session(session)
+                .message(null)
+                .biasType(metadata.biasType())
+                .distortedThoughtCiphertext(encrypt(distortedThought))
+                .distortedThoughtDekId(messageEncryptor.dekId())
+                .reconstructedThoughtCiphertext(encrypt(reconstructedThought))
+                .reconstructedThoughtDekId(messageEncryptor.dekId())
+                .emotionScoreBefore(emotionScoreBefore)
+                .emotionScoreAfter(null)
+                .build();
+
+        return cbtReconstructionRepository.save(reconstruction);
+    }
+
+    @Transactional
+    public CbtEmotionScoreResponse submitEmotionScore(
+            UUID userId,
+            UUID reconstructionId,
+            EmotionScoreRequest request) {
+
+        CbtReconstruction reconstruction = cbtReconstructionRepository.findById(reconstructionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CBT_RECONSTRUCTION_NOT_FOUND));
+        if (!reconstruction.getSession().belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+        if (reconstruction.getEmotionScoreAfter() != null) {
+            throw new BusinessException(ErrorCode.CBT_SCORE_NOT_REQUIRED);
+        }
+        reconstruction.submitEmotionScoreAfter(request.score());
+        return CbtEmotionScoreResponse.from(cbtReconstructionRepository.save(reconstruction));
+    }
+
+    private byte[] encrypt(String content) {
+        String safeContent = content == null ? "" : content;
+        return messageEncryptor.encrypt(safeContent.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/mio/session/service/CbtReconstructionService.java
+++ b/src/main/java/com/mio/session/service/CbtReconstructionService.java
@@ -17,6 +17,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.UUID;
 
 @Service
@@ -42,8 +44,7 @@ public class CbtReconstructionService {
         if (!session.belongsTo(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+        User user = userRepository.getReferenceById(userId);
 
         String reconstructedThought = metadata.reconstructedThought() != null
                 ? metadata.reconstructedThought()
@@ -71,16 +72,23 @@ public class CbtReconstructionService {
             UUID reconstructionId,
             EmotionScoreRequest request) {
 
+        int updated = cbtReconstructionRepository.submitEmotionScoreAfterIfPending(
+                reconstructionId,
+                userId,
+                request.score(),
+                OffsetDateTime.now(ZoneOffset.UTC));
+        if (updated == 1) {
+            CbtReconstruction updatedReconstruction = cbtReconstructionRepository.findById(reconstructionId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.CBT_RECONSTRUCTION_NOT_FOUND));
+            return CbtEmotionScoreResponse.from(updatedReconstruction);
+        }
+
         CbtReconstruction reconstruction = cbtReconstructionRepository.findById(reconstructionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CBT_RECONSTRUCTION_NOT_FOUND));
         if (!reconstruction.getSession().belongsTo(userId)) {
             throw new BusinessException(ErrorCode.FORBIDDEN);
         }
-        if (reconstruction.getEmotionScoreAfter() != null) {
-            throw new BusinessException(ErrorCode.CBT_SCORE_NOT_REQUIRED);
-        }
-        reconstruction.submitEmotionScoreAfter(request.score());
-        return CbtEmotionScoreResponse.from(cbtReconstructionRepository.save(reconstruction));
+        throw new BusinessException(ErrorCode.CBT_SCORE_NOT_REQUIRED);
     }
 
     private byte[] encrypt(String content) {

--- a/src/main/resources/db/migration/V32__add_cbt_reconstruction_updated_at.sql
+++ b/src/main/resources/db/migration/V32__add_cbt_reconstruction_updated_at.sql
@@ -1,0 +1,9 @@
+ALTER TABLE cbt_reconstructions
+    ADD COLUMN updated_at TIMESTAMPTZ;
+
+UPDATE cbt_reconstructions
+SET updated_at = created_at
+WHERE updated_at IS NULL;
+
+ALTER TABLE cbt_reconstructions
+    ALTER COLUMN updated_at SET NOT NULL;

--- a/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
+++ b/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
@@ -1,0 +1,51 @@
+package com.mio.ai.judge;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.safety.UserMessageSignal;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class CbtMetadataClassifierTest {
+
+    @Test
+    @DisplayName("LLM 응답이 markdown json fence로 감싸져도 파싱한다")
+    void classify_stripsMarkdownJsonFence() {
+        LlmClient llmClient = mock(LlmClient.class);
+        when(llmClient.complete(any(LlmRequest.class))).thenReturn("""
+                ```json
+                {
+                  "cbt_intervention_state": "completed",
+                  "completion_reason": "user_reframed_thought",
+                  "requires_emotion_score": true,
+                  "is_socratic": false,
+                  "bias_type": "catastrophizing",
+                  "reconstructed_thought": "최악은 아닐 수 있다"
+                }
+                ```
+                """);
+        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper());
+
+        CbtMetadataResult result = classifier.classify(
+                "socratic_asked",
+                List.of(),
+                "다른 가능성도 있는 것 같아",
+                "그 관점을 기억해볼까요?",
+                new UserMessageSignal(45, "catastrophizing"),
+                1,
+                false
+        );
+
+        assertThat(result.state()).isEqualTo(CbtInterventionState.COMPLETED);
+        assertThat(result.requiresEmotionScore()).isTrue();
+        assertThat(result.biasType()).isEqualTo("catastrophizing");
+    }
+}

--- a/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
+++ b/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
@@ -127,12 +127,24 @@ class WorkingMemoryTest {
     }
 
     @Test
+    @DisplayName("updateCbtInterventionState는 상태를 hash에 저장하고 TTL을 설정한다")
+    void updateCbtInterventionState_writes_state_and_sets_ttl() {
+        UUID sessionId = UUID.randomUUID();
+
+        workingMemory.updateCbtInterventionState(sessionId, "socratic_asked");
+
+        verify(hashOps).put(contains(sessionId.toString()), eq("cbt_intervention_state"), eq("socratic_asked"));
+        verify(redisTemplate).expire(contains(sessionId.toString()), eq(Duration.ofMinutes(90)));
+    }
+
+    @Test
     @DisplayName("getSessionDelta는 모든 필드를 합산하여 반환한다")
     void getSessionDelta_aggregates_all_fields() {
         UUID sessionId = UUID.randomUUID();
 
         given(hashOps.entries(contains("working"))).willReturn(Map.of(
                 "socratic_count", "1",
+                "cbt_intervention_state", "socratic_asked",
                 "risk_accumulation", "3",
                 "distortion:catastrophizing", "2",
                 "distortion:all_or_nothing", "1"
@@ -143,6 +155,7 @@ class WorkingMemoryTest {
         SessionDelta delta = workingMemory.getSessionDelta(sessionId);
 
         assertThat(delta.socraticQuestionsUsed()).isEqualTo(1);
+        assertThat(delta.cbtInterventionState()).isEqualTo("socratic_asked");
         assertThat(delta.sessionRiskAccumulation()).isEqualTo(3);
         assertThat(delta.distortionCount("catastrophizing")).isEqualTo(2);
         assertThat(delta.distortionCount("all_or_nothing")).isEqualTo(1);
@@ -153,8 +166,8 @@ class WorkingMemoryTest {
     @Test
     @DisplayName("socraticLimitReached는 2회 이상 시 true다")
     void socraticLimitReached_returns_true_at_two() {
-        SessionDelta delta2 = new SessionDelta(2, Map.of(), 0, Set.of(), Set.of());
-        SessionDelta delta1 = new SessionDelta(1, Map.of(), 0, Set.of(), Set.of());
+        SessionDelta delta2 = new SessionDelta(2, "none", Map.of(), 0, Set.of(), Set.of());
+        SessionDelta delta1 = new SessionDelta(1, "none", Map.of(), 0, Set.of(), Set.of());
 
         assertThat(delta2.socraticLimitReached()).isTrue();
         assertThat(delta1.socraticLimitReached()).isFalse();

--- a/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
+++ b/src/test/java/com/mio/ai/policy/PolicyEngineTest.java
@@ -147,7 +147,7 @@ class PolicyEngineTest {
     @Test
     @DisplayName("소크라테스 2회 제한 도달 시 SUPPORTIVE 유지")
     void socratic_limit_reached_keeps_supportive() {
-        SessionDelta limitReached = new SessionDelta(2, new java.util.HashMap<>(), 0, new java.util.HashSet<>(), new java.util.HashSet<>());
+        SessionDelta limitReached = new SessionDelta(2, "none", new java.util.HashMap<>(), 0, new java.util.HashSet<>(), new java.util.HashSet<>());
         var combined = combined(SecurityLevel.CLEAN, false, true, false);
         var decision = policyEngine.decide(combined, judgeResult(RiskLevel.MEDIUM), null, limitReached);
         assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);

--- a/src/test/java/com/mio/session/controller/CbtReconstructionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/CbtReconstructionControllerTest.java
@@ -75,4 +75,14 @@ class CbtReconstructionControllerTest {
                 .andExpect(status().isConflict())
                 .andExpect(jsonPath("$.error.code").value("CBT_SCORE_NOT_REQUIRED"));
     }
+
+    @Test
+    @DisplayName("POST /v1/cbt/reconstructions/{id}/emotion-score - principal 없으면 401")
+    void submitEmotionScore_missingPrincipal_returns401() throws Exception {
+        mockMvc.perform(post("/v1/cbt/reconstructions/{id}/emotion-score", TEST_RECONSTRUCTION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"score\":62}"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.error.code").value("UNAUTHORIZED"));
+    }
 }

--- a/src/test/java/com/mio/session/controller/CbtReconstructionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/CbtReconstructionControllerTest.java
@@ -1,0 +1,78 @@
+package com.mio.session.controller;
+
+import com.mio.auth.filter.JwtAuthenticationFilter;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.config.SecurityConfig;
+import com.mio.session.dto.CbtEmotionScoreResponse;
+import com.mio.session.service.CbtReconstructionService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        value = CbtReconstructionController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class},
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        }
+)
+@Import(GlobalExceptionHandler.class)
+class CbtReconstructionControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private CbtReconstructionService cbtReconstructionService;
+
+    private static final UUID TEST_USER_ID = UUID.randomUUID();
+    private static final UUID TEST_RECONSTRUCTION_ID = UUID.randomUUID();
+
+    @Test
+    @DisplayName("POST /v1/cbt/reconstructions/{id}/emotion-score - 점수 제출 성공")
+    void submitEmotionScore_success_returns200() throws Exception {
+        when(cbtReconstructionService.submitEmotionScore(eq(TEST_USER_ID), eq(TEST_RECONSTRUCTION_ID), any()))
+                .thenReturn(new CbtEmotionScoreResponse(TEST_RECONSTRUCTION_ID, 62, OffsetDateTime.now()));
+
+        mockMvc.perform(post("/v1/cbt/reconstructions/{id}/emotion-score", TEST_RECONSTRUCTION_ID)
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"score\":62}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reconstruction_id").value(TEST_RECONSTRUCTION_ID.toString()))
+                .andExpect(jsonPath("$.data.emotion_score_after").value(62));
+    }
+
+    @Test
+    @DisplayName("POST /v1/cbt/reconstructions/{id}/emotion-score - 이미 제출된 점수면 409")
+    void submitEmotionScore_notRequired_returns409() throws Exception {
+        when(cbtReconstructionService.submitEmotionScore(eq(TEST_USER_ID), eq(TEST_RECONSTRUCTION_ID), any()))
+                .thenThrow(new BusinessException(ErrorCode.CBT_SCORE_NOT_REQUIRED));
+
+        mockMvc.perform(post("/v1/cbt/reconstructions/{id}/emotion-score", TEST_RECONSTRUCTION_ID)
+                        .principal(() -> TEST_USER_ID.toString())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"score\":62}"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.error.code").value("CBT_SCORE_NOT_REQUIRED"));
+    }
+}

--- a/src/test/java/com/mio/session/service/CbtReconstructionServiceTest.java
+++ b/src/test/java/com/mio/session/service/CbtReconstructionServiceTest.java
@@ -1,0 +1,150 @@
+package com.mio.session.service;
+
+import com.mio.ai.judge.CbtInterventionState;
+import com.mio.ai.judge.CbtMetadataResult;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.CbtReconstruction;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.CbtEmotionScoreResponse;
+import com.mio.session.dto.EmotionScoreRequest;
+import com.mio.session.repository.CbtReconstructionRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CbtReconstructionServiceTest {
+
+    @Mock private CbtReconstructionRepository cbtReconstructionRepository;
+    @Mock private SessionRepository sessionRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private MessageEncryptor messageEncryptor;
+
+    private CbtReconstructionService service;
+    private UUID userId;
+    private User user;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        service = new CbtReconstructionService(
+                cbtReconstructionRepository,
+                sessionRepository,
+                userRepository,
+                messageEncryptor
+        );
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+        ReflectionTestUtils.setField(user, "id", userId);
+        session = Session.builder()
+                .user(user)
+                .characterId("mio")
+                .build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+    }
+
+    @Test
+    @DisplayName("completed 메타데이터로 CBT 감정 점수 target을 생성한다")
+    void createEmotionScoreTarget_savesReconstruction() {
+        when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(messageEncryptor.encrypt(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        when(messageEncryptor.dekId()).thenReturn("dek-test");
+        when(cbtReconstructionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CbtMetadataResult metadata = new CbtMetadataResult(
+                CbtInterventionState.COMPLETED,
+                "user_reframed_thought",
+                true,
+                false,
+                "catastrophizing",
+                "최악은 아닐 수 있다"
+        );
+
+        service.createEmotionScoreTarget(
+                userId,
+                session.getId(),
+                "다 망한 것 같아",
+                "다른 가능성도 같이 볼 수 있어요.",
+                metadata,
+                45
+        );
+
+        ArgumentCaptor<CbtReconstruction> captor = ArgumentCaptor.forClass(CbtReconstruction.class);
+        verify(cbtReconstructionRepository).save(captor.capture());
+        CbtReconstruction saved = captor.getValue();
+        assertThat(saved.getBiasType()).isEqualTo("catastrophizing");
+        assertThat(saved.getEmotionScoreBefore()).isEqualTo(45);
+        assertThat(new String(saved.getDistortedThoughtCiphertext(), StandardCharsets.UTF_8))
+                .isEqualTo("다 망한 것 같아");
+    }
+
+    @Test
+    @DisplayName("CBT 개입 후 감정 점수를 1회 제출한다")
+    void submitEmotionScore_updatesAfterScore() {
+        UUID reconstructionId = UUID.randomUUID();
+        CbtReconstruction reconstruction = reconstruction(reconstructionId, null);
+        when(cbtReconstructionRepository.findById(reconstructionId)).thenReturn(Optional.of(reconstruction));
+        when(cbtReconstructionRepository.save(reconstruction)).thenReturn(reconstruction);
+
+        CbtEmotionScoreResponse response =
+                service.submitEmotionScore(userId, reconstructionId, new EmotionScoreRequest(62));
+
+        assertThat(response.reconstructionId()).isEqualTo(reconstructionId);
+        assertThat(response.emotionScoreAfter()).isEqualTo(62);
+        assertThat(response.updatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("이미 제출된 CBT 감정 점수는 다시 제출할 수 없다")
+    void submitEmotionScore_alreadySubmitted_throws() {
+        UUID reconstructionId = UUID.randomUUID();
+        CbtReconstruction reconstruction = reconstruction(reconstructionId, 62);
+        when(cbtReconstructionRepository.findById(reconstructionId)).thenReturn(Optional.of(reconstruction));
+
+        assertThatThrownBy(() -> service.submitEmotionScore(userId, reconstructionId, new EmotionScoreRequest(70)))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(error -> assertThat(((BusinessException) error).getErrorCode())
+                        .isEqualTo(ErrorCode.CBT_SCORE_NOT_REQUIRED));
+    }
+
+    private CbtReconstruction reconstruction(UUID id, Integer afterScore) {
+        CbtReconstruction reconstruction = CbtReconstruction.builder()
+                .user(user)
+                .session(session)
+                .biasType("catastrophizing")
+                .distortedThoughtCiphertext("distorted".getBytes(StandardCharsets.UTF_8))
+                .distortedThoughtDekId("dek-test")
+                .reconstructedThoughtCiphertext("reconstructed".getBytes(StandardCharsets.UTF_8))
+                .reconstructedThoughtDekId("dek-test")
+                .emotionScoreBefore(45)
+                .emotionScoreAfter(afterScore)
+                .build();
+        ReflectionTestUtils.setField(reconstruction, "id", id);
+        return reconstruction;
+    }
+}

--- a/src/test/java/com/mio/session/service/CbtReconstructionServiceTest.java
+++ b/src/test/java/com/mio/session/service/CbtReconstructionServiceTest.java
@@ -23,6 +23,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -71,7 +73,7 @@ class CbtReconstructionServiceTest {
     @DisplayName("completed 메타데이터로 CBT 감정 점수 target을 생성한다")
     void createEmotionScoreTarget_savesReconstruction() {
         when(sessionRepository.findById(session.getId())).thenReturn(Optional.of(session));
-        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.getReferenceById(userId)).thenReturn(user);
         when(messageEncryptor.encrypt(any())).thenAnswer(invocation -> invocation.getArgument(0));
         when(messageEncryptor.dekId()).thenReturn("dek-test");
         when(cbtReconstructionRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -107,9 +109,14 @@ class CbtReconstructionServiceTest {
     @DisplayName("CBT 개입 후 감정 점수를 1회 제출한다")
     void submitEmotionScore_updatesAfterScore() {
         UUID reconstructionId = UUID.randomUUID();
-        CbtReconstruction reconstruction = reconstruction(reconstructionId, null);
+        CbtReconstruction reconstruction = reconstruction(reconstructionId, 62);
+        when(cbtReconstructionRepository.submitEmotionScoreAfterIfPending(
+                org.mockito.ArgumentMatchers.eq(reconstructionId),
+                org.mockito.ArgumentMatchers.eq(userId),
+                org.mockito.ArgumentMatchers.eq(62),
+                any()
+        )).thenReturn(1);
         when(cbtReconstructionRepository.findById(reconstructionId)).thenReturn(Optional.of(reconstruction));
-        when(cbtReconstructionRepository.save(reconstruction)).thenReturn(reconstruction);
 
         CbtEmotionScoreResponse response =
                 service.submitEmotionScore(userId, reconstructionId, new EmotionScoreRequest(62));
@@ -124,6 +131,12 @@ class CbtReconstructionServiceTest {
     void submitEmotionScore_alreadySubmitted_throws() {
         UUID reconstructionId = UUID.randomUUID();
         CbtReconstruction reconstruction = reconstruction(reconstructionId, 62);
+        when(cbtReconstructionRepository.submitEmotionScoreAfterIfPending(
+                org.mockito.ArgumentMatchers.eq(reconstructionId),
+                org.mockito.ArgumentMatchers.eq(userId),
+                org.mockito.ArgumentMatchers.eq(70),
+                any()
+        )).thenReturn(0);
         when(cbtReconstructionRepository.findById(reconstructionId)).thenReturn(Optional.of(reconstruction));
 
         assertThatThrownBy(() -> service.submitEmotionScore(userId, reconstructionId, new EmotionScoreRequest(70)))
@@ -145,6 +158,7 @@ class CbtReconstructionServiceTest {
                 .emotionScoreAfter(afterScore)
                 .build();
         ReflectionTestUtils.setField(reconstruction, "id", id);
+        ReflectionTestUtils.setField(reconstruction, "updatedAt", OffsetDateTime.now(ZoneOffset.UTC));
         return reconstruction;
     }
 }


### PR DESCRIPTION
## 요약
- Main LLM 응답 완료 후 CBT 메타데이터를 별도 classifier로 판정하도록 추가했습니다.
- SSE done 이벤트에 cbt_intervention_state, completion_reason, requires_emotion_score, emotion_score_target_id, emotion_score_phase를 포함하도록 확장했습니다.
- 세션 종료 후 감정 점수 제출 라우트는 제거하고, CBT 재구성 단위 점수 제출 API를 추가했습니다.
  - POST /v1/cbt/reconstructions/{reconstructionId}/emotion-score
- 사용자가 제출한 개입 후 감정 점수는 cbt_reconstructions.emotion_score_after에 저장합니다.
- WorkingMemory에 CBT 개입 상태를 저장하고, cbt_reconstructions.updated_at 컬럼을 추가하는 Flyway migration을 포함했습니다.

## 구현 방향
- 소크라테스 완료 여부는 키워드 매칭으로 판단하지 않습니다.
- 사용자에게 보이는 답변은 Main LLM이 생성하고, 상태 판정은 응답 완료 후 classifier가 구조화 메타데이터로 반환합니다.
- classifier가 completed이며 requires_emotion_score=true로 판정한 경우에만 FE가 감정 점수 입력 UI를 띄울 수 있도록 done 이벤트에 target id를 내려줍니다.
- messages.emotion_score와 sessions.emotion_score_ai는 내부 Safety/Memory 신호로 유지하고, 사용자 입력 점수로 사용하지 않습니다.

## 테스트
- 통과: ./gradlew test --tests "com.mio.session.service.CbtReconstructionServiceTest" --tests "com.mio.session.controller.CbtReconstructionControllerTest" --tests "com.mio.ai.memory.working.WorkingMemoryTest" --tests "com.mio.ai.policy.PolicyEngineTest" --tests "com.mio.ai.crisis.CrisisFlowServiceTest" --tests "com.mio.session.controller.SessionControllerTest" --tests "com.mio.session.service.SessionServiceTest"
- 전체 테스트: ./gradlew test는 로컬 PostgreSQL 연결 실패로 MioApplicationTests, AuthIntegrationTest의 Spring context setup 단계에서 실패했습니다. 원인은 Flyway가 PostgreSQL에 연결하지 못한 org.postgresql.util.PSQLException입니다.

Closes #175