### PR TITLE
fix: GRAPH_BELIEF_NEIGH retrieval 미구현 해결

### DIFF
--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -223,14 +223,14 @@ public class StructuredRetriever {
                            b.belief_kind
                              || ' [' || COALESCE(b.polarity, 'neutral') || ']'
                              || ' conf:' || ROUND(b.confidence::numeric, 2)
-                             || ' support:' || b.support_count
-                             || ' contradict:' || b.contradict_count AS content,
+                             || ' support:' || COALESCE(b.support_count, 0)
+                             || ' contradict:' || COALESCE(b.contradict_count, 0) AS content,
                            b.confidence AS score
                     FROM user_beliefs b
                     WHERE b.user_id = ?
                       AND b.status = 'active'
                       AND b.confidence BETWEEN 0.3 AND 0.85
-                    ORDER BY (b.support_count + b.contradict_count) DESC, b.confidence DESC
+                    ORDER BY (COALESCE(b.support_count, 0) + COALESCE(b.contradict_count, 0)) DESC, b.confidence DESC
                     LIMIT 5
                     """,
                     (rs, rowNum) -> new RetrievedItem(

--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -213,4 +213,39 @@ public class StructuredRetriever {
             return Collections.emptyList();
         }
     }
+
+    // belief_text는 AES-256 암호화 컬럼이므로 메타데이터 컬럼만 사용해 인접 신념 구성
+    public List<RetrievedItem> retrieveBeliefNeighbors(UUID userId) {
+        try {
+            return jdbcTemplate.query(
+                    """
+                    SELECT b.id::text,
+                           b.belief_kind
+                             || ' [' || COALESCE(b.polarity, 'neutral') || ']'
+                             || ' conf:' || ROUND(b.confidence::numeric, 2)
+                             || ' support:' || b.support_count
+                             || ' contradict:' || b.contradict_count AS content,
+                           b.confidence AS score
+                    FROM user_beliefs b
+                    WHERE b.user_id = ?
+                      AND b.status = 'active'
+                      AND b.confidence BETWEEN 0.3 AND 0.85
+                    ORDER BY (b.support_count + b.contradict_count) DESC, b.confidence DESC
+                    LIMIT 5
+                    """,
+                    (rs, rowNum) -> new RetrievedItem(
+                            rs.getString("id"),
+                            RetrievalSource.GRAPH_BELIEF_NEIGH,
+                            rs.getString("content"),
+                            "sensitive",
+                            rs.getDouble("score"),
+                            rowNum + 1
+                    ),
+                    userId
+            );
+        } catch (Exception e) {
+            log.warn("StructuredRetriever.retrieveBeliefNeighbors failed for userId={}", userId, e);
+            return Collections.emptyList();
+        }
+    }
 }

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -149,6 +149,8 @@ public class ContextPreWarmer {
                         () -> structuredRetriever.retrieveTriggers(userId, List.of()), retrievalPool);
                 case GRAPH_INTERVENTION_FIT -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveInterventionFit(userId), retrievalPool);
+                case GRAPH_BELIEF_NEIGH  -> CompletableFuture.supplyAsync(
+                        () -> structuredRetriever.retrieveBeliefNeighbors(userId), retrievalPool);
                 default                  -> CompletableFuture.completedFuture(List.of());
             };
             futures.add(future);


### PR DESCRIPTION
## Summary

- `StructuredRetriever.retrieveBeliefNeighbors(UUID userId)` 신규 구현
- `ContextPreWarmer.retrieveParallel()` switch에 `GRAPH_BELIEF_NEIGH` case 추가

## Root Cause

`RetrievalSource.GRAPH_BELIEF_NEIGH`가 switch `default`로 폴스루되어 항상 빈 리스트를 반환. 플래너가 해당 소스를 plan에 포함시켜도 실제로 데이터를 조회하지 못하는 상태였음.

## Implementation Notes

`user_beliefs.belief_text`는 AES-256으로 암호화된 컬럼이므로 SQL에서 직접 사용 불가. `belief_kind`, `polarity`, `confidence`, `support_count`, `contradict_count` 메타데이터 컬럼만으로 이웃 신념 컨텐츠를 구성.

confidence 0.3~0.85 범위를 대상으로 하며 증거 활동량(support + contradict 합계) 기준으로 정렬해 가장 활성화된 신념을 상위에 배치.

## Test plan
- [ ] `GRAPH_BELIEF_NEIGH`가 포함된 RetrievalPlan 실행 시 user_beliefs 쿼리 로그 발생 확인
- [ ] 암호화 컬럼 직접 참조 없음 확인 (SQL에 `belief_text_ciphertext` 없음)

Closes #194