### PR TITLE
feat: 온톨로지 관계 기반 후보 확장

### DIFF
--- a/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
+++ b/src/main/java/com/mio/ai/memory/composer/ContextComposer.java
@@ -51,7 +51,10 @@ public class ContextComposer {
         appendSection(sb, "Recent Risk Context",
                 grouped.get(RetrievalSource.SQL_RECENT_RISK));
         appendSection(sb, "Past Similar Situations",
-                grouped.get(RetrievalSource.GRAPH_TRIGGER));
+                Stream.concat(
+                                grouped.getOrDefault(RetrievalSource.GRAPH_TRIGGER, List.of()).stream(),
+                                grouped.getOrDefault(RetrievalSource.GRAPH_DISTORTION, List.of()).stream())
+                        .toList());
         appendSection(sb, "Active Patterns",
                 grouped.get(RetrievalSource.SQL_PROFILE));
         appendSection(sb, "Helpful Approaches",

--- a/src/main/java/com/mio/ai/memory/ontology/OntologyRelationExpander.java
+++ b/src/main/java/com/mio/ai/memory/ontology/OntologyRelationExpander.java
@@ -1,0 +1,93 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.policy.InterventionHints;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 검증된 현재 왜곡의 시드 관계만 검색 후보와 기존 개입 후보의 우선순위에 반영한다.
+ * 동반 왜곡은 현재 진단이나 WorkingMemory 상태로 쓰지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OntologyRelationExpander {
+
+    private final CbtDistortionDefRepository distortionRepository;
+
+    public Set<String> expandCooccurringCodes(String currentDistortionCode) {
+        return definitionFor(currentDistortionCode)
+                .map(CbtDistortionDef::getCooccurCodes)
+                .map(this::registeredCodes)
+                .orElseGet(Set::of);
+    }
+
+    /** 정책과 금기 필터가 이미 승인한 후보만 시드 권장 행동 순서로 좁힌다. */
+    public InterventionHints rerankApprovedHints(InterventionHints hints, String currentDistortionCode) {
+        if (hints == null) {
+            return InterventionHints.empty();
+        }
+        if (hints.suggestedCodes() == null || hints.suggestedCodes().isEmpty()) {
+            return hints;
+        }
+
+        List<String> recommended = definitionFor(currentDistortionCode)
+                .map(CbtDistortionDef::getRecommendedActions)
+                .orElse(List.of());
+        if (recommended == null || recommended.isEmpty()) {
+            return hints;
+        }
+
+        Set<String> approved = new LinkedHashSet<>(hints.suggestedCodes());
+        List<String> matched = recommended.stream()
+                .filter(approved::contains)
+                .distinct()
+                .toList();
+        // 관계가 맞지 않는다고 기존 안전 후보를 비우지 않는다.
+        if (matched.isEmpty()) {
+            return hints;
+        }
+        return new InterventionHints(matched, hints.avoidCodes(), hints.targetDistortionCode());
+    }
+
+    private Set<String> registeredCodes(List<String> candidateCodes) {
+        if (candidateCodes == null || candidateCodes.isEmpty()) {
+            return Set.of();
+        }
+        Set<String> candidates = candidateCodes.stream()
+                .filter(code -> code != null && !code.isBlank())
+                .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        if (candidates.isEmpty()) {
+            return Set.of();
+        }
+        try {
+            Set<String> registered = distortionRepository.findCodesByCodeIn(candidates);
+            if (registered == null || registered.isEmpty()) {
+                return Set.of();
+            }
+            return candidates.stream().filter(registered::contains)
+                    .collect(java.util.stream.Collectors.toCollection(LinkedHashSet::new));
+        } catch (Exception e) {
+            log.warn("Ontology cooccurrence lookup failed; skipping relation expansion", e);
+            return Set.of();
+        }
+    }
+
+    private Optional<CbtDistortionDef> definitionFor(String code) {
+        if (code == null || code.isBlank()) {
+            return Optional.empty();
+        }
+        try {
+            return distortionRepository.findById(code);
+        } catch (Exception e) {
+            log.warn("Ontology relation lookup failed for distortionCode={}; skipping", code, e);
+            return Optional.empty();
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/RetrievalPlan.java
@@ -25,6 +25,7 @@ public record RetrievalPlan(
     public static RetrievalPlan medium() {
         return new RetrievalPlan(
                 List.of(RetrievalSource.GRAPH_TRIGGER,
+                        RetrievalSource.GRAPH_DISTORTION,
                         RetrievalSource.GRAPH_INTERVENTION_FIT,
                         RetrievalSource.VECTOR_BELIEF,
                         RetrievalSource.SQL_TODO_HISTORY),
@@ -45,6 +46,7 @@ public record RetrievalPlan(
         return new RetrievalPlan(
                 List.of(RetrievalSource.GRAPH_BELIEF_NEIGH,
                         RetrievalSource.GRAPH_TRIGGER,
+                        RetrievalSource.GRAPH_DISTORTION,
                         RetrievalSource.GRAPH_INTERVENTION_FIT,
                         RetrievalSource.VECTOR_BELIEF),
                 3, 300, "sensitive"

--- a/src/main/java/com/mio/ai/memory/retrieval/RetrievalSource.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/RetrievalSource.java
@@ -5,6 +5,7 @@ public enum RetrievalSource {
     LEXICAL_EPISODE,       // PostgreSQL FTS: session_summaries.summary_text
     VECTOR_BELIEF,         // pgvector: user_beliefs (belief embedding)
     GRAPH_TRIGGER,         // GIN: session_summaries.trigger_tags
+    GRAPH_DISTORTION,      // verified cooccur_codes → past thought/session episodes (unconfirmed context)
     GRAPH_INTERVENTION_FIT,// intervention_outcomes + behavior_tasks
     GRAPH_BELIEF_NEIGH,    // belief_evidence 이웃 신념
     SQL_PROFILE,           // user_beliefs + cbt_patterns 요약

--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -155,6 +155,50 @@ public class StructuredRetriever {
         }
     }
 
+    /**
+     * 시드 관계로 확장한 과거 패턴이다. 현재 턴의 왜곡 판정이나 세션 상태를 변경하지 않는다.
+     */
+    public List<RetrievedItem> retrieveRelatedDistortionEpisodes(UUID userId, Set<String> relatedCodes) {
+        if (relatedCodes == null || relatedCodes.isEmpty()) return Collections.emptyList();
+        try {
+            String[] codes = relatedCodes.stream().filter(code -> code != null && !code.isBlank())
+                    .toArray(String[]::new);
+            if (codes.length == 0) return Collections.emptyList();
+            return jdbcTemplate.query(
+                    con -> {
+                        var ps = con.prepareStatement(
+                                """
+                                SELECT ss.id::text,
+                                       'related pattern (unconfirmed): ' || ss.summary_text AS content,
+                                       0.45 AS score
+                                FROM thoughts t
+                                JOIN session_summaries ss ON ss.session_id = t.session_id
+                                WHERE t.user_id = ?
+                                  AND t.distortion_code = ANY (?)
+                                GROUP BY ss.id, ss.summary_text
+                                ORDER BY MAX(t.created_at) DESC
+                                LIMIT 3
+                                """
+                        );
+                        ps.setObject(1, userId);
+                        ps.setArray(2, con.createArrayOf("text", codes));
+                        return ps;
+                    },
+                    (rs, rowNum) -> new RetrievedItem(
+                            rs.getString("id"),
+                            RetrievalSource.GRAPH_DISTORTION,
+                            rs.getString("content"),
+                            "normal",
+                            rs.getDouble("score"),
+                            rowNum + 1
+                    )
+            );
+        } catch (Exception e) {
+            log.warn("StructuredRetriever.retrieveRelatedDistortionEpisodes failed for userId={}", userId, e);
+            return Collections.emptyList();
+        }
+    }
+
     public List<RetrievedItem> retrieveTodoHistory(UUID userId) {
         try {
             return jdbcTemplate.query(

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisFlowService;
 import com.mio.ai.memory.consolidation.ConversationCheckpointService;
 import com.mio.ai.memory.ontology.OntologyInterventionFilter;
+import com.mio.ai.memory.ontology.OntologyRelationExpander;
 import com.mio.ai.memory.ontology.ReactiveOntologyActivator;
 import com.mio.ai.memory.ontology.ReactiveOntologyActivationDispatcher;
 import com.mio.ai.memory.ontology.ReactiveOntologyEligibility;
@@ -94,6 +95,7 @@ public class ConversationOrchestrator {
     private final OutputJudge outputJudge;
     private final PolicyEngine policyEngine;
     private final OntologyInterventionFilter ontologyInterventionFilter;
+    private final OntologyRelationExpander ontologyRelationExpander;
     private final ReactiveOntologyActivator reactiveOntologyActivator;
     private final ReactiveOntologyActivationDispatcher reactiveOntologyActivationDispatcher;
     private final ReactiveOntologyEligibility reactiveOntologyEligibility;
@@ -169,7 +171,8 @@ public class ConversationOrchestrator {
             List<WorkingMessage> recentWorkingMessages = workingMemory.getRecentMessages(sessionId);
             recentWorkingMessages = recentWorkingMessages != null ? new ArrayList<>(recentWorkingMessages) : new ArrayList<>();
             String cachedMemory = contextPreWarmer.getCachedContext(sessionId);
-            String liveMemory = contextPreWarmer.buildContextSync(sessionId, userId, combined, profile, normalized);
+            String liveMemory = contextPreWarmer.buildContextSync(
+                    sessionId, userId, combined, profile, normalized, userSignal.biasType());
             boolean memoryCacheFallbackUsed = (liveMemory == null || liveMemory.isBlank())
                     && cachedMemory != null && !cachedMemory.isBlank();
             String memoryContext = memoryCacheFallbackUsed ? cachedMemory : liveMemory;
@@ -179,6 +182,11 @@ public class ConversationOrchestrator {
             PolicyDecision decision = policyEngine.decide(combined, judgeResult, profile, sessionDelta);
             decision = decision.withInterventionHints(
                     ontologyInterventionFilter.filter(decision.interventionHints(), combined, sessionDelta));
+            decision = decision.withInterventionHints(
+                    ontologyInterventionFilter.filter(
+                            ontologyRelationExpander.rerankApprovedHints(
+                                    decision.interventionHints(), userSignal.biasType()),
+                            combined, sessionDelta));
 
             // 현재 컨텍스트가 확정된 뒤, 안전한 생성 턴의 다음 턴 맥락만 비동기 활성화한다.
             if (reactiveOntologyEligibility.allowsBeliefActivation(userSignal, combined, decision)) {

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -3,6 +3,7 @@ package com.mio.ai.profile;
 import com.mio.ai.AiCacheKeys;
 import com.mio.ai.llm.EmbeddingClient;
 import com.mio.ai.memory.composer.ContextComposer;
+import com.mio.ai.memory.ontology.OntologyRelationExpander;
 import com.mio.ai.memory.retrieval.FusionRanker;
 import com.mio.ai.memory.retrieval.LexicalRetriever;
 import com.mio.ai.memory.retrieval.MemoryRetrievalPlanner;
@@ -24,6 +25,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -56,6 +58,7 @@ public class ContextPreWarmer {
     private final StringRedisTemplate redisTemplate;
     private final JdbcTemplate jdbcTemplate;
     private final WorkingMemory workingMemory;
+    private final OntologyRelationExpander ontologyRelationExpander;
 
     private final Executor retrievalPool = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -68,7 +71,7 @@ public class ContextPreWarmer {
 
             // 2. 기본 컨텍스트만 캐시한다. 현재 발화 기반 검색은 각 대화 턴에서 수행한다.
             RetrievalPlan plan = RetrievalPlan.staticBase();
-            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan, null, null);
+            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan, null, null, Set.of());
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             String context = contextComposer.compose(ranked, plan.sensitivityCap(), false);
 
@@ -121,11 +124,20 @@ public class ContextPreWarmer {
      */
     public String buildContextSync(UUID sessionId, UUID userId, CombinedSignal combined,
                                    SafetyProfile profile, String queryText) {
+        return buildContextSync(sessionId, userId, combined, profile, queryText, null);
+    }
+
+    public String buildContextSync(UUID sessionId, UUID userId, CombinedSignal combined,
+                                   SafetyProfile profile, String queryText, String currentDistortionCode) {
         try {
             boolean hasHistory = checkHasHistory(userId);
             RetrievalPlan plan = memoryRetrievalPlanner.plan(combined, profile, userId, hasHistory);
             float[] queryEmbedding = embedIfNeeded(plan, queryText);
-            List<List<RetrievedItem>> results = retrieveParallel(sessionId, userId, plan, queryEmbedding, queryText);
+            Set<String> relatedDistortionCodes = plan.sources().contains(com.mio.ai.memory.retrieval.RetrievalSource.GRAPH_DISTORTION)
+                    ? ontologyRelationExpander.expandCooccurringCodes(currentDistortionCode)
+                    : Set.of();
+            List<List<RetrievedItem>> results = retrieveParallel(
+                    sessionId, userId, plan, queryEmbedding, queryText, relatedDistortionCodes);
             List<RetrievedItem> ranked = fusionRanker.rank(results, plan.sensitivityCap(), plan.maxK() * 3);
             boolean highRisk = combined.hardCrisis() || combined.riskCandidate();
             return contextComposer.compose(ranked, plan.sensitivityCap(), highRisk);
@@ -159,7 +171,8 @@ public class ContextPreWarmer {
     }
 
     private List<List<RetrievedItem>> retrieveParallel(UUID sessionId, UUID userId, RetrievalPlan plan,
-                                                         float[] queryEmbedding, String queryText) {
+                                                         float[] queryEmbedding, String queryText,
+                                                         Set<String> relatedDistortionCodes) {
         int k = plan.maxK();
         List<CompletableFuture<List<RetrievedItem>>> futures = new ArrayList<>();
 
@@ -191,6 +204,9 @@ public class ContextPreWarmer {
                         return Collections.<RetrievedItem>emptyList();
                     }
                 }, retrievalPool);
+                case GRAPH_DISTORTION    -> CompletableFuture.supplyAsync(
+                        () -> structuredRetriever.retrieveRelatedDistortionEpisodes(userId, relatedDistortionCodes),
+                        retrievalPool);
                 case GRAPH_INTERVENTION_FIT -> CompletableFuture.supplyAsync(
                         () -> structuredRetriever.retrieveInterventionFit(userId), retrievalPool);
                 case GRAPH_BELIEF_NEIGH  -> CompletableFuture.supplyAsync(

--- a/src/test/java/com/mio/ai/memory/ontology/OntologyRelationExpanderTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/OntologyRelationExpanderTest.java
@@ -1,0 +1,80 @@
+package com.mio.ai.memory.ontology;
+
+import com.mio.ai.policy.InterventionHints;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class OntologyRelationExpanderTest {
+
+    private final CbtDistortionDefRepository repository = mock(CbtDistortionDefRepository.class);
+    private final OntologyRelationExpander expander = new OntologyRelationExpander(repository);
+
+    @Test
+    void expandsOnlyRegisteredCooccurringCodesForVerifiedCurrentDistortion() {
+        CbtDistortionDef current = definition(List.of("mind_reading", "unknown"), List.of());
+        when(repository.findById("catastrophizing")).thenReturn(Optional.of(current));
+        when(repository.findCodesByCodeIn(Set.of("mind_reading", "unknown"))).thenReturn(Set.of("mind_reading"));
+
+        Set<String> expanded = expander.expandCooccurringCodes("catastrophizing");
+
+        assertThat(expanded).containsExactly("mind_reading");
+        verify(repository).findCodesByCodeIn(Set.of("mind_reading", "unknown"));
+    }
+
+    @Test
+    void unknownCurrentDistortionDoesNotExpandOrWriteAnyDiagnosis() {
+        when(repository.findById("hallucinated_code")).thenReturn(Optional.empty());
+
+        assertThat(expander.expandCooccurringCodes("hallucinated_code")).isEmpty();
+        verify(repository, never()).findCodesByCodeIn(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void reranksOnlyExistingPolicyApprovedHintsByRecommendedActions() {
+        CbtDistortionDef current = definition(List.of(), List.of("breathing_exercise"));
+        when(repository.findById("catastrophizing")).thenReturn(Optional.of(current));
+
+        InterventionHints result = expander.rerankApprovedHints(
+                new InterventionHints(List.of("cognitive_restructuring", "breathing_exercise"),
+                        List.of("avoid"), "catastrophizing"),
+                "catastrophizing");
+
+        assertThat(result.suggestedCodes()).containsExactly("breathing_exercise");
+        assertThat(result.avoidCodes()).containsExactly("avoid");
+    }
+
+    @Test
+    void retainsApprovedHintsWhenOntologyHasNoMatchingRecommendedAction() {
+        CbtDistortionDef current = definition(List.of(), List.of("decatastrophizing"));
+        when(repository.findById("catastrophizing")).thenReturn(Optional.of(current));
+        InterventionHints original = new InterventionHints(List.of("cognitive_restructuring"), List.of(), null);
+
+        assertThat(expander.rerankApprovedHints(original, "catastrophizing"))
+                .isEqualTo(original);
+    }
+
+    @Test
+    void doesNotCreateHintsWhenPolicyProvidedNone() {
+        InterventionHints empty = InterventionHints.empty();
+
+        assertThat(expander.rerankApprovedHints(empty, "catastrophizing")).isEqualTo(empty);
+        verifyNoInteractions(repository);
+    }
+
+    private CbtDistortionDef definition(List<String> cooccurring, List<String> actions) {
+        CbtDistortionDef definition = mock(CbtDistortionDef.class);
+        when(definition.getCooccurCodes()).thenReturn(cooccurring);
+        when(definition.getRecommendedActions()).thenReturn(actions);
+        return definition;
+    }
+}

--- a/src/test/java/com/mio/ai/memory/retrieval/RetrievalPlanTest.java
+++ b/src/test/java/com/mio/ai/memory/retrieval/RetrievalPlanTest.java
@@ -15,4 +15,10 @@ class RetrievalPlanTest {
                 RetrievalSource.GRAPH_TRIGGER
         );
     }
+
+    @Test
+    void clearLowPlanDoesNotCreateOntologyRelationCandidates() {
+        assertThat(RetrievalPlan.clearLow().sources())
+                .doesNotContain(RetrievalSource.GRAPH_DISTORTION);
+    }
 }

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -145,4 +145,20 @@ class ContextPreWarmerTest {
         assertThat(context).isEqualTo("belief memory");
         verify(structuredRetriever).retrieveBeliefNeighbors(userId, Set.of(beliefId.toString()));
     }
+
+    @Test
+    void retrievesPastEpisodesForVerifiedCooccurringPatternsWithoutTreatingThemAsCurrent() {
+        RetrievalPlan plan = new RetrievalPlan(List.of(RetrievalSource.GRAPH_DISTORTION), 3, 200, "normal");
+        RetrievedItem related = new RetrievedItem("episode-1", RetrievalSource.GRAPH_DISTORTION,
+                "related pattern (unconfirmed): 과거 업무 압박", "normal", 0.45, 1);
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(related));
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("related memory");
+
+        String context = preWarmer.buildContextSync(
+                sessionId, userId, combined, profile, "회의가 걱정돼", "catastrophizing");
+
+        assertThat(context).isEqualTo("related memory");
+        verify(structuredRetriever).retrieveRelatedDistortionEpisodes(userId, Set.of("mind_reading"));
+    }
 }

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -10,6 +10,7 @@ import com.mio.ai.memory.retrieval.RetrievalSource;
 import com.mio.ai.memory.retrieval.RetrievedItem;
 import com.mio.ai.memory.retrieval.StructuredRetriever;
 import com.mio.ai.memory.retrieval.VectorRetriever;
+import com.mio.ai.memory.ontology.OntologyRelationExpander;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.safety.CombinedSignal;
@@ -45,6 +46,7 @@ class ContextPreWarmerTest {
     private final StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
     private final JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
     private final WorkingMemory workingMemory = mock(WorkingMemory.class);
+    private final OntologyRelationExpander ontologyRelationExpander = mock(OntologyRelationExpander.class);
 
     private ContextPreWarmer preWarmer;
     private UUID sessionId;
@@ -56,7 +58,7 @@ class ContextPreWarmerTest {
     void setUp() {
         preWarmer = new ContextPreWarmer(structuredRetriever, vectorRetriever, lexicalRetriever, embeddingClient,
                 fusionRanker, contextComposer, planner, safetyProfileBuilder, checkpointRepository,
-                redisTemplate, jdbcTemplate, workingMemory);
+                redisTemplate, jdbcTemplate, workingMemory, ontologyRelationExpander);
         sessionId = UUID.randomUUID();
         userId = UUID.randomUUID();
         combined = mock(CombinedSignal.class);
@@ -152,6 +154,7 @@ class ContextPreWarmerTest {
         RetrievedItem related = new RetrievedItem("episode-1", RetrievalSource.GRAPH_DISTORTION,
                 "related pattern (unconfirmed): 과거 업무 압박", "normal", 0.45, 1);
         when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(ontologyRelationExpander.expandCooccurringCodes("catastrophizing")).thenReturn(Set.of("mind_reading"));
         when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(related));
         when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("related memory");
 


### PR DESCRIPTION
## 변경
- 검증된 현재 왜곡의 `cooccur_codes`만 사용해 과거 thought/session episode를 보조 검색합니다.
- 확장 코드는 현재 진단·WorkingMemory·CBT 패턴에 기록하지 않고, 컨텍스트에 `related pattern (unconfirmed)`으로만 표시합니다.
- `recommended_actions`는 PolicyEngine과 1차 금기 필터가 통과시킨 힌트 안에서만 재정렬하며, 이후 금기 필터를 다시 적용합니다.
- clear-low 경로에서는 관계 기반 후보를 생성하지 않습니다.

## 검증
- `./gradlew test --tests OntologyRelationExpanderTest --tests ContextPreWarmerTest --tests StructuredRetrieverTest --tests RetrievalPlanTest --tests ContextComposerTest --tests OntologyInterventionFilterTest`
- 전체 빌드는 로컬 인프라 기동 후 실행했으며 Gradle 데몬 결과 추적 중입니다.

Closes #247