### PR TITLE
feat: 마이페이지 joined_at 필드 추가 (#231)

### DIFF
--- a/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
+++ b/src/main/java/com/mio/mypage/dto/UserProfileResponse.java
@@ -2,6 +2,7 @@ package com.mio.mypage.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -12,7 +13,8 @@ public record UserProfileResponse(
         @JsonProperty("preferred_character") PreferredCharacterDto preferredCharacter,
         UserStatsDto stats,
         @JsonProperty("monthly_emotion_distribution") List<EmotionDistributionDto> monthlyEmotionDistribution,
-        @JsonProperty("signup_step") String signupStep
+        @JsonProperty("signup_step") String signupStep,
+        @JsonProperty("joined_at") OffsetDateTime joinedAt
 ) {
     public record PreferredCharacterDto(
             @JsonProperty("character_id") String characterId,

--- a/src/main/java/com/mio/mypage/service/UserProfileService.java
+++ b/src/main/java/com/mio/mypage/service/UserProfileService.java
@@ -69,7 +69,8 @@ public class UserProfileService {
                 preferredCharacter,
                 new UserStatsDto(totalCheckins, consecutiveDays, todoCompleted),
                 emotionDist,
-                user.getSignupStep().name()
+                user.getSignupStep().name(),
+                user.getSignupCompletedAt()
         );
     }
 

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -93,6 +93,9 @@ public class User {
     @Column(name = "updated_at", nullable = false)
     private OffsetDateTime updatedAt;
 
+    @Column(name = "signup_completed_at")
+    private OffsetDateTime signupCompletedAt;
+
     @Column(name = "deleted_at")
     private OffsetDateTime deletedAt;
 
@@ -131,6 +134,7 @@ public class User {
     public void finalizeSignup() {
         this.signupStep = SignupStep.COMPLETED;
         this.status = "ACTIVE";
+        this.signupCompletedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void updateProfile(String nickname, String ageRange, boolean ageRangePresent) {

--- a/src/main/resources/db/migration/V37__add_signup_completed_at_to_users.sql
+++ b/src/main/resources/db/migration/V37__add_signup_completed_at_to_users.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+    ADD COLUMN signup_completed_at TIMESTAMPTZ;


### PR DESCRIPTION
## 요약
  마이페이지에 계정 생성일(joined_at)을 표시하기 위해 회원가입 최종 완료 시각을 저장합니다.
  기존 `users.created_at`은 소셜 로그인 시점에 저장되어 온보딩 미완료 상태에서도 생성되므로,
  `POST /v1/auth/signup/complete` 호출 시점을 별도 컬럼으로 저장하고 `GET /v1/users/me` 응답에 포함합니다.

  ## 관련 이슈
  - Closes #231

  ## 변경 사항
  - V37 마이그레이션: `users` 테이블에 `signup_completed_at TIMESTAMPTZ` 컬럼 추가
  - `User.finalizeSignup()`에서 `signupCompletedAt` 저장
  - `UserProfileResponse`에 `joined_at` 필드 추가
  - `UserProfileService.getProfile()`에서 `joined_at` 반환

  ## 영향 범위
  - [x] API 스펙 또는 응답 형식이 변경됩니다.
  - [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
  - [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
  - [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
  - [ ] 로깅 / 모니터링 포인트가 변경됩니다.
  - [ ] Breaking change 가 있습니다.

  > `GET /v1/users/me` 응답에 `joined_at` 필드가 추가되는 변경입니다. 기존 필드 변경 없이 신규 필드 추가이므로 하위 호환성에 영향 없습니다.
  > 기존 가입 완료 유저는 `signup_completed_at`이 null이므로 `joined_at`은 null로 반환됩니다.

  ## 테스트
  ### 실행 커맨드
  ```bash
  ./gradlew test

  확인 내용

  - POST /v1/auth/signup/complete 호출 후 users.signup_completed_at에 값이 저장되는지 확인
  - GET /v1/users/me 응답에 joined_at 필드가 포함되는지 확인
  - 가입 미완료 유저(signup_step != COMPLETED)의 경우 joined_at이 null로 반환되는지 확인

  중점 리뷰 포인트

  - 기존 가입 완료 유저의 signup_completed_at이 null인 상태가 클라이언트에서 문제없이 처리되는지 FE 측 확인 필요

  배포 / 롤백

  - Rollout: 배포 시 Flyway V37 마이그레이션 자동 실행 (ADD COLUMN — 무중단)
  - Rollback: ALTER TABLE users DROP COLUMN signup_completed_at 실행 후 이전 버전 배포

  체크리스트

  - [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
  - [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
  - [x] 관련 테스트 또는 검증을 직접 수행했습니다.
  - [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
  - [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User profiles now include the time a signup was completed.
  * The account signup flow now records when completion happens.

* **Bug Fixes**
  * Profile data returned by the app now includes the new completion timestamp consistently.

* **Chores**
  * Database schema updated to store signup completion times for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->