### PR TITLE
fix(cd): 배포마다 데이터를 삭제하던 'docker compose down -v' 제거

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -113,9 +113,9 @@ jobs:
 
             docker compose -f docker-compose.prod.yml pull
 
-            # 볼륨 재초기화: 비밀번호 불일치 해결 (최초 1회)
-            docker compose -f docker-compose.prod.yml down -v
-
+            # up -d: 이미지가 갱신된 app 컨테이너만 재생성하고 postgres/redis 볼륨은 보존한다.
+            # (과거 'down -v'는 매 배포마다 named volume을 삭제해 DB가 전부 초기화되는 문제가 있었음.
+            #  비밀번호 변경 등으로 볼륨 리셋이 필요하면 워크플로우가 아니라 수동 1회 작업으로 수행한다.)
             docker compose -f docker-compose.prod.yml up -d --remove-orphans
 
             docker image prune -f


### PR DESCRIPTION
## 개요

CD 워크플로우가 `main` 푸시마다 `docker compose down -v`를 실행해 named volume(`postgres_data`, `redis_data`)을 삭제하고 있었습니다. 그 결과 **모든 배포에서 Postgres/Redis 데이터가 전부 초기화**되던 문제를 수정합니다.

주석상으로는 "비밀번호 불일치 해결 (최초 1회)"이라고 적혀 있었으나, 코드가 영구적으로 남아 매 배포마다 데이터가 유실됐습니다.

## 변경 사항

- `.github/workflows/cd.yml`에서 `docker compose down -v` 제거
- 배포는 `pull` 후 `up -d --remove-orphans`로 이미지가 갱신된 app 컨테이너만 재생성하고 데이터 볼륨은 보존
- 볼륨 리셋이 필요한 경우(비밀번호 변경 등)는 워크플로우가 아니라 수동 1회 작업으로 수행하도록 주석 명시

## 영향

- ⚠️ CD는 `main` 푸시에만 동작하므로, 이 수정이 실제 배포에 반영되려면 `develop → main` 머지가 필요합니다.

## 테스트 계획

- [ ] develop → main 배포 후, 재배포 시 DB 데이터가 보존되는지 확인
- [ ] `up -d --remove-orphans`로 app 컨테이너가 정상 갱신되는지 확인

Closes #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deployment behavior to avoid wiping persistent database and cache volumes during releases.
  * Deployment now preserves data between updates and only recreates the containers that changed.
  * Added guidance for performing a one-time manual volume reset when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->