### PR TITLE
fix: Todo 준비 후 세션 요약 완료 상태로 전환

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -14,7 +14,6 @@ import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.session.domain.SessionCheckpoint;
 import com.mio.session.domain.SessionSummary;
-import com.mio.session.domain.SummaryStatus;
 import com.mio.session.repository.SessionCheckpointRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
@@ -106,6 +105,7 @@ public class SessionConsolidator {
     // @TransactionalEventListener(AFTER_COMMIT): endSession 트랜잭션 커밋 후 실행 → 커밋된 데이터 안전하게 읽기
     // 진입점 자체에는 @Transactional을 두지 않는다. 1·2단계를 각각 self 프록시 + REQUIRES_NEW로
     // 호출해, 요약 트랜잭션이 먼저 커밋된 뒤 메모리 보강 트랜잭션이 독립적으로 실행되게 한다.
+    // summary_status=DONE은 사용자 응답에 필요한 Todo 저장까지 끝난 뒤 별도로 표시한다.
     // (진입점을 @Transactional로 두면 요약 tx가 커밋되지 않은 채 보강 tx가 suspend 상태로 겹쳐
     //  커넥션 동시 점유·가시성 문제가 생긴다.)
     @Async
@@ -114,7 +114,7 @@ public class SessionConsolidator {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
         EnrichmentInput enrichInput;
         try {
-            // 1단계: 세션 요약을 독립 트랜잭션(REQUIRES_NEW)에서 영속화하고 DONE까지 커밋한다.
+            // 1단계: 세션 요약을 독립 트랜잭션(REQUIRES_NEW)에서 영속화한다.
             // self 프록시로 호출해야 consolidate의 @Transactional 어드바이스가 적용된다.
             enrichInput = self.getObject().consolidate(
                     event.sessionId(), event.userId(), event.characterId(), event.socraticCount());
@@ -138,20 +138,30 @@ public class SessionConsolidator {
 
             // 3단계: Todo 자동 생성 (MIO-CBT-015, 세션 맥락 개인화 — 이슈 #228).
             // 블로킹 LLM 개인화 호출이 DB 트랜잭션 밖에서 실행되도록 enrichMemory 커밋 후 별도로 호출한다.
+            int generatedTodoCount;
             try {
-                todoRecommendationService.generateForSession(
+                generatedTodoCount = todoRecommendationService.generateForSession(
                         enrichInput.userId(), enrichInput.sessionId(),
                         new TodoRecommendationService.TodoGenerationInput(
                                 enrichInput.distortionCodes(), enrichInput.dominantEmotion(),
                                 enrichInput.triggerTags(), enrichInput.summaryText()));
             } catch (Exception e) {
                 log.warn("SessionConsolidator: todo generation failed sessionId={}", event.sessionId(), e);
+                summaryStatusWriter.markFailed(event.sessionId());
+                return;
             }
+            if (generatedTodoCount <= 0) {
+                log.warn("SessionConsolidator: no todo generated; summary not exposed sessionId={}",
+                        event.sessionId());
+                summaryStatusWriter.markFailed(event.sessionId());
+                return;
+            }
+            summaryStatusWriter.markDone(event.sessionId());
         }
     }
 
     /**
-     * 1단계: 세션 요약을 생성·영속화하고 summary_status=DONE까지 커밋한다(독립 트랜잭션).
+     * 1단계: 세션 요약을 생성·영속화한다(독립 트랜잭션).
      * 메모리 보강에 필요한 입력을 반환하며, 영속화할 요약이 없으면(세션/유저 부재·메시지 없음)
      * 상태를 변경하지 않고 null을 반환한다. (요약 row 없이 DONE으로 표시되어 조회 시 404가 나는 것을 방지)
      */
@@ -223,9 +233,6 @@ public class SessionConsolidator {
                 .distinct()
                 .toList();
 
-        // 요약 row가 실제로 영속화된 성공 경로에서만 DONE으로 표시한다(이 트랜잭션 커밋 시 함께 반영).
-        sessionRepository.updateSummaryStatus(sessionId, SummaryStatus.DONE);
-
         log.info("SessionConsolidator: summary persisted sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
                 sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
 
@@ -234,7 +241,7 @@ public class SessionConsolidator {
     }
 
     /**
-     * 2단계: 메모리 보강(cbt_patterns / emotional_states / thoughts·beliefs / todos)을
+     * 2단계: 메모리 보강(cbt_patterns / emotional_states / thoughts·beliefs)을
      * 요약과 분리된 별도 트랜잭션으로 실행한다. 이 단계의 실패는 요약 영속화에 영향을 주지 않는다.
      */
     @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/java/com/mio/ai/memory/consolidation/SummaryStatusWriter.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SummaryStatusWriter.java
@@ -18,6 +18,11 @@ public class SummaryStatusWriter {
     private final SessionRepository sessionRepository;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void markDone(UUID sessionId) {
+        sessionRepository.updateSummaryStatus(sessionId, SummaryStatus.DONE);
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void markFailed(UUID sessionId) {
         try {
             sessionRepository.updateSummaryStatus(sessionId, SummaryStatus.FAILED);

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
@@ -66,7 +66,7 @@ public class TodoRecommendationService {
      * (호출부 {@code SessionConsolidator#onSessionEnded}는 다른 트랜잭션이 열려있지 않은
      *  지점에서 호출한다.)
      */
-    public void generateForSession(UUID userId, UUID sessionId, TodoGenerationInput input) {
+    public int generateForSession(UUID userId, UUID sessionId, TodoGenerationInput input) {
         List<String> disliked = loadDislikedPatterns(userId);
         Set<String> distortions = Set.copyOf(input.distortionCodes());
         String emotion = input.dominantEmotion();
@@ -76,34 +76,34 @@ public class TodoRecommendationService {
                 .toList();
         if (pool.isEmpty()) {
             log.info("[TodoRecommendation] no candidate templates for userId={}", userId);
-            return;
+            return 0;
         }
 
         Map<String, Integer> historyAffinity = loadHistoryAffinity(userId);
         List<BehaviorTemplate> selected = selectBalanced(pool, distortions, emotion, historyAffinity);
         if (selected.isEmpty()) {
-            return;
+            return 0;
         }
 
         // LLM 개인화는 트랜잭션 밖에서 수행 (블로킹 HTTP 호출 동안 커넥션 점유 방지).
         List<String> actionTexts = actionPersonalizer.personalize(
                 input.sessionSummary(), input.triggerTags(), selected);
 
-        persistTasks(userId, sessionId, selected, actionTexts);
+        return persistTasks(userId, sessionId, selected, actionTexts);
     }
 
     /**
      * 선택·개인화가 끝난 Todo를 저장한다. {@code saveAll}이 자체 트랜잭션으로 원자적으로 처리하므로
      * 별도 트랜잭션 경계를 두지 않는다(별도로 두면 같은 빈 self-invocation이라 어차피 적용되지 않음).
      */
-    private void persistTasks(UUID userId, UUID sessionId,
-                              List<BehaviorTemplate> selected, List<String> actionTexts) {
+    private int persistTasks(UUID userId, UUID sessionId,
+                             List<BehaviorTemplate> selected, List<String> actionTexts) {
         User user = userRepository.findById(userId).orElse(null);
         Session session = sessionRepository.findById(sessionId).orElse(null);
         if (user == null || session == null) {
             log.warn("[TodoRecommendation] persist skipped — user or session not found userId={} sessionId={}",
                     userId, sessionId);
-            return;
+            return 0;
         }
 
         List<BehaviorTask> tasks = new ArrayList<>(selected.size());
@@ -113,6 +113,7 @@ public class TodoRecommendationService {
         behaviorTaskRepository.saveAll(tasks);
         log.info("[TodoRecommendation] generated {} todos for userId={} sessionId={}",
                 tasks.size(), userId, sessionId);
+        return tasks.size();
     }
 
     /** 카테고리별로 세션 신호 스코어 최고점 후보 중 무작위 1건 선택. */

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -16,6 +16,7 @@ import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -34,6 +35,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.inOrder;
 
 class SessionConsolidatorTest {
 
@@ -43,6 +45,9 @@ class SessionConsolidatorTest {
     private BeliefEvidenceAccumulator evidenceAccumulator;
     private JdbcTemplate jdbcTemplate;
     private SessionRepository sessionRepository;
+    private TodoRecommendationService todoRecommendationService;
+    private SummaryStatusWriter summaryStatusWriter;
+    private ObjectProvider<SessionConsolidator> self;
 
     private SessionConsolidator newConsolidator() {
         messageEncryptor = mock(MessageEncryptor.class);
@@ -51,11 +56,14 @@ class SessionConsolidatorTest {
         evidenceAccumulator = mock(BeliefEvidenceAccumulator.class);
         jdbcTemplate = mock(JdbcTemplate.class);
         sessionRepository = mock(SessionRepository.class);
+        todoRecommendationService = mock(TodoRecommendationService.class);
+        summaryStatusWriter = mock(SummaryStatusWriter.class);
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
 
         @SuppressWarnings("unchecked")
-        ObjectProvider<SessionConsolidator> self = mock(ObjectProvider.class);
+        ObjectProvider<SessionConsolidator> selfProvider = mock(ObjectProvider.class);
+        self = selfProvider;
 
         return new SessionConsolidator(
                 sessionRepository,
@@ -71,9 +79,9 @@ class SessionConsolidatorTest {
                 jdbcTemplate,
                 new ObjectMapper(),
                 mock(OntologyValidator.class),
-                mock(TodoRecommendationService.class),
-                mock(SummaryStatusWriter.class),
-                self
+                todoRecommendationService,
+                summaryStatusWriter,
+                selfProvider
         );
     }
 
@@ -85,6 +93,53 @@ class SessionConsolidatorTest {
 
     private ExtractorResult.ExtractedThought thought(String beliefKind, String polarity) {
         return new ExtractorResult.ExtractedThought("자동적 사고", "self_blame", beliefKind, polarity, 0.7);
+    }
+
+    @Test
+    @DisplayName("세션 요약 DONE은 Todo 저장 완료 후에만 표시한다")
+    void onSessionEnded_marksDoneOnlyAfterTodoGeneration() {
+        SessionConsolidator consolidator = newConsolidator();
+        SessionConsolidator proxy = mock(SessionConsolidator.class);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
+                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약"
+        );
+        when(self.getObject()).thenReturn(proxy);
+        when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
+        when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any()))
+                .thenReturn(3);
+
+        consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2));
+
+        InOrder inOrder = inOrder(proxy, todoRecommendationService, summaryStatusWriter);
+        inOrder.verify(proxy).consolidate(sessionId, userId, "mio", 2);
+        inOrder.verify(proxy).enrichMemory(input);
+        inOrder.verify(todoRecommendationService).generateForSession(eq(userId), eq(sessionId), any());
+        inOrder.verify(summaryStatusWriter).markDone(sessionId);
+        verify(sessionRepository, never()).updateSummaryStatus(sessionId, SummaryStatus.DONE);
+        verify(summaryStatusWriter, never()).markFailed(sessionId);
+    }
+
+    @Test
+    @DisplayName("Todo를 만들지 못하면 빈 Todo 요약을 노출하지 않고 실패 상태로 전환한다")
+    void onSessionEnded_whenTodoGenerationCreatesNoTasks_marksFailed() {
+        SessionConsolidator consolidator = newConsolidator();
+        SessionConsolidator proxy = mock(SessionConsolidator.class);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
+                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약"
+        );
+        when(self.getObject()).thenReturn(proxy);
+        when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
+        when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any()))
+                .thenReturn(0);
+
+        consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2));
+
+        verify(summaryStatusWriter, never()).markDone(sessionId);
+        verify(summaryStatusWriter).markFailed(sessionId);
     }
 
     @Test


### PR DESCRIPTION
## 요약
- 세션 요약의 `summary_status=DONE` 전환 시점을 Todo 저장 성공 이후로 늦췄습니다.
- `TodoRecommendationService`가 생성된 Todo 개수를 반환하게 해서, 컨솔리데이터가 빈 Todo 요약 노출을 막을 수 있게 했습니다.
- `DONE` 전환 순서와 Todo 0건 생성 시 실패 처리에 대한 회귀 테스트를 추가했습니다.

## 배경
summary 응답에는 Todo가 반드시 포함되어야 합니다. 기존에는 비동기 컨솔리데이션 중 `summary_status=DONE`이 Todo 생성/커밋보다 먼저 노출될 수 있어, `GET /v1/sessions/{id}/summary`가 완료 상태이면서도 `todos: []`를 반환하는 레이스가 있었습니다.

#228의 Todo 개인화/트랜잭션 분리 변경은 이미 `develop`에 merge되었습니다. 이 PR은 그 위에서 `DONE` 노출 시점을 Todo 저장 완료 이후로 조정하는 회귀 수정입니다.

## 테스트
- `./gradlew test --tests com.mio.ai.memory.consolidation.SessionConsolidatorTest --tests com.mio.ai.memory.consolidation.TodoRecommendationServiceTest --tests com.mio.session.service.SessionServiceTest --tests com.mio.session.controller.SessionControllerTest --tests com.mio.MioApplicationTests`

참고: Docker 재기동 후 전체 `./gradlew test`도 시작했지만 6분 이상 추가 출력 없이 진행되어 Gradle 프로세스를 남기지 않기 위해 중단했습니다. 직접 영향 범위 테스트와 애플리케이션 컨텍스트 테스트는 통과했습니다.

Closes #234