### PR TITLE
fix: session_summaries CBT 필드 기본값 버그 수정 (#191)

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -154,8 +154,8 @@ public class SessionConsolidator {
                         .map(ExtractorResult.ExtractedThought::thoughtText)
                         .filter(text -> text != null && !text.isBlank())
                         .toList());
-        boolean cbtIntervened = "cbt_success".equals(extracted.episodeType())
-                || "cbt_partial".equals(extracted.episodeType());
+        boolean cbtIntervened = "cbt_success".equalsIgnoreCase(extracted.episodeType())
+                || "cbt_partial".equalsIgnoreCase(extracted.episodeType());
 
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
                 dominantEmotion, extracted.triggerTags(), extracted.episodeType(),

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -142,9 +142,24 @@ public class SessionConsolidator {
         List<ExtractorResult.ExtractedThought> validThoughts = filterValidThoughts(extracted.thoughts());
         String dominantEmotion = filterValidEmotion(extracted.dominantEmotion());
 
-        // 6. session_summaries 저장/갱신
+        // 6. session_summaries 저장/갱신 (CBT 필드 포함)
+        String biasTypesJson = toJson(
+                validThoughts.stream()
+                        .map(ExtractorResult.ExtractedThought::distortionCode)
+                        .filter(code -> code != null && !code.isBlank())
+                        .distinct()
+                        .toList());
+        String keyThoughtsJson = toJson(
+                validThoughts.stream()
+                        .map(ExtractorResult.ExtractedThought::thoughtText)
+                        .filter(text -> text != null && !text.isBlank())
+                        .toList());
+        boolean cbtIntervened = "cbt_success".equals(extracted.episodeType())
+                || "cbt_partial".equals(extracted.episodeType());
+
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
-                dominantEmotion, extracted.triggerTags(), extracted.episodeType());
+                dominantEmotion, extracted.triggerTags(), extracted.episodeType(),
+                biasTypesJson, keyThoughtsJson, cbtIntervened);
 
         // emotion_score_ai: AI 추정 세션 감정 점수 (0~100) 저장
         if (extracted.emotionScore() != null) {
@@ -278,7 +293,10 @@ public class SessionConsolidator {
             String dekId,
             String dominantEmotion,
             List<String> triggerTags,
-            String episodeType) {
+            String episodeType,
+            String biasTypesJson,
+            String keyThoughtsJson,
+            boolean cbtIntervened) {
 
         String[] tagsArray = triggerTags.toArray(new String[0]);
 
@@ -289,11 +307,13 @@ public class SessionConsolidator {
                             UPDATE session_summaries
                             SET summary_text = ?, summary_ciphertext = ?, summary_dek_id = ?,
                                 dominant_emotion = ?, trigger_tags = ?, episode_type = ?,
+                                bias_types_detected = ?::jsonb, cbt_intervened = ?, key_thoughts = ?::jsonb,
                                 embedding_status = 'pending'
                             WHERE session_id = ?
                             """,
                             summaryText, ciphertext, dekId,
                             dominantEmotion, tagsArray, episodeType,
+                            biasTypesJson, cbtIntervened, keyThoughtsJson,
                             session.getId()
                     );
                 },
@@ -306,6 +326,9 @@ public class SessionConsolidator {
                             .summaryCiphertext(ciphertext)
                             .summaryDekId(dekId)
                             .dominantEmotion(dominantEmotion)
+                            .biasTypesDetected(biasTypesJson)
+                            .cbtIntervened(cbtIntervened)
+                            .keyThoughts(keyThoughtsJson)
                             .build();
                     // saveAndFlush: JPA flush 후 jdbcTemplate.update가 실제 row를 찾도록 보장
                     sessionSummaryRepository.saveAndFlush(summary);
@@ -315,6 +338,17 @@ public class SessionConsolidator {
                     );
                 }
         );
+    }
+
+    // ── JSON 직렬화 ───────────────────────────────────────────────
+
+    private String toJson(List<String> list) {
+        try {
+            return objectMapper.writeValueAsString(list);
+        } catch (Exception e) {
+            log.warn("SessionConsolidator: JSON serialization failed", e);
+            return "[]";
+        }
     }
 
     // ── cbt_patterns upsert ──────────────────────────────────────

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -19,7 +19,7 @@ public record SessionSummaryResponse(
         String summary,
         @JsonProperty("dominant_emotion") String dominantEmotion,
         @JsonProperty("avg_emotion_score") Integer avgEmotionScore,
-        @JsonProperty("bias_types_detected") String biasTypesDetected,
+        @JsonRawValue @JsonProperty("bias_types_detected") String biasTypesDetected,
         @JsonProperty("cbt_intervened") Boolean cbtIntervened,
         @JsonRawValue @JsonProperty("key_thoughts") String keyThoughts,
         @JsonProperty("socratic_count") Integer socraticCount,


### PR DESCRIPTION
## 문제

세션 종료 후 `session_summaries` 테이블의 CBT 관련 필드가 항상 기본값으로 저장되는 버그.

| 필드 | 기존 | 수정 후 |
|------|------|---------|
| `bias_types_detected` | 항상 `[]` | ExtractorResult의 distortionCode 목록 |
| `cbt_intervened` | 항상 `false` | episodeType이 `cbt_success` 또는 `cbt_partial`이면 `true` |
| `key_thoughts` | 항상 `null` | ExtractorResult의 thoughtText 목록 |

## 원인

`SessionConsolidator.upsertSessionSummary()`가 CBT 필드를 파라미터로 받지 않았고, UPDATE/INSERT 양쪽에서 모두 기본값을 사용했다.

## 수정 내용

**`SessionConsolidator.java`**
- `consolidate()`에서 `validThoughts`로부터 3개 CBT 값 도출
  - `biasTypesJson` : 중복 제거한 `distortionCode` 목록 → JSON 직렬화
  - `keyThoughtsJson` : `thoughtText` 목록 → JSON 직렬화
  - `cbtIntervened` : `episodeType` 이 `cbt_success` / `cbt_partial` 여부
- `upsertSessionSummary()` 시그니처에 3개 파라미터 추가
- UPDATE SQL에 `bias_types_detected = ?::jsonb`, `cbt_intervened = ?`, `key_thoughts = ?::jsonb` 추가
- INSERT 빌더에 `.biasTypesDetected()`, `.cbtIntervened()`, `.keyThoughts()` 추가
- `toJson(List<String>)` 헬퍼 추가 (직렬화 실패 시 `"[]"` 반환)

## 범위 외 (별도 이슈 예정)

- `socratic_count`: `WorkingMemory.clear()`와의 race condition으로 이번 PR에서 제외
- embedding pipeline: `VectorRetriever`가 항상 `queryEmbedding = null`로 호출되는 문제 (CRITICAL)
- `GRAPH_BELIEF_NEIGH`: `retrieveBeliefNeighbors()` 미구현 (HIGH)

## 테스트 계획

- [ ] 세션 종료 후 `session_summaries` 조회 → `bias_types_detected`, `cbt_intervened`, `key_thoughts` 실제 값 확인
- [ ] episodeType = `regular`인 세션 → `cbt_intervened = false` 확인
- [ ] episodeType = `cbt_success`인 세션 → `cbt_intervened = true` 확인
- [ ] distortionCode가 없는 세션 → `bias_types_detected = []` 확인

Closes #191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session summaries now include detected thought patterns and key thoughts.
  * CBT-related sessions are now marked more accurately based on the interaction outcome.
* **Bug Fixes**
  * Improved saving of session summary details so newly detected insights are retained consistently.
  * Updated summary processing to keep embeddings in a pending state when summaries are refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->