### PR TITLE
feat: 세션 종료 시 todo 항상 생성 및 세션 요약 응답에 주요감정·todo 포함

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -171,18 +171,16 @@ public class SessionConsolidator {
             persistThought(user, sessionId, extracted_thought);
         }
 
-        // 10. CBT 개입 감지 시 Todo 3건 자동 생성 (MIO-CBT-015)
+        // 10. 세션 종료 시 Todo 3건 자동 생성 (MIO-CBT-015)
         List<String> distortionCodes = validThoughts.stream()
                 .map(ExtractorResult.ExtractedThought::distortionCode)
                 .filter(code -> code != null && !code.isBlank())
                 .distinct()
                 .toList();
-        if (!distortionCodes.isEmpty()) {
-            try {
-                todoRecommendationService.generateForSession(user, session, distortionCodes, dominantEmotion);
-            } catch (Exception e) {
-                log.warn("SessionConsolidator: todo generation failed sessionId={}", sessionId, e);
-            }
+        try {
+            todoRecommendationService.generateForSession(user, session, distortionCodes, dominantEmotion);
+        } catch (Exception e) {
+            log.warn("SessionConsolidator: todo generation failed sessionId={}", sessionId, e);
         }
 
         log.info("SessionConsolidator: completed sessionId={} thoughts={} emotion={}",

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -4,8 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionSummary;
+import com.mio.todo.domain.BehaviorTask;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 public record SessionSummaryResponse(
@@ -15,12 +17,32 @@ public record SessionSummaryResponse(
         @JsonProperty("duration_seconds") long durationSeconds,
         @JsonProperty("message_count") int messageCount,
         String summary,
+        @JsonProperty("dominant_emotion") String dominantEmotion,
         @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
         @JsonProperty("bias_types_detected") String biasTypesDetected,
         @JsonProperty("cbt_intervened") Boolean cbtIntervened,
         @JsonRawValue @JsonProperty("key_thoughts") String keyThoughts,
-        @JsonProperty("socratic_count") Integer socraticCount
+        @JsonProperty("socratic_count") Integer socraticCount,
+        List<TodoItem> todos
 ) {
+    public record TodoItem(
+            @JsonProperty("todo_id") UUID todoId,
+            @JsonProperty("action_text") String actionText,
+            String category,
+            Integer difficulty,
+            @JsonProperty("estimated_minutes") Integer estimatedMinutes
+    ) {
+        public static TodoItem from(BehaviorTask task) {
+            return new TodoItem(
+                    task.getId(),
+                    task.getActionText(),
+                    task.getCategory(),
+                    task.getDifficulty(),
+                    task.getEstimatedMinutes()
+            );
+        }
+    }
+
     public static SessionSummaryResponse pending(Session session) {
         return new SessionSummaryResponse(
                 session.getId(),
@@ -28,11 +50,11 @@ public record SessionSummaryResponse(
                 session.getEndedAt(),
                 session.durationSeconds(),
                 session.getMessageCount(),
-                null, null, null, null, null, null
+                null, null, null, null, null, null, null, null
         );
     }
 
-    public static SessionSummaryResponse from(Session session, SessionSummary summary) {
+    public static SessionSummaryResponse from(Session session, SessionSummary summary, List<BehaviorTask> todos) {
         return new SessionSummaryResponse(
                 session.getId(),
                 session.getSummaryStatus().value(),
@@ -40,11 +62,13 @@ public record SessionSummaryResponse(
                 session.durationSeconds(),
                 session.getMessageCount(),
                 summary.getSummaryText(),
+                summary.getDominantEmotion(),
                 session.getAvgEmotionScore(),
                 summary.getBiasTypesDetected(),
                 summary.isCbtIntervened(),
                 summary.getKeyThoughts(),
-                summary.getSocraticCount()
+                summary.getSocraticCount(),
+                todos.stream().map(TodoItem::from).toList()
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -50,7 +50,7 @@ public record SessionSummaryResponse(
                 session.getEndedAt(),
                 session.durationSeconds(),
                 session.getMessageCount(),
-                null, null, null, null, null, null, null, null
+                null, null, null, null, null, null, null, List.of()
         );
     }
 

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -12,6 +12,7 @@ import com.mio.session.domain.SummaryStatus;
 import com.mio.session.dto.*;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,7 @@ public class SessionService {
 
     private final SessionRepository sessionRepository;
     private final SessionSummaryRepository sessionSummaryRepository;
+    private final BehaviorTaskRepository behaviorTaskRepository;
     private final UserRepository userRepository;
     private final SessionMessagePersistenceService sessionMessagePersistenceService;
     private final ConversationOrchestrator conversationOrchestrator;
@@ -162,7 +164,8 @@ public class SessionService {
         }
         var summary = sessionSummaryRepository.findBySession_Id(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
-        return SessionSummaryResponse.from(session, summary);
+        var todos = behaviorTaskRepository.findBySourceSession_Id(sessionId);
+        return SessionSummaryResponse.from(session, summary, todos);
     }
 
     /**

--- a/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
+++ b/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
@@ -20,6 +20,8 @@ public interface BehaviorTaskRepository extends JpaRepository<BehaviorTask, UUID
             UUID userId, TaskStatus status, OffsetDateTime from, OffsetDateTime to
     );
 
+    List<BehaviorTask> findBySourceSession_Id(UUID sourceSessionId);
+
     boolean existsByUser_IdAndGeneratedFromAndSourceSession_IdAndStatusAndCreatedAtBetween(
             UUID userId,
             String generatedFrom,

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -22,6 +22,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -177,7 +178,7 @@ class SessionControllerTest {
     void getSessionSummary_pending_returns202() throws Exception {
         SessionSummaryResponse response = new SessionSummaryResponse(
                 TEST_SESSION_ID, "pending", OffsetDateTime.now(), 300L, 5,
-                null, null, null, null, null, null
+                null, null, null, null, null, null, null, null
         );
         when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 
@@ -193,7 +194,7 @@ class SessionControllerTest {
     void getSessionSummary_done_returns200AndTransitionsToViewed() throws Exception {
         SessionSummaryResponse response = new SessionSummaryResponse(
                 TEST_SESSION_ID, "viewed", OffsetDateTime.now(), 300L, 5,
-                "세션 요약 내용", 70, "[]", false, null, null
+                "세션 요약 내용", null, 70, "[]", false, null, null, List.of()
         );
         when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -178,7 +178,7 @@ class SessionControllerTest {
     void getSessionSummary_pending_returns202() throws Exception {
         SessionSummaryResponse response = new SessionSummaryResponse(
                 TEST_SESSION_ID, "pending", OffsetDateTime.now(), 300L, 5,
-                null, null, null, null, null, null, null, null
+                null, null, null, null, null, null, null, List.of()
         );
         when(sessionService.getSessionSummary(eq(TEST_USER_ID), eq(TEST_SESSION_ID))).thenReturn(response);
 

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -16,6 +16,7 @@ import com.mio.session.dto.SendMessageRequest;
 import com.mio.session.dto.SessionResponse;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +50,7 @@ class SessionServiceTest {
 
     @Mock private SessionRepository sessionRepository;
     @Mock private SessionSummaryRepository sessionSummaryRepository;
+    @Mock private BehaviorTaskRepository behaviorTaskRepository;
     @Mock private UserRepository userRepository;
     @Mock private SessionMessagePersistenceService sessionMessagePersistenceService;
     @Mock private ConversationOrchestrator conversationOrchestrator;
@@ -66,7 +68,7 @@ class SessionServiceTest {
     void setUp() {
         lenient().when(redisTemplate.opsForValue()).thenReturn(valueOps);
         sessionService = new SessionService(
-                sessionRepository, sessionSummaryRepository, userRepository,
+                sessionRepository, sessionSummaryRepository, behaviorTaskRepository, userRepository,
                 sessionMessagePersistenceService, conversationOrchestrator, workingMemory,
                 eventPublisher, contextPreWarmer, redisTemplate
         );


### PR DESCRIPTION
## Summary
- `SessionConsolidator`: 인지왜곡 코드 유무와 무관하게 세션 종료 시 항상 todo 3건 생성
- `SessionSummaryResponse`: `dominant_emotion`, `todos` 필드 추가 (todos는 id/action_text/category/difficulty/estimated_minutes 간소화)
- `BehaviorTaskRepository`: `findBySourceSession_Id` 메서드 추가
- `SessionService`: `getSessionSummary()`에서 해당 세션 todos 조회 후 포함

## Test plan
- [ ] 인지왜곡 코드 없는 세션 종료 후 todo 3건 생성 확인
- [ ] `GET /v1/sessions/{id}/summary` 응답에 `dominant_emotion`, `todos` 포함 확인
- [ ] `todos` 배열 필드: `todo_id`, `action_text`, `category`, `difficulty`, `estimated_minutes` 검증
- [ ] 기존 빌드/단위 테스트 통과 확인

Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session summaries now include additional well-being and CBT insights, plus a list of recommended action items.

* **Bug Fixes**
  * Action items are now generated consistently during session consolidation, even when no distortion codes are present.
  * Session summary responses now return the latest action items along with the expanded summary details.

* **Chores**
  * Deployment now refreshes container data more cleanly and provides log output after startup for easier verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->