### PR TITLE
fix: SessionTimeoutJob Redis 누수 및 InterruptedException 미처리 수정

### DIFF
--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -81,6 +81,9 @@ public class OpenAiLlmClient implements LlmClient {
                         });
             }
 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("LLM streaming request interrupted", e);
         } catch (Exception e) {
             log.error("LLM streaming error: {}", e.getMessage());
             throw new RuntimeException("LLM streaming failed", e);
@@ -127,6 +130,9 @@ public class OpenAiLlmClient implements LlmClient {
             JsonNode root = objectMapper.readTree(response.body());
             return root.path("choices").path(0).path("message").path("content").asText();
 
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("LLM complete request interrupted", e);
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());
             throw new RuntimeException("LLM complete failed", e);

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -180,6 +180,9 @@ public class OpenAiLlmClient implements LlmClient {
                 result[i] = (float) embeddingNode.get(i).asDouble();
             }
             return result;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Embeddings request interrupted", e);
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
             throw new RuntimeException("Embeddings request failed", e);

--- a/src/main/java/com/mio/session/job/SessionTimeoutJob.java
+++ b/src/main/java/com/mio/session/job/SessionTimeoutJob.java
@@ -64,6 +64,7 @@ public class SessionTimeoutJob {
                 return Boolean.TRUE;
             });
             if (Boolean.TRUE.equals(ended)) {
+                workingMemory.clear(session.getId());
                 log.debug("SessionTimeoutJob: ended sessionId={}", session.getId());
             }
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

- `SessionTimeoutJob`: 세션 타임아웃 종료 후 `workingMemory.clear()` 누락으로 Redis 키가 TTL까지 잔존하는 메모리 누수 수정. `SessionService.endSession()`과 동일한 cleanup path 유지.
- `OpenAiLlmClient.embed()`: `catch(Exception)`이 `InterruptedException`을 삼켜 스레드 인터럽트 상태가 복원되지 않던 문제 수정. `InterruptedException` 전용 catch 블록 추가 + `Thread.currentThread().interrupt()` 호출.

Closes #203

## Test plan

- [ ] `SessionTimeoutJob`: 타임아웃 실행 후 Redis `working_memory:{sessionId}:*` 키가 정리되는지 확인
- [ ] `OpenAiLlmClient.embed()`: 인터럽트 발생 시 `Thread.isInterrupted()` 상태가 `true`로 복원되는지 확인
- [ ] `./gradlew build` CI 통과 확인