### PR TITLE
fix: EmbeddingWorker FOR UPDATE SKIP LOCKED으로 멀티 인스턴스 중복 API 호출 방지

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -29,11 +29,16 @@ public class EmbeddingWorker {
     public void processPending() {
         List<Map<String, Object>> rows = jdbcTemplate.queryForList(
                 """
-                SELECT id, summary_text
-                FROM session_summaries
-                WHERE embedding_status = 'pending'
-                ORDER BY created_at
-                LIMIT ?
+                UPDATE session_summaries
+                SET embedding_status = 'processing'
+                WHERE id IN (
+                    SELECT id FROM session_summaries
+                    WHERE embedding_status = 'pending'
+                    ORDER BY created_at
+                    LIMIT ?
+                    FOR UPDATE SKIP LOCKED
+                )
+                RETURNING id, summary_text
                 """,
                 BATCH_SIZE
         );
@@ -49,6 +54,14 @@ public class EmbeddingWorker {
     }
 
     private void embedOne(UUID summaryId, String summaryText) {
+        if (summaryText == null || summaryText.isBlank()) {
+            log.warn("EmbeddingWorker: summaryText is null or blank for summaryId={}, marking failed", summaryId);
+            jdbcTemplate.update(
+                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'processing'",
+                    summaryId
+            );
+            return;
+        }
         try {
             float[] embedding = openAiLlmClient.embed(summaryText);
             String vectorLiteral = toVectorLiteral(embedding);
@@ -59,7 +72,7 @@ public class EmbeddingWorker {
                     SET episode_emb = ?::vector,
                         embedding_status = 'done'
                     WHERE id = ?
-                      AND embedding_status = 'pending'
+                      AND embedding_status = 'processing'
                     """,
                     vectorLiteral, summaryId
             );
@@ -71,7 +84,7 @@ public class EmbeddingWorker {
         } catch (Exception e) {
             log.warn("EmbeddingWorker: failed for summaryId={}, marking failed", summaryId, e);
             jdbcTemplate.update(
-                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'pending'",
+                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'processing'",
                     summaryId
             );
         }


### PR DESCRIPTION
## Summary

- `processPending()`: `SELECT ... WHERE pending` → `UPDATE ... SET embedding_status = 'processing' WHERE id IN (SELECT ... FOR UPDATE SKIP LOCKED) RETURNING` 으로 원자적 행 점유
- `embedOne()`: null/blank 조기 검증 추가
- 성공/실패 CAS 조건을 `pending` → `processing`으로 통일

멀티 인스턴스 환경에서 동일 행에 대한 OpenAI API 중복 호출 제거.

## Test plan

- [ ] 단일 인스턴스: pending → processing → done/failed 흐름 정상 동작 확인
- [ ] embedding_status = 'processing' 행이 다른 인스턴스에게 노출되지 않음 확인

Closes #207