### PR TITLE
fix: 세션 요약 생성 실패 방지 — beliefKind 검증 + 컨솔리데이션 트랜잭션 분리 (#219)

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -29,13 +29,13 @@ public class ExtractorLlmClient {
               "thoughts": [
                 {
                   "thoughtText": "사용자의 자동적 사고 원문",
-                  "distortionCode": "overgeneralization|catastrophizing|mind_reading|all_or_nothing|self_blame|emotional_reasoning|null",
-                  "beliefKind": "core_self|core_other|core_world|intermediate_rule|compensatory_strategy|null",
-                  "polarity": "positive|negative|neutral",
+                  "distortionCode": "overgeneralization|catastrophizing|mind_reading|all_or_nothing|self_blame|emotional_reasoning 중 하나, 없으면 JSON null",
+                  "beliefKind": "core_self|core_other|core_world|intermediate_rule|compensatory_strategy 중 하나, 없으면 JSON null",
+                  "polarity": "positive|negative|neutral 중 하나, 불명확하면 JSON null",
                   "confidence": 0.0~1.0
                 }
               ],
-              "dominantEmotion": "happy|calm|anxious|sad|angry|ashamed|numb|tired|confused|null",
+              "dominantEmotion": "happy|calm|anxious|sad|angry|ashamed|numb|tired|confused 중 하나, 없으면 JSON null",
               "emotionScore": 0~100,
               "triggerTags": ["trigger1", "trigger2"],
               "episodeType": "crisis|cbt_success|cbt_partial|support_only|regular"
@@ -74,7 +74,9 @@ public class ExtractorLlmClient {
                  잡담, 계획 수립, 긍정적인 근황 이야기 등.
 
             - thoughts는 최대 3개만 추출합니다.
-            - distortionCode와 beliefKind는 시드에 없는 값이면 null로 설정하세요.
+            - distortionCode, beliefKind, polarity, dominantEmotion은 해당하는 값이 없으면
+              반드시 문자열 "null"이 아니라 JSON null로 설정하세요. (올바른 예: "beliefKind": null)
+            - 위 목록(시드)에 없는 값은 임의로 만들어내지 말고 JSON null로 두세요.
             - triggerTags는 구체적인 상황 키워드로 2~4개를 추출합니다.
             - emotionScore: 세션 종료 시점의 사용자 감정 상태를 0(매우 부정)~100(매우 긍정)으로 수치화합니다.
             """;

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -23,6 +23,7 @@ import com.mio.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -92,6 +93,15 @@ public class SessionConsolidator {
     private final OntologyValidator ontologyValidator;
     private final TodoRecommendationService todoRecommendationService;
     private final SummaryStatusWriter summaryStatusWriter;
+    // 메모리 보강을 별도 트랜잭션(REQUIRES_NEW)으로 호출하기 위한 self 프록시.
+    // self-invocation으로는 프록시 어드바이스(@Transactional)가 적용되지 않으므로 ObjectProvider로 우회.
+    private final ObjectProvider<SessionConsolidator> self;
+
+    // belief_kind / polarity DB CHECK 제약과 동일한 허용값 화이트리스트.
+    // ExtractorLLM이 문자열 "null"이나 시드 밖 환각값을 반환해도 DB 위반 없이 걸러내기 위함.
+    private static final Set<String> VALID_BELIEF_KINDS = Set.of(
+            "core_self", "core_other", "core_world", "intermediate_rule", "compensatory_strategy");
+    private static final Set<String> VALID_POLARITIES = Set.of("positive", "negative", "neutral");
 
     // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
     // @Transactional(REQUIRES_NEW): 응고 작업을 독립 트랜잭션으로 실행
@@ -102,30 +112,48 @@ public class SessionConsolidator {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onSessionEnded(SessionEndedEvent event) {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
+        EnrichmentInput enrichInput;
         try {
-            consolidate(event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
+            // 1단계: 사용자에게 노출되는 세션 요약을 이 트랜잭션에 영속화하고 DONE으로 표시한다.
+            enrichInput = consolidate(event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
             sessionRepository.updateSummaryStatus(event.sessionId(), SummaryStatus.DONE);
         } catch (Exception e) {
             log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
             // REQUIRES_NEW: 현재 트랜잭션이 rollback-only 또는 DB-aborted 상태일 수 있으므로
             // 별도 트랜잭션에서 failed 상태를 저장한다.
             summaryStatusWriter.markFailed(event.sessionId());
+            return;
+        }
+
+        // 2단계: thoughts/beliefs/cbt_patterns/todos 등 메모리 보강은 별도 트랜잭션(REQUIRES_NEW)에서
+        // best-effort로 실행한다. 보강 단계가 실패해도 이미 커밋될 요약을 롤백시키지 않는다.
+        if (enrichInput != null) {
+            try {
+                self.getObject().enrichMemory(enrichInput);
+            } catch (Exception e) {
+                log.error("SessionConsolidator: memory enrichment failed but summary preserved sessionId={}",
+                        event.sessionId(), e);
+            }
         }
     }
 
-    public void consolidate(UUID sessionId, UUID userId, String characterId, int socraticCount) {
+    /**
+     * 1단계: 세션 요약을 생성·영속화한다(현재 트랜잭션).
+     * 메모리 보강에 필요한 입력을 반환하며, 보강 대상이 없으면 null을 반환한다.
+     */
+    public EnrichmentInput consolidate(UUID sessionId, UUID userId, String characterId, int socraticCount) {
         var session = sessionRepository.findById(sessionId).orElse(null);
         var user = userRepository.findById(userId).orElse(null);
         if (session == null || user == null) {
             log.warn("SessionConsolidator: session or user not found sessionId={}", sessionId);
-            return;
+            return null;
         }
 
         // 1. 대화 컨텍스트 구성 (체크포인트 요약 + 잔여 메시지)
         String conversationText = buildConversationContext(sessionId);
         if (conversationText.isBlank()) {
             log.info("SessionConsolidator: no messages found for sessionId={}", sessionId);
-            return;
+            return null;
         }
 
         // 2. 세션 요약 생성 (LLM)
@@ -174,38 +202,64 @@ public class SessionConsolidator {
             );
         }
 
-        // 7. cbt_patterns 갱신 (세션 내 동일 왜곡 중복 방지 — distinct codes만 처리)
-        validThoughts.stream()
-                .map(ExtractorResult.ExtractedThought::distortionCode)
-                .filter(code -> code != null && !code.isBlank())
-                .distinct()
-                .forEach(code -> upsertCbtPattern(userId, code));
-
-        // 8. emotional_states INSERT
-        if (dominantEmotion != null) {
-            insertEmotionalState(user, sessionId, dominantEmotion);
-        }
-
-        // 9. thoughts + UserBelief 연결
-        for (ExtractorResult.ExtractedThought extracted_thought : validThoughts) {
-            persistThought(user, sessionId, extracted_thought);
-        }
-
-        // 10. 세션 종료 시 Todo 3건 자동 생성 (MIO-CBT-015)
         List<String> distortionCodes = validThoughts.stream()
                 .map(ExtractorResult.ExtractedThought::distortionCode)
                 .filter(code -> code != null && !code.isBlank())
                 .distinct()
                 .toList();
+
+        log.info("SessionConsolidator: summary persisted sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
+                sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
+
+        return new EnrichmentInput(userId, sessionId, validThoughts, dominantEmotion, distortionCodes);
+    }
+
+    /**
+     * 2단계: 메모리 보강(cbt_patterns / emotional_states / thoughts·beliefs / todos)을
+     * 요약과 분리된 별도 트랜잭션으로 실행한다. 이 단계의 실패는 요약 영속화에 영향을 주지 않는다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void enrichMemory(EnrichmentInput in) {
+        var user = userRepository.findById(in.userId()).orElse(null);
+        var session = sessionRepository.findById(in.sessionId()).orElse(null);
+        if (user == null || session == null) {
+            log.warn("SessionConsolidator: enrich skipped — session or user not found sessionId={}", in.sessionId());
+            return;
+        }
+        UUID sessionId = in.sessionId();
+
+        // 7. cbt_patterns 갱신 (세션 내 동일 왜곡 중복 방지 — distinct codes만 처리)
+        in.distortionCodes().forEach(code -> upsertCbtPattern(in.userId(), code));
+
+        // 8. emotional_states INSERT
+        if (in.dominantEmotion() != null) {
+            insertEmotionalState(user, sessionId, in.dominantEmotion());
+        }
+
+        // 9. thoughts + UserBelief 연결
+        for (ExtractorResult.ExtractedThought extractedThought : in.validThoughts()) {
+            persistThought(user, sessionId, extractedThought);
+        }
+
+        // 10. 세션 종료 시 Todo 3건 자동 생성 (MIO-CBT-015)
         try {
-            todoRecommendationService.generateForSession(user, session, distortionCodes, dominantEmotion);
+            todoRecommendationService.generateForSession(user, session, in.distortionCodes(), in.dominantEmotion());
         } catch (Exception e) {
             log.warn("SessionConsolidator: todo generation failed sessionId={}", sessionId, e);
         }
 
-        log.info("SessionConsolidator: completed sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
-                sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
+        log.info("SessionConsolidator: enrichment completed sessionId={} thoughts={} emotion={}",
+                sessionId, in.validThoughts().size(), in.dominantEmotion());
     }
+
+    /** 2단계 메모리 보강에 필요한 입력 (요약 트랜잭션 종료 후 별도 트랜잭션으로 전달). */
+    public record EnrichmentInput(
+            UUID userId,
+            UUID sessionId,
+            List<ExtractorResult.ExtractedThought> validThoughts,
+            String dominantEmotion,
+            List<String> distortionCodes
+    ) {}
 
     // ── 대화 컨텍스트 구성 ────────────────────────────────────────
 
@@ -405,20 +459,30 @@ public class SessionConsolidator {
         thoughtRepository.save(thought);
 
         // UserBelief 연결 (new belief로 추가 또는 existing에 evidence 추가)
-        if (extracted.beliefKind() != null) {
-            addBeliefEvidence(user, sessionId, extracted);
+        // ExtractorLLM이 문자열 "null"·시드 밖 환각값을 반환할 수 있으므로 DB CHECK 허용값으로 검증한다.
+        // !=null 만으로는 문자열 "null"을 거르지 못해 user_beliefs CHECK(23514) 위반을 유발한다.
+        String beliefKind = extracted.beliefKind();
+        if (beliefKind != null && !VALID_BELIEF_KINDS.contains(beliefKind)) {
+            log.warn("SessionConsolidator: discarded unknown beliefKind='{}' sessionId={}", beliefKind, sessionId);
+            beliefKind = null;
+        }
+        if (beliefKind != null) {
+            addBeliefEvidence(user, sessionId, extracted, beliefKind);
         }
     }
 
     private void addBeliefEvidence(User user, UUID sessionId,
-                                   ExtractorResult.ExtractedThought extracted) {
+                                   ExtractorResult.ExtractedThought extracted, String beliefKind) {
+        // polarity도 DB CHECK(IN positive/negative/neutral) 대상 — 허용값 밖이면 null(컬럼 nullable)로 정규화.
+        String polarity = VALID_POLARITIES.contains(extracted.polarity()) ? extracted.polarity() : null;
+
         List<UserBelief> existing = beliefRepository.findByUser_IdAndStatus(user.getId(), "active");
         // 동일 beliefKind + polarity의 기존 신념에 support/contradict 증거 추가
         // 없으면 새 belief 생성
         UserBelief belief = existing.stream()
-                .filter(b -> b.getBeliefKind().equals(extracted.beliefKind())
+                .filter(b -> b.getBeliefKind().equals(beliefKind)
                         && b.getPolarity() != null
-                        && b.getPolarity().equals(extracted.polarity()))
+                        && b.getPolarity().equals(polarity))
                 .findFirst()
                 .orElseGet(() -> {
                     byte[] enc = messageEncryptor.encrypt(
@@ -427,13 +491,13 @@ public class SessionConsolidator {
                             .user(user)
                             .beliefTextCiphertext(enc)
                             .beliefTextDekId(messageEncryptor.dekId())
-                            .beliefKind(extracted.beliefKind())
-                            .polarity(extracted.polarity())
+                            .beliefKind(beliefKind)
+                            .polarity(polarity)
                             .build();
                     return beliefRepository.save(newBelief);
                 });
 
-        String evidenceKind = "negative".equals(extracted.polarity()) ? "support" : "contradict";
+        String evidenceKind = "negative".equals(polarity) ? "support" : "contradict";
         evidenceAccumulator.accumulate(belief, evidenceKind, sessionId, null);
     }
 

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -104,19 +104,20 @@ public class SessionConsolidator {
     private static final Set<String> VALID_POLARITIES = Set.of("positive", "negative", "neutral");
 
     // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
-    // @Transactional(REQUIRES_NEW): 응고 작업을 독립 트랜잭션으로 실행
-    //   - @TransactionalEventListener와 @Transactional 조합 시 REQUIRES_NEW 또는 NOT_SUPPORTED 필수
-    //   - self-invocation 방지: 진입점(onSessionEnded)에 @Transactional 선언
+    // 진입점 자체에는 @Transactional을 두지 않는다. 1·2단계를 각각 self 프록시 + REQUIRES_NEW로
+    // 호출해, 요약 트랜잭션이 먼저 커밋된 뒤 메모리 보강 트랜잭션이 독립적으로 실행되게 한다.
+    // (진입점을 @Transactional로 두면 요약 tx가 커밋되지 않은 채 보강 tx가 suspend 상태로 겹쳐
+    //  커넥션 동시 점유·가시성 문제가 생긴다.)
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void onSessionEnded(SessionEndedEvent event) {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
         EnrichmentInput enrichInput;
         try {
-            // 1단계: 사용자에게 노출되는 세션 요약을 이 트랜잭션에 영속화하고 DONE으로 표시한다.
-            enrichInput = consolidate(event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
-            sessionRepository.updateSummaryStatus(event.sessionId(), SummaryStatus.DONE);
+            // 1단계: 세션 요약을 독립 트랜잭션(REQUIRES_NEW)에서 영속화하고 DONE까지 커밋한다.
+            // self 프록시로 호출해야 consolidate의 @Transactional 어드바이스가 적용된다.
+            enrichInput = self.getObject().consolidate(
+                    event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
         } catch (Exception e) {
             log.error("SessionConsolidator failed for sessionId={}", event.sessionId(), e);
             // REQUIRES_NEW: 현재 트랜잭션이 rollback-only 또는 DB-aborted 상태일 수 있으므로
@@ -126,7 +127,7 @@ public class SessionConsolidator {
         }
 
         // 2단계: thoughts/beliefs/cbt_patterns/todos 등 메모리 보강은 별도 트랜잭션(REQUIRES_NEW)에서
-        // best-effort로 실행한다. 보강 단계가 실패해도 이미 커밋될 요약을 롤백시키지 않는다.
+        // best-effort로 실행한다. 1단계 요약은 이미 커밋되었으므로 보강 실패가 요약에 영향을 주지 않는다.
         if (enrichInput != null) {
             try {
                 self.getObject().enrichMemory(enrichInput);
@@ -138,9 +139,11 @@ public class SessionConsolidator {
     }
 
     /**
-     * 1단계: 세션 요약을 생성·영속화한다(현재 트랜잭션).
-     * 메모리 보강에 필요한 입력을 반환하며, 보강 대상이 없으면 null을 반환한다.
+     * 1단계: 세션 요약을 생성·영속화하고 summary_status=DONE까지 커밋한다(독립 트랜잭션).
+     * 메모리 보강에 필요한 입력을 반환하며, 영속화할 요약이 없으면(세션/유저 부재·메시지 없음)
+     * 상태를 변경하지 않고 null을 반환한다. (요약 row 없이 DONE으로 표시되어 조회 시 404가 나는 것을 방지)
      */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public EnrichmentInput consolidate(UUID sessionId, UUID userId, String characterId, int socraticCount) {
         var session = sessionRepository.findById(sessionId).orElse(null);
         var user = userRepository.findById(userId).orElse(null);
@@ -207,6 +210,9 @@ public class SessionConsolidator {
                 .filter(code -> code != null && !code.isBlank())
                 .distinct()
                 .toList();
+
+        // 요약 row가 실제로 영속화된 성공 경로에서만 DONE으로 표시한다(이 트랜잭션 커밋 시 함께 반영).
+        sessionRepository.updateSummaryStatus(sessionId, SummaryStatus.DONE);
 
         log.info("SessionConsolidator: summary persisted sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
                 sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
@@ -479,10 +485,10 @@ public class SessionConsolidator {
         List<UserBelief> existing = beliefRepository.findByUser_IdAndStatus(user.getId(), "active");
         // 동일 beliefKind + polarity의 기존 신념에 support/contradict 증거 추가
         // 없으면 새 belief 생성
+        // polarity가 둘 다 null이어도 동일 신념으로 매칭한다(중복 belief 생성 방지).
         UserBelief belief = existing.stream()
                 .filter(b -> b.getBeliefKind().equals(beliefKind)
-                        && b.getPolarity() != null
-                        && b.getPolarity().equals(polarity))
+                        && java.util.Objects.equals(b.getPolarity(), polarity))
                 .findFirst()
                 .orElseGet(() -> {
                     byte[] enc = messageEncryptor.encrypt(

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -7,6 +7,7 @@ import com.mio.ai.memory.episodic.UserBelief;
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.SummaryStatus;
 import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
@@ -20,6 +21,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,6 +42,7 @@ class SessionConsolidatorTest {
     private UserBeliefRepository beliefRepository;
     private BeliefEvidenceAccumulator evidenceAccumulator;
     private JdbcTemplate jdbcTemplate;
+    private SessionRepository sessionRepository;
 
     private SessionConsolidator newConsolidator() {
         messageEncryptor = mock(MessageEncryptor.class);
@@ -47,6 +50,7 @@ class SessionConsolidatorTest {
         beliefRepository = mock(UserBeliefRepository.class);
         evidenceAccumulator = mock(BeliefEvidenceAccumulator.class);
         jdbcTemplate = mock(JdbcTemplate.class);
+        sessionRepository = mock(SessionRepository.class);
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
 
@@ -54,7 +58,7 @@ class SessionConsolidatorTest {
         ObjectProvider<SessionConsolidator> self = mock(ObjectProvider.class);
 
         return new SessionConsolidator(
-                mock(SessionRepository.class),
+                sessionRepository,
                 mock(SessionSummaryRepository.class),
                 mock(SessionCheckpointRepository.class),
                 mock(UserRepository.class),
@@ -144,6 +148,20 @@ class SessionConsolidatorTest {
         assertThat(captor.getValue().getBeliefKind()).isEqualTo("core_self");
         assertThat(captor.getValue().getPolarity()).isEqualTo("negative");
         verify(evidenceAccumulator).accumulate(any(), eq("support"), eq(sessionId), eq(null));
+    }
+
+    @Test
+    @DisplayName("세션을 찾지 못하면 요약을 영속화하지 않고 DONE으로 표시하지 않는다")
+    void consolidate_sessionNotFound_doesNotMarkDone() {
+        SessionConsolidator consolidator = newConsolidator();
+        when(sessionRepository.findById(any())).thenReturn(Optional.empty());
+
+        SessionConsolidator.EnrichmentInput result =
+                consolidator.consolidate(UUID.randomUUID(), UUID.randomUUID(), "char-1", 0);
+
+        assertThat(result).isNull();
+        // 요약 row가 없는데 DONE으로 표시되면 조회 시 404가 발생하므로, 상태를 건드리지 않아야 한다.
+        verify(sessionRepository, never()).updateSummaryStatus(any(), any());
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -3,16 +3,19 @@ package com.mio.ai.memory.consolidation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.episodic.ThoughtRepository;
+import com.mio.ai.memory.episodic.UserBelief;
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -20,37 +23,72 @@ import java.util.List;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class SessionConsolidatorTest {
 
-    @Test
-    @DisplayName("세션 종료 요약은 최근 40개로 자르지 않고 전체 대화를 시간순으로 조회한다")
-    void loadConversationLines_does_not_limit_to_recent_40_messages() {
-        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
-        UUID sessionId = UUID.randomUUID();
-        when(jdbcTemplate.queryForList(anyString(), eq(sessionId))).thenReturn(List.of());
-        SessionConsolidator consolidator = new SessionConsolidator(
+    private MessageEncryptor messageEncryptor;
+    private ThoughtRepository thoughtRepository;
+    private UserBeliefRepository beliefRepository;
+    private BeliefEvidenceAccumulator evidenceAccumulator;
+    private JdbcTemplate jdbcTemplate;
+
+    private SessionConsolidator newConsolidator() {
+        messageEncryptor = mock(MessageEncryptor.class);
+        thoughtRepository = mock(ThoughtRepository.class);
+        beliefRepository = mock(UserBeliefRepository.class);
+        evidenceAccumulator = mock(BeliefEvidenceAccumulator.class);
+        jdbcTemplate = mock(JdbcTemplate.class);
+        when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
+        when(messageEncryptor.dekId()).thenReturn("app-key-v1");
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<SessionConsolidator> self = mock(ObjectProvider.class);
+
+        return new SessionConsolidator(
                 mock(SessionRepository.class),
                 mock(SessionSummaryRepository.class),
                 mock(SessionCheckpointRepository.class),
                 mock(UserRepository.class),
-                mock(ThoughtRepository.class),
-                mock(UserBeliefRepository.class),
-                mock(BeliefEvidenceAccumulator.class),
+                thoughtRepository,
+                beliefRepository,
+                evidenceAccumulator,
                 mock(ExtractorLlmClient.class),
                 mock(LlmClient.class),
-                mock(MessageEncryptor.class),
+                messageEncryptor,
                 jdbcTemplate,
                 new ObjectMapper(),
                 mock(OntologyValidator.class),
                 mock(TodoRecommendationService.class),
-                mock(SummaryStatusWriter.class)
+                mock(SummaryStatusWriter.class),
+                self
         );
+    }
+
+    private User userWithId() {
+        User user = mock(User.class);
+        when(user.getId()).thenReturn(UUID.randomUUID());
+        return user;
+    }
+
+    private ExtractorResult.ExtractedThought thought(String beliefKind, String polarity) {
+        return new ExtractorResult.ExtractedThought("자동적 사고", "self_blame", beliefKind, polarity, 0.7);
+    }
+
+    @Test
+    @DisplayName("세션 종료 요약은 최근 40개로 자르지 않고 전체 대화를 시간순으로 조회한다")
+    void loadConversationLines_does_not_limit_to_recent_40_messages() {
+        SessionConsolidator consolidator = newConsolidator();
+        UUID sessionId = UUID.randomUUID();
+        when(jdbcTemplate.queryForList(anyString(), eq(sessionId))).thenReturn(List.of());
 
         ReflectionTestUtils.invokeMethod(consolidator, "loadConversationLines", sessionId);
 
@@ -58,5 +96,69 @@ class SessionConsolidatorTest {
         verify(jdbcTemplate).queryForList(sqlCaptor.capture(), eq(sessionId));
         assertThat(sqlCaptor.getValue().toLowerCase()).doesNotContain("limit 40");
         assertThat(sqlCaptor.getValue().toLowerCase()).contains("order by created_at asc");
+    }
+
+    @Test
+    @DisplayName("ExtractorLLM이 문자열 \"null\" beliefKind를 반환하면 belief를 만들지 않고 예외도 없다")
+    void persistThought_stringNullBeliefKind_skipsBeliefWithoutError() {
+        SessionConsolidator consolidator = newConsolidator();
+        User user = userWithId();
+
+        assertThatCode(() -> ReflectionTestUtils.invokeMethod(
+                consolidator, "persistThought", user, UUID.randomUUID(), thought("null", "negative")
+        )).doesNotThrowAnyException();
+
+        verify(thoughtRepository).save(any());
+        // 허용값 밖 beliefKind는 belief 영속 경로에 진입하지 않아 DB CHECK 위반을 원천 차단한다.
+        verifyNoInteractions(beliefRepository);
+        verifyNoInteractions(evidenceAccumulator);
+    }
+
+    @Test
+    @DisplayName("시드에 없는 환각 beliefKind도 걸러내고 belief를 만들지 않는다")
+    void persistThought_unknownBeliefKind_skipsBelief() {
+        SessionConsolidator consolidator = newConsolidator();
+        User user = userWithId();
+
+        ReflectionTestUtils.invokeMethod(
+                consolidator, "persistThought", user, UUID.randomUUID(), thought("core_belief", "negative"));
+
+        verify(beliefRepository, never()).save(any());
+        verifyNoInteractions(evidenceAccumulator);
+    }
+
+    @Test
+    @DisplayName("허용된 beliefKind는 정상적으로 UserBelief를 생성한다")
+    void persistThought_validBeliefKind_createsBelief() {
+        SessionConsolidator consolidator = newConsolidator();
+        User user = userWithId();
+        UUID sessionId = UUID.randomUUID();
+        when(beliefRepository.findByUser_IdAndStatus(any(), eq("active"))).thenReturn(List.of());
+        when(beliefRepository.save(any(UserBelief.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ReflectionTestUtils.invokeMethod(
+                consolidator, "persistThought", user, sessionId, thought("core_self", "negative"));
+
+        ArgumentCaptor<UserBelief> captor = ArgumentCaptor.forClass(UserBelief.class);
+        verify(beliefRepository).save(captor.capture());
+        assertThat(captor.getValue().getBeliefKind()).isEqualTo("core_self");
+        assertThat(captor.getValue().getPolarity()).isEqualTo("negative");
+        verify(evidenceAccumulator).accumulate(any(), eq("support"), eq(sessionId), eq(null));
+    }
+
+    @Test
+    @DisplayName("허용값 밖 polarity는 null로 정규화되어 DB CHECK 위반을 막는다")
+    void persistThought_invalidPolarity_normalizedToNull() {
+        SessionConsolidator consolidator = newConsolidator();
+        User user = userWithId();
+        when(beliefRepository.findByUser_IdAndStatus(any(), eq("active"))).thenReturn(List.of());
+        when(beliefRepository.save(any(UserBelief.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        ReflectionTestUtils.invokeMethod(
+                consolidator, "persistThought", user, UUID.randomUUID(), thought("core_self", "null"));
+
+        ArgumentCaptor<UserBelief> captor = ArgumentCaptor.forClass(UserBelief.class);
+        verify(beliefRepository).save(captor.capture());
+        assertThat(captor.getValue().getPolarity()).isNull();
     }
 }


### PR DESCRIPTION
## 배경
프론트에서 `GET /v1/sessions/{id}/summary` 호출 시 `410 GONE` + `세션 요약 생성에 실패했습니다.` 가 반복 발생.
EC2 운영 로그 분석 결과 **프론트 입력 문제가 아니라**, 세션 종료 후 비동기 컨솔리데이션이 DB CHECK 위반으로 통째 롤백되어 `summary_status=FAILED`로 고정된 것.

## 근본 원인
```
SQLState: 23514
ERROR: new row for relation "user_beliefs" violates check constraint "user_beliefs_belief_kind_check"
SessionConsolidator failed for sessionId=3c2cb3ca-...
```
- `ExtractorLlmClient` 프롬프트가 "값 없으면 `null`"로 지시 → LLM이 JSON null이 아니라 **문자열 `"null"`**(또는 시드 밖 환각값)을 반환.
- `SessionConsolidator.persistThought`의 가드가 `beliefKind != null` 뿐 → 문자열 `"null"`을 통과시켜 `user_beliefs`에 insert → `belief_kind NOT NULL CHECK IN(...)` 위반.
- 요약 저장 + thought/belief/todo가 **단일 트랜잭션**이라, belief insert 실패가 **정상 생성된 요약까지 동반 롤백** → `FAILED` 영구 고정.
- `distortionCode`/`emotion`/`episodeType`은 화이트리스트 검증이 있어 안전. **`beliefKind`/`polarity`만 검증 누락**이 직접 원인.

## 변경 사항
- **P0 (root cause)** `beliefKind`/`polarity`를 DB CHECK 허용값 화이트리스트로 검증. 허용값 밖(문자열 `"null"`·환각값 포함)이면 belief 생성을 건너뛰어 DB 위반을 원천 차단.
- **P1 (resilience)** 요약 영속화(`consolidate`)와 메모리 보강(`enrichMemory`: cbt_patterns/emotional_states/thoughts·beliefs/todos)을 **REQUIRES_NEW로 트랜잭션 분리**. 보강 단계 실패가 사용자 요약을 롤백하지 못하게 함(요약은 DONE 유지, 보강 실패는 로그만).
- **P2 (prevention)** ExtractorLLM 프롬프트 정정 — 문자열 `"null"` 유도 제거, JSON null 사용 명시.

## 영향 범위
- `summary_status=failed` 세션은 전체 **1건**(`3c2cb3ca-...`). 본 수정 배포 후 별도 운영 작업으로 재생성 복구 예정(기존 stale todo 3건 정리 동반).
- `consolidate()`/`enrichMemory()` 외부 호출처 없음.

## 테스트
- `SessionConsolidatorTest` 5건 통과 (`./gradlew test --tests "*SessionConsolidatorTest"`):
  - [x] 문자열 `"null"` beliefKind → belief 미생성·예외 없음
  - [x] 시드 밖 환각 beliefKind → 스킵
  - [x] 허용 beliefKind → 정상 UserBelief 생성
  - [x] 허용값 밖 polarity → null 정규화
  - [x] 기존 회귀(전체 대화 시간순 조회) 유지
- 전체 통합 스위트는 인프라(DB/Redis) 의존으로 CI에서 검증.

## TODO (배포 후)
- [ ] 머지·배포 완료 확인
- [ ] 막힌 세션 `3c2cb3ca-...` 재생성 복구 (stale todo 3건 삭제 후 재컨솔리데이션 → summary DONE·본문 채워짐 확인)

Closes #219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session summaries now flow into memory enrichment automatically after a session ends, improving follow-up context.

* **Bug Fixes**
  * Improved handling of missing or unclear AI-extracted fields by storing blank values consistently instead of invalid placeholders.
  * Prevented invalid belief details from being saved, reducing failed updates and data issues.
  * Made session summary processing more resilient: if one step fails, the system now records the failure cleanly and stops further processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->