### PR TITLE
fix: ContextPreWarmer GRAPH_TRIGGER 빈 트리거 목록 버그 수정

### DIFF
--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -147,10 +148,16 @@ public class ContextPreWarmer {
                         () -> structuredRetriever.retrieveRecentRisk(userId), retrievalPool);
                 case SQL_TODO_HISTORY    -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveTodoHistory(userId), retrievalPool);
-                case GRAPH_TRIGGER       -> CompletableFuture.supplyAsync(
-                        () -> structuredRetriever.retrieveTriggers(userId,
-                                new ArrayList<>(workingMemory.getSessionDelta(sessionId).currentSessionTriggers())),
-                        retrievalPool);
+                case GRAPH_TRIGGER       -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        List<String> triggers = new ArrayList<>(
+                                workingMemory.getSessionDelta(sessionId).currentSessionTriggers());
+                        return structuredRetriever.retrieveTriggers(userId, triggers);
+                    } catch (Exception e) {
+                        log.warn("ContextPreWarmer: GRAPH_TRIGGER triggers fetch failed for sessionId={}", sessionId, e);
+                        return Collections.<RetrievedItem>emptyList();
+                    }
+                }, retrievalPool);
                 case GRAPH_INTERVENTION_FIT -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveInterventionFit(userId), retrievalPool);
                 case GRAPH_BELIEF_NEIGH  -> CompletableFuture.supplyAsync(

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -8,6 +8,7 @@ import com.mio.ai.memory.retrieval.RetrievalPlan;
 import com.mio.ai.memory.retrieval.RetrievedItem;
 import com.mio.ai.memory.retrieval.StructuredRetriever;
 import com.mio.ai.memory.retrieval.VectorRetriever;
+import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.session.repository.SessionCheckpointRepository;
 import lombok.RequiredArgsConstructor;
@@ -47,6 +48,7 @@ public class ContextPreWarmer {
     private final SessionCheckpointRepository checkpointRepository;
     private final StringRedisTemplate redisTemplate;
     private final JdbcTemplate jdbcTemplate;
+    private final WorkingMemory workingMemory;
 
     private final Executor retrievalPool = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -59,7 +61,7 @@ public class ContextPreWarmer {
 
             // 2. 기본 컨텍스트: clearLow plan
             RetrievalPlan plan = RetrievalPlan.clearLow();
-            List<List<RetrievedItem>> results = retrieveParallel(userId, plan);
+            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan);
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             String context = contextComposer.compose(ranked, plan.sensitivityCap(), false);
 
@@ -115,7 +117,7 @@ public class ContextPreWarmer {
         try {
             boolean hasHistory = checkHasHistory(userId);
             RetrievalPlan plan = memoryRetrievalPlanner.plan(combined, profile, userId, hasHistory);
-            List<List<RetrievedItem>> results = retrieveParallel(userId, plan);
+            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan);
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             boolean highRisk = combined.hardCrisis() || combined.riskCandidate();
             return contextComposer.compose(ranked, plan.sensitivityCap(), highRisk);
@@ -127,7 +129,7 @@ public class ContextPreWarmer {
 
     // ── 실제 병렬 retrieval (CompletableFuture) ────────────────────
 
-    private List<List<RetrievedItem>> retrieveParallel(UUID userId, RetrievalPlan plan) {
+    private List<List<RetrievedItem>> retrieveParallel(UUID sessionId, UUID userId, RetrievalPlan plan) {
         int k = plan.maxK();
         List<CompletableFuture<List<RetrievedItem>>> futures = new ArrayList<>();
 
@@ -146,7 +148,9 @@ public class ContextPreWarmer {
                 case SQL_TODO_HISTORY    -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveTodoHistory(userId), retrievalPool);
                 case GRAPH_TRIGGER       -> CompletableFuture.supplyAsync(
-                        () -> structuredRetriever.retrieveTriggers(userId, List.of()), retrievalPool);
+                        () -> structuredRetriever.retrieveTriggers(userId,
+                                new ArrayList<>(workingMemory.getSessionDelta(sessionId).currentSessionTriggers())),
+                        retrievalPool);
                 case GRAPH_INTERVENTION_FIT -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveInterventionFit(userId), retrievalPool);
                 case GRAPH_BELIEF_NEIGH  -> CompletableFuture.supplyAsync(


### PR DESCRIPTION
## 변경 요약

- `ContextPreWarmer.retrieveParallel()`에 `sessionId` 파라미터 추가
- `WorkingMemory` 주입 추가
- `GRAPH_TRIGGER` 케이스에서 `List.of()` 대신 `workingMemory.getSessionDelta(sessionId).currentSessionTriggers()` 사용

## 문제

`GRAPH_TRIGGER` 소스는 현재 세션에서 발생한 트리거 태그와 겹치는 과거 세션 요약을 검색하는 용도다.
그런데 `retrieveParallel()`에 `sessionId`가 없어서 `List.of()`(빈 리스트)를 전달하고 있었음.

`StructuredRetriever.retrieveTriggers()`는 리스트가 비어있으면 즉시 `Collections.emptyList()` 반환 → `medium` / `high` 플랜에 `GRAPH_TRIGGER`가 포함돼도 항상 빈 결과.

## 동작 변화

- `preWarm()` 시점 (세션 시작 직후): 트리거가 아직 없으므로 빈 리스트 → 기존과 동일, 불필요한 DB 쿼리 없음
- `buildContextSync()` 시점 (cache miss, 대화 중): 트리거가 쌓여있으면 실제 과거 세션 요약 반환

## 테스트 계획

- [ ] `GRAPH_TRIGGER` 포함 플랜에서 트리거가 있을 때 과거 세션이 컨텍스트에 포함되는지 확인
- [ ] 트리거가 없을 때 빈 결과 반환 (빠른 종료) 확인
- [ ] `./gradlew build` CI 통과

Closes #205