### PR TITLE
fix: HTTP Basic, Form Login 명시적 비활성화 (#178)

### DIFF
--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -34,6 +34,8 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth


### PR DESCRIPTION
## Summary

- `SecurityConfig.filterChain()`에 `.httpBasic(disable)`, `.formLogin(disable)` 추가
- JWT 기반 인증만 사용하는 앱에서 미사용 Spring Security 인증 경로를 명시적으로 차단

## 변경 내용

```java
http
    .csrf(AbstractHttpConfigurer::disable)
    .httpBasic(AbstractHttpConfigurer::disable)   // 추가
    .formLogin(AbstractHttpConfigurer::disable)   // 추가
    .sessionManagement(...)
```

## Test plan

- [ ] `./gradlew build` 통과 확인
- [ ] 배포 후 운영 로그에 `Using generated security password` 경고 미출력 확인
- [ ] 기존 JWT 인증 API 정상 동작 확인

Closes #178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated security settings so the app no longer exposes unwanted HTTP Basic or form-based login prompts.
  * Improved consistency in authentication behavior by relying only on the intended access flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->