### PR TITLE
feat: AI 파이프라인 컨텍스트 연속성 + 멀티캐릭터 + emotion_score 개선

### DIFF
--- a/src/main/java/com/mio/ai/AiCacheKeys.java
+++ b/src/main/java/com/mio/ai/AiCacheKeys.java
@@ -1,0 +1,8 @@
+package com.mio.ai;
+
+public final class AiCacheKeys {
+
+    private AiCacheKeys() {}
+
+    public static final String CHECKPOINT_CACHE_KEY = "session:%s:checkpoint_cache";
+}

--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -127,7 +127,6 @@ public class CbtMetadataClassifier {
         }
         if (!CbtMetadataResult.isAllowedBiasType(biasType)) {
             biasType = null;
-            requiresEmotionScore = false;
         }
         String reconstructedThought = textOrNull(root, "reconstructed_thought");
         return new CbtMetadataResult(

--- a/src/main/java/com/mio/ai/judge/CbtMetadataResult.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataResult.java
@@ -24,9 +24,7 @@ public record CbtMetadataResult(
     }
 
     public boolean shouldCreateEmotionScoreTarget() {
-        return state == CbtInterventionState.COMPLETED
-                && requiresEmotionScore
-                && isAllowedBiasType(biasType);
+        return state == CbtInterventionState.COMPLETED && requiresEmotionScore;
     }
 
     public static boolean isAllowedBiasType(String biasType) {

--- a/src/main/java/com/mio/ai/llm/LlmRequest.java
+++ b/src/main/java/com/mio/ai/llm/LlmRequest.java
@@ -22,8 +22,10 @@ public record LlmRequest(
                                 List<WorkingMessage> history, String userMessage) {
         List<Message> messages = new ArrayList<>();
         messages.add(new Message("system", systemPrompt));
-        for (WorkingMessage wm : history) {
-            messages.add(new Message(wm.role(), wm.content()));
+        if (history != null) {
+            for (WorkingMessage wm : history) {
+                messages.add(new Message(wm.role(), wm.content()));
+            }
         }
         messages.add(new Message("user", userMessage));
         return new LlmRequest(model, List.copyOf(messages));

--- a/src/main/java/com/mio/ai/llm/LlmRequest.java
+++ b/src/main/java/com/mio/ai/llm/LlmRequest.java
@@ -1,5 +1,8 @@
 package com.mio.ai.llm;
 
+import com.mio.ai.memory.working.WorkingMessage;
+
+import java.util.ArrayList;
 import java.util.List;
 
 public record LlmRequest(
@@ -13,5 +16,16 @@ public record LlmRequest(
                 new Message("system", systemPrompt),
                 new Message("user", userMessage)
         ));
+    }
+
+    public static LlmRequest of(String model, String systemPrompt,
+                                List<WorkingMessage> history, String userMessage) {
+        List<Message> messages = new ArrayList<>();
+        messages.add(new Message("system", systemPrompt));
+        for (WorkingMessage wm : history) {
+            messages.add(new Message(wm.role(), wm.content()));
+        }
+        messages.add(new Message("user", userMessage));
+        return new LlmRequest(model, List.copyOf(messages));
     }
 }

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -84,6 +84,7 @@ public class ConversationCheckpointService {
             if (records.isEmpty()) return;
 
             String summaryText = generateSummary(records.stream().map(MessageRecord::line).toList());
+            if (summaryText == null) return;
             OffsetDateTime coveredUpTo = records.stream()
                     .map(MessageRecord::createdAt)
                     .max(OffsetDateTime::compareTo)
@@ -165,8 +166,9 @@ public class ConversationCheckpointService {
             );
         } catch (Exception e) {
             log.warn("ConversationCheckpointService: summary generation failed", e);
-            return "중간 요약을 생성할 수 없습니다.";
+            return null;
         }
-        return sb.toString().trim();
+        String result = sb.toString().trim();
+        return result.isBlank() ? null : result;
     }
 }

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -1,5 +1,6 @@
 package com.mio.ai.memory.consolidation;
 
