### PR TITLE
fix: key_thoughts 포맷을 명세대로 {content, distortion_type} 객체 배열로 수정

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -149,12 +149,15 @@ public class SessionConsolidator {
                         .filter(code -> code != null && !code.isBlank())
                         .distinct()
                         .toList());
-        String keyThoughtsJson = toJsonObjects(
+        String keyThoughtsJson = toJson(
                 validThoughts.stream()
                         .filter(t -> t.thoughtText() != null && !t.thoughtText().isBlank())
-                        .map(t -> java.util.Map.of(
-                                "content", t.thoughtText(),
-                                "distortion_type", t.distortionCode() != null ? t.distortionCode() : ""))
+                        .map(t -> {
+                            java.util.Map<String, String> m = new java.util.LinkedHashMap<>();
+                            m.put("content", t.thoughtText());
+                            m.put("distortion_type", t.distortionCode());
+                            return m;
+                        })
                         .toList());
         boolean cbtIntervened = "cbt_success".equalsIgnoreCase(extracted.episodeType())
                 || "cbt_partial".equalsIgnoreCase(extracted.episodeType());
@@ -346,16 +349,7 @@ public class SessionConsolidator {
 
     // ── JSON 직렬화 ───────────────────────────────────────────────
 
-    private String toJson(List<String> list) {
-        try {
-            return objectMapper.writeValueAsString(list);
-        } catch (Exception e) {
-            log.warn("SessionConsolidator: JSON serialization failed", e);
-            return "[]";
-        }
-    }
-
-    private String toJsonObjects(List<java.util.Map<String, String>> list) {
+    private String toJson(List<?> list) {
         try {
             return objectMapper.writeValueAsString(list);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -149,10 +149,12 @@ public class SessionConsolidator {
                         .filter(code -> code != null && !code.isBlank())
                         .distinct()
                         .toList());
-        String keyThoughtsJson = toJson(
+        String keyThoughtsJson = toJsonObjects(
                 validThoughts.stream()
-                        .map(ExtractorResult.ExtractedThought::thoughtText)
-                        .filter(text -> text != null && !text.isBlank())
+                        .filter(t -> t.thoughtText() != null && !t.thoughtText().isBlank())
+                        .map(t -> java.util.Map.of(
+                                "content", t.thoughtText(),
+                                "distortion_type", t.distortionCode() != null ? t.distortionCode() : ""))
                         .toList());
         boolean cbtIntervened = "cbt_success".equalsIgnoreCase(extracted.episodeType())
                 || "cbt_partial".equalsIgnoreCase(extracted.episodeType());
@@ -345,6 +347,15 @@ public class SessionConsolidator {
     // ── JSON 직렬화 ───────────────────────────────────────────────
 
     private String toJson(List<String> list) {
+        try {
+            return objectMapper.writeValueAsString(list);
+        } catch (Exception e) {
+            log.warn("SessionConsolidator: JSON serialization failed", e);
+            return "[]";
+        }
+    }
+
+    private String toJsonObjects(List<java.util.Map<String, String>> list) {
         try {
             return objectMapper.writeValueAsString(list);
         } catch (Exception e) {


### PR DESCRIPTION
## Summary

- `SessionConsolidator`에서 `key_thoughts` 생성 시 `thoughtText` 문자열만 저장하던 방식을 `{content, distortion_type}` 객체 배열로 변경
- DB 컬럼은 `JSONB`이므로 마이그레이션 불필요
- `SessionSummaryResponse`는 `@JsonRawValue`로 그대로 통과하므로 변경 불필요

## Before / After

**Before**
```json
"key_thoughts": ["취업 스트레스로 인한 자기 의심", "헬스를 시작하겠다는 결정"]
```

**After**
```json
"key_thoughts": [
  {"content": "취업 스트레스로 인한 자기 의심", "distortion_type": "mind_reading"},
  {"content": "헬스를 시작하겠다는 결정", "distortion_type": ""}
]
```

## Test plan

- [ ] 세션 종료 후 `GET /v1/sessions/{id}/summary` 응답에서 `key_thoughts`가 객체 배열인지 확인
- [ ] `distortion_type`이 없는 thought의 경우 빈 문자열(`""`)로 내려가는지 확인
- [ ] `bias_types_detected`와 `key_thoughts[].distortion_type` 값이 일치하는지 확인

Closes #209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session summaries now store key thoughts with both the thought text and its associated distortion type.
  * Empty distortion values are handled cleanly, improving consistency in saved summary data.
* **Bug Fixes**
  * Improved JSON handling so summary data falls back safely if serialization fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->