### PR TITLE
feat: 현재 발화 기반 반응형 온톨로지 활성화

### DIFF
--- a/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
+++ b/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
@@ -62,7 +62,10 @@ public class ContextComposer {
                                 grouped.getOrDefault(RetrievalSource.LEXICAL_EPISODE, List.of()).stream())
                         .toList());
         appendSection(sb, "Belief Context",
-                grouped.get(RetrievalSource.VECTOR_BELIEF));
+                Stream.concat(
+                                grouped.getOrDefault(RetrievalSource.VECTOR_BELIEF, List.of()).stream(),
+                                grouped.getOrDefault(RetrievalSource.GRAPH_BELIEF_NEIGH, List.of()).stream())
+                        .toList());
         appendSection(sb, "Recent Activities",
                 grouped.get(RetrievalSource.SQL_TODO_HISTORY));
 

--- a/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
@@ -1,0 +1,74 @@
+package com.mio.ai.memory.ontology;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 현재 발화의 관계 맥락을 위한 최소 구조화 추출기.
+ * 결과는 WorkingMemory TTL 내 활성화에만 사용하며 신념·증거를 새로 저장하지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
+
+    private static final String MODEL = "gpt-4o-mini";
+    private static final String SYSTEM_PROMPT = """
+            당신은 CBT 대화에서 현재 사용자의 발화만 분류합니다.
+            반드시 아래 JSON 객체만 반환하세요.
+            {
+              "distortionCode": "overgeneralization|catastrophizing|mind_reading|all_or_nothing|self_blame|emotional_reasoning 중 하나 또는 null",
+              "beliefKind": "core_self|core_other|core_world|intermediate_rule|compensatory_strategy 중 하나 또는 null",
+              "polarity": "positive|negative|neutral 중 하나 또는 null"
+            }
+            발화에 명시적 근거가 없으면 null을 사용합니다. 새 코드나 설명을 만들지 마세요.
+            """;
+
+    private final LlmClient llmClient;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public TurnOntologySignal extract(String userMessage) {
+        if (userMessage == null || userMessage.isBlank()) {
+            return TurnOntologySignal.empty();
+        }
+        try {
+            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            JsonNode node = objectMapper.readTree(stripCodeFence(response));
+            return new TurnOntologySignal(
+                    nullableText(node, "distortionCode"),
+                    nullableText(node, "beliefKind"),
+                    nullableText(node, "polarity")
+            );
+        } catch (Exception e) {
+            log.warn("LlmTurnOntologyExtractor failed; skipping current-turn activation", e);
+            return TurnOntologySignal.empty();
+        }
+    }
+
+    private String nullableText(JsonNode node, String fieldName) {
+        JsonNode value = node.get(fieldName);
+        if (value == null || value.isNull()) {
+            return null;
+        }
+        String text = value.asText();
+        return "null".equalsIgnoreCase(text) ? null : text;
+    }
+
+    private String stripCodeFence(String response) {
+        if (response == null) {
+            return "";
+        }
+        String cleaned = response.trim();
+        if (cleaned.startsWith("```")) {
+            return cleaned.replaceFirst("^```(?:json)?\\s*", "")
+                    .replaceFirst("\\s*```$", "").trim();
+        }
+        return cleaned;
+    }
+}

