### PR TITLE
feat: TODO 부분완료(partial_completed) 상태 추가

### DIFF
--- a/src/main/java/com/mio/report/dto/ReportCommonDto.java
+++ b/src/main/java/com/mio/report/dto/ReportCommonDto.java
@@ -11,6 +11,7 @@ public class ReportCommonDto {
     public record TodoSummaryDto(
             int total,
             int completed,
+            @JsonProperty("partial_completed") int partialCompleted,
             int skipped,
             int expired,
             @JsonProperty("completion_rate") double completionRate,

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -212,7 +212,7 @@ public class ReportService {
     private TodoSummaryDto buildTodoSummary(UUID userId, OffsetDateTime start, OffsetDateTime end) {
         List<Object[]> rows = behaviorTaskRepository.findTodoStatsByUserAndPeriod(userId, start, end);
 
-        int total = 0, completed = 0, skipped = 0, expired = 0;
+        int total = 0, completed = 0, partialCompleted = 0, skipped = 0, expired = 0;
         Map<String, Integer> categoryDist = new LinkedHashMap<>();
 
         for (Object[] row : rows) {
@@ -221,16 +221,17 @@ public class ReportService {
             int count         = ((Long) row[2]).intValue();
             total += count;
             switch (status) {
-                case COMPLETED -> completed += count;
-                case SKIPPED   -> skipped += count;
-                case EXPIRED   -> expired += count;
+                case COMPLETED         -> completed += count;
+                case PARTIAL_COMPLETED -> partialCompleted += count;
+                case SKIPPED           -> skipped += count;
+                case EXPIRED           -> expired += count;
                 default -> {}
             }
             categoryDist.merge(category, count, Integer::sum);
         }
 
         double completionRate = total > 0 ? Math.round(completed * 1000.0 / total) / 10.0 : 0.0;
-        return new TodoSummaryDto(total, completed, skipped, expired, completionRate, categoryDist);
+        return new TodoSummaryDto(total, completed, partialCompleted, skipped, expired, completionRate, categoryDist);
     }
 
     private SessionSummaryDto buildSessionSummary(UUID userId, OffsetDateTime start, OffsetDateTime end) {

--- a/src/main/java/com/mio/todo/domain/BehaviorTask.java
+++ b/src/main/java/com/mio/todo/domain/BehaviorTask.java
@@ -77,7 +77,7 @@ public class BehaviorTask {
     private OffsetDateTime completedAt;
 
     public void complete(Integer beforeEmotion, Integer afterEmotion, String feedback) {
-        if (TaskStatus.SUGGESTED != this.status) {
+        if (this.status != TaskStatus.SUGGESTED && this.status != TaskStatus.PARTIAL_COMPLETED) {
             throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
         }
         validateEmotionRange(beforeEmotion);
@@ -87,6 +87,18 @@ public class BehaviorTask {
         this.afterEmotion = afterEmotion;
         this.feedback = feedback;
         this.completedAt = OffsetDateTime.now(AppConstants.ZONE);
+    }
+
+    public void partialComplete(Integer beforeEmotion, Integer afterEmotion, String feedback) {
+        if (this.status != TaskStatus.SUGGESTED) {
+            throw new BusinessException(ErrorCode.TODO_ALREADY_COMPLETED);
+        }
+        validateEmotionRange(beforeEmotion);
+        validateEmotionRange(afterEmotion);
+        this.status = TaskStatus.PARTIAL_COMPLETED;
+        this.beforeEmotion = beforeEmotion;
+        this.afterEmotion = afterEmotion;
+        this.feedback = feedback;
     }
 
     public void skip() {

--- a/src/main/java/com/mio/todo/domain/TaskStatus.java
+++ b/src/main/java/com/mio/todo/domain/TaskStatus.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 public enum TaskStatus {
     SUGGESTED("suggested"),
     COMPLETED("completed"),
+    PARTIAL_COMPLETED("partial_completed"),
     SKIPPED("skipped"),
     EXPIRED("expired");
 

--- a/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Pattern;
 
 public record TodoCheckinRequest(
         @NotBlank
-        @Pattern(regexp = "completed|skipped", message = "status는 completed 또는 skipped 이어야 합니다.")
+        @Pattern(regexp = "completed|partial_completed|skipped", message = "status는 completed, partial_completed, 또는 skipped 이어야 합니다.")
         String status,
 
         @JsonProperty("before_emotion")

--- a/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
+++ b/src/main/java/com/mio/todo/dto/TodoCheckinResponse.java
@@ -17,12 +17,15 @@ public record TodoCheckinResponse(
         String characterReaction
 ) {
     private static final String REACTION_COMPLETED = "잘했어! 작은 것부터 하나씩 해나가는 게 진짜 대단한 거야 🎉";
+    private static final String REACTION_PARTIAL_COMPLETED = "절반이라도 해낸 거야, 충분히 잘했어! 다음에 마저 해봐요 💪";
     private static final String REACTION_SKIPPED = "괜찮아, 다음에 또 도전해봐요!";
 
     public static TodoCheckinResponse from(BehaviorTask task) {
-        String reaction = TaskStatus.COMPLETED == task.getStatus()
-                ? REACTION_COMPLETED
-                : REACTION_SKIPPED;
+        String reaction = switch (task.getStatus()) {
+            case COMPLETED -> REACTION_COMPLETED;
+            case PARTIAL_COMPLETED -> REACTION_PARTIAL_COMPLETED;
+            default -> REACTION_SKIPPED;
+        };
         return new TodoCheckinResponse(
                 task.getStatus().value(),
                 task.getBeforeEmotion(),

--- a/src/main/java/com/mio/todo/event/TodoPartialCompletedEvent.java
+++ b/src/main/java/com/mio/todo/event/TodoPartialCompletedEvent.java
@@ -1,0 +1,13 @@
+package com.mio.todo.event;
+
+import java.util.UUID;
+
+public record TodoPartialCompletedEvent(
+        UUID userId,
+        UUID behaviorTaskId,
+        UUID sessionId,
+        String interventionKind,
+        Integer beforeEmotionScore,
+        Integer afterEmotionScore,
+        String characterId
+) {}

--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -9,6 +9,7 @@ import com.mio.todo.dto.TodoCheckinRequest;
 import com.mio.todo.dto.TodoCheckinResponse;
 import com.mio.todo.dto.TodoResponse;
 import com.mio.todo.event.TodoCompletedEvent;
+import com.mio.todo.event.TodoPartialCompletedEvent;
 import com.mio.todo.event.TodoSkippedEvent;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
@@ -28,7 +29,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TodoService {
 
-    private static final Set<String> VALID_CHECKIN_STATUSES = Set.of("completed", "skipped");
+    private static final Set<String> VALID_CHECKIN_STATUSES = Set.of("completed", "partial_completed", "skipped");
 
     private final UserRepository userRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
@@ -73,6 +74,9 @@ public class TodoService {
         if ("completed".equals(request.status())) {
             task.complete(request.beforeEmotion(), request.afterEmotion(), request.feedback());
             publishCompletedEvent(userId, task, request);
+        } else if ("partial_completed".equals(request.status())) {
+            task.partialComplete(request.beforeEmotion(), request.afterEmotion(), request.feedback());
+            publishPartialCompletedEvent(userId, task, request);
         } else {
             task.skip();
             publishSkippedEvent(userId, task);
@@ -116,6 +120,20 @@ public class TodoService {
         UUID sessionId = task.getSourceSession() != null
                 ? task.getSourceSession().getId() : null;
         eventPublisher.publishEvent(new TodoCompletedEvent(
+                userId,
+                task.getId(),
+                sessionId,
+                task.getInterventionKind(),
+                request.beforeEmotion(),
+                request.afterEmotion(),
+                task.getCharacterId()
+        ));
+    }
+
+    private void publishPartialCompletedEvent(UUID userId, BehaviorTask task, TodoCheckinRequest request) {
+        UUID sessionId = task.getSourceSession() != null
+                ? task.getSourceSession().getId() : null;
+        eventPublisher.publishEvent(new TodoPartialCompletedEvent(
                 userId,
                 task.getId(),
                 sessionId,

--- a/src/main/resources/db/migration/V35__add_partial_completed_task_status.sql
+++ b/src/main/resources/db/migration/V35__add_partial_completed_task_status.sql
@@ -1,0 +1,9 @@
+-- behavior_tasks.status CHECK constraint에 'partial_completed' 추가
+-- 부분완료: SUGGESTED → PARTIAL_COMPLETED (재체크인으로 COMPLETED 전환 가능)
+
+ALTER TABLE behavior_tasks
+    DROP CONSTRAINT IF EXISTS behavior_tasks_status_check;
+
+ALTER TABLE behavior_tasks
+    ADD CONSTRAINT behavior_tasks_status_check
+        CHECK (status IN ('suggested', 'completed', 'partial_completed', 'skipped', 'expired'));


### PR DESCRIPTION
## Summary

- `TaskStatus`에 `PARTIAL_COMPLETED` 열거값 추가 (DB: `partial_completed`)
- `BehaviorTask.partialComplete()` 메서드 추가, `complete()`가 PARTIAL_COMPLETED 상태에서도 호출 가능하도록 가드 완화 (재체크인 허용)
- `TodoCheckinRequest` status 유효값에 `partial_completed` 포함, `TodoCheckinResponse`에 전용 캐릭터 반응 추가
- `TodoPartialCompletedEvent` 신설로 부분완료 시 별도 이벤트 발행
- `ReportService` / `ReportCommonDto`: 부분완료 집계 카운터 추가, 완료율 산정에서는 제외
- Flyway V35: `behavior_tasks` CHECK 제약에 `partial_completed` 포함

## 정책 요약

| 항목 | 내용 |
|------|------|
| 완료율 산입 | ❌ 제외 |
| 프로필 카운트 | ❌ 제외 |
| 재체크인 | ✅ `partial_completed` → `completed` 허용 |
| `completed` 후 재기록 | ❌ 불가 (409) |
| 할 일 알림 발송 | ✅ 유지 |
| 이벤트 | `TodoPartialCompletedEvent` 별도 발행 |

## Test plan

- [ ] `POST /v1/todos/{id}/checkin` — `status: partial_completed` 요청 → 200, `character_reaction` 확인
- [ ] 부분완료 후 `status: completed` 재체크인 → 200 정상
- [ ] 부분완료 후 `status: partial_completed` 재체크인 → 409 CONFLICT
- [ ] 완료(`completed`) 후 재체크인 → 409 CONFLICT
- [ ] `GET /v1/reports/weekly` — `partial_completed` 카운트 집계, `completion_rate` 미산입 확인
- [ ] DB V35 마이그레이션 정상 적용 확인

Closes #216