### PR TITLE
fix: 'processing' embedding_status 허용해 임베딩 파이프라인 복구 (#251)

### DIFF
--- a/src/main/resources/db/migration/V39__allow_processing_embedding_status.sql
+++ b/src/main/resources/db/migration/V39__allow_processing_embedding_status.sql
@@ -1,0 +1,19 @@
+-- [issue #251] EmbeddingWorker는 pending 행을 claim할 때 embedding_status를 'processing'으로
+-- UPDATE하지만, V3에서 정의된 CHECK 제약은 ('pending','done','failed')만 허용해
+-- 매 스케줄 사이클마다 제약 위반으로 롤백되어 임베딩 파이프라인이 전면 중단됐다.
+-- CHECK 제약에 'processing'을 추가해 정상 전이(pending → processing → done/failed)를 허용한다.
+--
+-- sessions.embedding_status는 현재 워커가 갱신하지 않지만, 동일한 낡은 제약을 갖고 있어
+-- 향후 같은 문제가 재발하지 않도록 두 테이블을 일관되게 확장한다.
+
+ALTER TABLE session_summaries
+    DROP CONSTRAINT session_summaries_embedding_status_check;
+ALTER TABLE session_summaries
+    ADD CONSTRAINT session_summaries_embedding_status_check
+        CHECK (embedding_status IN ('pending', 'processing', 'done', 'failed'));
+
+ALTER TABLE sessions
+    DROP CONSTRAINT sessions_embedding_status_check;
+ALTER TABLE sessions
+    ADD CONSTRAINT sessions_embedding_status_check
+        CHECK (embedding_status IN ('pending', 'processing', 'done', 'failed'));

--- a/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
@@ -1,0 +1,112 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.llm.OpenAiLlmClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * EmbeddingWorker가 pending 행을 claim할 때 사용하는 'processing' 상태가
+ * session_summaries CHECK 제약을 위반하지 않고, pending → processing → done/failed로
+ * 전이되는지 실제 DB에 대해 검증하는 회귀 테스트 (issue #251).
+ *
+ * <p>V39 이전 스키마에서는 CHECK 제약이 ('pending','done','failed')만 허용하므로
+ * claim 단계의 UPDATE ... SET embedding_status = 'processing' 자체가
+ * DataIntegrityViolationException으로 실패한다 → 이 테스트가 RED가 된다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class EmbeddingWorkerIntegrationTest {
+
+    private static final int EMBEDDING_DIM = 1536;
+
+    @Autowired
+    private EmbeddingWorker embeddingWorker;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @MockBean
+    private OpenAiLlmClient openAiLlmClient;
+
+    private UUID userId;
+    private UUID sessionId;
+    private UUID summaryId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+        summaryId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "embed-worker-it-" + userId);
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id) VALUES (?, ?, 'mio')",
+                sessionId, userId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // session_summaries/messages는 sessions FK의 ON DELETE CASCADE로 함께 제거된다.
+        jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
+    }
+
+    private void insertPendingSummary(String summaryText) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO session_summaries (id, user_id, session_id, character_id, summary_text, embedding_status)
+                VALUES (?, ?, ?, 'mio', ?, 'pending')
+                """,
+                summaryId, userId, sessionId, summaryText);
+    }
+
+    private String currentStatus() {
+        return jdbcTemplate.queryForObject(
+                "SELECT embedding_status FROM session_summaries WHERE id = ?", String.class, summaryId);
+    }
+
+    @Test
+    @DisplayName("pending 행을 claim해 임베딩 성공 시 제약 위반 없이 done으로 전이하고 episode_emb를 채운다")
+    void processPending_success_transitionsToDone() {
+        insertPendingSummary("오늘은 발표 때문에 많이 긴장했지만 잘 끝냈다.");
+
+        float[] vector = new float[EMBEDDING_DIM];
+        for (int i = 0; i < EMBEDDING_DIM; i++) {
+            vector[i] = 0.001f * i;
+        }
+        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus()).isEqualTo("done");
+        Boolean embFilled = jdbcTemplate.queryForObject(
+                "SELECT episode_emb IS NOT NULL FROM session_summaries WHERE id = ?", Boolean.class, summaryId);
+        assertThat(embFilled).isTrue();
+    }
+
+    @Test
+    @DisplayName("임베딩 호출이 실패하면 제약 위반 없이 processing을 거쳐 failed로 전이한다")
+    void processPending_embeddingError_transitionsToFailed() {
+        insertPendingSummary("임베딩 호출이 실패하는 케이스.");
+        when(openAiLlmClient.embed(anyString())).thenThrow(new RuntimeException("embedding API down"));
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus()).isEqualTo("failed");
+    }
+}


### PR DESCRIPTION
## 문제

프로덕션 앱 로그에 **30초마다** 아래 에러가 반복 발생:

```
ERROR [scheduling-1] DataIntegrityViolationException
new row for relation "session_summaries" violates check constraint
"session_summaries_embedding_status_check"
```

## 근본 원인

- `EmbeddingWorker.processPending()`(`@Scheduled(30s)`)가 pending 행을 claim할 때 `SET embedding_status = 'processing'`으로 UPDATE
- 그러나 `V3__init_session.sql`의 CHECK 제약은 `('pending','done','failed')`만 허용 — **`'processing'` 누락**
- → 매 사이클 트랜잭션 롤백, 워커가 처리할 행을 확보하지 못함

## 영향

- `session_summaries`가 전부 `pending`에 고착 (프로덕션 확인 시 10건, `done` 0건)
- 임베딩 미생성 → `VectorRetriever`(`WHERE embedding_status = 'done'`)가 항상 빈 결과 → **벡터 기반 메모리 검색 사실상 비활성화**

## 변경

- **`V39__allow_processing_embedding_status.sql`** — `session_summaries` + `sessions` 두 테이블 CHECK에 `processing` 추가 (drop → add constraint). `sessions`는 현재 워커가 갱신하진 않으나 동일한 낡은 제약을 보유해 일관성 목적으로 함께 확장
- **`EmbeddingWorkerIntegrationTest`** — 실제 DB(integration-test 프로파일)에 대해:
  - pending claim → `processing` → **`done`** 전이 + `episode_emb` 채움 검증
  - 임베딩 호출 실패 시 → `processing` → **`failed`** 전이 검증
  - V39 이전 스키마에서는 claim 단계에서 `DataIntegrityViolationException`으로 RED가 되어 버그를 재현

## 배포 후

- 기존 `pending` 행은 V39가 main에 반영되면 다음 30초 사이클부터 워커가 자동 소비 (임베딩 성공 시 `done`, 실패 시 `failed`)

## 후속 (별도 이슈로 분리)

- 외부 Embedding API 호출 중 프로세스 종료 시 `processing` 고착 행 회수/재시도 정책(stale reclaim). 이번 P0 범위 밖.

## 테스트 계획

- [x] `EmbeddingWorkerIntegrationTest` 로컬 GREEN (tests=2, failures=0, errors=0)
- [x] V39 로컬 DB 적용·제약 확인 (`session_summaries_embedding_status_check`, `sessions_embedding_status_check` 모두 `processing` 포함)
- [ ] CI 전체 빌드 통과 확인

Closes #251