### PR TITLE
fix: 현재 발화 기반 메모리 검색 연결

### DIFF
--- a/src/main/java/com/mio/ai/llm/EmbeddingClient.java
+++ b/src/main/java/com/mio/ai/llm/EmbeddingClient.java
@@ -1,0 +1,7 @@
+package com.mio.ai.llm;
+
+/** Generates a semantic embedding for a non-blank text query. */
+public interface EmbeddingClient {
+
+    float[] embed(String text);
+}

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -20,7 +20,7 @@ import java.util.stream.Stream;
 
 @Component
 @Slf4j
-public class OpenAiLlmClient implements LlmClient {
+public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
     private static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
     private static final String EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings";

--- a/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
+++ b/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import java.util.stream.Collectors;
 
 /**
@@ -56,7 +57,10 @@ public class ContextComposer {
         appendSection(sb, "Helpful Approaches",
                 grouped.get(RetrievalSource.GRAPH_INTERVENTION_FIT));
         appendSection(sb, "Recent Episodes",
-                grouped.get(RetrievalSource.VECTOR_EPISODE));
+                Stream.concat(
+                                grouped.getOrDefault(RetrievalSource.VECTOR_EPISODE, List.of()).stream(),
+                                grouped.getOrDefault(RetrievalSource.LEXICAL_EPISODE, List.of()).stream())
+                        .toList());
         appendSection(sb, "Belief Context",
                 grouped.get(RetrievalSource.VECTOR_BELIEF));
         appendSection(sb, "Recent Activities",

--- a/src/main/java/com/mio/ai/memory/retrieval/LexicalRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/LexicalRetriever.java
@@ -38,7 +38,7 @@ public class LexicalRetriever {
                     """,
                     (rs, rowNum) -> new RetrievedItem(
                             rs.getString("id"),
-                            RetrievalSource.VECTOR_EPISODE,
+                            RetrievalSource.LEXICAL_EPISODE,
                             rs.getString("content"),
                             "normal",
                             rs.getDouble("score"),

--- a/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
@@ -15,6 +15,7 @@ public record RetrievalPlan(
     public static RetrievalPlan clearLow() {
         return new RetrievalPlan(
                 List.of(RetrievalSource.VECTOR_EPISODE,
+                        RetrievalSource.LEXICAL_EPISODE,
                         RetrievalSource.SQL_PROFILE,
                         RetrievalSource.SQL_RHYTHM),
                 3, 200, "normal"
@@ -52,8 +53,17 @@ public record RetrievalPlan(
     public static RetrievalPlan newUser() {
         return new RetrievalPlan(
                 List.of(RetrievalSource.SQL_PROFILE,
-                        RetrievalSource.VECTOR_EPISODE),
+                        RetrievalSource.VECTOR_EPISODE,
+                        RetrievalSource.LEXICAL_EPISODE),
                 2, 150, "normal"
+        );
+    }
+
+    /** Session-start cache must not contain a query-dependent memory result. */
+    public static RetrievalPlan staticBase() {
+        return new RetrievalPlan(
+                List.of(RetrievalSource.SQL_PROFILE, RetrievalSource.SQL_RHYTHM),
+                3, 200, "normal"
         );
     }
 }