+import com.mio.ai.AiCacheKeys;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.common.crypto.MessageEncryptor;
@@ -17,6 +18,8 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -51,7 +54,6 @@ public class ConversationCheckpointService {
             - 이전 요약의 연속선상에서 맥락을 유지합니다
             """;
 
-    private static final String CHECKPOINT_CACHE_KEY = "session:%s:checkpoint_cache";
     private static final Duration CHECKPOINT_TTL = Duration.ofHours(2);
 
     private final SessionRepository sessionRepository;
@@ -100,8 +102,13 @@ public class ConversationCheckpointService {
                     .coveredUpToAt(coveredUpTo)
                     .build();
             checkpointRepository.save(checkpoint);
-            redisTemplate.opsForValue().set(
-                    CHECKPOINT_CACHE_KEY.formatted(sessionId), summaryText, CHECKPOINT_TTL);
+            String cacheKey = AiCacheKeys.CHECKPOINT_CACHE_KEY.formatted(sessionId);
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    redisTemplate.opsForValue().set(cacheKey, summaryText, CHECKPOINT_TTL);
+                }
+            });
             log.info("ConversationCheckpointService: saved checkpoint seq={} sessionId={}", seq, sessionId);
 
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -11,6 +11,7 @@ import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -18,6 +19,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -49,12 +51,16 @@ public class ConversationCheckpointService {
             - 이전 요약의 연속선상에서 맥락을 유지합니다
             """;
 
+    private static final String CHECKPOINT_CACHE_KEY = "session:%s:checkpoint_cache";
+    private static final Duration CHECKPOINT_TTL = Duration.ofHours(2);
+
     private final SessionRepository sessionRepository;
     private final SessionCheckpointRepository checkpointRepository;
     private final UserRepository userRepository;
     private final LlmClient llmClient;
     private final MessageEncryptor messageEncryptor;
     private final JdbcTemplate jdbcTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     record MessageRecord(String line, OffsetDateTime createdAt) {}
 
@@ -94,6 +100,8 @@ public class ConversationCheckpointService {
                     .coveredUpToAt(coveredUpTo)
                     .build();
             checkpointRepository.save(checkpoint);
+            redisTemplate.opsForValue().set(
+                    CHECKPOINT_CACHE_KEY.formatted(sessionId), summaryText, CHECKPOINT_TTL);
             log.info("ConversationCheckpointService: saved checkpoint seq={} sessionId={}", seq, sessionId);
 
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -158,6 +158,7 @@ public class ConversationOrchestrator {
             String memoryContext = memoryCacheHit
                     ? cachedMemory
                     : contextPreWarmer.buildContextSync(sessionId, userId, combined, profile);
+            String checkpointSummary = contextPreWarmer.getCachedCheckpoint(sessionId);
 
             // 6. Policy decision (10-step)
             PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
@@ -187,8 +188,12 @@ public class ConversationOrchestrator {
                 // OutputGuard 실행 여부는 deliveryMode로 제어 (requireOutputGuard 필드는 감사 로그용)
                 // GENERATE: build prompt with GenerationMode instruction
                 String systemPrompt = promptBuilder.buildSystemPrompt(
-                        decision.generationMode(), decision.interventionHints(), memoryContext);
-                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, userMessage);
+                        decision.generationMode(), decision.interventionHints(), memoryContext,
+                        user.getPreferredCharacterId(), checkpointSummary);
+                List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
+                        ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
+                        : recentWorkingMessages;
+                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage);
                 StringBuilder contentBuilder = new StringBuilder();
 
                 DeliveryMode deliveryMode = decision.deliveryMode();

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -8,6 +8,7 @@ import com.mio.ai.memory.retrieval.RetrievedItem;
 import com.mio.ai.memory.retrieval.StructuredRetriever;
 import com.mio.ai.memory.retrieval.VectorRetriever;
 import com.mio.ai.safety.CombinedSignal;
+import com.mio.session.repository.SessionCheckpointRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -34,6 +35,8 @@ public class ContextPreWarmer {
 
     private static final String CONTEXT_CACHE_KEY = "session:%s:context_cache";
     private static final Duration CONTEXT_TTL = Duration.ofMinutes(5);
+    static final String CHECKPOINT_CACHE_KEY = "session:%s:checkpoint_cache";
+    private static final Duration CHECKPOINT_TTL = Duration.ofHours(2);
 
     private final StructuredRetriever structuredRetriever;
     private final VectorRetriever vectorRetriever;
@@ -41,6 +44,7 @@ public class ContextPreWarmer {
     private final ContextComposer contextComposer;
     private final MemoryRetrievalPlanner memoryRetrievalPlanner;
     private final SafetyProfileBuilder safetyProfileBuilder;
+    private final SessionCheckpointRepository checkpointRepository;
     private final StringRedisTemplate redisTemplate;
     private final JdbcTemplate jdbcTemplate;
 
@@ -67,6 +71,19 @@ public class ContextPreWarmer {
                 log.debug("ContextPreWarmer: cached context for sessionId={} length={}",
                         sessionId, context.length());
             }
+
+            // 4. 최신 체크포인트 요약 Redis 캐싱
+            checkpointRepository.findTopBySession_IdOrderByCheckpointSeqDesc(sessionId)
+                    .ifPresent(cp -> {
+                        String summary = cp.getSummaryText();
+                        if (summary != null && !summary.isBlank()) {
+                            redisTemplate.opsForValue().set(
+                                    CHECKPOINT_CACHE_KEY.formatted(sessionId), summary, CHECKPOINT_TTL
+                            );
+                            log.debug("ContextPreWarmer: cached checkpoint seq={} sessionId={}",
+                                    cp.getCheckpointSeq(), sessionId);
+                        }
+                    });
         } catch (Exception e) {
             log.warn("ContextPreWarmer failed for sessionId={}", sessionId, e);
         }
@@ -77,6 +94,15 @@ public class ContextPreWarmer {
             return redisTemplate.opsForValue().get(CONTEXT_CACHE_KEY.formatted(sessionId));
         } catch (Exception e) {
             log.warn("ContextPreWarmer.getCachedContext failed", e);
+            return null;
+        }
+    }
+
+    public String getCachedCheckpoint(UUID sessionId) {
+        try {
+            return redisTemplate.opsForValue().get(CHECKPOINT_CACHE_KEY.formatted(sessionId));
+        } catch (Exception e) {
+            log.warn("ContextPreWarmer.getCachedCheckpoint failed", e);
             return null;
         }
     }

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -1,5 +1,6 @@
 package com.mio.ai.profile;
 
+import com.mio.ai.AiCacheKeys;
 import com.mio.ai.memory.composer.ContextComposer;
 import com.mio.ai.memory.retrieval.FusionRanker;
 import com.mio.ai.memory.retrieval.MemoryRetrievalPlanner;
@@ -35,7 +36,6 @@ public class ContextPreWarmer {
 
     private static final String CONTEXT_CACHE_KEY = "session:%s:context_cache";
     private static final Duration CONTEXT_TTL = Duration.ofMinutes(5);
-    static final String CHECKPOINT_CACHE_KEY = "session:%s:checkpoint_cache";
     private static final Duration CHECKPOINT_TTL = Duration.ofHours(2);
 
     private final StructuredRetriever structuredRetriever;
@@ -78,7 +78,7 @@ public class ContextPreWarmer {
                         String summary = cp.getSummaryText();
                         if (summary != null && !summary.isBlank()) {
                             redisTemplate.opsForValue().set(
-                                    CHECKPOINT_CACHE_KEY.formatted(sessionId), summary, CHECKPOINT_TTL
+                                    AiCacheKeys.CHECKPOINT_CACHE_KEY.formatted(sessionId), summary, CHECKPOINT_TTL
                             );
                             log.debug("ContextPreWarmer: cached checkpoint seq={} sessionId={}",
                                     cp.getCheckpointSeq(), sessionId);
@@ -100,7 +100,7 @@ public class ContextPreWarmer {
 
     public String getCachedCheckpoint(UUID sessionId) {
         try {
-            return redisTemplate.opsForValue().get(CHECKPOINT_CACHE_KEY.formatted(sessionId));
+            return redisTemplate.opsForValue().get(AiCacheKeys.CHECKPOINT_CACHE_KEY.formatted(sessionId));
         } catch (Exception e) {
             log.warn("ContextPreWarmer.getCachedCheckpoint failed", e);
             return null;

--- a/src/main/java/com/mio/ai/prompt/PromptBuilder.java
+++ b/src/main/java/com/mio/ai/prompt/PromptBuilder.java
@@ -81,7 +81,8 @@ public class PromptBuilder {
 
     private String resolveBasePrompt(String characterId) {
         if (characterId == null) return CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER);
-        return CHARACTER_BASE_PROMPTS.getOrDefault(characterId, CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER));
+        String normalized = characterId.trim().toLowerCase();
+        return CHARACTER_BASE_PROMPTS.getOrDefault(normalized, CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER));
     }
 
     private String buildModeInstruction(GenerationMode mode) {

--- a/src/main/java/com/mio/ai/prompt/PromptBuilder.java
+++ b/src/main/java/com/mio/ai/prompt/PromptBuilder.java
@@ -4,15 +4,49 @@ import com.mio.ai.policy.GenerationMode;
 import com.mio.ai.policy.InterventionHints;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
 @Component
 public class PromptBuilder {
 
-    private static final String BASE_PROMPT =
-            "당신은 Mio입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, " +
-            "사용자의 감정을 진심으로 이해하고 지지합니다. " +
+    private static final Map<String, String> CHARACTER_BASE_PROMPTS = Map.of(
+            "mio",
+            "당신은 미오입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, " +
+            "사용자의 감정을 진심으로 이해하고 곁에서 지지합니다. " +
             "CBT(인지행동치료) 원칙에 기반해 사용자가 스스로 감정을 탐색할 수 있도록 돕습니다. " +
             "진단이나 처방을 내리지 않으며, 의존성을 강화하는 표현은 하지 않습니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.";
+            "응답은 2-4문장으로 간결하게 유지합니다.",
+
+            "bau",
+            "당신은 바우입니다. 활기차고 응원해주는 AI 코칭 캐릭터로, " +
+            "사용자가 작은 변화와 행동에서 자신감을 찾도록 돕습니다. " +
+            "CBT(인지행동치료) 원칙에 기반해 구체적인 다음 단계를 함께 탐색합니다. " +
+            "진단이나 처방을 내리지 않으며, 긍정적인 모멘텀을 유지합니다. " +
+            "응답은 2-4문장으로 간결하게 유지합니다.",
+
+            "rumi",
+            "당신은 루미입니다. 명확하고 논리적인 AI 코칭 캐릭터로, " +
+            "사용자의 생각 패턴을 체계적으로 탐색하고 정리할 수 있도록 돕습니다. " +
+            "CBT(인지행동치료) 원칙에 기반해 인지 왜곡을 함께 살펴봅니다. " +
+            "진단이나 처방을 내리지 않으며, 단정적 표현을 피합니다. " +
+            "응답은 2-4문장으로 간결하게 유지합니다.",
+
+            "momo",
+            "당신은 모모입니다. 온화하고 수용적인 AI 코칭 캐릭터로, " +
+            "지치고 힘든 사용자의 마음을 따뜻하게 감싸드립니다. " +
+            "CBT(인지행동치료) 원칙에 기반해 사용자가 자기 자신을 있는 그대로 받아들이도록 돕습니다. " +
+            "진단이나 처방을 내리지 않으며, 압박감을 주는 표현은 하지 않습니다. " +
+            "응답은 2-4문장으로 간결하게 유지합니다.",
+
+            "chichi",
+            "당신은 치치입니다. 현실적이고 직접적인 AI 코칭 캐릭터로, " +
+            "사용자가 실질적인 해결책을 찾고 변화를 이끌 수 있도록 돕습니다. " +
+            "CBT(인지행동치료) 원칙에 기반해 구체적이고 실천 가능한 접근을 제안합니다. " +
+            "진단이나 처방을 내리지 않으며, 불필요한 감정적 표현은 최소화합니다. " +
+            "응답은 2-4문장으로 간결하게 유지합니다."
+    );
+
+    private static final String DEFAULT_CHARACTER = "mio";
 
     private static final String SUPPORTIVE_INSTRUCTION =
             "\n\n[현재 세션 지시] 감정을 먼저 충분히 인정하고 공감하세요. " +
@@ -23,18 +57,31 @@ public class PromptBuilder {
             "단정적 표현을 사용하지 마세요. 사용자의 말을 조심스럽게 반영하세요.";
 
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints) {
-        return buildSystemPrompt(mode, hints, null);
+        return buildSystemPrompt(mode, hints, null, DEFAULT_CHARACTER, null);
     }
 
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints, String memoryContext) {
-        String base = BASE_PROMPT + buildModeInstruction(mode);
+        return buildSystemPrompt(mode, hints, memoryContext, DEFAULT_CHARACTER, null);
+    }
+
+    public String buildSystemPrompt(GenerationMode mode, InterventionHints hints,
+                                    String memoryContext, String characterId, String checkpointSummary) {
+        String base = resolveBasePrompt(characterId) + buildModeInstruction(mode);
         if (hints != null && !hints.suggestedCodes().isEmpty()) {
             base += buildHintsInstruction(hints);
+        }
+        if (checkpointSummary != null && !checkpointSummary.isBlank()) {
+            base += "\n\n## 이전 대화 요약\n" + checkpointSummary;
         }
         if (memoryContext != null && !memoryContext.isBlank()) {
             base += "\n\n" + memoryContext;
         }
         return base;
+    }
+
+    private String resolveBasePrompt(String characterId) {
+        if (characterId == null) return CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER);
+        return CHARACTER_BASE_PROMPTS.getOrDefault(characterId, CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER));
     }
 
     private String buildModeInstruction(GenerationMode mode) {

--- a/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
+++ b/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
@@ -17,7 +17,7 @@ class PromptBuilderTest {
     @DisplayName("NORMAL 모드는 기본 프롬프트만 반환한다")
     void normal_mode_returns_base_prompt() {
         String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty());
-        assertThat(prompt).contains("Mio");
+        assertThat(prompt).contains("미오");
         assertThat(prompt).doesNotContain("현재 세션 지시");
     }
 


### PR DESCRIPTION
## Summary

- **대화 히스토리 전달**: `LlmRequest`에 history 오버로드 추가, Orchestrator에서 최대 10개(5턴) working messages를 LLM에 전달
- **멀티캐릭터 지원**: `PromptBuilder`의 하드코딩된 Mio 프롬프트를 5종 캐릭터 맵(mio/bau/rumi/momo/chichi)으로 교체, `user.preferredCharacterId` 반영
- **체크포인트 요약 활용**: `ContextPreWarmer` 세션 시작 시 최신 checkpoint Redis 캐싱, Orchestrator에서 시스템 프롬프트에 삽입. `ConversationCheckpointService` 저장 후 write-through로 항상 최신 상태 유지
- **emotion_score_target 누락 수정**: `CbtMetadataResult.shouldCreateEmotionScoreTarget()`의 `isAllowedBiasType` 게이트 제거 — COMPLETED + requiresEmotionScore 조건만으로 항상 target 생성

## Test Plan

- [ ] 동일 세션에서 2턴 이상 대화 후 AI가 이전 발언을 참조하는지 확인
- [ ] 사용자 preferredCharacterId 변경 후 대화 시 해당 캐릭터 페르소나로 응답하는지 확인
- [ ] 20턴 대화 이후 체크포인트 요약이 프롬프트에 포함되는지 로그 확인
- [ ] CBT 소크라테스 흐름 완료 시 emotion_score_target_id가 DoneEvent에 항상 포함되는지 확인
- [ ] Redis MISS 시 fallback 정상 동작 확인 (getCachedCheckpoint null 반환 → PromptBuilder null 처리)

Closes #180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation generation now uses the most recent chat history and a cached conversation summary to improve context-aware replies.
  * System prompts now adapt to the selected character (with a default fallback) and can include a “previous conversation summary” when available.
* **Bug Fixes**
  * Improved emotion scoring enablement for completed items when emotion scoring is required.
* **Performance**
  * Added short-lived caching of checkpoint summary text to reduce repeated context-loading work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->