### PR TITLE
fix: AI 파이프라인 컨텍스트 연속성 후속 버그픽스 3건

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -104,12 +104,16 @@ public class ConversationCheckpointService {
                     .build();
             checkpointRepository.save(checkpoint);
             String cacheKey = AiCacheKeys.CHECKPOINT_CACHE_KEY.formatted(sessionId);
-            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-                @Override
-                public void afterCommit() {
-                    redisTemplate.opsForValue().set(cacheKey, summaryText, CHECKPOINT_TTL);
-                }
-            });
+            if (TransactionSynchronizationManager.isSynchronizationActive()) {
+                TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        redisTemplate.opsForValue().set(cacheKey, summaryText, CHECKPOINT_TTL);
+                    }
+                });
+            } else {
+                redisTemplate.opsForValue().set(cacheKey, summaryText, CHECKPOINT_TTL);
+            }
             log.info("ConversationCheckpointService: saved checkpoint seq={} sessionId={}", seq, sessionId);
 
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -60,6 +60,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -190,9 +191,11 @@ public class ConversationOrchestrator {
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints(), memoryContext,
                         user.getPreferredCharacterId(), checkpointSummary);
-                List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
-                        ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
-                        : recentWorkingMessages;
+                List<WorkingMessage> historyCopy = recentWorkingMessages != null
+                        ? new ArrayList<>(recentWorkingMessages) : List.of();
+                List<WorkingMessage> historySlice = historyCopy.size() > 10
+                        ? historyCopy.subList(historyCopy.size() - 10, historyCopy.size())
+                        : historyCopy;
                 LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage);
                 StringBuilder contentBuilder = new StringBuilder();
 

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -154,6 +154,7 @@ public class ConversationOrchestrator {
             // 5. Working Memory (CBT counters) + Memory Context
             SessionDelta sessionDelta = workingMemory.getSessionDelta(sessionId);
             List<WorkingMessage> recentWorkingMessages = workingMemory.getRecentMessages(sessionId);
+            recentWorkingMessages = recentWorkingMessages != null ? new ArrayList<>(recentWorkingMessages) : new ArrayList<>();
             String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
             boolean memoryCacheHit = cachedMemory != null;
             String memoryContext = memoryCacheHit
@@ -191,11 +192,9 @@ public class ConversationOrchestrator {
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints(), memoryContext,
                         user.getPreferredCharacterId(), checkpointSummary);
-                List<WorkingMessage> historyCopy = recentWorkingMessages != null
-                        ? new ArrayList<>(recentWorkingMessages) : List.of();
-                List<WorkingMessage> historySlice = historyCopy.size() > 10
-                        ? historyCopy.subList(historyCopy.size() - 10, historyCopy.size())
-                        : historyCopy;
+                List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
+                        ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
+                        : recentWorkingMessages;
                 LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage);
                 StringBuilder contentBuilder = new StringBuilder();
 

--- a/src/main/java/com/mio/session/domain/CbtReconstruction.java
+++ b/src/main/java/com/mio/session/domain/CbtReconstruction.java
@@ -42,7 +42,7 @@ public class CbtReconstruction {
      * overgeneralization / catastrophizing / mind_reading /
      * all_or_nothing / self_blame / emotional_reasoning
      */
-    @Column(name = "bias_type", nullable = false)
+    @Column(name = "bias_type")
     private String biasType;
 
     @Getter(AccessLevel.NONE)

--- a/src/main/resources/db/migration/V33__make_cbt_reconstruction_bias_type_nullable.sql
+++ b/src/main/resources/db/migration/V33__make_cbt_reconstruction_bias_type_nullable.sql
@@ -1,0 +1,4 @@
+-- cbt_reconstructions.bias_type: NOT NULL 제약 해제
+-- LLM이 valid bias_type 없이 requires_emotion_score=true를 반환할 수 있으므로
+-- 감정 점수 타겟 생성이 bias_type 누락으로 차단되지 않도록 nullable 허용
+ALTER TABLE cbt_reconstructions ALTER COLUMN bias_type DROP NOT NULL;


### PR DESCRIPTION
Closes #183

## 수정 내용

### 1. [HIGH] ConversationOrchestrator — NPE / ConcurrentModificationException
`recentWorkingMessages.subList()` 호출 시 null이거나 외부에서 수정될 수 있는 리스트에 직접 접근하는 문제.
- `new ArrayList<>(recentWorkingMessages)` 방어 복사 후 subList 호출로 변경

### 2. [MEDIUM] ConversationCheckpointService — IllegalStateException
`@Async` + `REQUIRES_NEW` 조합에서 트랜잭션 동기화 미활성 상황에 `registerSynchronization()` 호출 시 예외 발생.
- `isSynchronizationActive()` 가드 추가, 비활성 시 Redis 직접 쓰기로 폴백

### 3. [MEDIUM] CbtReconstruction.biasType — DB NOT NULL 제약 위반
LLM이 valid biasType 없이 `requires_emotion_score=true` 반환 시 `cbt_reconstructions.bias_type NOT NULL` 제약 위반.
- V33 Flyway 마이그레이션으로 `bias_type` nullable 허용
- 엔티티 `@Column(nullable = false)` 제거

## 영향 범위

- `ConversationOrchestrator.java`
- `ConversationCheckpointService.java`
- `CbtReconstruction.java`
- `V33__make_cbt_reconstruction_bias_type_nullable.sql` (신규)

## 테스트 계획

- [ ] `./gradlew build` CI 통과 확인
- [ ] DB 마이그레이션 V33 적용 후 schema validate 통과
- [ ] 히스토리 있는 세션에서 ConversationOrchestrator NPE 미발생 확인
- [ ] biasType null인 CbtReconstruction 저장 정상 처리 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of checkpoint saving so updates are stored immediately when needed, while still waiting for transaction completion when available.
  * Prevented errors when building prompt history by safely handling missing recent messages and keeping only the latest 10.
  * Allowed reconstructed CBT entries to omit the bias type field when unavailable.

* **Chores**
  * Updated the database schema to support optional bias type values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->