--- a/src/main/java/com/mio/ai/memory/retrieval/RetrievalSource.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/RetrievalSource.java
@@ -2,6 +2,7 @@ package com.mio.ai.memory.retrieval;
 
 public enum RetrievalSource {
     VECTOR_EPISODE,        // pgvector: session_summaries.episode_emb
+    LEXICAL_EPISODE,       // PostgreSQL FTS: session_summaries.summary_text
     VECTOR_BELIEF,         // pgvector: user_beliefs (belief embedding)
     GRAPH_TRIGGER,         // GIN: session_summaries.trigger_tags
     GRAPH_INTERVENTION_FIT,// intervention_outcomes + behavior_tasks

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -156,9 +156,10 @@ public class ConversationOrchestrator {
             List<WorkingMessage> recentWorkingMessages = workingMemory.getRecentMessages(sessionId);
             recentWorkingMessages = recentWorkingMessages != null ? new ArrayList<>(recentWorkingMessages) : new ArrayList<>();
             String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
-            boolean memoryCacheHit = cachedMemory != null;
             String liveMemory = contextPreWarmer.buildContextSync(sessionId, userId, combined, profile, normalized);
-            String memoryContext = liveMemory != null && !liveMemory.isBlank() ? liveMemory : cachedMemory;
+            boolean memoryCacheFallbackUsed = (liveMemory == null || liveMemory.isBlank())
+                    && cachedMemory != null && !cachedMemory.isBlank();
+            String memoryContext = memoryCacheFallbackUsed ? cachedMemory : liveMemory;
             String checkpointSummary = contextPreWarmer.getCachedCheckpoint(sessionId);
 
             // 6. Policy decision (10-step)
@@ -386,7 +387,7 @@ public class ConversationOrchestrator {
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
                     inputJudgeCalled, preFilterResult, judgeActionResult,
-                    profile.source(), safetyProfileCacheHit, memoryCacheHit);
+                    profile.source(), safetyProfileCacheHit, memoryCacheFallbackUsed);
 
             emitter.complete();
 

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -157,9 +157,8 @@ public class ConversationOrchestrator {
             recentWorkingMessages = recentWorkingMessages != null ? new ArrayList<>(recentWorkingMessages) : new ArrayList<>();
             String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
             boolean memoryCacheHit = cachedMemory != null;
-            String memoryContext = memoryCacheHit
-                    ? cachedMemory
-                    : contextPreWarmer.buildContextSync(sessionId, userId, combined, profile);
+            String liveMemory = contextPreWarmer.buildContextSync(sessionId, userId, combined, profile, normalized);
+            String memoryContext = liveMemory != null && !liveMemory.isBlank() ? liveMemory : cachedMemory;
             String checkpointSummary = contextPreWarmer.getCachedCheckpoint(sessionId);
 
             // 6. Policy decision (10-step)

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * POST /v1/sessions 직후 비동기 context + safety profile 사전 빌드 (§12.4.1).
@@ -41,6 +42,7 @@ public class ContextPreWarmer {
     private static final String CONTEXT_CACHE_KEY = "session:%s:context_cache";
     private static final Duration CONTEXT_TTL = Duration.ofMinutes(5);
     private static final Duration CHECKPOINT_TTL = Duration.ofHours(2);
+    private static final long MAX_EMBEDDING_WAIT_MS = 250;
 
     private final StructuredRetriever structuredRetriever;
     private final VectorRetriever vectorRetriever;
@@ -140,12 +142,20 @@ public class ContextPreWarmer {
                 || queryText == null || queryText.isBlank()) {
             return null;
         }
+        CompletableFuture<float[]> embeddingFuture = CompletableFuture.supplyAsync(
+                () -> embeddingClient.embed(queryText), retrievalPool);
         try {
-            return embeddingClient.embed(queryText);
+            long timeoutMs = Math.min(plan.budgetMs(), MAX_EMBEDDING_WAIT_MS);
+            return embeddingFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            embeddingFuture.cancel(true);
+            log.warn("ContextPreWarmer: embedding interrupted; continuing without vector retrieval");
         } catch (Exception e) {
+            embeddingFuture.cancel(true);
             log.warn("ContextPreWarmer: embedding failed; continuing without vector retrieval", e);
-            return null;
         }
+        return null;
     }
 
     private List<List<RetrievedItem>> retrieveParallel(UUID sessionId, UUID userId, RetrievalPlan plan,

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -1,8 +1,10 @@
 package com.mio.ai.profile;
 
 import com.mio.ai.AiCacheKeys;
+import com.mio.ai.llm.EmbeddingClient;
 import com.mio.ai.memory.composer.ContextComposer;
 import com.mio.ai.memory.retrieval.FusionRanker;
+import com.mio.ai.memory.retrieval.LexicalRetriever;
 import com.mio.ai.memory.retrieval.MemoryRetrievalPlanner;
 import com.mio.ai.memory.retrieval.RetrievalPlan;
 import com.mio.ai.memory.retrieval.RetrievedItem;
@@ -42,6 +44,8 @@ public class ContextPreWarmer {
 
     private final StructuredRetriever structuredRetriever;
     private final VectorRetriever vectorRetriever;
+    private final LexicalRetriever lexicalRetriever;
+    private final EmbeddingClient embeddingClient;
     private final FusionRanker fusionRanker;
     private final ContextComposer contextComposer;
     private final MemoryRetrievalPlanner memoryRetrievalPlanner;
@@ -60,9 +64,9 @@ public class ContextPreWarmer {
             // 1. SafetyProfile 빌드 + 캐싱
             safetyProfileBuilder.buildAndCache(sessionId.toString(), userId.toString());
 
-            // 2. 기본 컨텍스트: clearLow plan
-            RetrievalPlan plan = RetrievalPlan.clearLow();
-            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan);
+            // 2. 기본 컨텍스트만 캐시한다. 현재 발화 기반 검색은 각 대화 턴에서 수행한다.
+            RetrievalPlan plan = RetrievalPlan.staticBase();
+            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan, null, null);
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             String context = contextComposer.compose(ranked, plan.sensitivityCap(), false);
 
@@ -114,11 +118,12 @@ public class ContextPreWarmer {
      * cache MISS 시 동기 fallback — 실시간 risk tier 기반 동적 검색 (§12.4 MISS → ~50ms).
      */
     public String buildContextSync(UUID sessionId, UUID userId, CombinedSignal combined,
-                                   SafetyProfile profile) {
+                                   SafetyProfile profile, String queryText) {
         try {
             boolean hasHistory = checkHasHistory(userId);
             RetrievalPlan plan = memoryRetrievalPlanner.plan(combined, profile, userId, hasHistory);
-            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan);
+            float[] queryEmbedding = embedIfNeeded(plan, queryText);
+            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan, queryEmbedding, queryText);
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             boolean highRisk = combined.hardCrisis() || combined.riskCandidate();
             return contextComposer.compose(ranked, plan.sensitivityCap(), highRisk);
@@ -130,14 +135,32 @@ public class ContextPreWarmer {
 
     // ── 실제 병렬 retrieval (CompletableFuture) ────────────────────
 
-    private List<List<RetrievedItem>> retrieveParallel(UUID sessionId, UUID userId, RetrievalPlan plan) {
+    private float[] embedIfNeeded(RetrievalPlan plan, String queryText) {
+        if (!plan.sources().contains(com.mio.ai.memory.retrieval.RetrievalSource.VECTOR_EPISODE)
+                || queryText == null || queryText.isBlank()) {
+            return null;
+        }
+        try {
+            return embeddingClient.embed(queryText);
+        } catch (Exception e) {
+            log.warn("ContextPreWarmer: embedding failed; continuing without vector retrieval", e);
+            return null;
+        }
+    }
+
+    private List<List<RetrievedItem>> retrieveParallel(UUID sessionId, UUID userId, RetrievalPlan plan,
+                                                         float[] queryEmbedding, String queryText) {
         int k = plan.maxK();
         List<CompletableFuture<List<RetrievedItem>>> futures = new ArrayList<>();
 
         for (var source : plan.sources()) {
             CompletableFuture<List<RetrievedItem>> future = switch (source) {
-                case VECTOR_EPISODE      -> CompletableFuture.supplyAsync(
-                        () -> vectorRetriever.retrieveEpisodes(userId, null, k), retrievalPool);
+                case VECTOR_EPISODE      -> queryEmbedding == null
+                        ? CompletableFuture.completedFuture(List.of())
+                        : CompletableFuture.supplyAsync(
+                                () -> vectorRetriever.retrieveEpisodes(userId, queryEmbedding, k), retrievalPool);
+                case LEXICAL_EPISODE     -> CompletableFuture.supplyAsync(
+                        () -> lexicalRetriever.retrieveByKeywords(userId, queryText, k), retrievalPool);
                 case VECTOR_BELIEF       -> CompletableFuture.supplyAsync(
                         () -> vectorRetriever.retrieveBeliefs(userId, null, k), retrievalPool);
                 case SQL_PROFILE         -> CompletableFuture.supplyAsync(

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -102,4 +102,28 @@ class ContextPreWarmerTest {
         verify(vectorRetriever, never()).retrieveEpisodes(any(), any(), any(Integer.class));
         verify(lexicalRetriever).retrieveByKeywords(userId, "회의가 걱정돼", 3);
     }
+
+    @Test
+    void limitsEmbeddingWaitAndContinuesWithLexicalRetrieval() throws Exception {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        RetrievedItem episode = new RetrievedItem("episode-3", RetrievalSource.LEXICAL_EPISODE,
+                "발표 전 긴장", "normal", 0.7, 1);
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed("발표가 걱정돼")).thenAnswer(invocation -> {
+            Thread.sleep(1_000);
+            return new float[]{0.1f};
+        });
+        when(lexicalRetriever.retrieveByKeywords(userId, "발표가 걱정돼", 3)).thenReturn(List.of(episode));
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("lexical memory");
+
+        long startedAt = System.nanoTime();
+        String context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "발표가 걱정돼");
+        long elapsedMs = (System.nanoTime() - startedAt) / 1_000_000;
+
+        assertThat(context).isEqualTo("lexical memory");
+        assertThat(elapsedMs).isLessThan(700);
+        verify(lexicalRetriever).retrieveByKeywords(userId, "발표가 걱정돼", 3);
+    }
 }

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -1,0 +1,105 @@
+package com.mio.ai.profile;
+
+import com.mio.ai.llm.EmbeddingClient;
+import com.mio.ai.memory.composer.ContextComposer;
+import com.mio.ai.memory.retrieval.FusionRanker;
+import com.mio.ai.memory.retrieval.LexicalRetriever;
+import com.mio.ai.memory.retrieval.MemoryRetrievalPlanner;
+import com.mio.ai.memory.retrieval.RetrievalPlan;
+import com.mio.ai.memory.retrieval.RetrievalSource;
+import com.mio.ai.memory.retrieval.RetrievedItem;
+import com.mio.ai.memory.retrieval.StructuredRetriever;
+import com.mio.ai.memory.retrieval.VectorRetriever;
+import com.mio.ai.memory.working.WorkingMemory;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.session.repository.SessionCheckpointRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ContextPreWarmerTest {
+
+    private final StructuredRetriever structuredRetriever = mock(StructuredRetriever.class);
+    private final VectorRetriever vectorRetriever = mock(VectorRetriever.class);
+    private final LexicalRetriever lexicalRetriever = mock(LexicalRetriever.class);
+    private final EmbeddingClient embeddingClient = mock(EmbeddingClient.class);
+    private final FusionRanker fusionRanker = mock(FusionRanker.class);
+    private final ContextComposer contextComposer = mock(ContextComposer.class);
+    private final MemoryRetrievalPlanner planner = mock(MemoryRetrievalPlanner.class);
+    private final SafetyProfileBuilder safetyProfileBuilder = mock(SafetyProfileBuilder.class);
+    private final SessionCheckpointRepository checkpointRepository = mock(SessionCheckpointRepository.class);
+    private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+    private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+    private final WorkingMemory workingMemory = mock(WorkingMemory.class);
+
+    private ContextPreWarmer preWarmer;
+    private UUID sessionId;
+    private UUID userId;
+    private CombinedSignal combined;
+    private SafetyProfile profile;
+
+    @BeforeEach
+    void setUp() {
+        preWarmer = new ContextPreWarmer(structuredRetriever, vectorRetriever, lexicalRetriever, embeddingClient,
+                fusionRanker, contextComposer, planner, safetyProfileBuilder, checkpointRepository,
+                redisTemplate, jdbcTemplate, workingMemory);
+        sessionId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+        combined = mock(CombinedSignal.class);
+        profile = mock(SafetyProfile.class);
+        when(jdbcTemplate.queryForObject(any(String.class), eq(Integer.class), eq(userId))).thenReturn(1);
+    }
+
+    @Test
+    void retrievesVectorAndLexicalEpisodesForCurrentMessage() {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        float[] embedding = {0.1f, 0.2f};
+        RetrievedItem episode = new RetrievedItem("episode-1", RetrievalSource.VECTOR_EPISODE,
+                "회의가 불안했던 날", "normal", 0.9, 1);
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed("회의 때문에 불안해")).thenReturn(embedding);
+        when(vectorRetriever.retrieveEpisodes(userId, embedding, 3)).thenReturn(List.of(episode));
+        when(lexicalRetriever.retrieveByKeywords(userId, "회의 때문에 불안해", 3)).thenReturn(List.of());
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("live memory");
+
+        String context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "회의 때문에 불안해");
+
+        assertThat(context).isEqualTo("live memory");
+        verify(embeddingClient).embed("회의 때문에 불안해");
+        verify(vectorRetriever).retrieveEpisodes(userId, embedding, 3);
+        verify(lexicalRetriever).retrieveByKeywords(userId, "회의 때문에 불안해", 3);
+    }
+
+    @Test
+    void fallsBackToLexicalRetrievalWhenEmbeddingFails() {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        RetrievedItem episode = new RetrievedItem("episode-2", RetrievalSource.LEXICAL_EPISODE,
+                "회의 전 긴장", "normal", 0.7, 1);
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed("회의가 걱정돼")).thenThrow(new RuntimeException("timeout"));
+        when(lexicalRetriever.retrieveByKeywords(userId, "회의가 걱정돼", 3)).thenReturn(List.of(episode));
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("lexical memory");
+
+        String context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "회의가 걱정돼");
+
+        assertThat(context).isEqualTo("lexical memory");
+        verify(vectorRetriever, never()).retrieveEpisodes(any(), any(), any(Integer.class));
+        verify(lexicalRetriever).retrieveByKeywords(userId, "회의가 걱정돼", 3);
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 세션 시작 캐시에는 정적 프로필·리듬 맥락만 저장합니다.
- 매 대화 턴마다 정규화된 현재 발화로 임베딩을 한 번 생성해 벡터 검색을 수행합니다.
- 어휘 검색을 실제 retrieval plan에 연결하고 별도 `LEXICAL_EPISODE` provenance를 부여했습니다.
- 임베딩 실패 시 벡터 검색만 건너뛰고 어휘·구조화 검색을 계속하며, live 결과가 비어 있을 때만 기존 캐시를 fallback으로 사용합니다.

## 제외
- REST/SSE·DB 스키마·To-do 정책 변경 없음
- FTS GIN 인덱스는 별도 성능 작업

## 검증
- `./gradlew test --tests com.mio.ai.profile.ContextPreWarmerTest` 통과
- 메모리·프로필·오케스트레이터 관련 테스트 통과

Closes #239