### PR TITLE
fix: 안전 신호의 '확인 못함'을 값에 담고 보수적으로 동작

### DIFF
--- a/src/main/java/com/mio/ai/moderation/ModerationResult.java
+++ b/src/main/java/com/mio/ai/moderation/ModerationResult.java
@@ -2,13 +2,45 @@ package com.mio.ai.moderation;
 
 import java.util.Map;
 
+/**
+ * L0 Moderation 판정 결과.
+ *
+ * @param resolved 판정을 실제로 받아왔는지 (이슈 #263).
+ *                 {@code false} 면 나머지 필드는 판정 결과가 아니라 fail-open 폴백값이다.
+ *                 이 구분이 없으면 "위험 신호 없음"과 "안전 계층이 통째로 빠진 상태"가 같은 값이 된다.
+ */
 public record ModerationResult(
+        boolean resolved,
         boolean flagged,
         Map<String, Boolean> categories,
         Map<String, Double> categoryScores
 ) {
+    public ModerationResult {
+        categories = categories != null ? Map.copyOf(categories) : Map.of();
+        categoryScores = categoryScores != null ? Map.copyOf(categoryScores) : Map.of();
+    }
+
+    /** 조회 성공 여부 개념 도입 이전 시그니처 — 기존 호출부 호환용 (이슈 #263). */
+    public ModerationResult(
+            boolean flagged,
+            Map<String, Boolean> categories,
+            Map<String, Double> categoryScores) {
+        this(true, flagged, categories, categoryScores);
+    }
+
+    /** 판정을 받아왔고 아무 카테고리도 걸리지 않았다. */
+    public static ModerationResult clear() {
+        return new ModerationResult(true, false, Map.of(), Map.of());
+    }
+
+    /**
+     * 판정을 받아오지 못했다.
+     *
+     * <p>fail-open 자체는 타당한 설계다 — 하드 실패로 바꾸면 Moderation API 장애가 곧
+     * 서비스 중단이 된다. 다만 그 상태가 값에 남아야 사후에 구분할 수 있다.
+     */
     public static ModerationResult failOpen() {
-        return new ModerationResult(false, Map.of(), Map.of());
+        return new ModerationResult(false, false, Map.of(), Map.of());
     }
 
     public boolean isSelfHarmFlagged() {

--- a/src/main/java/com/mio/ai/moderation/OpenAiModerationClient.java
+++ b/src/main/java/com/mio/ai/moderation/OpenAiModerationClient.java
@@ -2,6 +2,7 @@ package com.mio.ai.moderation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -19,17 +20,29 @@ public class OpenAiModerationClient {
 
     private static final String MODERATION_URL = "https://api.openai.com/v1/moderations";
 
+    /**
+     * L0 판정 시도 횟수. {@code outcome} 태그로 성공/실패를 가른다 (이슈 #263).
+     *
+     * <p>실패율이 임계치를 넘으면 안전 계층 하나가 빠진 채로 서비스가 도는 상태이므로 알람이 필요하다.
+     * 임계치와 채널은 운영 구성의 몫이라 여기서는 지표만 노출한다. 레지스트리가 붙기 전까지는
+     * {@code ai_policy_decisions} 트레이스의 {@code l0_resolved} 로 같은 비율을 집계할 수 있다.
+     */
+    private static final String MODERATION_METRIC = "mio.moderation.requests";
+
     private final String apiKey;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     public OpenAiModerationClient(
             @Value("${openai.api-key}") String apiKey,
             HttpClient httpClient,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            MeterRegistry meterRegistry) {
         this.apiKey = apiKey;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
     }
 
     public ModerationResult moderate(String text) {
@@ -47,14 +60,21 @@ public class OpenAiModerationClient {
 
             if (response.statusCode() != 200) {
                 log.warn("Moderation API returned {}, fail-open", response.statusCode());
-                return ModerationResult.failOpen();
+                return failOpen("http_" + response.statusCode());
             }
 
-            return parseResponse(response.body());
+            ModerationResult result = parseResponse(response.body());
+            meterRegistry.counter(MODERATION_METRIC, "outcome", "resolved").increment();
+            return result;
         } catch (Exception e) {
             log.warn("Moderation API error, fail-open: {}", e.getMessage());
-            return ModerationResult.failOpen();
+            return failOpen("exception");
         }
+    }
+
+    private ModerationResult failOpen(String reason) {
+        meterRegistry.counter(MODERATION_METRIC, "outcome", "fail_open", "reason", reason).increment();
+        return ModerationResult.failOpen();
     }
 
     private ModerationResult parseResponse(String body) throws Exception {

--- a/src/main/java/com/mio/ai/moderation/OpenAiModerationClient.java
+++ b/src/main/java/com/mio/ai/moderation/OpenAiModerationClient.java
@@ -64,6 +64,12 @@ public class OpenAiModerationClient {
             }
 
             ModerationResult result = parseResponse(response.body());
+            if (result == null) {
+                // HTTP 200 이어도 스키마가 온전하지 않으면 판정을 받은 게 아니다.
+                // 이걸 resolved 로 집계하면 불완전한 응답이 다시 "안전 판정"과 같아진다 (이슈 #263).
+                log.warn("Moderation API returned malformed 200 response, fail-open");
+                return failOpen("malformed_response");
+            }
             meterRegistry.counter(MODERATION_METRIC, "outcome", "resolved").increment();
             return result;
         } catch (Exception e) {
@@ -77,18 +83,36 @@ public class OpenAiModerationClient {
         return ModerationResult.failOpen();
     }
 
+    /**
+     * @return 스키마가 온전하지 않으면 {@code null} — 호출부가 fail-open 으로 처리한다.
+     *         기본값으로 메워 반환하면 {@code flagged=false}·빈 카테고리가 되어 정상 안전 판정과
+     *         구별되지 않는다. self-harm 카테고리가 통째로 빠진 응답이 "자해 신호 없음"이 되는 것이
+     *         정확히 이 이슈가 막으려는 상태다 (이슈 #263).
+     */
     private ModerationResult parseResponse(String body) throws Exception {
         JsonNode root = objectMapper.readTree(body);
-        JsonNode result = root.path("results").get(0);
+        JsonNode results = root.path("results");
+        if (!results.isArray() || results.isEmpty()) {
+            return null;
+        }
+
+        JsonNode result = results.get(0);
+        JsonNode categoriesNode = result.path("categories");
+        JsonNode scoresNode = result.path("category_scores");
+        if (!result.path("flagged").isBoolean()
+                || !categoriesNode.isObject() || categoriesNode.isEmpty()
+                || !scoresNode.isObject() || scoresNode.isEmpty()) {
+            return null;
+        }
 
         boolean flagged = result.path("flagged").asBoolean(false);
 
         Map<String, Boolean> categories = new HashMap<>();
-        result.path("categories").fields()
+        categoriesNode.fields()
                 .forEachRemaining(e -> categories.put(e.getKey(), e.getValue().asBoolean(false)));
 
         Map<String, Double> scores = new HashMap<>();
-        result.path("category_scores").fields()
+        scoresNode.fields()
                 .forEachRemaining(e -> scores.put(e.getKey(), e.getValue().asDouble(0.0)));
 
         return new ModerationResult(flagged, categories, scores);

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -49,6 +49,7 @@ public class AiDecisionLogger {
             String l1ThresholdSource,
             boolean safetyProfileCacheHit,
             boolean memoryCacheHit,
+            boolean safetyProfileDegraded,
             CrisisTrigger appliedCrisisTrigger) {
 
         try {
@@ -57,7 +58,7 @@ public class AiDecisionLogger {
                     crisisFlowTriggered, decision,
                     inputJudgeCalled, preFilterResult, outputJudgeResult,
                     l1ThresholdSource, safetyProfileCacheHit, memoryCacheHit,
-                    appliedCrisisTrigger);
+                    safetyProfileDegraded, appliedCrisisTrigger);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -97,7 +98,7 @@ public class AiDecisionLogger {
         log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered,
                 false, OutputPreFilterResult.pass(), null,
-                "default", false, false, decision.crisisTrigger());
+                "default", false, false, false, decision.crisisTrigger());
     }
 
     private Map<String, Object> buildTrace(
@@ -113,6 +114,7 @@ public class AiDecisionLogger {
             String l1ThresholdSource,
             boolean safetyProfileCacheHit,
             boolean memoryCacheHit,
+            boolean safetyProfileDegraded,
             CrisisTrigger appliedCrisisTrigger) {
 
         Map<String, Object> l1Flags = new LinkedHashMap<>();
@@ -134,6 +136,9 @@ public class AiDecisionLogger {
         Map<String, Object> trace = new LinkedHashMap<>();
         trace.put("schema_version", SCHEMA_VERSION);
         trace.put("l0_flagged", moderation.flagged());
+        // l0_flagged=false 가 "안전 판정"인지 "판정을 못 받아온 것"인지 구분한다.
+        // 이게 없으면 안전 계층 하나가 통째로 빠진 채 처리된 턴을 사후에 식별할 수 없다 (이슈 #263).
+        trace.put("l0_resolved", moderation.resolved());
         trace.put("l0_category_scores", moderation.categoryScores());
         trace.put("l1_flags", l1Flags);
         trace.put("l1_combined_confidence", l1Result.combinedConfidence());
@@ -141,6 +146,9 @@ public class AiDecisionLogger {
         trace.put("input_judge_called", inputJudgeCalled);
         trace.put("risk_level", decision.riskLevel() != null ? decision.riskLevel().name() : null);
         trace.put("safety_profile_cache_hit", safetyProfileCacheHit);
+        // 근거 조회에 실패해 보수적 기본값으로 채운 프로파일인지 (이슈 #261).
+        // 위기 이력을 확인하지 못한 턴은 임계값·force_judge 가 실제 이력과 무관하게 결정된다.
+        trace.put("safety_profile_degraded", safetyProfileDegraded);
         trace.put("memory_cache_hit", memoryCacheHit);
         trace.put("llm_model", "gpt-4o");
         trace.put("llm_ttft_ms", ttftMs);

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -425,7 +425,7 @@ public class ConversationOrchestrator {
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
                     inputJudgeCalled, preFilterResult, judgeActionResult,
                     profile.source(), safetyProfileCacheHit, memoryCacheFallbackUsed,
-                    appliedCrisisTrigger);
+                    profile.degraded(), appliedCrisisTrigger);
 
             emitter.complete();
 

--- a/src/main/java/com/mio/ai/profile/SafetyProfile.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfile.java
@@ -1,11 +1,17 @@
 package com.mio.ai.profile;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import java.util.List;
 import java.util.Map;
 
 /**
  * Memory Layer의 durable artifacts를 얇은 구조화 JSON으로 사전 계산한 프로파일 (§17).
  * 원문 belief text 없음 — 구조화 필드만.
+ *
+ * @param degraded 근거 조회에 실패해 보수적 기본값으로 채운 프로파일인지 (이슈 #261).
+ *                 {@code source} 는 "얼마나 개인화됐는가"를, 이 값은 "근거를 확인했는가"를 나타낸다.
+ *                 둘은 독립이라 하나로 합치지 않는다.
  */
 public record SafetyProfile(
         String userId,
@@ -22,10 +28,32 @@ public record SafetyProfile(
         int activeNegativeBeliefCount,
         String copingStyle,                     // "avoidance" | "approach" | null
         List<String> dominantTriggerKinds,
-        String sensitivityCap                   // "normal" | "sensitive" | "restricted"
+        String sensitivityCap,                  // "normal" | "sensitive" | "restricted"
+        boolean degraded
 ) {
     public static final String SOURCE_DEFAULT      = "default";
     public static final String SOURCE_PERSONALIZED = "personalized";
+
+    /** degraded 도입 이전 시그니처 — 기존 호출부 호환용 (이슈 #261). */
+    public SafetyProfile(
+            String userId, String source,
+            Map<String, Double> dynamicThresholds,
+            List<String> effectiveInterventions,
+            List<String> ineffectiveInterventions,
+            List<String> policyFlags,
+            double riskPriorScore,
+            int recentCrisisSeverityMax,
+            List<String> commonDistortionCodes,
+            int activeNegativeBeliefCount,
+            String copingStyle,
+            List<String> dominantTriggerKinds,
+            String sensitivityCap) {
+        this(userId, source, dynamicThresholds,
+                effectiveInterventions, ineffectiveInterventions, policyFlags,
+                riskPriorScore, recentCrisisSeverityMax, commonDistortionCodes,
+                activeNegativeBeliefCount, copingStyle, dominantTriggerKinds, sensitivityCap,
+                false);
+    }
 
     /** 기존 생성자와의 하위 호환 (13개 인자 → 기본값 채움) */
     public SafetyProfile(
@@ -40,7 +68,7 @@ public record SafetyProfile(
         this(userId, source, dynamicThresholds,
                 effectiveInterventions, ineffectiveInterventions, policyFlags,
                 riskPriorScore, recentCrisisSeverityMax, commonDistortionCodes,
-                0, null, List.of(), "sensitive");
+                0, null, List.of(), "sensitive", false);
     }
 
     // ── threshold accessors ──────────────────────────────────────
@@ -65,6 +93,12 @@ public record SafetyProfile(
         return policyFlags != null && policyFlags.contains("force_judge");
     }
 
+    /**
+     * {@code isX()} 형태라 Jackson 이 게터로 인식해 {@code "personalized"} 필드를 JSON 에 함께
+     * 써 넣는다. 그 필드는 레코드 컴포넌트가 아니라 역직렬화할 수 없으므로, 관대한 매퍼가
+     * 무시해주지 않으면 캐시 로드가 통째로 실패한다. 파생값이니 직렬화에서 제외한다.
+     */
+    @JsonIgnore
     public boolean isPersonalized() {
         return SOURCE_PERSONALIZED.equals(source);
     }

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -215,13 +215,33 @@ public class SafetyProfileBuilder {
             var sessionMeta   = sessionMF.join();
 
             int crisisMax = crisisHistory.maxSeverity();
-            // 위기 이력을 확인하지 못한 상태. 위험 없음이 아니라 "모름"이므로 보수적으로 간다.
-            boolean degraded = !crisisHistory.resolved();
 
-            // 데이터 없으면 default. 단 위기 이력 조회가 실패했다면 그 사실이 사라지면 안 된다.
-            if (!beliefs.hasData() && patterns.topDistortionCodes().isEmpty()) {
-                recordBuildOutcome(degraded);
-                return degraded ? buildDegraded(userId) : buildDefault(userId);
+            // 위험도 산정에 쓰이는 근거를 하나라도 확인하지 못한 상태.
+            // 위험 없음이 아니라 "모름"이므로 보수적으로 간다.
+            //
+            // outcomes·sessionMeta는 제외한다. 개입 힌트 품질과 personalized 라벨에만 영향을 주고
+            // 위험 게이팅(riskPrior·force_judge·임계값)에는 들어가지 않는다.
+            boolean degraded = !crisisHistory.resolved()
+                    || !beliefs.resolved()
+                    || !patterns.resolved();
+
+            // 근거가 없으면 default. 단 "없음"을 확인한 경우여야 한다.
+            //
+            // 조회 실패로 비어 보이는 것과 실제로 비어 있는 것을 구분하지 않으면, 여기서
+            // 프로파일이 통째로 default가 되어 아래 riskPrior·force_judge 계산이 아예 실행되지
+            // 않는다. crisisMax도 함께 본다 — 첫 세션에서 위기를 겪은 사용자는 아직 belief도
+            // cbt_pattern도 없어서(컨솔리데이션 전) 이 분기에 걸리는데, 그 사용자가 정확히
+            // 이 PR이 보호하려는 대상이다.
+            boolean noEvidence = !beliefs.hasData()
+                    && patterns.topDistortionCodes().isEmpty()
+                    && crisisMax == 0;
+            if (!degraded && noEvidence) {
+                recordBuildOutcome(false);
+                return buildDefault(userId);
+            }
+            if (degraded && noEvidence) {
+                recordBuildOutcome(true);
+                return buildDegraded(userId);
             }
 
             // personalized 전환 조건: 7일 이상 사용 OR 10세션 이상
@@ -280,10 +300,12 @@ public class SafetyProfileBuilder {
             int negCount = (int) rows.stream()
                     .filter(r -> "negative".equals(r.get("polarity"))).count();
             String coping = negCount > 2 ? "avoidance" : null;
-            return new BeliefSummary(negCount, coping, !rows.isEmpty());
+            return new BeliefSummary(negCount, coping, !rows.isEmpty(), true);
         } catch (Exception e) {
             log.warn("queryActiveBeliefs failed", e);
-            return new BeliefSummary(0, null, false);
+            // hasData=false 는 "신념이 없다"와 같은 값이라 조회 실패와 구분되지 않는다.
+            // resolved 로 그 차이를 남긴다 (이슈 #261).
+            return BeliefSummary.unresolved();
         }
     }
 
@@ -325,10 +347,10 @@ public class SafetyProfileBuilder {
                     .map(r -> (String) r.get("pattern_type"))
                     .toList();
             List<String> triggers = codes.stream().limit(2).toList();
-            return new PatternSummary(codes, triggers);
+            return new PatternSummary(codes, triggers, true);
         } catch (Exception e) {
             log.warn("queryCbtPatterns failed", e);
-            return new PatternSummary(List.of(), List.of());
+            return PatternSummary.unresolved();
         }
     }
 
@@ -419,8 +441,20 @@ public class SafetyProfileBuilder {
         }
     }
 
-    private record BeliefSummary(int negativeCount, String copingStyle, boolean hasData) {}
-    private record PatternSummary(List<String> topDistortionCodes, List<String> triggerKinds) {}
+    /** @param resolved 조회에 성공했는지. {@code false} 면 {@code hasData} 는 판정값이 아니다. */
+    private record BeliefSummary(int negativeCount, String copingStyle, boolean hasData, boolean resolved) {
+        static BeliefSummary unresolved() {
+            return new BeliefSummary(0, null, false, false);
+        }
+    }
+
+    /** @param resolved 조회에 성공했는지. {@code false} 면 빈 목록은 판정값이 아니다. */
+    private record PatternSummary(
+            List<String> topDistortionCodes, List<String> triggerKinds, boolean resolved) {
+        static PatternSummary unresolved() {
+            return new PatternSummary(List.of(), List.of(), false);
+        }
+    }
     private record OutcomeSummary(List<String> effectiveKinds, List<String> ineffectiveKinds) {}
     private record SessionMeta(int totalSessions, int daysSinceFirst) {}
 }

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -2,6 +2,7 @@ package com.mio.ai.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisDetectedEvent;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
@@ -11,7 +12,6 @@ import org.springframework.stereotype.Component;
 
 import java.time.Duration;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -34,7 +34,7 @@ public class SafetyProfileBuilder {
     private static final String PROFILE_KEY = "session:%s:safety_profile";
     private static final Duration PROFILE_TTL = Duration.ofMinutes(90);
 
-    // 보수적 default — 신규 사용자 (모든 임계값을 민감한 쪽으로)
+    // 신규 사용자 기본값
     private static final Map<String, Double> DEFAULT_THRESHOLDS = Map.of(
             "emotion_drop_threshold", 30.0,
             "repetitive_negative_count", 3.0,
@@ -42,9 +42,28 @@ public class SafetyProfileBuilder {
             "burst_window_minutes", 5.0
     );
 
+    // high-prior 사용자 또는 위험도를 확인하지 못한 경우 — 더 낮은 임계값으로 일찍 반응한다.
+    private static final Map<String, Double> SENSITIVE_THRESHOLDS = Map.of(
+            "emotion_drop_threshold", 25.0,
+            "repetitive_negative_count", 2.0,
+            "message_burst_count", 8.0,
+            "burst_window_minutes", 5.0
+    );
+
+    /**
+     * 프로파일 빌드 결과. {@code outcome=degraded} 는 근거 조회에 실패해 보수적 기본값으로
+     * 채운 경우다 (이슈 #261).
+     *
+     * <p>이 값이 치솟으면 <b>전체 트래픽에 InputJudge 호출이 한 번씩 더 붙는다</b>. 위기 이력을
+     * 확인하지 못한 이상 누가 고위험 사용자인지 알 수 없어 전원에게 {@code force_judge} 를 붙이기
+     * 때문이다. 보호를 잃지 않는 방향을 택한 대가이므로, 운영이 그 상태를 즉시 볼 수 있어야 한다.
+     */
+    private static final String PROFILE_BUILD_METRIC = "mio.safety_profile.builds";
+
     private final StringRedisTemplate redisTemplate;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     private final Executor profileBuildPool = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -150,6 +169,24 @@ public class SafetyProfileBuilder {
     }
 
     /**
+     * 안전 신호를 확인하지 못한 채 만든 프로파일 (이슈 #261).
+     *
+     * <p>{@link #buildDefault} 와 값이 같아 보이지만 성격이 다르다. default 는 "이력이 없는
+     * 신규 사용자"이고 이쪽은 "이력을 조회하지 못한 사용자"다. 후자는 최근 severity 3 위기를
+     * 겪었을 수도 있으므로 {@code force_judge} 와 민감 임계값을 붙인다.
+     */
+    SafetyProfile buildDegraded(String userId) {
+        return new SafetyProfile(
+                userId, SafetyProfile.SOURCE_DEFAULT,
+                SENSITIVE_THRESHOLDS,
+                List.of(), List.of(), List.of("force_judge"),
+                0.0, 0, List.of(),
+                0, null, List.of(), "sensitive",
+                true
+        );
+    }
+
+    /**
      * 5개 쿼리 병렬 빌드 (~25ms).
      * 데이터 부족 시 default 반환.
      */
@@ -171,15 +208,20 @@ public class SafetyProfileBuilder {
 
             CompletableFuture.allOf(beliefsF, crisisF, patternsF, outcomesF, sessionMF).join();
 
-            var beliefs     = beliefsF.join();
-            var crisisMax   = crisisF.join();
-            var patterns    = patternsF.join();
-            var outcomes    = outcomesF.join();
-            var sessionMeta = sessionMF.join();
+            var beliefs       = beliefsF.join();
+            var crisisHistory = crisisF.join();
+            var patterns      = patternsF.join();
+            var outcomes      = outcomesF.join();
+            var sessionMeta   = sessionMF.join();
 
-            // 데이터 없으면 default
+            int crisisMax = crisisHistory.maxSeverity();
+            // 위기 이력을 확인하지 못한 상태. 위험 없음이 아니라 "모름"이므로 보수적으로 간다.
+            boolean degraded = !crisisHistory.resolved();
+
+            // 데이터 없으면 default. 단 위기 이력 조회가 실패했다면 그 사실이 사라지면 안 된다.
             if (!beliefs.hasData() && patterns.topDistortionCodes().isEmpty()) {
-                return buildDefault(userId);
+                recordBuildOutcome(degraded);
+                return degraded ? buildDegraded(userId) : buildDefault(userId);
             }
 
             // personalized 전환 조건: 7일 이상 사용 OR 10세션 이상
@@ -190,13 +232,17 @@ public class SafetyProfileBuilder {
             double riskPrior = Math.min(1.0,
                     (crisisMax * 0.3) + (beliefs.negativeCount() * 0.1));
 
-            // dynamic_thresholds — high-prior 사용자는 민감하게
-            Map<String, Double> thresholds = computeThresholds(riskPrior);
+            // dynamic_thresholds — high-prior 사용자는 민감하게.
+            // 이력을 모르는 상태도 민감한 쪽으로 둔다.
+            Map<String, Double> thresholds = computeThresholds(riskPrior, degraded);
 
             List<String> policyFlags = new ArrayList<>();
             if (riskPrior > 0.5) policyFlags.add("dependency_caution");
-            if (crisisMax >= 2)  policyFlags.add("force_judge");
+            // 이력이 실제로 없는 사용자에게는 InputJudge 호출이 조금 늘 뿐이지만,
+            // 이력이 있는 사용자는 조회 실패에도 보호를 잃지 않는다.
+            if (crisisMax >= 2 || degraded) policyFlags.add("force_judge");
 
+            recordBuildOutcome(degraded);
             return new SafetyProfile(
                     userId, source, thresholds,
                     outcomes.effectiveKinds(),
@@ -207,11 +253,15 @@ public class SafetyProfileBuilder {
                     beliefs.negativeCount(),
                     beliefs.copingStyle(),
                     patterns.triggerKinds(),
-                    "sensitive"
+                    "sensitive",
+                    degraded
             );
         } catch (Exception e) {
-            log.warn("SafetyProfileBuilder.buildSync failed for userId={}, falling back to default", userId, e);
-            return buildDefault(userId);
+            log.warn("SafetyProfileBuilder.buildSync failed for userId={}, falling back to degraded", userId, e);
+            // 병렬 쿼리가 통째로 실패한 경우다. 위기 이력을 포함해 아무것도 확인하지 못했으므로
+            // 평범한 default 보다 보수적인 프로파일을 쓴다.
+            recordBuildOutcome(true);
+            return buildDegraded(userId);
         }
     }
 
@@ -237,7 +287,14 @@ public class SafetyProfileBuilder {
         }
     }
 
-    private int queryRecentCrisis(UUID userId) {
+    /**
+     * 최근 14일 위기 이력 조회 (이슈 #261).
+     *
+     * <p>실패 시 {@code 0} 을 반환하면 "위기 이력 없음"과 같은 값이 되어, DB 일시 장애가
+     * "이 사용자는 위기 이력이 없다"로 해석된다. 최근 severity 3 위기를 겪은 사용자가 장애 중에
+     * 가장 둔감한 설정으로 대화하게 되는 방향이라 조회 여부를 값에 담는다.
+     */
+    private CrisisHistory queryRecentCrisis(UUID userId) {
         try {
             Integer max = jdbcTemplate.queryForObject(
                     """
@@ -247,10 +304,10 @@ public class SafetyProfileBuilder {
                       AND created_at > NOW() - INTERVAL '14 days'
                     """, Integer.class, userId
             );
-            return max != null ? max : 0;
+            return CrisisHistory.resolved(max != null ? max : 0);
         } catch (Exception e) {
             log.warn("queryRecentCrisis failed", e);
-            return 0;
+            return CrisisHistory.unresolved();
         }
     }
 
@@ -325,20 +382,42 @@ public class SafetyProfileBuilder {
         }
     }
 
+    /** DB 조회를 실제로 수행한 빌드에서만 기록한다 — 캐시 HIT 나 단순 default 반환은 세지 않는다. */
+    private void recordBuildOutcome(boolean degraded) {
+        meterRegistry.counter(PROFILE_BUILD_METRIC, "outcome", degraded ? "degraded" : "resolved")
+                .increment();
+    }
+
     // ── threshold 계산 ────────────────────────────────────────────
 
-    private Map<String, Double> computeThresholds(double riskPrior) {
-        Map<String, Double> t = new HashMap<>(DEFAULT_THRESHOLDS);
-        if (riskPrior > 0.4) {
-            // high-prior → 더 민감하게 (낮은 임계값)
-            t.put("emotion_drop_threshold", 25.0);
-            t.put("repetitive_negative_count", 2.0);
-            t.put("message_burst_count", 8.0);
+    /**
+     * @param forceSensitive riskPrior 를 신뢰할 수 없을 때 민감한 쪽으로 강제한다.
+     *                       riskPrior 는 위기 이력에서 계산되는데, 그 조회가 실패하면 값이 0 이라
+     *                       "위험 없음"과 구별되지 않는다 (이슈 #261).
+     */
+    private Map<String, Double> computeThresholds(double riskPrior, boolean forceSensitive) {
+        if (riskPrior > 0.4 || forceSensitive) {
+            return SENSITIVE_THRESHOLDS;
         }
-        return Map.copyOf(t);
+        return DEFAULT_THRESHOLDS;
     }
 
     // ── 내부 DTO ──────────────────────────────────────────────────
+
+    /**
+     * 위기 이력 조회 결과 (이슈 #261).
+     *
+     * @param resolved 조회에 성공했는지. {@code false} 면 {@code maxSeverity} 는 판정값이 아니다.
+     */
+    private record CrisisHistory(int maxSeverity, boolean resolved) {
+        static CrisisHistory resolved(int maxSeverity) {
+            return new CrisisHistory(maxSeverity, true);
+        }
+
+        static CrisisHistory unresolved() {
+            return new CrisisHistory(0, false);
+        }
+    }
 
     private record BeliefSummary(int negativeCount, String copingStyle, boolean hasData) {}
     private record PatternSummary(List<String> topDistortionCodes, List<String> triggerKinds) {}

--- a/src/test/java/com/mio/ai/moderation/OpenAiModerationClientTest.java
+++ b/src/test/java/com/mio/ai/moderation/OpenAiModerationClientTest.java
@@ -96,6 +96,51 @@ class OpenAiModerationClientTest {
         assertThat(counter("fail_open")).isEqualTo(1.0);
     }
 
+    /**
+     * HTTP 200 이어도 스키마가 온전하지 않으면 판정을 받은 게 아니다.
+     *
+     * <p>기본값으로 메우면 {@code flagged=false} + 빈 카테고리가 되어 정상 안전 판정과
+     * 구별되지 않는다. self-harm 카테고리가 통째로 빠진 응답이 "자해 신호 없음"이 되는 것이
+     * 정확히 이 이슈가 막으려는 상태다.
+     */
+    @Test
+    @DisplayName("HTTP 200이어도 스키마가 불완전하면 resolved=false로 처리한다")
+    void malformed200ResponseIsNotTreatedAsResolved() throws Exception {
+        stubResponse(200, """
+                {"results":[{}]}
+                """);
+
+        ModerationResult result = client.moderate("죽고싶다");
+
+        assertThat(result.resolved())
+                .as("판정을 받지 못했으므로 정상 안전 판정과 같은 값이면 안 된다")
+                .isFalse();
+        assertThat(counter("resolved")).isZero();
+        assertThat(counter("fail_open")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("results가 비어 있으면 resolved=false로 처리한다")
+    void emptyResultsArrayIsNotTreatedAsResolved() throws Exception {
+        stubResponse(200, """
+                {"results":[]}
+                """);
+
+        assertThat(client.moderate("죽고싶다").resolved()).isFalse();
+        assertThat(counter("fail_open")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("categories만 빠진 부분 응답도 resolved=false로 처리한다")
+    void partialResponseMissingCategoriesIsNotResolved() throws Exception {
+        stubResponse(200, """
+                {"results":[{"flagged":false,"category_scores":{"self-harm":0.01}}]}
+                """);
+
+        assertThat(client.moderate("죽고싶다").resolved()).isFalse();
+        assertThat(counter("fail_open")).isEqualTo(1.0);
+    }
+
     @Test
     @DisplayName("판정 성공한 '이상 없음'과 fail-open은 서로 다른 값이다")
     void clearAndFailOpenAreDistinct() {

--- a/src/test/java/com/mio/ai/moderation/OpenAiModerationClientTest.java
+++ b/src/test/java/com/mio/ai/moderation/OpenAiModerationClientTest.java
@@ -1,0 +1,110 @@
+package com.mio.ai.moderation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 이슈 #263 — L0 fail-open 이 관측되지 않으면 안전 계층 이탈이 조용히 지나간다.
+ *
+ * <p>fail-open 자체는 유지한다. 하드 실패로 바꾸면 Moderation 장애가 곧 서비스 중단이 된다.
+ * 바꾸는 것은 그 상태가 값과 지표에 남느냐다.
+ */
+class OpenAiModerationClientTest {
+
+    private HttpClient httpClient;
+    private MeterRegistry meterRegistry;
+    private OpenAiModerationClient client;
+
+    @BeforeEach
+    void setUp() {
+        httpClient = mock(HttpClient.class);
+        meterRegistry = new SimpleMeterRegistry();
+        client = new OpenAiModerationClient("sk-test", httpClient, new ObjectMapper(), meterRegistry);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubResponse(int status, String body) throws Exception {
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(status);
+        when(response.body()).thenReturn(body);
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+    }
+
+    private double counter(String outcome) {
+        return meterRegistry.find("mio.moderation.requests")
+                .tag("outcome", outcome)
+                .counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @Test
+    @DisplayName("정상 응답은 resolved=true로 표시된다")
+    void successfulModerationIsResolved() throws Exception {
+        stubResponse(200, """
+                {"results":[{"flagged":false,"categories":{"self-harm":false},
+                 "category_scores":{"self-harm":0.01}}]}
+                """);
+
+        ModerationResult result = client.moderate("오늘 날씨가 좋네요");
+
+        assertThat(result.resolved()).isTrue();
+        assertThat(result.flagged()).isFalse();
+        assertThat(counter("resolved")).isEqualTo(1.0);
+        assertThat(counter("fail_open")).isZero();
+    }
+
+    @Test
+    @DisplayName("HTTP 오류는 fail-open이되 resolved=false로 구분된다")
+    void httpErrorIsFailOpenButMarkedUnresolved() throws Exception {
+        stubResponse(500, "");
+
+        ModerationResult result = client.moderate("오늘 날씨가 좋네요");
+
+        assertThat(result.flagged())
+                .as("fail-open 은 유지한다 — 판정 로직은 기존대로 flagged 만 본다")
+                .isFalse();
+        assertThat(result.resolved())
+                .as("'위험 신호 없음'과 '판정을 못 받아옴'이 같은 값이면 안 된다")
+                .isFalse();
+        assertThat(counter("fail_open")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("네트워크 예외도 resolved=false로 구분된다")
+    void networkFailureIsMarkedUnresolved() throws Exception {
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new java.io.IOException("connection reset"));
+
+        ModerationResult result = client.moderate("오늘 날씨가 좋네요");
+
+        assertThat(result.resolved()).isFalse();
+        assertThat(counter("fail_open")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("판정 성공한 '이상 없음'과 fail-open은 서로 다른 값이다")
+    void clearAndFailOpenAreDistinct() {
+        ModerationResult clear = ModerationResult.clear();
+        ModerationResult failOpen = ModerationResult.failOpen();
+
+        assertThat(clear.flagged()).isEqualTo(failOpen.flagged());
+        assertThat(clear.resolved()).isTrue();
+        assertThat(failOpen.resolved()).isFalse();
+        assertThat(clear).isNotEqualTo(failOpen);
+    }
+}

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -65,6 +65,7 @@ class AiDecisionLoggerTest {
                 "default",
                 false,
                 false,
+                false,
                 decision.crisisTrigger()
         );
 
@@ -116,6 +117,7 @@ class AiDecisionLoggerTest {
                 null,
                 null,
                 "default",
+                false,
                 false,
                 false,
                 decision.crisisTrigger()
@@ -172,6 +174,7 @@ class AiDecisionLoggerTest {
                 "default",
                 false,
                 false,
+                false,
                 CrisisTrigger.OUTPUT_GUARD
         );
 
@@ -185,5 +188,95 @@ class AiDecisionLoggerTest {
         assertThat(captor.getValue().getAction())
                 .as("PolicyEngine 이 내린 결정 자체는 그대로 남는다")
                 .isEqualTo("GENERATE");
+    }
+
+    /**
+     * 이슈 #263 / #261 — 안전 신호를 확인하지 못한 턴을 사후에 식별할 수 있어야 한다.
+     *
+     * <p>{@code l0_flagged=false} 만으로는 "안전 판정"과 "판정을 못 받아옴"이 구분되지 않고,
+     * 프로파일도 마찬가지로 근거 없이 만들어졌는지가 드러나지 않는다. 두 상태 모두
+     * 안전 계층이 실질적으로 빠진 채 처리된 턴이므로 트레이스에 남는다.
+     */
+    @Test
+    @DisplayName("L0 미판정과 프로파일 degraded 상태를 트레이스에 남긴다")
+    void logPersistsUnresolvedSafetySignals() {
+        PolicyDecision decision = generateDecision("pd_degraded");
+
+        logger.log(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                decision,
+                ModerationResult.failOpen(),
+                SafetyL1Result.clear(),
+                SecurityAssessment.clean(),
+                100,
+                10,
+                false,
+                false,
+                null,
+                null,
+                "default",
+                false,
+                false,
+                true,
+                null
+        );
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .contains("\"l0_flagged\":false")
+                .contains("\"l0_resolved\":false")
+                .contains("\"safety_profile_degraded\":true");
+    }
+
+    @Test
+    @DisplayName("정상 판정 턴은 l0_resolved=true로 남는다")
+    void logMarksResolvedModeration() {
+        PolicyDecision decision = generateDecision("pd_ok");
+
+        logger.log(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                decision,
+                ModerationResult.clear(),
+                SafetyL1Result.clear(),
+                SecurityAssessment.clean(),
+                100,
+                10,
+                false,
+                false,
+                null,
+                null,
+                "default",
+                false,
+                false,
+                false,
+                null
+        );
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .contains("\"l0_resolved\":true")
+                .contains("\"safety_profile_degraded\":false");
+    }
+
+    private PolicyDecision generateDecision(String decisionId) {
+        return new PolicyDecision(
+                decisionId,
+                DecisionAction.GENERATE,
+                GenerationMode.NORMAL,
+                DeliveryMode.SPECULATIVE,
+                SecurityLevel.CLEAN,
+                true,
+                true,
+                false,
+                InterventionHints.empty(),
+                "test-policy",
+                RiskLevel.CLEAR_LOW
+        );
     }
 }

--- a/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
+++ b/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
@@ -168,6 +169,85 @@ class SafetyProfileBuilderTest {
                 .counters().stream()
                 .mapToDouble(io.micrometer.core.instrument.Counter::count)
                 .sum();
+    }
+
+    /**
+     * 첫 세션에서 위기를 겪은 사용자는 아직 belief 도 cbt_pattern 도 없다 — 둘 다 세션
+     * 컨솔리데이션이 끝나야 생기기 때문이다. 그런데 "근거 없음" 조기 반환이 위기 이력을 보지
+     * 않으면 그 사용자가 buildDefault 로 떨어져 force_judge·민감 임계값·riskPrior 를 전부 잃는다.
+     *
+     * <p>조회 실패가 아니라 정상 조회인데도 보호가 사라지는 경로라 degraded 로도 잡히지 않는다.
+     */
+    @Test
+    @DisplayName("belief·pattern이 없어도 위기 이력이 있으면 보호를 유지한다")
+    void crisisHistoryAlonePreventsDefaultFallback() {
+        when(jdbcTemplate.queryForList(contains("user_beliefs"), any(UUID.class)))
+                .thenReturn(List.of());
+        when(jdbcTemplate.queryForList(contains("cbt_patterns"), any(UUID.class)))
+                .thenReturn(List.of());
+        stubCrisisQuery(3);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.hasForceJudge())
+                .as("최근 severity 3 위기를 겪은 사용자가 default 로 떨어지면 안 된다")
+                .isTrue();
+        assertThat(profile.recentCrisisSeverityMax()).isEqualTo(3);
+        assertThat(profile.riskPriorScore()).isCloseTo(0.9, within(1e-9));
+        assertThat(profile.emotionDropThreshold()).isEqualTo(25.0);
+        assertThat(profile.degraded())
+                .as("조회는 전부 성공했으므로 degraded 가 아니다")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("근거가 실제로 하나도 없으면 default로 떨어진다")
+    void noEvidenceAtAllFallsBackToDefault() {
+        when(jdbcTemplate.queryForList(contains("user_beliefs"), any(UUID.class)))
+                .thenReturn(List.of());
+        when(jdbcTemplate.queryForList(contains("cbt_patterns"), any(UUID.class)))
+                .thenReturn(List.of());
+        stubCrisisQuery(0);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.hasForceJudge()).isFalse();
+        assertThat(profile.emotionDropThreshold()).isEqualTo(30.0);
+        assertThat(profile.degraded()).isFalse();
+    }
+
+    /**
+     * belief 조회 실패도 "신념 없음"과 같은 값(빈 목록)이 되어 조기 반환 조건을 만족시킨다.
+     * 위기 이력 조회와 같은 결함 계열이다.
+     */
+    @Test
+    @DisplayName("belief 조회 실패로 비어 보이는 경우도 degraded로 처리한다")
+    void unresolvedBeliefQueryIsDegraded() {
+        when(jdbcTemplate.queryForList(contains("user_beliefs"), any(UUID.class)))
+                .thenThrow(new RuntimeException("connection reset"));
+        when(jdbcTemplate.queryForList(contains("cbt_patterns"), any(UUID.class)))
+                .thenReturn(List.of());
+        stubCrisisQuery(0);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.degraded())
+                .as("조회 실패로 비어 보이는 것과 실제로 비어 있는 것은 다르다")
+                .isTrue();
+        assertThat(profile.hasForceJudge()).isTrue();
+    }
+
+    @Test
+    @DisplayName("cbt_pattern 조회 실패도 degraded로 처리한다")
+    void unresolvedPatternQueryIsDegraded() {
+        when(jdbcTemplate.queryForList(contains("cbt_patterns"), any(UUID.class)))
+                .thenThrow(new RuntimeException("connection reset"));
+        stubCrisisQuery(0);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.degraded()).isTrue();
+        assertThat(profile.hasForceJudge()).isTrue();
     }
 
     @Test

--- a/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
+++ b/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
@@ -1,0 +1,183 @@
+package com.mio.ai.profile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 이슈 #261 — 위기 이력 조회 실패를 "위기 이력 없음"으로 처리하지 않는다.
+ *
+ * <p>{@code crisisMax = 0} 은 조회 실패와 이력 없음을 같은 값으로 만든다. 그 결과
+ * {@code force_judge} 가 빠지고 임계값이 둔해져, 최근 severity 3 위기를 겪은 사용자가
+ * DB 장애 중에 가장 둔감한 설정으로 대화하게 된다.
+ */
+class SafetyProfileBuilderTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private MeterRegistry meterRegistry;
+    private SafetyProfileBuilder builder;
+
+    private final String userId = UUID.randomUUID().toString();
+
+    @BeforeEach
+    void setUp() {
+        jdbcTemplate = mock(JdbcTemplate.class);
+        meterRegistry = new SimpleMeterRegistry();
+        builder = new SafetyProfileBuilder(
+                mock(StringRedisTemplate.class), jdbcTemplate, new ObjectMapper(), meterRegistry);
+        stubNonCrisisQueries();
+    }
+
+    /** 위기 이력 외 나머지 쿼리는 정상 응답 — 프로파일이 default 로 빠지지 않을 만큼의 데이터를 준다. */
+    private void stubNonCrisisQueries() {
+        when(jdbcTemplate.queryForList(contains("user_beliefs"), any(UUID.class)))
+                .thenReturn(List.of(Map.of("belief_kind", "self", "polarity", "negative", "confidence", 0.8)));
+        when(jdbcTemplate.queryForList(contains("cbt_patterns"), any(UUID.class)))
+                .thenReturn(List.of(Map.of("pattern_type", "catastrophizing", "recurrence_count", 3)));
+        when(jdbcTemplate.queryForList(contains("intervention_outcomes"), any(UUID.class)))
+                .thenReturn(List.of());
+        when(jdbcTemplate.queryForMap(contains("FROM sessions"), any(UUID.class)))
+                .thenReturn(Map.of("total_sessions", 3L, "days_since_first", 2.0));
+    }
+
+    private void stubCrisisQuery(Integer maxSeverity) {
+        when(jdbcTemplate.queryForObject(contains("crisis_events"), eq(Integer.class), any(UUID.class)))
+                .thenReturn(maxSeverity);
+    }
+
+    private void stubCrisisQueryFailure() {
+        when(jdbcTemplate.queryForObject(contains("crisis_events"), eq(Integer.class), any(UUID.class)))
+                .thenThrow(new RuntimeException("connection reset"));
+    }
+
+    @Test
+    @DisplayName("위기 이력 조회에 실패하면 force_judge를 붙이고 임계값을 민감하게 둔다")
+    void unresolvedCrisisHistoryFallsBackConservatively() {
+        stubCrisisQueryFailure();
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.hasForceJudge())
+                .as("조회 실패는 '위기 이력 없음'이 아니다 — 애매한 발화에서 Judge 를 생략하면 안 된다")
+                .isTrue();
+        assertThat(profile.emotionDropThreshold())
+                .as("임계값이 둔해지면 감정 급락 탐지가 늦어진다")
+                .isEqualTo(25.0);
+        assertThat(profile.repetitiveNegativeCount()).isEqualTo(2);
+        assertThat(profile.degraded())
+                .as("근거를 확인하지 못한 프로파일임이 값에 남아야 한다")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("위기 이력이 실제로 없으면 기본 임계값을 유지한다")
+    void resolvedEmptyCrisisHistoryStaysDefault() {
+        stubCrisisQuery(0);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.hasForceJudge()).isFalse();
+        assertThat(profile.emotionDropThreshold()).isEqualTo(30.0);
+        assertThat(profile.degraded()).isFalse();
+    }
+
+    /**
+     * 조회 실패와 실제 이력의 결과가 같아 보이면 안 된다.
+     *
+     * <p>{@code force_judge} 와 임계값은 같아도 {@code recentCrisisSeverityMax} 는 달라야 한다 —
+     * 실패 시 severity 를 지어내면 riskPrior 와 crisis_events 분석이 오염된다.
+     */
+    @Test
+    @DisplayName("조회 실패는 실제 위기 이력과 구별된다 — severity를 지어내지 않는다")
+    void unresolvedIsDistinguishableFromRealHistory() {
+        stubCrisisQuery(3);
+        SafetyProfile withHistory = builder.buildSync(userId);
+
+        stubCrisisQueryFailure();
+        SafetyProfile unresolved = builder.buildSync(userId);
+
+        assertThat(withHistory.hasForceJudge()).isTrue();
+        assertThat(unresolved.hasForceJudge()).isTrue();
+
+        assertThat(withHistory.recentCrisisSeverityMax()).isEqualTo(3);
+        assertThat(unresolved.recentCrisisSeverityMax())
+                .as("확인하지 못한 severity 를 값으로 채우지 않는다")
+                .isZero();
+
+        assertThat(withHistory.degraded()).isFalse();
+        assertThat(unresolved.degraded()).isTrue();
+    }
+
+    @Test
+    @DisplayName("병렬 쿼리가 전부 실패해도 default가 아니라 보수적 프로파일로 떨어진다")
+    void totalQueryFailureFallsBackToDegraded() {
+        JdbcTemplate broken = mock(JdbcTemplate.class);
+        when(broken.queryForList(any(String.class), any(UUID.class)))
+                .thenThrow(new RuntimeException("db down"));
+        when(broken.queryForObject(any(String.class), eq(Integer.class), any(UUID.class)))
+                .thenThrow(new RuntimeException("db down"));
+        when(broken.queryForMap(any(String.class), any(UUID.class)))
+                .thenThrow(new RuntimeException("db down"));
+
+        SafetyProfile profile = new SafetyProfileBuilder(
+                mock(StringRedisTemplate.class), broken, new ObjectMapper(), meterRegistry).buildSync(userId);
+
+        assertThat(profile.hasForceJudge()).isTrue();
+        assertThat(profile.emotionDropThreshold()).isEqualTo(25.0);
+        assertThat(profile.degraded()).isTrue();
+    }
+
+    /**
+     * degraded 프로파일은 전체 트래픽에 InputJudge 호출을 한 번씩 더 붙인다. 위기 이력을
+     * 확인하지 못한 이상 누가 고위험 사용자인지 알 수 없어 전원에게 {@code force_judge} 를
+     * 붙이기 때문이다. 운영이 그 상태를 즉시 볼 수 있어야 해서 지표로 노출한다.
+     */
+    @Test
+    @DisplayName("빌드 결과를 지표로 노출한다 — degraded 급증은 LLM 부하 급증을 뜻한다")
+    void buildOutcomeIsExposedAsMetric() {
+        stubCrisisQuery(0);
+        builder.buildSync(userId);
+
+        stubCrisisQueryFailure();
+        builder.buildSync(userId);
+        builder.buildSync(userId);
+
+        assertThat(counter("resolved")).isEqualTo(1.0);
+        assertThat(counter("degraded")).isEqualTo(2.0);
+    }
+
+    private double counter(String outcome) {
+        return meterRegistry.find("mio.safety_profile.builds")
+                .tag("outcome", outcome)
+                .counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count)
+                .sum();
+    }
+
+    @Test
+    @DisplayName("신규 사용자의 default 프로파일은 degraded가 아니다")
+    void defaultProfileIsNotDegraded() {
+        SafetyProfile profile = builder.buildDefault(userId);
+
+        assertThat(profile.degraded())
+                .as("이력이 없는 것과 확인하지 못한 것은 다르다")
+                .isFalse();
+        assertThat(profile.hasForceJudge()).isFalse();
+    }
+}

--- a/src/test/java/com/mio/ai/profile/SafetyProfileSerializationTest.java
+++ b/src/test/java/com/mio/ai/profile/SafetyProfileSerializationTest.java
@@ -1,0 +1,96 @@
+package com.mio.ai.profile;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SafetyProfile 은 Redis 에 JSON 으로 캐싱된다 (TTL 90분).
+ *
+ * <p>필드를 추가한 배포 직후에는 이전 형태로 직렬화된 항목이 캐시에 남아 있다.
+ * 그 JSON 이 역직렬화에 실패하면 프로파일 로드가 통째로 실패하므로 고정해 둔다 (이슈 #261).
+ */
+class SafetyProfileSerializationTest {
+
+    /** 알 수 없는 필드에 엄격한 매퍼 — 직렬화 형태가 그대로 되읽히는지 검증한다. */
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** 프로덕션(Spring Boot 자동 구성)과 같이 알 수 없는 필드를 무시하는 매퍼. */
+    private final ObjectMapper lenientMapper = new ObjectMapper()
+            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+    @Test
+    @DisplayName("degraded 필드가 없는 이전 형태의 캐시 JSON도 역직렬화된다")
+    void deserializesLegacyJsonWithoutDegradedField() throws Exception {
+        String legacyJson = """
+                {"userId":"u1","source":"personalized",
+                 "dynamicThresholds":{"emotion_drop_threshold":25.0},
+                 "effectiveInterventions":[],"ineffectiveInterventions":[],
+                 "policyFlags":["force_judge"],"riskPriorScore":0.9,
+                 "recentCrisisSeverityMax":3,"commonDistortionCodes":[],
+                 "activeNegativeBeliefCount":0,"copingStyle":null,
+                 "dominantTriggerKinds":[],"sensitivityCap":"sensitive"}
+                """;
+
+        SafetyProfile profile = objectMapper.readValue(legacyJson, SafetyProfile.class);
+
+        assertThat(profile.recentCrisisSeverityMax()).isEqualTo(3);
+        assertThat(profile.hasForceJudge()).isTrue();
+        assertThat(profile.degraded())
+                .as("필드가 없던 시절의 프로파일은 정상 조회로 만들어진 것이다")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("degraded 프로파일은 직렬화 왕복 후에도 값이 유지된다")
+    void degradedSurvivesRoundTrip() throws Exception {
+        SafetyProfile degraded = new SafetyProfile(
+                "u1", SafetyProfile.SOURCE_DEFAULT,
+                Map.of("emotion_drop_threshold", 25.0),
+                List.of(), List.of(), List.of("force_judge"),
+                0.0, 0, List.of(),
+                0, null, List.of(), "sensitive",
+                true);
+
+        String json = objectMapper.writeValueAsString(degraded);
+        SafetyProfile restored = objectMapper.readValue(json, SafetyProfile.class);
+
+        assertThat(restored.degraded())
+                .as("캐시를 거쳐도 근거 없이 만들어진 프로파일임을 잃지 않는다")
+                .isTrue();
+        assertThat(restored.hasForceJudge()).isTrue();
+
+        assertThat(json)
+                .as("isPersonalized() 는 파생값이라 직렬화 형태에 섞이면 안 된다")
+                .doesNotContain("\"personalized\"");
+    }
+
+    /**
+     * {@code isPersonalized()} 가 게터로 인식되던 시절의 캐시 항목에는 {@code "personalized"} 가 들어 있다.
+     * 배포 직후 그 항목들이 남아 있으므로 관대한 매퍼에서 계속 읽혀야 한다.
+     */
+    @Test
+    @DisplayName("파생 필드가 섞여 있던 이전 캐시 항목도 계속 읽힌다")
+    void deserializesLegacyJsonWithDerivedPersonalizedField() throws Exception {
+        String legacyJson = """
+                {"userId":"u1","source":"personalized","personalized":true,
+                 "dynamicThresholds":{},
+                 "effectiveInterventions":[],"ineffectiveInterventions":[],
+                 "policyFlags":[],"riskPriorScore":0.0,
+                 "recentCrisisSeverityMax":0,"commonDistortionCodes":[],
+                 "activeNegativeBeliefCount":0,"copingStyle":null,
+                 "dominantTriggerKinds":[],"sensitivityCap":"sensitive"}
+                """;
+
+        SafetyProfile profile = lenientMapper.readValue(legacyJson, SafetyProfile.class);
+
+        assertThat(profile.isPersonalized()).isTrue();
+        assertThat(profile.degraded()).isFalse();
+    }
+}

--- a/src/test/java/com/mio/ai/qa/CrisisDetectionCorpusQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CrisisDetectionCorpusQaTest.java
@@ -68,7 +68,7 @@ class CrisisDetectionCorpusQaTest {
             ModerationResult moderation) {
 
         static Probe of(String category, Truth truth, String message) {
-            return new Probe(category, truth, message, List.of(), ModerationResult.failOpen());
+            return new Probe(category, truth, message, List.of(), ModerationResult.clear());
         }
     }
 
@@ -559,7 +559,7 @@ class CrisisDetectionCorpusQaTest {
     private static void addWithHistory(List<Probe> target, String category, Truth truth,
                                        List<SafetyL1HistoryMessage> history, String... messages) {
         for (String message : messages) {
-            target.add(new Probe(category, truth, message, history, ModerationResult.failOpen()));
+            target.add(new Probe(category, truth, message, history, ModerationResult.clear()));
         }
     }
 

--- a/src/test/java/com/mio/ai/safety/SafetyL1ContextMarkerTest.java
+++ b/src/test/java/com/mio/ai/safety/SafetyL1ContextMarkerTest.java
@@ -23,7 +23,7 @@ class SafetyL1ContextMarkerTest {
 
     private SafetyL1Result check(String message) {
         return safetyL1.check(new SafetyL1Input(
-                message.toLowerCase(java.util.Locale.ROOT), List.of(), ModerationResult.failOpen()));
+                message.toLowerCase(java.util.Locale.ROOT), List.of(), ModerationResult.clear()));
     }
 
     private void assertDowngraded(String message) {

--- a/src/test/java/com/mio/ai/safety/SafetyL1Test.java
+++ b/src/test/java/com/mio/ai/safety/SafetyL1Test.java
@@ -15,11 +15,11 @@ class SafetyL1Test {
     private final SafetyL1 safetyL1 = new SafetyL1();
 
     private SafetyL1Input input(String normalizedMessage) {
-        return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.failOpen());
+        return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.clear());
     }
 
     private SafetyL1Input inputWithProfile(String normalizedMessage, SafetyProfile profile) {
-        return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.failOpen(), profile);
+        return new SafetyL1Input(normalizedMessage, List.of(), ModerationResult.clear(), profile);
     }
 
     @Test
@@ -69,7 +69,7 @@ class SafetyL1Test {
         var result = safetyL1.check(new SafetyL1Input(
                 "방금 일이 생기고 나서 마음이 확 무너졌어요",
                 List.of(new SafetyL1HistoryMessage("오늘은 괜찮았어요", 70, null)),
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null,
                 25,
                 "catastrophizing"
@@ -88,7 +88,7 @@ class SafetyL1Test {
                         new SafetyL1HistoryMessage("지난번에도 비슷했어요", 45, "overgeneralization"),
                         new SafetyL1HistoryMessage("저는 늘 이런 식이에요", 45, "overgeneralization")
                 ),
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null,
                 45,
                 "overgeneralization"
@@ -104,7 +104,7 @@ class SafetyL1Test {
         var result = safetyL1.check(new SafetyL1Input(
                 "이게 더 큰 문제로 번질까 봐 걱정돼요",
                 List.of(),
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null,
                 45,
                 "catastrophizing"
@@ -119,7 +119,7 @@ class SafetyL1Test {
         var result = safetyL1.check(new SafetyL1Input(
                 "안 좋게 흘러갈 것 같다는 생각이 자꾸 들어요",
                 List.of(),
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null,
                 45,
                 "fortune_telling"

--- a/src/test/java/com/mio/ai/safety/SafetySignalCombinerTest.java
+++ b/src/test/java/com/mio/ai/safety/SafetySignalCombinerTest.java
@@ -31,7 +31,7 @@ class SafetySignalCombinerTest {
         CombinedSignal combined = combiner.combine(
                 SecurityAssessment.clean(),
                 l1,
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null
         );
 
@@ -57,7 +57,7 @@ class SafetySignalCombinerTest {
         CombinedSignal combined = combiner.combine(
                 SecurityAssessment.clean(),
                 l1,
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null
         );
 
@@ -81,7 +81,7 @@ class SafetySignalCombinerTest {
         CombinedSignal combined = combiner.combine(
                 SecurityAssessment.clean(),
                 l1,
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null
         );
 
@@ -105,7 +105,7 @@ class SafetySignalCombinerTest {
         CombinedSignal combined = combiner.combine(
                 SecurityAssessment.clean(),
                 l1,
-                ModerationResult.failOpen(),
+                ModerationResult.clear(),
                 null
         );
 


### PR DESCRIPTION
## 문제

안전 신호가 **"측정하지 못한 것"과 "측정했고 안전한 것"을 같은 값으로** 표현하고 있었다.

| 이슈 | 겸직 중인 값 | 두 의미 |
|---|---|---|
| #261 | `crisisMax = 0` | 위기 이력 없음 / 조회 실패해서 모름 |
| #263 | `flagged = false` | 안전 판정됨 / 호출 실패해서 모름 |

`#255`(PR #259)에서 `parseRiskLevel`·`hardCrisisUnverified`로 이 패턴을 한 번 깼고, `#260`(PR #264)에서 `ATTACK` 채널을 분리했다. 이 PR은 남은 두 곳이다.

---

## #261 — 위기 이력 조회 실패가 '위기 이력 없음'이 된다

`SafetyProfileBuilder.queryRecentCrisis` 가 실패 시 `0` 을 반환했다. `crisisMax` 는 세 곳으로 흐른다.

| 항목 | severity 3 이력 | 조회 실패 (이전) |
|---|---|---|
| `riskPrior` 기여분 | 0.9 | **0** |
| `force_judge` | 부착 | **누락** |
| 동적 임계값 | 민감 | **둔감** |

즉 **최근 severity 3 위기를 겪은 사용자가 DB 장애 중에 가장 둔감한 설정으로 대화하게 된다.** 보호가 가장 필요한 사람에게서 보호가 사라지는 방향이다.

### 수정

- `CrisisHistory(maxSeverity, resolved)` 로 조회 여부를 값에 담는다
- 미해결이면 `force_judge` 를 붙이고 임계값을 민감한 쪽으로 둔다
- **severity 자체는 지어내지 않는다.** `recentCrisisSeverityMax` 는 0을 유지해 `riskPrior` 와 `crisis_events` 분석이 오염되지 않게 한다
- 병렬 쿼리 전체 실패 시 `buildDefault`(신규 사용자 취급) 대신 신규 `buildDegraded` 로 떨어진다

### ⚠️ 받아들인 트레이드오프 — 장애 시 Judge 팬아웃

장애 중에는 **누가 고위험 사용자인지 알 수 없어 전원에게 `force_judge` 가 붙는다.** `force_judge` 의 한계 효용은 "L1 신호가 하나도 없는 턴"이므로(다른 신호가 있으면 이미 Judge를 탄다), 사실상 전체 트래픽에 `InputJudge`(gpt-4o-mini, 동기, critical path) 호출이 한 번씩 더해진다.

- DB가 **완전히** 죽으면 `sessionRepository.findById` 부터 실패해 트래픽 자체가 없다. 실제 시나리오는 `crisis_events` 쿼리만 느려지는 **부분 장애**이고 이때 트래픽은 계속 흐른다
- 보호를 잃지 않는 방향을 택했으므로, 대신 **운영이 그 상태를 즉시 볼 수 있어야 한다** → `mio.safety_profile.builds{outcome=resolved|degraded}` 카운터 추가
- 서킷 브레이커·레이트 리미터는 `InputJudge`/`LlmClient` 에 원래 없다. 이 PR로 생긴 문제가 아니라 기존 공백이며 별도 후속 대상

---

## #263 — L0 fail-open 이 관측되지 않는다

**fail-open 동작 자체는 유지한다.** 하드 실패로 바꾸면 Moderation 장애가 곧 서비스 중단이 된다. 바꾸는 것은 그 상태가 남느냐다.

- `ModerationResult.resolved` 추가 — `failOpen()` 은 `false`, 신규 `clear()` 는 `true`
- `mio.moderation.requests{outcome=resolved|fail_open, reason}` 카운터
- 트레이스에 `l0_resolved` 기록

판정 로직은 기존대로 `flagged` 만 보므로 **동작 변화 없음**.

### 이슈의 4단계는 넣지 않았다

"L0 실패 시 InputJudge 호출 조건 완화"는 의도적으로 제외했다. L0 장애 중 모든 턴이 Judge를 타게 되어 장애 시점에 LLM 부하가 급증한다. 이슈도 동작 변경이라 별도 판단 대상으로 분리해 뒀다.

---

## 함께 고친 잠재 버그 — 캐시 JSON 오염

`SafetyProfile.isPersonalized()` 가 `isX()` 형태라 Jackson 이 게터로 인식해 **역직렬화할 수 없는 `"personalized"` 필드를 캐시 JSON에 써 넣고 있었다.**

Spring Boot 자동 구성 `ObjectMapper` 가 알 수 없는 필드를 무시해줘서 프로덕션에서는 드러나지 않았을 뿐, 엄격한 매퍼를 쓰는 순간 프로파일 로드가 통째로 실패한다. `@JsonIgnore` 로 막고 구·신 캐시 형태 양방향 호환을 테스트로 고정했다.

**캐시 호환성** — `SafetyProfile` 은 Redis에 JSON으로 캐싱된다(TTL 90분). `degraded` 필드 추가 배포 직후 이전 형태 항목이 남아 있으므로 세 방향을 모두 고정했다.

- `degraded` 없는 구 JSON → 역직렬화 성공, `degraded=false`
- `"personalized"` 가 섞인 구 JSON → 관대한 매퍼(프로덕션과 동일)에서 계속 읽힘
- 신규 JSON 왕복 → `degraded` 보존, `"personalized"` 미포함

---

## 테스트 픽스처 정정

테스트에서 "L0 신호 없음"을 뜻하던 `ModerationResult.failOpen()` 을 `clear()` 로 바꿨다. 그대로 두면 **모든 테스트가 L0 장애 상황을 흉내내게 된다** — `resolved` 에 동작이 붙는 순간 조용히 어긋난다.

바뀐 파일의 테스트들은 `ModerationResult` 의 `flagged`/`resolved` 를 단정하지 않고 L1·combiner·코퍼스 픽스처로만 쓰므로 의도 변화는 없다.

## 변경 파일

**main**
- `ai/moderation/ModerationResult.java` — `resolved` + `clear()`
- `ai/moderation/OpenAiModerationClient.java` — 실패율 카운터
- `ai/profile/SafetyProfileBuilder.java` — `CrisisHistory`, `buildDegraded`, `SENSITIVE_THRESHOLDS`, 빌드 결과 카운터
- `ai/profile/SafetyProfile.java` — `degraded` 필드, `@JsonIgnore`
- `ai/orchestrator/AiDecisionLogger.java` — `l0_resolved`, `safety_profile_degraded`
- `ai/orchestrator/ConversationOrchestrator.java` — 배선

**test** — `SafetyProfileBuilderTest`(6), `SafetyProfileSerializationTest`(3), `OpenAiModerationClientTest`(4) 신설 + `AiDecisionLoggerTest` 보강

## 테스트

**511건 전부 통과.**

## 리뷰 노트

`java-reviewer` 서브에이전트 리뷰 통과 (CRITICAL·HIGH 결함 0건). 확인된 사항:
- Redis 캐시 구/신 형태 양방향 호환 — 누락 케이스 없음
- `degraded` 가 false로 새는 경로 없음 (조기 return 분기 포함 전 경로 추적)
- `computeThresholds` 리팩터로 키 누락 없음 — `burst_window_minutes` 포함 4개 값 모두 기존과 동일
- `ModerationResult` 3인자 호환 생성자의 `resolved=true` 기본값이 안전 — 실패는 전부 `failOpen()` 경유
- `failOpen()` → `clear()` 교체가 기존 테스트 의도를 바꾸지 않음

지적받은 운영 리스크(Judge 팬아웃)는 위 "받아들인 트레이드오프"에 명시했고, 미사용 `HashMap` import 도 제거했다.

## 남은 것

- `#263` 4단계(L0 실패 시 Judge 조건 완화) — 별도 판단
- `InputJudge`/`LlmClient` 서킷 브레이커 — 기존 공백, 별도 이슈 후보

Closes #261
Closes #263
