### PR TITLE
fix: 온톨로지 금기 조건을 대화 힌트에 적용

### DIFF
--- a/src/main/java/com/mio/ai/memory/ontology/OntologyInterventionFilter.java
+++ b/src/main/java/com/mio/ai/memory/ontology/OntologyInterventionFilter.java
@@ -1,0 +1,77 @@
+package com.mio.ai.memory.ontology;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.safety.CombinedSignal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Applies ontology-declared intervention constraints before hints reach the prompt. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OntologyInterventionFilter {
+
+    private final InterventionDefRepository interventionDefRepository;
+    private final ObjectMapper objectMapper;
+
+    public InterventionHints filter(InterventionHints hints, CombinedSignal combined, SessionDelta sessionDelta) {
+        if (hints == null || hints.suggestedCodes() == null || hints.suggestedCodes().isEmpty()) {
+            return InterventionHints.empty();
+        }
+
+        try {
+            Map<String, InterventionDef> definitions = definitionsByCode(hints.suggestedCodes());
+            List<String> eligible = hints.suggestedCodes().stream()
+                    .filter(code -> isEligible(definitions.get(code), combined, sessionDelta))
+                    .toList();
+            return new InterventionHints(eligible, hints.avoidCodes(), hints.targetDistortionCode());
+        } catch (Exception e) {
+            log.warn("Ontology intervention lookup failed; omitting intervention hints", e);
+            return InterventionHints.empty();
+        }
+    }
+
+    private Map<String, InterventionDef> definitionsByCode(List<String> codes) {
+        Map<String, InterventionDef> definitions = new HashMap<>();
+        interventionDefRepository.findAllById(codes)
+                .forEach(definition -> definitions.put(definition.getCode(), definition));
+        return definitions;
+    }
+
+    private boolean isEligible(InterventionDef definition, CombinedSignal combined, SessionDelta sessionDelta) {
+        if (definition == null) {
+            return false;
+        }
+        try {
+            JsonNode constraints = objectMapper.readTree(definition.getContraindicatedWhen());
+            if (constraints.path("high_crisis").asBoolean(false) && combined.hardCrisis()) {
+                return false;
+            }
+            if (constraints.path("requires_calm_state").asBoolean(false) && !isCalm(combined)) {
+                return false;
+            }
+            int sessionLimit = constraints.path("session_limit").asInt(-1);
+            return sessionLimit < 0 || sessionDelta == null || sessionDelta.socraticQuestionsUsed() < sessionLimit;
+        } catch (Exception e) {
+            log.warn("Invalid intervention constraints for code={}; omitting hint", definition.getCode(), e);
+            return false;
+        }
+    }
+
+    private boolean isCalm(CombinedSignal combined) {
+        return !combined.hardCrisis()
+                && !combined.riskCandidate()
+                && !combined.emotionSpike()
+                && !combined.repetitiveNegative()
+                && !combined.dependencyHint()
+                && !combined.l0Flagged();
+    }
+}

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.memory.consolidation.ConversationCheckpointService;
+import com.mio.ai.memory.ontology.OntologyInterventionFilter;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
@@ -89,6 +90,7 @@ public class ConversationOrchestrator {
     private final OutputPreFilter outputPreFilter;
     private final OutputJudge outputJudge;
     private final PolicyEngine policyEngine;
+    private final OntologyInterventionFilter ontologyInterventionFilter;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
     private final CrisisFlowService crisisFlowService;
@@ -164,6 +166,8 @@ public class ConversationOrchestrator {
 
             // 6. Policy decision (10-step)
             PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
+            decision = decision.withInterventionHints(
+                    ontologyInterventionFilter.filter(decision.interventionHints(), combined, sessionDelta));
 
             // 7. Execute based on decision
             String assistantContent;

--- a/src/main/java/com/mio/ai/policy/PolicyDecision.java
+++ b/src/main/java/com/mio/ai/policy/PolicyDecision.java
@@ -16,4 +16,11 @@ public record PolicyDecision(
         String policyVersion,
         RiskLevel riskLevel
 ) {
+
+    public PolicyDecision withInterventionHints(InterventionHints hints) {
+        return new PolicyDecision(
+                decisionId, action, generationMode, deliveryMode, securityLevel,
+                allowGeneration, allowStreaming, requireOutputGuard, hints, policyVersion, riskLevel
+        );
+    }
 }

--- a/src/test/java/com/mio/ai/memory/ontology/OntologyInterventionFilterTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/OntologyInterventionFilterTest.java
@@ -1,0 +1,89 @@
+package com.mio.ai.memory.ontology;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OntologyInterventionFilterTest {
+
+    private final InterventionDefRepository repository = mock(InterventionDefRepository.class);
+    private final OntologyInterventionFilter filter = new OntologyInterventionFilter(repository, new ObjectMapper());
+
+    @Test
+    void excludesInterventionThatRequiresCalmWhenRiskSignalsAreActive() {
+        InterventionDef restructuring = definition("cognitive_restructuring",
+                "{\"requires_calm_state\": true, \"high_crisis\": true}");
+        when(repository.findAllById(List.of("cognitive_restructuring"))).thenReturn(List.of(restructuring));
+
+        InterventionHints result = filter.filter(
+                new InterventionHints(List.of("cognitive_restructuring"), List.of(), null),
+                combined(false, true, false, false), sessionDelta(0));
+
+        assertThat(result.suggestedCodes()).isEmpty();
+    }
+
+    @Test
+    void excludesInterventionAtItsOntologySessionLimit() {
+        InterventionDef socratic = definition("socratic_questioning", "{\"session_limit\": 2}");
+        when(repository.findAllById(List.of("socratic_questioning"))).thenReturn(List.of(socratic));
+
+        InterventionHints result = filter.filter(
+                new InterventionHints(List.of("socratic_questioning"), List.of(), null),
+                combined(false, false, false, false), sessionDelta(2));
+
+        assertThat(result.suggestedCodes()).isEmpty();
+    }
+
+    @Test
+    void preservesKnownEligibleInterventionAndDropsUnknownCode() {
+        InterventionDef breathing = definition("breathing_exercise", "{\"high_crisis\": false}");
+        when(repository.findAllById(List.of("breathing_exercise", "unknown"))).thenReturn(List.of(breathing));
+
+        InterventionHints result = filter.filter(
+                new InterventionHints(List.of("breathing_exercise", "unknown"), List.of("avoid"), "target"),
+                combined(false, false, false, false), sessionDelta(0));
+
+        assertThat(result.suggestedCodes()).containsExactly("breathing_exercise");
+        assertThat(result.avoidCodes()).containsExactly("avoid");
+        assertThat(result.targetDistortionCode()).isEqualTo("target");
+    }
+
+    @Test
+    void failsClosedWhenOntologyLookupFails() {
+        when(repository.findAllById(List.of("breathing_exercise"))).thenThrow(new RuntimeException("db unavailable"));
+
+        InterventionHints result = filter.filter(
+                new InterventionHints(List.of("breathing_exercise"), List.of(), null),
+                combined(false, false, false, false), sessionDelta(0));
+
+        assertThat(result.suggestedCodes()).isEmpty();
+    }
+
+    private InterventionDef definition(String code, String contraindicatedWhen) {
+        InterventionDef definition = mock(InterventionDef.class);
+        when(definition.getCode()).thenReturn(code);
+        when(definition.getContraindicatedWhen()).thenReturn(contraindicatedWhen);
+        return definition;
+    }
+
+    private CombinedSignal combined(boolean hardCrisis, boolean riskCandidate,
+                                    boolean emotionSpike, boolean repetitiveNegative) {
+        return new CombinedSignal(SecurityLevel.CLEAN, hardCrisis, riskCandidate, emotionSpike,
+                repetitiveNegative, false, false, false, SafetyL1Result.clear(), 0.0);
+    }
+
+    private SessionDelta sessionDelta(int socraticCount) {
+        return new SessionDelta(socraticCount, "none", Map.of(), 0, java.util.Set.of(), java.util.Set.of());
+    }
+}

--- a/src/test/java/com/mio/ai/memory/ontology/OntologyInterventionFilterTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/OntologyInterventionFilterTest.java
@@ -34,6 +34,18 @@ class OntologyInterventionFilterTest {
     }
 
     @Test
+    void excludesInterventionMarkedUnsafeForHighCrisis() {
+        InterventionDef evidenceGathering = definition("evidence_gathering", "{\"high_crisis\": true}");
+        when(repository.findAllById(List.of("evidence_gathering"))).thenReturn(List.of(evidenceGathering));
+
+        InterventionHints result = filter.filter(
+                new InterventionHints(List.of("evidence_gathering"), List.of(), null),
+                combined(true, false, false, false), sessionDelta(0));
+
+        assertThat(result.suggestedCodes()).isEmpty();
+    }
+
+    @Test
     void excludesInterventionAtItsOntologySessionLimit() {
         InterventionDef socratic = definition("socratic_questioning", "{\"session_limit\": 2}");
         when(repository.findAllById(List.of("socratic_questioning"))).thenReturn(List.of(socratic));


### PR DESCRIPTION
## 변경 사항
- `intervention_def.contraindicated_when`을 최종 PolicyDecision의 prompt hint에 적용합니다.
- `high_crisis`, `requires_calm_state`, `session_limit` 조건을 결정론적으로 판정합니다.
- 정의 누락·JSON 파싱 오류·DB 조회 실패는 fail-closed로 해당 개입을 제외합니다.

## 제외
- To-do 자동 생성 정책 및 추천 변경 없음
- trigger tag 분류 체계·추출 모델 변경 없음
- REST/SSE/DB 스키마 변경 없음

## 검증
- OntologyInterventionFilterTest: 고위기·비안정·세션 한도·미정의 코드·조회 실패
- PolicyEngine 및 오케스트레이터 관련 테스트 통과

Closes #241