--- a/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivationDispatcher.java
+++ b/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivationDispatcher.java
@@ -1,0 +1,25 @@
+package com.mio.ai.memory.ontology;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.task.TaskRejectedException;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/** 보조 온톨로지 작업의 executor 포화가 주 대화 요청을 실패시키지 않도록 격리한다. */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReactiveOntologyActivationDispatcher {
+
+    private final ReactiveOntologyActivator activator;
+
+    public void activateBeliefs(UUID userId, UUID sessionId, String normalizedMessage) {
+        try {
+            activator.activateBeliefs(userId, sessionId, normalizedMessage);
+        } catch (TaskRejectedException e) {
+            log.warn("Reactive ontology activation queue is full; skipping sessionId={}", sessionId);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
+++ b/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
@@ -1,0 +1,94 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.memory.episodic.UserBeliefRepository;
+import com.mio.ai.memory.working.WorkingMemory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * 현재 발화의 검증된 온톨로지 신호를 세션 WorkingMemory에만 반영한다.
+ * 활성화는 다음 턴의 관계 검색에 사용되며 새로운 신념/증거를 영속화하지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ReactiveOntologyActivator {
+
+    private static final Set<String> VALID_BELIEF_KINDS = Set.of(
+            "core_self", "core_other", "core_world", "intermediate_rule", "compensatory_strategy");
+    private static final Set<String> VALID_POLARITIES = Set.of("positive", "negative", "neutral");
+
+    private final CbtDistortionDefRepository distortionRepository;
+    private final UserBeliefRepository beliefRepository;
+    private final WorkingMemory workingMemory;
+    private final TurnOntologyExtractor turnOntologyExtractor;
+    private final OntologyValidator ontologyValidator;
+
+    /**
+     * 규칙 기반으로 이미 감지된 왜곡에서만 같은 발화에 명시적으로 등장한 시드 트리거를 활성화한다.
+     */
+    public void activateVerifiedTriggers(UUID sessionId, String normalizedMessage, String distortionCode) {
+        if (sessionId == null || normalizedMessage == null || normalizedMessage.isBlank()
+                || distortionCode == null || distortionCode.isBlank()) {
+            return;
+        }
+        try {
+            distortionRepository.findById(distortionCode)
+                    .map(CbtDistortionDef::getTypicalTriggers)
+                    .orElse(List.of())
+                    .stream()
+                    .filter(Objects::nonNull)
+                    .filter(trigger -> !trigger.isBlank())
+                    .filter(trigger -> containsNormalized(normalizedMessage, trigger))
+                    .forEach(trigger -> workingMemory.addSessionTrigger(sessionId, trigger));
+        } catch (Exception e) {
+            log.warn("ReactiveOntologyActivator: trigger activation skipped for sessionId={}", sessionId, e);
+        }
+    }
+
+    /**
+     * LLM 결과는 온톨로지와 DB 허용값으로 다시 검증한다. 이 호출은 응답 스트리밍을 지연시키지 않는다.
+     */
+    @Async("ontologyActivationExecutor")
+    public void activateBeliefs(UUID userId, UUID sessionId, String normalizedMessage) {
+        if (userId == null || sessionId == null || normalizedMessage == null || normalizedMessage.isBlank()) {
+            return;
+        }
+        try {
+            TurnOntologySignal signal = turnOntologyExtractor.extract(normalizedMessage);
+            if (!ontologyValidator.isValidDistortionCode(signal.distortionCode())) {
+                return;
+            }
+
+            activateVerifiedTriggers(sessionId, normalizedMessage, signal.distortionCode());
+            if (!VALID_BELIEF_KINDS.contains(signal.beliefKind()) || !VALID_POLARITIES.contains(signal.polarity())) {
+                return;
+            }
+
+            beliefRepository.findByUser_IdAndStatus(userId, "active").stream()
+                    .filter(belief -> signal.beliefKind().equals(belief.getBeliefKind()))
+                    .filter(belief -> signal.polarity().equals(belief.getPolarity()))
+                    .map(belief -> belief.getId())
+                    .filter(Objects::nonNull)
+                    .map(UUID::toString)
+                    .forEach(beliefId -> workingMemory.addActivatedBeliefId(sessionId, beliefId));
+        } catch (Exception e) {
+            log.warn("ReactiveOntologyActivator: belief activation skipped for sessionId={}", sessionId, e);
+        }
+    }
+
+    private boolean containsNormalized(String message, String trigger) {
+        return compact(message).contains(compact(trigger));
+    }
+
+    private String compact(String value) {
+        return value.replaceAll("\\s+", "").trim();
+    }
+}

--- a/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
+++ b/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
@@ -2,6 +2,8 @@ package com.mio.ai.memory.ontology;
 
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.ai.memory.working.WorkingMemory;
+import com.mio.session.domain.SessionStatus;
+import com.mio.session.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -30,6 +32,7 @@ public class ReactiveOntologyActivator {
     private final WorkingMemory workingMemory;
     private final TurnOntologyExtractor turnOntologyExtractor;
     private final OntologyValidator ontologyValidator;
+    private final SessionRepository sessionRepository;
 
     /**
      * 규칙 기반으로 이미 감지된 왜곡에서만 같은 발화에 명시적으로 등장한 시드 트리거를 활성화한다.
@@ -62,23 +65,28 @@ public class ReactiveOntologyActivator {
             return;
         }
         try {
+            if (!isSessionActive(sessionId) || !workingMemory.tryAcquireOntologyActivation(sessionId)) {
+                return;
+            }
             TurnOntologySignal signal = turnOntologyExtractor.extract(normalizedMessage);
-            if (!ontologyValidator.isValidDistortionCode(signal.distortionCode())) {
+            if (!isSessionActive(sessionId) || !ontologyValidator.isValidDistortionCode(signal.distortionCode())) {
                 return;
             }
 
-            activateVerifiedTriggers(sessionId, normalizedMessage, signal.distortionCode());
             if (!VALID_BELIEF_KINDS.contains(signal.beliefKind()) || !VALID_POLARITIES.contains(signal.polarity())) {
                 return;
             }
 
-            beliefRepository.findByUser_IdAndStatus(userId, "active").stream()
+            List<String> activatedBeliefIds = beliefRepository.findByUser_IdAndStatus(userId, "active").stream()
                     .filter(belief -> signal.beliefKind().equals(belief.getBeliefKind()))
                     .filter(belief -> signal.polarity().equals(belief.getPolarity()))
                     .map(belief -> belief.getId())
                     .filter(Objects::nonNull)
                     .map(UUID::toString)
-                    .forEach(beliefId -> workingMemory.addActivatedBeliefId(sessionId, beliefId));
+                    .toList();
+            if (activatedBeliefIds.size() == 1 && isSessionActive(sessionId)) {
+                workingMemory.addActivatedBeliefId(sessionId, activatedBeliefIds.getFirst());
+            }
         } catch (Exception e) {
             log.warn("ReactiveOntologyActivator: belief activation skipped for sessionId={}", sessionId, e);
         }
@@ -90,5 +98,9 @@ public class ReactiveOntologyActivator {
 
     private String compact(String value) {
         return value.replaceAll("\\s+", "").trim();
+    }
+
+    private boolean isSessionActive(UUID sessionId) {
+        return sessionRepository.existsByIdAndStatus(sessionId, SessionStatus.ACTIVE);
     }
 }

--- a/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyEligibility.java
+++ b/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyEligibility.java
@@ -1,0 +1,35 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.UserMessageSignal;
+import com.mio.ai.security.SecurityLevel;
+import org.springframework.stereotype.Component;
+
+/** 안전 정책과 결정론 신호가 모두 충족된 턴만 반응형 온톨로지 활성화를 허용한다. */
+@Component
+public class ReactiveOntologyEligibility {
+
+    public boolean allowsTriggerActivation(UserMessageSignal signal, CombinedSignal combined) {
+        return signal != null
+                && signal.biasType() != null
+                && combined.securityLevel() == SecurityLevel.CLEAN
+                && !combined.hardCrisis()
+                && !combined.l0Flagged();
+    }
+
+    public boolean allowsBeliefActivation(UserMessageSignal signal, CombinedSignal combined,
+                                          PolicyDecision decision) {
+        return allowsTriggerActivation(signal, combined)
+                && decision.action() == DecisionAction.GENERATE
+                && isEligibleRisk(decision.riskLevel());
+    }
+
+    private boolean isEligibleRisk(RiskLevel riskLevel) {
+        return riskLevel == RiskLevel.CLEAR_LOW
+                || riskLevel == RiskLevel.LOW
+                || riskLevel == RiskLevel.MEDIUM;
+    }
+}

--- a/src/main/java/com/mio/ai/memory/ontology/TurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/TurnOntologyExtractor.java
@@ -1,0 +1,6 @@
+package com.mio.ai.memory.ontology;
+
+public interface TurnOntologyExtractor {
+
+    TurnOntologySignal extract(String userMessage);
+}

--- a/src/main/java/com/mio/ai/memory/ontology/TurnOntologySignal.java
+++ b/src/main/java/com/mio/ai/memory/ontology/TurnOntologySignal.java
@@ -1,0 +1,12 @@
+package com.mio.ai.memory.ontology;
+
+/** 현재 발화에서만 추출한 온톨로지 활성화 후보. 영속 데이터 생성에는 사용하지 않는다. */
+public record TurnOntologySignal(
+        String distortionCode,
+        String beliefKind,
+        String polarity
+) {
+    public static TurnOntologySignal empty() {
+        return new TurnOntologySignal(null, null, null);
+    }
+}

--- a/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
@@ -44,6 +44,7 @@ public record RetrievalPlan(
     public static RetrievalPlan cbtIntervention() {
         return new RetrievalPlan(
                 List.of(RetrievalSource.GRAPH_BELIEF_NEIGH,
+                        RetrievalSource.GRAPH_TRIGGER,
                         RetrievalSource.GRAPH_INTERVENTION_FIT,
                         RetrievalSource.VECTOR_BELIEF),
                 3, 300, "sensitive"

--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -219,6 +219,9 @@ public class StructuredRetriever {
     public List<RetrievedItem> retrieveBeliefNeighbors(UUID userId, Set<String> activatedBeliefIds) {
         try {
             List<UUID> beliefIds = toUuids(activatedBeliefIds);
+            if (activatedBeliefIds != null && !activatedBeliefIds.isEmpty() && beliefIds.isEmpty()) {
+                return Collections.emptyList();
+            }
             if (!beliefIds.isEmpty()) {
                 return jdbcTemplate.query(
                         con -> {
@@ -297,6 +300,9 @@ public class StructuredRetriever {
     }
 
     private UUID toUuid(String value) {
+        if (value == null) {
+            return null;
+        }
         try {
             return UUID.fromString(value);
         } catch (IllegalArgumentException e) {

--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import java.sql.Array;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -215,8 +216,44 @@ public class StructuredRetriever {
     }
 
     // belief_text는 AES-256 암호화 컬럼이므로 메타데이터 컬럼만 사용해 인접 신념 구성
-    public List<RetrievedItem> retrieveBeliefNeighbors(UUID userId) {
+    public List<RetrievedItem> retrieveBeliefNeighbors(UUID userId, Set<String> activatedBeliefIds) {
         try {
+            List<UUID> beliefIds = toUuids(activatedBeliefIds);
+            if (!beliefIds.isEmpty()) {
+                return jdbcTemplate.query(
+                        con -> {
+                            var ps = con.prepareStatement(
+                                    """
+                                    SELECT b.id::text,
+                                           b.belief_kind
+                                             || ' [' || COALESCE(b.polarity, 'neutral') || ']'
+                                             || ' conf:' || ROUND(b.confidence::numeric, 2)
+                                             || ' support:' || COALESCE(b.support_count, 0)
+                                             || ' contradict:' || COALESCE(b.contradict_count, 0) AS content,
+                                           b.confidence AS score
+                                    FROM user_beliefs b
+                                    WHERE b.user_id = ?
+                                      AND b.status = 'active'
+                                      AND b.id = ANY (?)
+                                    ORDER BY b.last_activated_at DESC, b.confidence DESC
+                                    LIMIT 5
+                                    """
+                            );
+                            ps.setObject(1, userId);
+                            Array pgArray = con.createArrayOf("uuid", beliefIds.toArray(UUID[]::new));
+                            ps.setArray(2, pgArray);
+                            return ps;
+                        },
+                        (rs, rowNum) -> new RetrievedItem(
+                                rs.getString("id"),
+                                RetrievalSource.GRAPH_BELIEF_NEIGH,
+                                rs.getString("content"),
+                                "sensitive",
+                                rs.getDouble("score"),
+                                rowNum + 1
+                        )
+                );
+            }
             return jdbcTemplate.query(
                     """
                     SELECT b.id::text,
@@ -246,6 +283,24 @@ public class StructuredRetriever {
         } catch (Exception e) {
             log.warn("StructuredRetriever.retrieveBeliefNeighbors failed for userId={}", userId, e);
             return Collections.emptyList();
+        }
+    }
+
+    private List<UUID> toUuids(Set<String> activatedBeliefIds) {
+        if (activatedBeliefIds == null || activatedBeliefIds.isEmpty()) {
+            return List.of();
+        }
+        return activatedBeliefIds.stream()
+                .map(this::toUuid)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+    }
+
+    private UUID toUuid(String value) {
+        try {
+            return UUID.fromString(value);
+        } catch (IllegalArgumentException e) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
+++ b/src/main/java/com/mio/ai/memory/working/WorkingMemory.java
@@ -36,6 +36,7 @@ public class WorkingMemory {
     private static final String WORKING_KEY   = "session:%s:working";
     private static final String BELIEFS_KEY   = "session:%s:beliefs";
     private static final String TRIGGERS_KEY  = "session:%s:triggers";
+    private static final String ONTOLOGY_ACTIVATION_KEY = "session:%s:ontology_activation";
 
     private static final String FIELD_SOCRATIC_COUNT    = "socratic_count";
     private static final String FIELD_CBT_STATE         = "cbt_intervention_state";
@@ -43,6 +44,7 @@ public class WorkingMemory {
     private static final String FIELD_DISTORTION_PREFIX = "distortion:";
 
     private static final Duration SESSION_TTL = Duration.ofMinutes(90);
+    private static final Duration ONTOLOGY_ACTIVATION_TTL = Duration.ofSeconds(45);
 
     private final StringRedisTemplate redisTemplate;
     private final ObjectMapper objectMapper;
@@ -135,6 +137,17 @@ public class WorkingMemory {
         redisTemplate.expire(k, SESSION_TTL);
     }
 
+    /** 같은 세션에서 진행 중이거나 막 끝난 온톨로지 LLM 호출을 중복 억제한다. */
+    public boolean tryAcquireOntologyActivation(UUID sessionId) {
+        try {
+            return Boolean.TRUE.equals(redisTemplate.opsForValue().setIfAbsent(
+                    ontologyActivationKey(sessionId), "1", ONTOLOGY_ACTIVATION_TTL));
+        } catch (Exception e) {
+            log.warn("WorkingMemory.tryAcquireOntologyActivation failed for sessionId={} — skipping", sessionId, e);
+            return false;
+        }
+    }
+
     // ── 전체 조회 ────────────────────────────────────────────────
 
     public SessionDelta getSessionDelta(UUID sessionId) {
@@ -181,7 +194,8 @@ public class WorkingMemory {
                     messagesKey(sessionId),
                     workingKey(sessionId),
                     beliefsKey(sessionId),
-                    triggersKey(sessionId)
+                    triggersKey(sessionId),
+                    ontologyActivationKey(sessionId)
             ));
         } catch (Exception e) {
             log.warn("WorkingMemory.clear failed for sessionId={} — TTL will expire keys", sessionId, e);
@@ -194,6 +208,7 @@ public class WorkingMemory {
     private String workingKey(UUID sessionId)   { return WORKING_KEY.formatted(sessionId); }
     private String beliefsKey(UUID sessionId)   { return BELIEFS_KEY.formatted(sessionId); }
     private String triggersKey(UUID sessionId)  { return TRIGGERS_KEY.formatted(sessionId); }
+    private String ontologyActivationKey(UUID sessionId) { return ONTOLOGY_ACTIVATION_KEY.formatted(sessionId); }
 
     // ── 직렬화 ───────────────────────────────────────────────────
 

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -6,6 +6,7 @@ import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.memory.ontology.OntologyInterventionFilter;
 import com.mio.ai.memory.ontology.ReactiveOntologyActivator;
+import com.mio.ai.memory.ontology.ReactiveOntologyEligibility;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
@@ -93,6 +94,7 @@ public class ConversationOrchestrator {
     private final PolicyEngine policyEngine;
     private final OntologyInterventionFilter ontologyInterventionFilter;
     private final ReactiveOntologyActivator reactiveOntologyActivator;
+    private final ReactiveOntologyEligibility reactiveOntologyEligibility;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
     private final CrisisFlowService crisisFlowService;
@@ -147,11 +149,9 @@ public class ConversationOrchestrator {
                             userSignal.biasType()));
             CombinedSignal combined = signalCombiner.combine(securityAssessment, l1Result, moderation, profile);
 
-            // 현재 발화가 시드 트리거를 명시할 때만 즉시 활성화해 같은 턴의 GRAPH_TRIGGER에 반영한다.
-            reactiveOntologyActivator.activateVerifiedTriggers(sessionId, normalized, userSignal.biasType());
-            // 신념 활성화는 응답 지연을 막기 위해 비동기로 실행하며, 위기 발화에는 추가 LLM 호출을 하지 않는다.
-            if (!combined.hardCrisis()) {
-                reactiveOntologyActivator.activateBeliefs(userId, sessionId, normalized);
+            // 안전한 결정론 신호만 같은 턴의 GRAPH_TRIGGER에 반영한다.
+            if (reactiveOntologyEligibility.allowsTriggerActivation(userSignal, combined)) {
+                reactiveOntologyActivator.activateVerifiedTriggers(sessionId, normalized, userSignal.biasType());
             }
 
             // 4. InputJudge (conditional)
@@ -177,6 +177,11 @@ public class ConversationOrchestrator {
             PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
             decision = decision.withInterventionHints(
                     ontologyInterventionFilter.filter(decision.interventionHints(), combined, sessionDelta));
+
+            // 현재 컨텍스트가 확정된 뒤, 안전한 생성 턴의 다음 턴 맥락만 비동기 활성화한다.
+            if (reactiveOntologyEligibility.allowsBeliefActivation(userSignal, combined, decision)) {
+                reactiveOntologyActivator.activateBeliefs(userId, sessionId, normalized);
+            }
 
             // 7. Execute based on decision
             String assistantContent;

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -6,6 +6,7 @@ import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.memory.ontology.OntologyInterventionFilter;
 import com.mio.ai.memory.ontology.ReactiveOntologyActivator;
+import com.mio.ai.memory.ontology.ReactiveOntologyActivationDispatcher;
 import com.mio.ai.memory.ontology.ReactiveOntologyEligibility;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
@@ -94,6 +95,7 @@ public class ConversationOrchestrator {
     private final PolicyEngine policyEngine;
     private final OntologyInterventionFilter ontologyInterventionFilter;
     private final ReactiveOntologyActivator reactiveOntologyActivator;
+    private final ReactiveOntologyActivationDispatcher reactiveOntologyActivationDispatcher;
     private final ReactiveOntologyEligibility reactiveOntologyEligibility;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
@@ -180,7 +182,7 @@ public class ConversationOrchestrator {
 
             // 현재 컨텍스트가 확정된 뒤, 안전한 생성 턴의 다음 턴 맥락만 비동기 활성화한다.
             if (reactiveOntologyEligibility.allowsBeliefActivation(userSignal, combined, decision)) {
-                reactiveOntologyActivator.activateBeliefs(userId, sessionId, normalized);
+                reactiveOntologyActivationDispatcher.activateBeliefs(userId, sessionId, normalized);
             }
 
             // 7. Execute based on decision

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.memory.ontology.OntologyInterventionFilter;
+import com.mio.ai.memory.ontology.ReactiveOntologyActivator;
 import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
@@ -91,6 +92,7 @@ public class ConversationOrchestrator {
     private final OutputJudge outputJudge;
     private final PolicyEngine policyEngine;
     private final OntologyInterventionFilter ontologyInterventionFilter;
+    private final ReactiveOntologyActivator reactiveOntologyActivator;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
     private final CrisisFlowService crisisFlowService;
@@ -144,6 +146,13 @@ public class ConversationOrchestrator {
                             userSignal.emotionScore(),
                             userSignal.biasType()));
             CombinedSignal combined = signalCombiner.combine(securityAssessment, l1Result, moderation, profile);
+
+            // 현재 발화가 시드 트리거를 명시할 때만 즉시 활성화해 같은 턴의 GRAPH_TRIGGER에 반영한다.
+            reactiveOntologyActivator.activateVerifiedTriggers(sessionId, normalized, userSignal.biasType());
+            // 신념 활성화는 응답 지연을 막기 위해 비동기로 실행하며, 위기 발화에는 추가 LLM 호출을 하지 않는다.
+            if (!combined.hardCrisis()) {
+                reactiveOntologyActivator.activateBeliefs(userId, sessionId, normalized);
+            }
 
             // 4. InputJudge (conditional)
             InputJudgeResult judgeResult = null;

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -194,7 +194,16 @@ public class ContextPreWarmer {
                 case GRAPH_INTERVENTION_FIT -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveInterventionFit(userId), retrievalPool);
                 case GRAPH_BELIEF_NEIGH  -> CompletableFuture.supplyAsync(
-                        () -> structuredRetriever.retrieveBeliefNeighbors(userId), retrievalPool);
+                        () -> {
+                            try {
+                                return structuredRetriever.retrieveBeliefNeighbors(
+                                        userId, workingMemory.getSessionDelta(sessionId).activatedBeliefIds());
+                            } catch (Exception e) {
+                                log.warn("ContextPreWarmer: GRAPH_BELIEF_NEIGH activation fetch failed for sessionId={}",
+                                        sessionId, e);
+                                return Collections.<RetrievedItem>emptyList();
+                            }
+                        }, retrievalPool);
                 default                  -> CompletableFuture.completedFuture(List.of());
             };
             futures.add(future);

--- a/src/main/java/com/mio/config/AiConfig.java
+++ b/src/main/java/com/mio/config/AiConfig.java
@@ -26,6 +26,11 @@ public class AiConfig {
         return Executors.newVirtualThreadPerTaskExecutor();
     }
 
+    @Bean(name = "ontologyActivationExecutor")
+    public Executor ontologyActivationExecutor() {
+        return Executors.newVirtualThreadPerTaskExecutor();
+    }
+
     @Bean(name = "aiDecisionLoggerExecutor")
     public Executor aiDecisionLoggerExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/main/java/com/mio/config/AiConfig.java
+++ b/src/main/java/com/mio/config/AiConfig.java
@@ -28,7 +28,13 @@ public class AiConfig {
 
     @Bean(name = "ontologyActivationExecutor")
     public Executor ontologyActivationExecutor() {
-        return Executors.newVirtualThreadPerTaskExecutor();
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(20);
+        executor.setThreadNamePrefix("ontology-activation-");
+        executor.initialize();
+        return executor;
     }
 
     @Bean(name = "aiDecisionLoggerExecutor")

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -53,6 +53,8 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
 
     boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);
 
+    boolean existsByIdAndStatus(UUID id, SessionStatus status);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("UPDATE Session s SET s.summaryStatus = :status WHERE s.id = :sessionId")
     void updateSummaryStatus(@Param("sessionId") UUID sessionId, @Param("status") SummaryStatus status);

--- a/src/test/java/com/mio/ai/memory/composer/ContextComposerTest.java
+++ b/src/test/java/com/mio/ai/memory/composer/ContextComposerTest.java
@@ -1,0 +1,31 @@
+package com.mio.ai.memory.composer;
+
+import com.mio.ai.memory.retrieval.RetrievalSource;
+import com.mio.ai.memory.retrieval.RetrievedItem;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ContextComposerTest {
+
+    @Test
+    void includesActivatedBeliefNeighborsInBeliefContext() {
+        ContextSanitizer sanitizer = mock(ContextSanitizer.class);
+        InjectionScanner injectionScanner = mock(InjectionScanner.class);
+        ContextComposer composer = new ContextComposer(sanitizer, injectionScanner);
+        RetrievedItem belief = new RetrievedItem("belief-1", RetrievalSource.GRAPH_BELIEF_NEIGH,
+                "core_self [negative] conf:0.70", "sensitive", 0.7, 1);
+        when(sanitizer.sanitize(List.of(belief), "sensitive")).thenReturn(List.of(belief));
+        when(injectionScanner.sanitize(anyString())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        String context = composer.compose(List.of(belief), "sensitive", false);
+
+        assertThat(context).contains("[Belief Context]");
+        assertThat(context).contains("core_self [negative] conf:0.70");
+    }
+}

--- a/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
@@ -1,0 +1,30 @@
+package com.mio.ai.memory.ontology;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class LlmTurnOntologyExtractorTest {
+
+    @Test
+    void parsesCodeFenceAndLiteralNullAsAbsentValues() {
+        LlmClient llmClient = mock(LlmClient.class);
+        when(llmClient.completeJson(any())).thenReturn("""
+                ```json
+                {"distortionCode":"mind_reading","beliefKind":"null","polarity":null}
+                ```
+                """);
+        LlmTurnOntologyExtractor extractor = new LlmTurnOntologyExtractor(llmClient, new ObjectMapper());
+
+        TurnOntologySignal signal = extractor.extract("다들 나를 싫어하는 것 같아");
+
+        assertThat(signal.distortionCode()).isEqualTo("mind_reading");
+        assertThat(signal.beliefKind()).isNull();
+        assertThat(signal.polarity()).isNull();
+    }
+}

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivationDispatcherTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivationDispatcherTest.java
@@ -1,0 +1,26 @@
+package com.mio.ai.memory.ontology;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.task.TaskRejectedException;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+class ReactiveOntologyActivationDispatcherTest {
+
+    @Test
+    void ignoresRejectedBackgroundActivationWithoutFailingConversation() {
+        ReactiveOntologyActivator activator = mock(ReactiveOntologyActivator.class);
+        ReactiveOntologyActivationDispatcher dispatcher = new ReactiveOntologyActivationDispatcher(activator);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        doThrow(new TaskRejectedException("queue full"))
+                .when(activator).activateBeliefs(userId, sessionId, "업무 압박이 너무 커");
+
+        assertThatCode(() -> dispatcher.activateBeliefs(userId, sessionId, "업무 압박이 너무 커"))
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
@@ -1,0 +1,90 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.memory.episodic.UserBelief;
+import com.mio.ai.memory.episodic.UserBeliefRepository;
+import com.mio.ai.memory.working.WorkingMemory;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ReactiveOntologyActivatorTest {
+
+    private final CbtDistortionDefRepository distortionRepository = mock(CbtDistortionDefRepository.class);
+    private final UserBeliefRepository beliefRepository = mock(UserBeliefRepository.class);
+    private final WorkingMemory workingMemory = mock(WorkingMemory.class);
+    private final TurnOntologyExtractor turnOntologyExtractor = mock(TurnOntologyExtractor.class);
+    private final OntologyValidator ontologyValidator = mock(OntologyValidator.class);
+
+    private ReactiveOntologyActivator activator;
+    private UUID userId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        activator = new ReactiveOntologyActivator(
+                distortionRepository, beliefRepository, workingMemory, turnOntologyExtractor, ontologyValidator);
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+    }
+
+    @Test
+    void activatesOnlySeedTriggerExplicitlyPresentInCurrentUtterance() {
+        CbtDistortionDef distortion = mock(CbtDistortionDef.class);
+        when(distortion.getTypicalTriggers()).thenReturn(List.of("업무 압박", "건강 걱정"));
+        when(distortionRepository.findById("catastrophizing")).thenReturn(Optional.of(distortion));
+
+        activator.activateVerifiedTriggers(sessionId, "업무 압박 때문에 최악일 것 같아", "catastrophizing");
+
+        verify(workingMemory).addSessionTrigger(sessionId, "업무 압박");
+        verify(workingMemory, never()).addSessionTrigger(sessionId, "건강 걱정");
+    }
+
+    @Test
+    void activatesExistingBeliefAndSeedTriggerFromValidatedStructuredExtraction() {
+        CbtDistortionDef distortion = mock(CbtDistortionDef.class);
+        UserBelief matchingBelief = mock(UserBelief.class);
+        UserBelief otherBelief = mock(UserBelief.class);
+        UUID matchingBeliefId = UUID.randomUUID();
+
+        when(turnOntologyExtractor.extract("발표에서 다들 나를 싫어하는 것 같아"))
+                .thenReturn(new TurnOntologySignal("mind_reading", "core_other", "negative"));
+        when(ontologyValidator.isValidDistortionCode("mind_reading")).thenReturn(true);
+        when(distortion.getTypicalTriggers()).thenReturn(List.of("발표", "사회적 상황"));
+        when(distortionRepository.findById("mind_reading")).thenReturn(Optional.of(distortion));
+        when(beliefRepository.findByUser_IdAndStatus(userId, "active"))
+                .thenReturn(List.of(matchingBelief, otherBelief));
+        when(matchingBelief.getId()).thenReturn(matchingBeliefId);
+        when(matchingBelief.getBeliefKind()).thenReturn("core_other");
+        when(matchingBelief.getPolarity()).thenReturn("negative");
+        when(otherBelief.getBeliefKind()).thenReturn("core_self");
+        when(otherBelief.getPolarity()).thenReturn("negative");
+
+        activator.activateBeliefs(userId, sessionId, "발표에서 다들 나를 싫어하는 것 같아");
+
+        verify(workingMemory).addSessionTrigger(sessionId, "발표");
+        verify(workingMemory).addActivatedBeliefId(sessionId, matchingBeliefId.toString());
+    }
+
+    @Test
+    void ignoresUnknownStructuredDistortionWithoutWritingWorkingMemory() {
+        when(turnOntologyExtractor.extract(anyString()))
+                .thenReturn(new TurnOntologySignal("invented_code", "core_self", "negative"));
+        when(ontologyValidator.isValidDistortionCode("invented_code")).thenReturn(false);
+
+        activator.activateBeliefs(userId, sessionId, "무엇이든 안 될 것 같아");
+
+        verify(workingMemory, never()).addSessionTrigger(eq(sessionId), anyString());
+        verify(workingMemory, never()).addActivatedBeliefId(eq(sessionId), anyString());
+        verify(beliefRepository, never()).findByUser_IdAndStatus(userId, "active");
+    }
+}

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
@@ -41,6 +41,7 @@ class ReactiveOntologyActivatorTest {
         userId = UUID.randomUUID();
         sessionId = UUID.randomUUID();
         when(sessionRepository.existsByIdAndStatus(sessionId, SessionStatus.ACTIVE)).thenReturn(true);
+        when(workingMemory.tryAcquireOntologyActivation(sessionId)).thenReturn(true);
     }
 
     @Test
@@ -56,8 +57,7 @@ class ReactiveOntologyActivatorTest {
     }
 
     @Test
-    void activatesExistingBeliefAndSeedTriggerFromValidatedStructuredExtraction() {
-        CbtDistortionDef distortion = mock(CbtDistortionDef.class);
+    void activatesExistingBeliefFromValidatedStructuredExtraction() {
         UserBelief matchingBelief = mock(UserBelief.class);
         UserBelief otherBelief = mock(UserBelief.class);
         UUID matchingBeliefId = UUID.randomUUID();
@@ -65,8 +65,6 @@ class ReactiveOntologyActivatorTest {
         when(turnOntologyExtractor.extract("발표에서 다들 나를 싫어하는 것 같아"))
                 .thenReturn(new TurnOntologySignal("mind_reading", "core_other", "negative"));
         when(ontologyValidator.isValidDistortionCode("mind_reading")).thenReturn(true);
-        when(distortion.getTypicalTriggers()).thenReturn(List.of("발표", "사회적 상황"));
-        when(distortionRepository.findById("mind_reading")).thenReturn(Optional.of(distortion));
         when(beliefRepository.findByUser_IdAndStatus(userId, "active"))
                 .thenReturn(List.of(matchingBelief, otherBelief));
         when(matchingBelief.getId()).thenReturn(matchingBeliefId);
@@ -77,7 +75,6 @@ class ReactiveOntologyActivatorTest {
 
         activator.activateBeliefs(userId, sessionId, "발표에서 다들 나를 싫어하는 것 같아");
 
-        verify(workingMemory).addSessionTrigger(sessionId, "발표");
         verify(workingMemory).addActivatedBeliefId(sessionId, matchingBeliefId.toString());
     }
 

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
@@ -3,6 +3,8 @@ package com.mio.ai.memory.ontology;
 import com.mio.ai.memory.episodic.UserBelief;
 import com.mio.ai.memory.episodic.UserBeliefRepository;
 import com.mio.ai.memory.working.WorkingMemory;
+import com.mio.session.domain.SessionStatus;
+import com.mio.session.repository.SessionRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -15,6 +17,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 class ReactiveOntologyActivatorTest {
@@ -24,6 +27,7 @@ class ReactiveOntologyActivatorTest {
     private final WorkingMemory workingMemory = mock(WorkingMemory.class);
     private final TurnOntologyExtractor turnOntologyExtractor = mock(TurnOntologyExtractor.class);
     private final OntologyValidator ontologyValidator = mock(OntologyValidator.class);
+    private final SessionRepository sessionRepository = mock(SessionRepository.class);
 
     private ReactiveOntologyActivator activator;
     private UUID userId;
@@ -32,9 +36,11 @@ class ReactiveOntologyActivatorTest {
     @BeforeEach
     void setUp() {
         activator = new ReactiveOntologyActivator(
-                distortionRepository, beliefRepository, workingMemory, turnOntologyExtractor, ontologyValidator);
+                distortionRepository, beliefRepository, workingMemory, turnOntologyExtractor, ontologyValidator,
+                sessionRepository);
         userId = UUID.randomUUID();
         sessionId = UUID.randomUUID();
+        when(sessionRepository.existsByIdAndStatus(sessionId, SessionStatus.ACTIVE)).thenReturn(true);
     }
 
     @Test
@@ -86,5 +92,34 @@ class ReactiveOntologyActivatorTest {
         verify(workingMemory, never()).addSessionTrigger(eq(sessionId), anyString());
         verify(workingMemory, never()).addActivatedBeliefId(eq(sessionId), anyString());
         verify(beliefRepository, never()).findByUser_IdAndStatus(userId, "active");
+    }
+
+    @Test
+    void doesNotActivateAmbiguousBeliefsThatShareKindAndPolarity() {
+        UserBelief first = mock(UserBelief.class);
+        UserBelief second = mock(UserBelief.class);
+        when(turnOntologyExtractor.extract("나는 아무것도 못하는 사람인 것 같아"))
+                .thenReturn(new TurnOntologySignal("overgeneralization", "core_self", "negative"));
+        when(ontologyValidator.isValidDistortionCode("overgeneralization")).thenReturn(true);
+        when(distortionRepository.findById("overgeneralization")).thenReturn(Optional.empty());
+        when(beliefRepository.findByUser_IdAndStatus(userId, "active")).thenReturn(List.of(first, second));
+        when(first.getBeliefKind()).thenReturn("core_self");
+        when(first.getPolarity()).thenReturn("negative");
+        when(second.getBeliefKind()).thenReturn("core_self");
+        when(second.getPolarity()).thenReturn("negative");
+
+        activator.activateBeliefs(userId, sessionId, "나는 아무것도 못하는 사람인 것 같아");
+
+        verify(workingMemory, never()).addActivatedBeliefId(eq(sessionId), anyString());
+    }
+
+    @Test
+    void skipsAsyncActivationWhenSessionHasAlreadyEnded() {
+        when(sessionRepository.existsByIdAndStatus(sessionId, SessionStatus.ACTIVE)).thenReturn(false);
+
+        activator.activateBeliefs(userId, sessionId, "발표에서 다들 나를 싫어하는 것 같아");
+
+        verify(turnOntologyExtractor, never()).extract(anyString());
+        verifyNoInteractions(beliefRepository, workingMemory);
     }
 }

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyEligibilityTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyEligibilityTest.java
@@ -1,0 +1,57 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.memory.working.SessionDelta;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.UserMessageSignal;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ReactiveOntologyEligibilityTest {
+
+    private final ReactiveOntologyEligibility eligibility = new ReactiveOntologyEligibility();
+
+    @Test
+    void rejectsAttackInputBeforeWritingTriggersOrCallingExtractor() {
+        assertThat(eligibility.allowsTriggerActivation(signal("catastrophizing"), combined(SecurityLevel.ATTACK, false, false)))
+                .isFalse();
+    }
+
+    @Test
+    void callsExtractorOnlyForSafeGeneratedTurnsWithDeterministicSignal() {
+        assertThat(eligibility.allowsBeliefActivation(
+                signal("catastrophizing"), combined(SecurityLevel.CLEAN, false, false), decision(RiskLevel.MEDIUM)))
+                .isTrue();
+        assertThat(eligibility.allowsBeliefActivation(
+                signal(null), combined(SecurityLevel.CLEAN, false, false), decision(RiskLevel.CLEAR_LOW)))
+                .isFalse();
+        assertThat(eligibility.allowsBeliefActivation(
+                signal("catastrophizing"), combined(SecurityLevel.CLEAN, false, true), decision(RiskLevel.MEDIUM)))
+                .isFalse();
+    }
+
+    private UserMessageSignal signal(String biasType) {
+        return new UserMessageSignal(45, biasType);
+    }
+
+    private CombinedSignal combined(SecurityLevel securityLevel, boolean hardCrisis, boolean l0Flagged) {
+        return new CombinedSignal(securityLevel, hardCrisis, false, false, false, false,
+                l0Flagged, false, null, 1.0);
+    }
+
+    private PolicyDecision decision(RiskLevel riskLevel) {
+        return new PolicyDecision("decision", DecisionAction.GENERATE, GenerationMode.NORMAL,
+                DeliveryMode.SPECULATIVE, SecurityLevel.CLEAN, true, true, false,
+                InterventionHints.empty(), "test", riskLevel);
+    }
+}

--- a/src/test/java/com/mio/ai/memory/retrieval/RetrievalPlanTest.java
+++ b/src/test/java/com/mio/ai/memory/retrieval/RetrievalPlanTest.java
@@ -1,0 +1,18 @@
+package com.mio.ai.memory.retrieval;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RetrievalPlanTest {
+
+    @Test
+    void cbtInterventionPlanIncludesBothActivatedBeliefsAndTriggers() {
+        RetrievalPlan plan = RetrievalPlan.cbtIntervention();
+
+        assertThat(plan.sources()).contains(
+                RetrievalSource.GRAPH_BELIEF_NEIGH,
+                RetrievalSource.GRAPH_TRIGGER
+        );
+    }
+}

--- a/src/test/java/com/mio/ai/memory/retrieval/StructuredRetrieverTest.java
+++ b/src/test/java/com/mio/ai/memory/retrieval/StructuredRetrieverTest.java
@@ -1,0 +1,25 @@
+package com.mio.ai.memory.retrieval;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class StructuredRetrieverTest {
+
+    @Test
+    void failsClosedWhenActivationSetContainsOnlyMalformedIds() {
+        JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
+        StructuredRetriever retriever = new StructuredRetriever(jdbcTemplate);
+
+        var result = retriever.retrieveBeliefNeighbors(UUID.randomUUID(), Set.of("not-a-uuid"));
+
+        assertThat(result).isEmpty();
+        verifyNoInteractions(jdbcTemplate);
+    }
+}

--- a/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
+++ b/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
@@ -178,14 +178,14 @@ class WorkingMemoryTest {
     }
 
     @Test
-    @DisplayName("clear는 4개 키를 모두 삭제한다")
-    void clear_deletes_all_four_keys() {
+    @DisplayName("clear는 5개 키를 모두 삭제한다")
+    void clear_deletes_all_five_keys() {
         UUID sessionId = UUID.randomUUID();
 
         workingMemory.clear(sessionId);
 
         verify(redisTemplate).delete(argThat((List<String> keys) ->
-                keys.size() == 4 && keys.stream().allMatch(k -> k.contains(sessionId.toString()))
+                keys.size() == 5 && keys.stream().allMatch(k -> k.contains(sessionId.toString()))
         ));
     }
 

--- a/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
+++ b/src/test/java/com/mio/ai/memory/working/WorkingMemoryTest.java
@@ -8,6 +8,7 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -27,6 +28,7 @@ class WorkingMemoryTest {
     private ListOperations<String, String> listOps;
     private HashOperations<String, Object, Object> hashOps;
     private SetOperations<String, String> setOps;
+    private ValueOperations<String, String> valueOps;
     private WorkingMemory workingMemory;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -38,10 +40,12 @@ class WorkingMemoryTest {
         listOps = mock(ListOperations.class);
         hashOps = mock(HashOperations.class);
         setOps = mock(SetOperations.class);
+        valueOps = mock(ValueOperations.class);
 
         given(redisTemplate.opsForList()).willReturn(listOps);
         given(redisTemplate.opsForHash()).willReturn(hashOps);
         given(redisTemplate.opsForSet()).willReturn(setOps);
+        given(redisTemplate.opsForValue()).willReturn(valueOps);
 
         workingMemory = new WorkingMemory(redisTemplate, objectMapper);
     }
@@ -195,5 +199,17 @@ class WorkingMemoryTest {
 
         verify(setOps).add(contains(sessionId.toString()), eq("work_pressure"));
         verify(redisTemplate).expire(contains(sessionId.toString()), eq(Duration.ofMinutes(90)));
+    }
+
+    @Test
+    @DisplayName("tryAcquireOntologyActivation은 세션당 중복 LLM 호출을 막는다")
+    void tryAcquireOntologyActivation_uses_ttl_lock() {
+        UUID sessionId = UUID.randomUUID();
+        given(valueOps.setIfAbsent(anyString(), eq("1"), eq(Duration.ofSeconds(45)))).willReturn(true);
+
+        boolean acquired = workingMemory.tryAcquireOntologyActivation(sessionId);
+
+        assertThat(acquired).isTrue();
+        verify(valueOps).setIfAbsent(contains(sessionId.toString()), eq("1"), eq(Duration.ofSeconds(45)));
     }
 }

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -10,6 +10,7 @@ import com.mio.ai.memory.retrieval.RetrievalSource;
 import com.mio.ai.memory.retrieval.RetrievedItem;
 import com.mio.ai.memory.retrieval.StructuredRetriever;
 import com.mio.ai.memory.retrieval.VectorRetriever;
+import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.session.repository.SessionCheckpointRepository;
@@ -19,6 +20,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -125,5 +127,22 @@ class ContextPreWarmerTest {
         assertThat(context).isEqualTo("lexical memory");
         assertThat(elapsedMs).isLessThan(700);
         verify(lexicalRetriever).retrieveByKeywords(userId, "발표가 걱정돼", 3);
+    }
+
+    @Test
+    void retrievesOnlyActivatedBeliefNeighborsForCurrentSession() {
+        UUID beliefId = UUID.randomUUID();
+        RetrievalPlan plan = new RetrievalPlan(List.of(RetrievalSource.GRAPH_BELIEF_NEIGH), 3, 200, "normal");
+        SessionDelta delta = new SessionDelta(0, "none", java.util.Map.of(), 0,
+                Set.of(beliefId.toString()), Set.of());
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(workingMemory.getSessionDelta(sessionId)).thenReturn(delta);
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of());
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("belief memory");
+
+        String context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "회의가 걱정돼");
+
+        assertThat(context).isEqualTo("belief memory");
+        verify(structuredRetriever).retrieveBeliefNeighbors(userId, Set.of(beliefId.toString()));
     }
 }


### PR DESCRIPTION
## 변경 사항
- 현재 발화의 시드 `typical_triggers`를 같은 세션 WorkingMemory에 검증된 값만 활성화합니다.
- 비동기 구조화 추출 결과를 온톨로지·허용 신념 값으로 재검증해 기존 신념 ID만 활성화합니다. 새 신념·증거는 생성하지 않습니다.
- 활성 신념 ID가 있으면 해당 노드만 검색하고, CBT 검색 계획에서 활성 트리거와 신념을 함께 검색합니다.

## 안전성
- 위기 발화에는 추가 온톨로지 LLM 호출을 하지 않습니다.
- 트리거는 시드 표현이 현재 발화에 실제 포함될 때만 저장하며 자유 텍스트를 저장하지 않습니다.
- SQL은 파라미터/UUID 배열 바인딩을 사용합니다.

## 검증
- `./gradlew test --tests 'com.mio.ai.memory.retrieval.RetrievalPlanTest' --tests 'com.mio.ai.memory.ontology.ReactiveOntologyActivatorTest' --tests 'com.mio.ai.profile.ContextPreWarmerTest'` 통과 (8 tests).\n- 전체 `./gradlew test`는 이 환경에서 `:testClasses` 이후 종료 결과를 반환하지 않아 확정하지 못했습니다.\n\nCloses #244

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered ontology extraction from the current user message to identify distortion, belief kind, and polarity.
  * Added eligibility-gated, async activation of matching triggers and beliefs, plus per-session protection against duplicate ontology LLM calls.
  * Belief-neighbor retrieval now uses beliefs activated during the current session, and belief context includes both vector and graph belief neighbors.
  * CBT retrieval plans now include graph trigger context.
* **Bug Fixes**
  * Safely ignores null/blank inputs, invalid extractions, and malformed activation identifiers without impacting conversation flow.
* **Tests**
  * Added unit tests covering ontology extraction, eligibility, activation, and retrieval behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->