### PR TITLE
fix: behavior_tasks.action_text 컬럼명 오타 수정 (#200)

### DIFF
--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -159,7 +159,7 @@ public class StructuredRetriever {
             return jdbcTemplate.query(
                     """
                     SELECT id::text,
-                           title || ' [' || status || ']' AS content,
+                           action_text || ' [' || status || ']' AS content,
                            CASE status WHEN 'completed' THEN 1.0 WHEN 'skipped' THEN 0.3 ELSE 0.5 END AS score
                     FROM behavior_tasks
                     WHERE user_id = ?


### PR DESCRIPTION
## Summary

- `StructuredRetriever.retrieveTodoHistory()`에서 존재하지 않는 `title` 컬럼을 참조하던 버그 수정
- 실제 DDL 컬럼명 `action_text`로 교체
- 기존 코드는 SQL 실행 시 항상 예외가 발생했고, catch 블록에서 조용히 빈 리스트를 반환해 `SQL_TODO_HISTORY` 검색 결과가 항상 비어있던 문제

## Root Cause

`behavior_tasks` 테이블 DDL (V22)의 컬럼명은 `action_text`이며, 설계 문서 §19.2에도 "직전 7일 동일 action_text 중복 회피"로 명시되어 있음. 구현 당시 `title`로 잘못 작성된 것으로 추정.

## Changes

- `StructuredRetriever.java`: SQL 쿼리에서 `title` → `action_text`

## Test Plan

- [ ] `behavior_tasks`에 데이터 삽입 후 `retrieveTodoHistory()` 호출 시 정상 반환 확인
- [ ] `SQL_TODO_HISTORY` 검색 소스를 포함한 시나리오에서 컨텍스트 정상 구성 확인

Closes #200