### PR TITLE
fix: socratic_count Redis 클리어 이전 캡처로 레이스 컨디션 해결

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -103,7 +103,7 @@ public class SessionConsolidator {
     public void onSessionEnded(SessionEndedEvent event) {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
         try {
-            consolidate(event.sessionId(), event.userId(), event.characterId());
+            consolidate(event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
             sessionRepository.updateSummaryStatus(event.sessionId(), SummaryStatus.DONE);
         } catch (Exception e) {
             log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
@@ -113,7 +113,7 @@ public class SessionConsolidator {
         }
     }
 
-    public void consolidate(UUID sessionId, UUID userId, String characterId) {
+    public void consolidate(UUID sessionId, UUID userId, String characterId, int socraticCount) {
         var session = sessionRepository.findById(sessionId).orElse(null);
         var user = userRepository.findById(userId).orElse(null);
         if (session == null || user == null) {
@@ -159,7 +159,7 @@ public class SessionConsolidator {
 
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
                 dominantEmotion, extracted.triggerTags(), extracted.episodeType(),
-                biasTypesJson, keyThoughtsJson, cbtIntervened);
+                biasTypesJson, keyThoughtsJson, cbtIntervened, socraticCount);
 
         // emotion_score_ai: AI 추정 세션 감정 점수 (0~100) 저장
         if (extracted.emotionScore() != null) {
@@ -296,7 +296,8 @@ public class SessionConsolidator {
             String episodeType,
             String biasTypesJson,
             String keyThoughtsJson,
-            boolean cbtIntervened) {
+            boolean cbtIntervened,
+            int socraticCount) {
 
         String[] tagsArray = triggerTags.toArray(new String[0]);
 
@@ -308,13 +309,13 @@ public class SessionConsolidator {
                             SET summary_text = ?, summary_ciphertext = ?, summary_dek_id = ?,
                                 dominant_emotion = ?, trigger_tags = ?, episode_type = ?,
                                 bias_types_detected = ?::jsonb, cbt_intervened = ?, key_thoughts = ?::jsonb,
-                                embedding_status = 'pending'
+                                socratic_count = ?, embedding_status = 'pending'
                             WHERE session_id = ?
                             """,
                             summaryText, ciphertext, dekId,
                             dominantEmotion, tagsArray, episodeType,
                             biasTypesJson, cbtIntervened, keyThoughtsJson,
-                            session.getId()
+                            socraticCount, session.getId()
                     );
                 },
                 () -> {
@@ -329,6 +330,7 @@ public class SessionConsolidator {
                             .biasTypesDetected(biasTypesJson)
                             .cbtIntervened(cbtIntervened)
                             .keyThoughts(keyThoughtsJson)
+                            .socraticCount(socraticCount)
                             .build();
                     // saveAndFlush: JPA flush 후 jdbcTemplate.update가 실제 row를 찾도록 보장
                     sessionSummaryRepository.saveAndFlush(summary);

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionEndedEvent.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionEndedEvent.java
@@ -5,5 +5,6 @@ import java.util.UUID;
 public record SessionEndedEvent(
         UUID sessionId,
         UUID userId,
-        String characterId
+        String characterId,
+        int socraticCount
 ) {}

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -1,6 +1,7 @@
 package com.mio.session.job;
 
 import com.mio.ai.memory.consolidation.SessionEndedEvent;
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.session.domain.Session;
 import com.mio.session.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class SessionTimeoutJob {
     private final SessionRepository sessionRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final TransactionTemplate transactionTemplate;
+    private final WorkingMemory workingMemory;
 
     @Scheduled(fixedDelay = 5 * 60 * 1000)
     public void run() {
@@ -56,8 +58,9 @@ public class SessionTimeoutJob {
                     log.debug("SessionTimeoutJob: sessionId={} no longer timed out, skipping", session.getId());
                     return Boolean.FALSE;
                 }
+                int socraticCount = workingMemory.getSocraticQuestionCount(session.getId());
                 eventPublisher.publishEvent(
-                        new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId()));
+                        new SessionEndedEvent(session.getId(), session.getUser().getId(), session.getCharacterId(), socraticCount));
                 return Boolean.TRUE;
             });
             if (Boolean.TRUE.equals(ended)) {

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -129,7 +129,9 @@ public class SessionService {
 
         // @TransactionalEventListener(AFTER_COMMIT) 캡처용: 트랜잭션 내 발행해야 커밋 후 리스너 실행됨
         String characterId = session.getCharacterId();
-        eventPublisher.publishEvent(new SessionEndedEvent(sessionId, userId, characterId));
+        // clear() 이전에 읽어야 race condition 방지 (async consolidator보다 clear()가 먼저 실행될 수 있음)
+        int socraticCount = workingMemory.getSocraticQuestionCount(sessionId);
+        eventPublisher.publishEvent(new SessionEndedEvent(sessionId, userId, characterId, socraticCount));
 
         // Redis 정리는 커밋 후 실행 (트랜잭션 불필요)
         TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {

--- a/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
+++ b/src/test/java/com/mio/session/job/SessionTimeoutJobTest.java
@@ -1,6 +1,7 @@
 package com.mio.session.job;
 
 import com.mio.ai.memory.consolidation.SessionEndedEvent;
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.session.domain.Session;
 import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
@@ -33,7 +34,9 @@ class SessionTimeoutJobTest {
         SessionRepository sessionRepository = mock(SessionRepository.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
-        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+        WorkingMemory workingMemory = mock(WorkingMemory.class);
+        when(workingMemory.getSocraticQuestionCount(any())).thenReturn(0);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate, workingMemory);
 
         UUID userId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
@@ -61,7 +64,9 @@ class SessionTimeoutJobTest {
         SessionRepository sessionRepository = mock(SessionRepository.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
-        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+        WorkingMemory workingMemory = mock(WorkingMemory.class);
+        when(workingMemory.getSocraticQuestionCount(any())).thenReturn(0);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate, workingMemory);
 
         UUID sessionId = UUID.randomUUID();
         Session session = buildSession(UUID.randomUUID(), sessionId);
@@ -85,7 +90,9 @@ class SessionTimeoutJobTest {
         SessionRepository sessionRepository = mock(SessionRepository.class);
         ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
         TransactionTemplate transactionTemplate = mock(TransactionTemplate.class);
-        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate);
+        WorkingMemory workingMemory = mock(WorkingMemory.class);
+        when(workingMemory.getSocraticQuestionCount(any())).thenReturn(0);
+        SessionTimeoutJob job = new SessionTimeoutJob(sessionRepository, eventPublisher, transactionTemplate, workingMemory);
 
         UUID sessionId1 = UUID.randomUUID();
         UUID sessionId2 = UUID.randomUUID();


### PR DESCRIPTION
## Summary

- `SessionEndedEvent`에 `socraticCount` 필드 추가
- `SessionService.endSession()`에서 `workingMemory.clear()` 이전에 동기적으로 `getSocraticQuestionCount()` 읽어 이벤트에 포함
- `SessionConsolidator`가 Redis 대신 이벤트 페이로드의 값을 받아 DB에 저장하도록 변경
- `SessionTimeoutJob`도 같은 패턴으로 수정 (두 번째 이벤트 발행 지점)

## Root Cause

`endSession()` 트랜잭션 커밋 후 `afterCommit()` 훅의 `workingMemory.clear()`와 `@TransactionalEventListener(AFTER_COMMIT) + @Async`의 `SessionConsolidator` 실행 순서가 비결정적이어서, clear()가 먼저 실행되면 consolidator가 Redis에서 `socratic_count`를 읽지 못함.

## Fix

`socraticCount`를 트랜잭션 내(clear 호출 이전)에 읽어 `SessionEndedEvent` 페이로드에 포함. Consolidator는 Redis 대신 이벤트 객체에서 값을 가져오므로 레이스가 발생하지 않음.

## Test plan
- [ ] 세션 종료 후 `session_summaries.socratic_count` 컬럼에 실제 소크라틱 질문 횟수가 저장되는지 확인
- [ ] 30분 타임아웃으로 종료된 세션에도 동일하게 동작하는지 확인 (`SessionTimeoutJob` 경로)

Closes #195