### PR TITLE
fix: 내부 LLM 생성 모드를 텍스트와 JSON으로 분리

### DIFF
--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -65,7 +65,7 @@ public class CbtMetadataClassifier {
                     assistantResponse,
                     userSignal,
                     socraticQuestionsUsed));
-            String responseJson = llmClient.complete(request);
+            String responseJson = llmClient.completeJson(request);
             return parse(responseJson, CbtInterventionState.fromWireValue(previousState), userSignal);
         } catch (Exception e) {
             log.warn("CBT metadata classifier failed, defaulting to none: {}", e.getMessage());

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -65,7 +65,7 @@ public class InputJudge {
         try {
             String contextPrompt = buildContextPrompt(profile, message);
             LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt);
-            String responseJson = llmClient.complete(request);
+            String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {
             log.warn("InputJudge failed, using fallback CLEAR_LOW: {}", e.getMessage());

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -43,7 +43,7 @@ public class OutputJudge {
         try {
             String userContent = buildJudgePrompt(aiResponse, preFilterResult);
             LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent);
-            String responseJson = llmClient.complete(request);
+            String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {
             log.warn("OutputJudge failed, defaulting to REPLACE: {}", e.getMessage());

--- a/src/main/java/com/mio/ai/llm/LlmClient.java
+++ b/src/main/java/com/mio/ai/llm/LlmClient.java
@@ -14,12 +14,17 @@ public interface LlmClient {
      */
     long stream(LlmRequest request, Consumer<String> chunkHandler);
 
+    /** Sends a non-streaming request for a natural-language response. */
+    String completeText(LlmRequest request);
+
+    /** Sends a non-streaming request that must return a structured JSON object. */
+    String completeJson(LlmRequest request);
+
     /**
-     * Sends a non-streaming request and returns the full response content.
-     * Used for Judge calls (InputJudge, OutputJudge) that require structured JSON.
-     *
-     * @param request the LLM request
-     * @return the full response content string
+     * Legacy structured-response bridge. New call sites must select their output mode explicitly.
      */
-    String complete(LlmRequest request);
+    @Deprecated(forRemoval = false)
+    default String complete(LlmRequest request) {
+        return completeJson(request);
+    }
 }

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -142,9 +142,18 @@ public class OpenAiLlmClient implements LlmClient {
     }
 
     @Override
-    public String complete(LlmRequest request) {
+    public String completeText(LlmRequest request) {
+        return complete(request, false);
+    }
+
+    @Override
+    public String completeJson(LlmRequest request) {
+        return complete(request, true);
+    }
+
+    private String complete(LlmRequest request, boolean jsonResponse) {
         try {
-            String requestBody = buildNonStreamingRequestBody(request);
+            String requestBody = buildNonStreamingRequestBody(request, jsonResponse);
 
             HttpRequest httpRequest = HttpRequest.newBuilder()
                     .uri(URI.create(CHAT_URL))
@@ -175,7 +184,7 @@ public class OpenAiLlmClient implements LlmClient {
         }
     }
 
-    private String buildNonStreamingRequestBody(LlmRequest request) throws Exception {
+    private String buildNonStreamingRequestBody(LlmRequest request, boolean jsonResponse) throws Exception {
         List<Map<String, String>> messages = request.messages().stream()
                 .map(m -> Map.of("role", m.role(), "content", m.content()))
                 .toList();
@@ -184,7 +193,9 @@ public class OpenAiLlmClient implements LlmClient {
         body.put("model", request.model());
         body.put("messages", messages);
         body.put("stream", false);
-        body.put("response_format", Map.of("type", "json_object"));
+        if (jsonResponse) {
+            body.put("response_format", Map.of("type", "json_object"));
+        }
 
         return objectMapper.writeValueAsString(body);
     }

--- a/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
@@ -175,7 +175,7 @@ public class WeeklyReflectionJob {
 
     private String generateText(String systemPrompt, String context) {
         try {
-            return llmClient.complete(LlmRequest.of("gpt-4o-mini", systemPrompt, context));
+            return llmClient.completeText(LlmRequest.of("gpt-4o-mini", systemPrompt, context));
         } catch (Exception e) {
             log.warn("[WeeklyReflectionJob] LLM call failed: {}", e.getMessage());
             return null;

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -191,7 +191,7 @@ public class ConversationOrchestrator {
                 // GENERATE: build prompt with GenerationMode instruction
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints(), memoryContext,
-                        user.getPreferredCharacterId(), checkpointSummary);
+                        session.getCharacterId(), checkpointSummary);
                 List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;

--- a/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
+++ b/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
@@ -38,7 +38,7 @@ public class CheckinAiResponseGenerator {
     public void generateAndSave(UUID checkinId, String emotionType, int conditionScore, String timeOfDay) {
         try {
             String userMessage = buildPrompt(emotionType, conditionScore, timeOfDay);
-            String response = llmClient.complete(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            String response = llmClient.completeText(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
 
             if (response == null || response.isBlank()) {
                 log.debug("[CheckinAiResponseGenerator] no response for checkinId={}", checkinId);

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -41,7 +41,7 @@ public class ReportNarrativeService {
                                     List<DistortionDto> distortionTop3) {
         String userMessage = buildUserMessage(periodLabel, checkinCount, avgEmotionScore, distortionTop3);
         try {
-            String response = llmClient.complete(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
             return parseResponse(response);
         } catch (Exception e) {
             log.warn("ReportNarrative generation failed: period={} error={}", periodLabel, e.getClass().getSimpleName());

--- a/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
+++ b/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
@@ -20,7 +20,7 @@ class CbtMetadataClassifierTest {
     @DisplayName("LLM 응답이 markdown json fence로 감싸져도 파싱한다")
     void classify_stripsMarkdownJsonFence() {
         LlmClient llmClient = mock(LlmClient.class);
-        when(llmClient.complete(any(LlmRequest.class))).thenReturn("""
+        when(llmClient.completeJson(any(LlmRequest.class))).thenReturn("""
                 ```json
                 {
                   "cbt_intervention_state": "completed",
@@ -53,7 +53,7 @@ class CbtMetadataClassifierTest {
     @DisplayName("이미 completed 상태인 후속 턴에서는 감정점수 target 생성을 다시 요구하지 않는다")
     void classify_completedPreviousState_suppressesDuplicateEmotionScoreTarget() {
         LlmClient llmClient = mock(LlmClient.class);
-        when(llmClient.complete(any(LlmRequest.class))).thenReturn("""
+        when(llmClient.completeJson(any(LlmRequest.class))).thenReturn("""
                 {
                   "cbt_intervention_state": "completed",
                   "completion_reason": "user_reframed_thought",

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -1,0 +1,87 @@
+package com.mio.ai.llm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Flow;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenAiLlmClientTest {
+
+    @Test
+    void completeText_doesNotRequestJsonResponseFormat() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = successfulResponse();
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+        OpenAiLlmClient client = new OpenAiLlmClient("test-key", httpClient, new ObjectMapper());
+
+        client.completeText(LlmRequest.of("gpt-4o-mini", "system", "user"));
+
+        String body = requestBody(capturedRequest(httpClient));
+        assertThat(body).contains("\"stream\":false");
+        assertThat(body).doesNotContain("response_format");
+    }
+
+    @Test
+    void completeJson_requestsJsonObjectResponseFormat() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = successfulResponse();
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
+        OpenAiLlmClient client = new OpenAiLlmClient("test-key", httpClient, new ObjectMapper());
+
+        client.completeJson(LlmRequest.of("gpt-4o-mini", "system", "user"));
+
+        assertThat(requestBody(capturedRequest(httpClient)))
+                .contains("\"response_format\":{\"type\":\"json_object\"}");
+    }
+
+    private HttpResponse<String> successfulResponse() {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"choices\":[{\"message\":{\"content\":\"answer\"}}]}");
+        return response;
+    }
+
+    private HttpRequest capturedRequest(HttpClient httpClient) throws Exception {
+        var captor = org.mockito.ArgumentCaptor.forClass(HttpRequest.class);
+        org.mockito.Mockito.verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+        return captor.getValue();
+    }
+
+    private String requestBody(HttpRequest request) {
+        CompletableFuture<String> result = new CompletableFuture<>();
+        StringBuilder body = new StringBuilder();
+        request.bodyPublisher().orElseThrow().subscribe(new Flow.Subscriber<>() {
+            @Override
+            public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+
+            @Override
+            public void onNext(ByteBuffer item) {
+                body.append(StandardCharsets.UTF_8.decode(item.duplicate()));
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                result.completeExceptionally(throwable);
+            }
+
+            @Override
+            public void onComplete() {
+                result.complete(body.toString());
+            }
+        });
+        return result.join();
+    }
+}

--- a/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
@@ -1,0 +1,190 @@
+package com.mio.ai.qa;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.judge.CbtInterventionState;
+import com.mio.ai.judge.CbtMetadataClassifier;
+import com.mio.ai.judge.CbtMetadataResult;
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.judge.RiskVerdict;
+import com.mio.ai.judge.SecurityVerdict;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.memory.working.WorkingMessage;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.PolicyEngine;
+import com.mio.ai.profile.SafetyProfile;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.safety.UserMessageSignal;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * QA 시나리오 SC-21 ~ SC-24
+ * CBT 메타데이터 분류기가 위기/비위기/소크라테스 한도 상황에서 올바르게 동작하는지 검증한다.
+ */
+@DisplayName("[QA] CBT 메타데이터 분류기")
+@ExtendWith(MockitoExtension.class)
+class CbtMetadataQaTest {
+
+    @Mock
+    private LlmClient llmClient;
+
+    private CbtMetadataClassifier classifier;
+    private PolicyEngine policyEngine;
+    private SafetyProfile defaultProfile;
+
+    @BeforeEach
+    void setUp() {
+        classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper());
+        policyEngine = new PolicyEngine();
+        defaultProfile = new SafetyProfile(
+                "test_user", "default", Map.of(), List.of(), List.of(),
+                List.of(), 0.0, 0, List.of()
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SC-21: crisisFlowTriggered=true → LLM 호출 없이 none 반환
+    // ─────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("SC-21: 위기 흐름 활성 시 LLM 호출 없이 NONE 상태를 반환한다")
+    void sc21_crisisFlowTriggered_noneWithoutLlmCall() {
+        CbtMetadataResult result = classifier.classify(
+                "none",
+                List.of(WorkingMessage.user("죽고싶다")),
+                "죽고싶다",
+                "위기 응답입니다.",
+                null,
+                0,
+                true  // crisisFlowTriggered=true
+        );
+
+        assertThat(result.state()).isEqualTo(CbtInterventionState.NONE);
+        assertThat(result.requiresEmotionScore()).isFalse();
+        // LLM은 절대 호출되면 안 됨
+        verify(llmClient, never()).completeJson(any());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SC-22: LLM이 socratic_asked 반환 → state=SOCRATIC_ASKED
+    // ─────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("SC-22: LLM이 socratic_asked를 반환하면 state가 SOCRATIC_ASKED로 매핑된다")
+    void sc22_llmReturnsSocraticAsked_stateCorrectlyMapped() throws Exception {
+        String llmJson = """
+                {
+                  "cbt_intervention_state": "socratic_asked",
+                  "completion_reason": null,
+                  "requires_emotion_score": false,
+                  "is_socratic": true,
+                  "bias_type": "catastrophizing",
+                  "reconstructed_thought": null
+                }
+                """;
+        when(llmClient.completeJson(any())).thenReturn(llmJson);
+
+        CbtMetadataResult result = classifier.classify(
+                "none",
+                List.of(
+                        WorkingMessage.user("이번에도 망할 것 같아"),
+                        WorkingMessage.assistant("그 생각이 얼마나 사실에 가깝게 느껴지시나요?")
+                ),
+                "그럴 것 같아요",
+                "어떤 근거로 그렇게 생각하시나요?",
+                new UserMessageSignal(40, "catastrophizing"),
+                1,
+                false
+        );
+
+        assertThat(result.state()).isEqualTo(CbtInterventionState.SOCRATIC_ASKED);
+        assertThat(result.socratic()).isTrue();
+        assertThat(result.requiresEmotionScore()).isFalse();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SC-23: PolicyEngine - 소크라테스 2회 도달 → InterventionHints 비어있음 (MIO-CBT-011)
+    // ─────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("SC-23: 소크라테스 질문 2회 도달 시 PolicyEngine이 빈 InterventionHints를 반환한다 (MIO-CBT-011)")
+    void sc23_socraticLimitReached_emptyInterventionHints() {
+        var combined = new CombinedSignal(
+                SecurityLevel.CLEAN, false, true, false, false, false,
+                false, true,
+                SafetyL1Result.clear(), 0.6
+        );
+        var judgeResult = new InputJudgeResult(
+                SecurityVerdict.clean(),
+                new RiskVerdict(RiskLevel.MEDIUM, List.of(), GenerationMode.SUPPORTIVE, DeliveryMode.CAUTIOUS_SPECULATIVE, false),
+                0.65
+        );
+        // 소크라테스 질문 2회 → socraticLimitReached()=true
+        var sessionDelta = new SessionDelta(2, "socratic_asked", new HashMap<>(), 0, new HashSet<>(), new HashSet<>());
+
+        var decision = policyEngine.decide(combined, judgeResult, defaultProfile, sessionDelta);
+
+        assertThat(decision.generationMode()).isEqualTo(GenerationMode.SUPPORTIVE);
+        assertThat(decision.interventionHints()).isNotNull();
+        assertThat(decision.interventionHints().suggestedCodes()).isEmpty();
+        // LLM은 이 테스트에서 전혀 관여 없음
+        verify(llmClient, never()).completeJson(any());
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // SC-24: LLM이 completed + requires_emotion_score=true 반환 → requiresEmotionScore=true
+    // ─────────────────────────────────────────────────────────────────────────
+    @Test
+    @DisplayName("SC-24: LLM이 completed+requiresEmotionScore를 반환하면 감정점수 타겟 생성이 요청된다")
+    void sc24_llmReturnsCompleted_requiresEmotionScore() throws Exception {
+        String llmJson = """
+                {
+                  "cbt_intervention_state": "completed",
+                  "completion_reason": "user_reframed_thought",
+                  "requires_emotion_score": true,
+                  "is_socratic": false,
+                  "bias_type": "overgeneralization",
+                  "reconstructed_thought": "이번 한 번의 실패가 항상 실패한다는 뜻은 아니야"
+                }
+                """;
+        when(llmClient.completeJson(any())).thenReturn(llmJson);
+
+        CbtMetadataResult result = classifier.classify(
+                "socratic_asked",
+                List.of(
+                        WorkingMessage.user("항상 이런 식인 것 같아"),
+                        WorkingMessage.assistant("'항상'이라는 생각의 근거는 무엇인가요?"),
+                        WorkingMessage.user("생각해보니 항상은 아닌 것 같아요")
+                ),
+                "이번 한 번이었던 것 같아요",
+                "그렇군요! 이번에 새로운 시각을 갖게 되셨네요.",
+                new UserMessageSignal(60, "overgeneralization"),
+                1,
+                false
+        );
+
+        assertThat(result.state()).isEqualTo(CbtInterventionState.COMPLETED);
+        assertThat(result.requiresEmotionScore()).isTrue();
+        assertThat(result.biasType()).isEqualTo("overgeneralization");
+        assertThat(result.reconstructedThought()).isNotBlank();
+        assertThat(result.shouldCreateEmotionScoreTarget()).isTrue();
+    }
+}

--- a/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
@@ -1,0 +1,32 @@
+package com.mio.checkin.service;
+
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CheckinAiResponseGeneratorTest {
+
+    @Test
+    void generatesNaturalLanguageCheckinCommentWithTextMode() {
+        LlmClient llmClient = mock(LlmClient.class);
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        UUID checkinId = UUID.randomUUID();
+        when(llmClient.completeText(any(LlmRequest.class))).thenReturn("오늘도 잘 버텼어요.");
+        CheckinAiResponseGenerator generator = new CheckinAiResponseGenerator(llmClient, jdbcTemplate);
+
+        generator.generateAndSave(checkinId, "anxious", 3, "morning");
+
+        verify(llmClient).completeText(any(LlmRequest.class));
+        verify(jdbcTemplate).update(eq("UPDATE checkins SET ai_response = ? WHERE id = ?"),
+                eq("오늘도 잘 버텼어요."), eq(checkinId));
+    }
+}

--- a/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
+++ b/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
@@ -1,0 +1,31 @@
+package com.mio.report.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ReportNarrativeServiceTest {
+
+    @Test
+    void parsesNarrativeFromJsonMode() {
+        LlmClient llmClient = mock(LlmClient.class);
+        when(llmClient.completeJson(any(LlmRequest.class)))
+                .thenReturn("{\"narrative\":\"이번 주도 잘 해냈어요.\",\"coaching_direction\":\"작은 휴식을 이어가요.\"}");
+        ReportNarrativeService service = new ReportNarrativeService(llmClient, new ObjectMapper());
+
+        ReportNarrativeService.NarrativeResult result = service.generate("이번 주", 2, 42.0, List.of());
+
+        assertThat(result.narrative()).isEqualTo("이번 주도 잘 해냈어요.");
+        assertThat(result.coachingDirection()).isEqualTo("작은 휴식을 이어가요.");
+        verify(llmClient).completeJson(any(LlmRequest.class));
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 비스트림 LLM 호출을 자연어 `completeText`와 구조화 `completeJson`으로 분리했습니다.
- JSON 모드는 판정기와 리포트에만 적용하고, 체크인 코멘트·주간 회고는 자연어 모드를 사용합니다.
- 활성 대화 프롬프트가 사용자 선호가 아닌 세션에 기록된 캐릭터를 사용하도록 고정했습니다.
- 기존 `complete`는 내부 호환을 위한 deprecated JSON 브리지로 유지했습니다.

## 검증
- `./gradlew test --tests ...` 관련 AI 판정·LLM·체크인·리포트 테스트 통과
- 전체 로컬 테스트는 DB 미기동 컨텍스트 테스트와 이 PR에 포함하지 않은 미추적 QA 파일의 이전 mock 계약으로 통과하지 못했습니다. CI 환경에서 최종 확인이 필요합니다.

Closes #237

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit AI generation modes for plain text and structured JSON to improve consistency across features.
  * Structured generation now requests machine-readable JSON for consistent parsing.
  * Conversation generation now uses the character selected for the current session.

* **Bug Fixes**
  * Improved reliability of AI judge, report narrative, check-in response, and CBT metadata classification by using the appropriate response mode and JSON parsing.

* **Tests**
  * Added and updated test coverage for JSON/text modes, request payload behavior, parsing, and persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->