### PR TITLE
feat: 임베딩 파이프라인 구현 (EmbeddingWorker)

### DIFF
--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -148,6 +148,9 @@ public class OpenAiLlmClient implements LlmClient {
     }
 
     public float[] embed(String text) {
+        if (text == null || text.isBlank()) {
+            throw new IllegalArgumentException("embed() requires non-blank text");
+        }
         try {
             String requestBody = objectMapper.writeValueAsString(
                     Map.of("model", EMBEDDING_MODEL, "input", text));
@@ -168,7 +171,10 @@ public class OpenAiLlmClient implements LlmClient {
             }
 
             JsonNode root = objectMapper.readTree(response.body());
-            JsonNode embeddingNode = root.path("data").get(0).path("embedding");
+            JsonNode embeddingNode = root.path("data").path(0).path("embedding");
+            if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
+                throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
+            }
             float[] result = new float[embeddingNode.size()];
             for (int i = 0; i < result.length; i++) {
                 result[i] = (float) embeddingNode.get(i).asDouble();
@@ -183,7 +189,7 @@ public class OpenAiLlmClient implements LlmClient {
     private String extractDeltaContent(String json) {
         try {
             JsonNode root = objectMapper.readTree(json);
-            JsonNode delta = root.path("choices").get(0).path("delta");
+            JsonNode delta = root.path("choices").path(0).path("delta");
             JsonNode content = delta.path("content");
             if (!content.isMissingNode() && !content.isNull()) {
                 return content.asText();

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -23,6 +23,8 @@ import java.util.stream.Stream;
 public class OpenAiLlmClient implements LlmClient {
 
     private static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
+    private static final String EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings";
+    private static final String EMBEDDING_MODEL = "text-embedding-3-small";
     private static final String DONE_MARKER = "data: [DONE]";
     private static final String DATA_PREFIX = "data: ";
 
@@ -143,6 +145,39 @@ public class OpenAiLlmClient implements LlmClient {
         body.put("response_format", Map.of("type", "json_object"));
 
         return objectMapper.writeValueAsString(body);
+    }
+
+    public float[] embed(String text) {
+        try {
+            String requestBody = objectMapper.writeValueAsString(
+                    Map.of("model", EMBEDDING_MODEL, "input", text));
+
+            HttpRequest httpRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(EMBEDDINGS_URL))
+                    .header("Authorization", "Bearer " + apiKey)
+                    .header("Content-Type", "application/json")
+                    .timeout(Duration.ofSeconds(30))
+                    .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(
+                    httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() != 200) {
+                throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
+            }
+
+            JsonNode root = objectMapper.readTree(response.body());
+            JsonNode embeddingNode = root.path("data").get(0).path("embedding");
+            float[] result = new float[embeddingNode.size()];
+            for (int i = 0; i < result.length; i++) {
+                result[i] = (float) embeddingNode.get(i).asDouble();
+            }
+            return result;
+        } catch (Exception e) {
+            log.error("Embeddings API error: {}", e.getMessage());
+            throw new RuntimeException("Embeddings request failed", e);
+        }
     }
 
     private String extractDeltaContent(String json) {

--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -1,0 +1,84 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.llm.OpenAiLlmClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * session_summaries.embedding_status = 'pending' 행을 주기적으로 소비해
+ * OpenAI Embeddings API(text-embedding-3-small)를 호출하고 episode_emb를 갱신한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EmbeddingWorker {
+
+    private static final int BATCH_SIZE = 20;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final OpenAiLlmClient openAiLlmClient;
+
+    @Scheduled(fixedDelay = 30_000)
+    public void processPending() {
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                """
+                SELECT id, summary_text
+                FROM session_summaries
+                WHERE embedding_status = 'pending'
+                  AND summary_text IS NOT NULL
+                ORDER BY created_at
+                LIMIT ?
+                """,
+                BATCH_SIZE
+        );
+
+        if (rows.isEmpty()) return;
+        log.debug("EmbeddingWorker: processing {} pending rows", rows.size());
+
+        for (Map<String, Object> row : rows) {
+            UUID id = UUID.fromString(row.get("id").toString());
+            String summaryText = (String) row.get("summary_text");
+            embedOne(id, summaryText);
+        }
+    }
+
+    private void embedOne(UUID summaryId, String summaryText) {
+        try {
+            float[] embedding = openAiLlmClient.embed(summaryText);
+            String vectorLiteral = toVectorLiteral(embedding);
+
+            jdbcTemplate.update(
+                    """
+                    UPDATE session_summaries
+                    SET episode_emb = ?::vector,
+                        embedding_status = 'done'
+                    WHERE id = ?
+                    """,
+                    vectorLiteral, summaryId
+            );
+            log.debug("EmbeddingWorker: embedded summaryId={}", summaryId);
+        } catch (Exception e) {
+            log.warn("EmbeddingWorker: failed for summaryId={}, marking failed", summaryId, e);
+            jdbcTemplate.update(
+                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ?",
+                    summaryId
+            );
+        }
+    }
+
+    private String toVectorLiteral(float[] embedding) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < embedding.length; i++) {
+            if (i > 0) sb.append(',');
+            sb.append(embedding[i]);
+        }
+        return sb.append(']').toString();
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -54,27 +54,32 @@ public class EmbeddingWorker {
             float[] embedding = openAiLlmClient.embed(summaryText);
             String vectorLiteral = toVectorLiteral(embedding);
 
-            jdbcTemplate.update(
+            int updated = jdbcTemplate.update(
                     """
                     UPDATE session_summaries
                     SET episode_emb = ?::vector,
                         embedding_status = 'done'
                     WHERE id = ?
+                      AND embedding_status = 'pending'
                     """,
                     vectorLiteral, summaryId
             );
-            log.debug("EmbeddingWorker: embedded summaryId={}", summaryId);
+            if (updated == 0) {
+                log.debug("EmbeddingWorker: summaryId={} already processed by another instance, skipping", summaryId);
+            } else {
+                log.debug("EmbeddingWorker: embedded summaryId={}", summaryId);
+            }
         } catch (Exception e) {
             log.warn("EmbeddingWorker: failed for summaryId={}, marking failed", summaryId, e);
             jdbcTemplate.update(
-                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ?",
+                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'pending'",
                     summaryId
             );
         }
     }
 
     private String toVectorLiteral(float[] embedding) {
-        StringBuilder sb = new StringBuilder("[");
+        StringBuilder sb = new StringBuilder(embedding.length * 12);
         for (int i = 0; i < embedding.length; i++) {
             if (i > 0) sb.append(',');
             sb.append(embedding[i]);

--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -32,7 +32,6 @@ public class EmbeddingWorker {
                 SELECT id, summary_text
                 FROM session_summaries
                 WHERE embedding_status = 'pending'
-                  AND summary_text IS NOT NULL
                 ORDER BY created_at
                 LIMIT ?
                 """,
@@ -79,7 +78,8 @@ public class EmbeddingWorker {
     }
 
     private String toVectorLiteral(float[] embedding) {
-        StringBuilder sb = new StringBuilder(embedding.length * 12);
+        StringBuilder sb = new StringBuilder(embedding.length * 12 + 2);
+        sb.append('[');
         for (int i = 0; i < embedding.length; i++) {
             if (i > 0) sb.append(',');
             sb.append(embedding[i]);


### PR DESCRIPTION
## Summary

- `OpenAiLlmClient.embed(String text): float[]` 추가 — `text-embedding-3-small` 모델, 기존 API 키·HttpClient 재사용
- `EmbeddingWorker` 신규 구현 — `@Scheduled(fixedDelay=30_000)`, `embedding_status='pending'` 행을 배치(20건)로 소비

## Flow

```
SessionConsolidator → session_summaries.embedding_status = 'pending'
EmbeddingWorker (30s) → OpenAI Embeddings API
                      → UPDATE episode_emb = ?::vector, embedding_status = 'done'
VectorRetriever        → WHERE embedding_status = 'done' 쿼리로 사용
```

## Notes

- 같은 OpenAI API 키로 GPT-4o(chat) + text-embedding-3-small(embeddings) 동시 호출 가능 (별도 키 불필요)
- 실패 시 `embedding_status = 'failed'`로 갱신, 무한 재시도 방지
- `summary_text`는 평문 컬럼 (`summary_ciphertext`가 암호화본) — 임베딩 입력으로 직접 사용

## Test plan
- [ ] 세션 종료 후 30초 내 `session_summaries.embedding_status`가 `done`으로 변경되는지 확인
- [ ] `episode_emb` 컬럼에 1536차원 벡터 저장 확인
- [ ] OpenAI API 오류 시 `failed`로 갱신되는지 확인

Closes #193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background processing for text embeddings, allowing summaries to be converted into vector form automatically.
  * Introduced support for generating embeddings from the app’s AI client.

* **Bug Fixes**
  * Improved error handling for embedding requests and processing failures.
  * Made JSON parsing more resilient when reading streamed AI responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->