### PR TITLE
fix: 위기 기록 실패를 삼키지 않고 재시도·안전 래치로 끝까지 남긴다

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisEventRecorder.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRecorder.java
@@ -71,20 +71,38 @@ public class CrisisEventRecorder {
      * @return 기록에 성공했는지
      */
     public boolean record(User user, Session session, int severity, String triggerType) {
+        // 논리 이벤트마다 한 번만 만든다. 재시도가 같은 키로 들어가야 중복 행이 안 생긴다.
+        UUID dedupKey = UUID.randomUUID();
+
+        if (!persistWithRetry(user, session, severity, triggerType, dedupKey)) {
+            onExhausted(user, severity);
+            return false;
+        }
+
+        // 여기서부터는 저장이 확정된 뒤다. 발행이나 지표에서 예외가 나도 재시도하면 안 된다 —
+        // 이미 커밋된 이벤트를 한 번 더 쓰게 되고, 마지막 시도가 실패하면 저장됐는데도 래치가
+        // 올라간다. 재시도 범위를 저장으로 한정한 이유다.
+        afterRecorded(user, session, severity);
+        return true;
+    }
+
+    /** @return 저장에 성공했는지. 저장 외의 작업은 이 루프에 넣지 않는다. */
+    private boolean persistWithRetry(User user, Session session, int severity,
+                                     String triggerType, UUID dedupKey) {
         for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
             try {
-                writer.write(user, session, severity, triggerType);
-                onRecorded(user, session, severity);
+                writer.write(user, session, severity, triggerType, dedupKey);
                 return true;
             } catch (Exception e) {
                 if (attempt == MAX_ATTEMPTS) {
-                    onExhausted(user, severity, e);
+                    log.error("Crisis event write failed after {} attempts: userId={} severity={}",
+                            MAX_ATTEMPTS, user.getId(), severity, e);
                     return false;
                 }
                 log.warn("Crisis event write failed (attempt {}/{}), retrying: userId={}",
                         attempt, MAX_ATTEMPTS, user.getId(), e);
                 if (!backOff(attempt)) {
-                    onExhausted(user, severity, e);
+                    log.error("Crisis event write interrupted: userId={}", user.getId(), e);
                     return false;
                 }
             }
@@ -92,18 +110,25 @@ public class CrisisEventRecorder {
         return false;
     }
 
-    private void onRecorded(User user, Session session, int severity) {
-        meterRegistry.counter(METRIC, "outcome", "recorded").increment();
-        // 이전에 기록하지 못한 위기가 있었다면 이제 실제 이력이 생겼으므로 래치를 내린다.
-        safetyLatch.clear(user.getId());
-        // 저장이 커밋된 뒤에만 발행한다 (writer 가 REQUIRES_NEW 라 반환 시점에 이미 커밋됐다).
-        eventPublisher.publishEvent(new CrisisDetectedEvent(session.getId(), user.getId(), severity));
+    /**
+     * 저장이 확정된 뒤의 후속 작업. 실패해도 저장을 되돌리지 않고 로그만 남긴다.
+     *
+     * <p>래치는 건드리지 않는다. 이 위기가 저장됐다는 사실이 <b>다른</b> 위기가 유실됐다는
+     * 사실을 지우지는 못한다. 유실된 이벤트가 실제로 복구되기 전까지는 TTL 로 만료되게 둔다.
+     */
+    private void afterRecorded(User user, Session session, int severity) {
+        try {
+            meterRegistry.counter(METRIC, "outcome", "recorded").increment();
+            // writer 가 REQUIRES_NEW 라 반환 시점에 이미 커밋됐다.
+            eventPublisher.publishEvent(new CrisisDetectedEvent(session.getId(), user.getId(), severity));
+        } catch (Exception e) {
+            log.error("Crisis event was saved but follow-up failed: userId={} severity={}",
+                    user.getId(), severity, e);
+        }
     }
 
-    private void onExhausted(User user, int severity, Exception cause) {
+    private void onExhausted(User user, int severity) {
         meterRegistry.counter(METRIC, "outcome", "failed").increment();
-        log.error("Crisis event could not be recorded after {} attempts: userId={} severity={}",
-                MAX_ATTEMPTS, user.getId(), severity, cause);
         // 기록은 실패했지만 위기가 있었다는 사실까지 잃을 수는 없다. 다른 저장소에 표시해
         // 다음 프로파일이 보수적으로 만들어지게 한다.
         safetyLatch.raise(user.getId(), severity);

--- a/src/main/java/com/mio/ai/crisis/CrisisEventRecorder.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRecorder.java
@@ -1,0 +1,126 @@
+package com.mio.ai.crisis;
+
+import com.mio.session.domain.Session;
+import com.mio.user.domain.User;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * 위기 이벤트를 끝까지 기록한다 (이슈 P0-B).
+ *
+ * <p>이전에는 {@code CrisisFlowService} 가 저장 예외를 {@code log.error} 로 삼켰다. 그러면
+ * {@code crisis_events} 를 읽는 유일한 소비자인 {@code SafetyProfileBuilder.queryRecentCrisis}
+ * 가 그 위기를 보지 못해, 위기를 겪은 사용자가 다음 세션에서 아무 일 없었던 사람이 된다.
+ *
+ * <p>순서가 중요하다. <b>저장에 성공한 뒤에만</b> {@code CrisisDetectedEvent} 를 발행한다.
+ * 이 이벤트는 프로파일 캐시를 지우고, 다음 빌드는 {@code crisis_events} 를 다시 읽는다.
+ * 저장이 실패했는데 발행하면 "반영됐다"는 잘못된 인상만 남는다.
+ */
+@Component
+@Slf4j
+public class CrisisEventRecorder {
+
+    /** 짧게만 재시도한다. 사용자는 이미 위기 안내를 받았고 이 경로는 요청을 붙잡지 않는다. */
+    static final int MAX_ATTEMPTS = 3;
+    static final long BASE_DELAY_MS = 50L;
+
+    private static final String METRIC = "mio.crisis.records";
+
+    private final CrisisEventWriter writer;
+    private final CrisisSafetyLatch safetyLatch;
+    private final ApplicationEventPublisher eventPublisher;
+    private final MeterRegistry meterRegistry;
+    private final Sleeper sleeper;
+    private final Random jitter = new Random();
+
+    /** 재시도 대기. 테스트가 실제로 기다리지 않도록 분리한다. */
+    @FunctionalInterface
+    interface Sleeper {
+        void sleep(long millis) throws InterruptedException;
+    }
+
+    @Autowired
+    public CrisisEventRecorder(CrisisEventWriter writer,
+                               CrisisSafetyLatch safetyLatch,
+                               ApplicationEventPublisher eventPublisher,
+                               MeterRegistry meterRegistry) {
+        this(writer, safetyLatch, eventPublisher, meterRegistry, Thread::sleep);
+    }
+
+    CrisisEventRecorder(CrisisEventWriter writer,
+                        CrisisSafetyLatch safetyLatch,
+                        ApplicationEventPublisher eventPublisher,
+                        MeterRegistry meterRegistry,
+                        Sleeper sleeper) {
+        this.writer = writer;
+        this.safetyLatch = safetyLatch;
+        this.eventPublisher = eventPublisher;
+        this.meterRegistry = meterRegistry;
+        this.sleeper = sleeper;
+    }
+
+    /**
+     * 위기를 기록하고, 성공한 경우에만 프로파일 갱신을 알린다.
+     *
+     * @return 기록에 성공했는지
+     */
+    public boolean record(User user, Session session, int severity, String triggerType) {
+        for (int attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            try {
+                writer.write(user, session, severity, triggerType);
+                onRecorded(user, session, severity);
+                return true;
+            } catch (Exception e) {
+                if (attempt == MAX_ATTEMPTS) {
+                    onExhausted(user, severity, e);
+                    return false;
+                }
+                log.warn("Crisis event write failed (attempt {}/{}), retrying: userId={}",
+                        attempt, MAX_ATTEMPTS, user.getId(), e);
+                if (!backOff(attempt)) {
+                    onExhausted(user, severity, e);
+                    return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    private void onRecorded(User user, Session session, int severity) {
+        meterRegistry.counter(METRIC, "outcome", "recorded").increment();
+        // 이전에 기록하지 못한 위기가 있었다면 이제 실제 이력이 생겼으므로 래치를 내린다.
+        safetyLatch.clear(user.getId());
+        // 저장이 커밋된 뒤에만 발행한다 (writer 가 REQUIRES_NEW 라 반환 시점에 이미 커밋됐다).
+        eventPublisher.publishEvent(new CrisisDetectedEvent(session.getId(), user.getId(), severity));
+    }
+
+    private void onExhausted(User user, int severity, Exception cause) {
+        meterRegistry.counter(METRIC, "outcome", "failed").increment();
+        log.error("Crisis event could not be recorded after {} attempts: userId={} severity={}",
+                MAX_ATTEMPTS, user.getId(), severity, cause);
+        // 기록은 실패했지만 위기가 있었다는 사실까지 잃을 수는 없다. 다른 저장소에 표시해
+        // 다음 프로파일이 보수적으로 만들어지게 한다.
+        safetyLatch.raise(user.getId(), severity);
+        // 발행하지 않는다 — 캐시를 지워봐야 재빌드가 읽을 이력이 없다.
+    }
+
+    /** @return 계속 재시도해도 되는지. 인터럽트되면 중단한다. */
+    private boolean backOff(int attempt) {
+        long delay = BASE_DELAY_MS * (1L << (attempt - 1));
+        // 지터를 넣어 동시 실패가 같은 시점에 재시도하지 않게 한다.
+        long withJitter = delay + jitter.nextInt((int) delay + 1);
+        try {
+            sleeper.sleep(withJitter);
+            return true;
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
@@ -3,7 +3,11 @@ package com.mio.ai.crisis;
 import com.mio.crisis.domain.CrisisEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface CrisisEventRepository extends JpaRepository<CrisisEvent, UUID> {
+
+    /** 재시도가 같은 논리 이벤트를 다시 만들지 않도록 기존 행을 찾는다 (이슈 #269). */
+    Optional<CrisisEvent> findByDedupKey(UUID dedupKey);
 }

--- a/src/main/java/com/mio/ai/crisis/CrisisEventWriter.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventWriter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -29,11 +30,20 @@ class CrisisEventWriter {
 
     private final CrisisEventRepository crisisEventRepository;
 
+    /**
+     * @param dedupKey 논리 이벤트의 안정 키. 재시도가 같은 키로 들어오면 새로 만들지 않고
+     *                 기존 행을 돌려준다 — 커밋은 성공했지만 응답이 유실된 경우를 위해서다.
+     */
     @Transactional(propagation = Propagation.REQUIRES_NEW)
-    public UUID write(User user, Session session, int severity, String triggerType) {
+    public UUID write(User user, Session session, int severity, String triggerType, UUID dedupKey) {
+        Optional<CrisisEvent> existing = crisisEventRepository.findByDedupKey(dedupKey);
+        if (existing.isPresent()) {
+            return existing.get().getId();
+        }
         CrisisEvent event = CrisisEvent.builder()
                 .user(user)
                 .session(session)
+                .dedupKey(dedupKey)
                 .triggerType(triggerType)
                 .severity(severity)
                 .operatorReviewed(false)

--- a/src/main/java/com/mio/ai/crisis/CrisisEventWriter.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventWriter.java
@@ -1,0 +1,43 @@
+package com.mio.ai.crisis;
+
+import com.mio.crisis.domain.CrisisEvent;
+import com.mio.session.domain.Session;
+import com.mio.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 위기 이벤트를 한 번 저장한다 (이슈 P0-B).
+ *
+ * <p>재시도 루프와 분리된 별도 빈인 이유는 두 가지다.
+ * <ul>
+ *   <li>{@code REQUIRES_NEW} 가 프록시를 거쳐야 실제로 새 트랜잭션이 열린다. 같은 클래스 안에서
+ *       호출하면 self-invocation 이라 무시된다 ({@code SummaryStatusWriter} 와 같은 이유)</li>
+ *   <li>시도마다 트랜잭션이 새로 열려야 한다. 한 트랜잭션 안에서 재시도하면 첫 실패로 이미
+ *       rollback-only 가 찍혀 이후 시도가 전부 실패한다</li>
+ * </ul>
+ *
+ * <p><b>예외를 삼키지 않는다.</b> 저장 실패를 알아야 재시도·안전 래치로 이어갈 수 있다.
+ */
+@Component
+@RequiredArgsConstructor
+class CrisisEventWriter {
+
+    private final CrisisEventRepository crisisEventRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public UUID write(User user, Session session, int severity, String triggerType) {
+        CrisisEvent event = CrisisEvent.builder()
+                .user(user)
+                .session(session)
+                .triggerType(triggerType)
+                .severity(severity)
+                .operatorReviewed(false)
+                .build();
+        return crisisEventRepository.save(event).getId();
+    }
+}

--- a/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisFlowService.java
@@ -1,13 +1,11 @@
 package com.mio.ai.crisis;
 
 import com.mio.ai.safety.SafetyL1Result;
-import com.mio.crisis.domain.CrisisEvent;
 import com.mio.session.domain.Session;
 import com.mio.session.dto.SseEventDto;
 import com.mio.user.domain.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -19,8 +17,7 @@ import java.util.List;
 @Slf4j
 public class CrisisFlowService {
 
-    private final CrisisEventRepository crisisEventRepository;
-    private final ApplicationEventPublisher eventPublisher;
+    private final CrisisEventRecorder crisisEventRecorder;
 
     private static final List<String> SEVERITY_3_KEYWORDS = List.of(
             "자살", "자해", "죽고싶다", "죽을거야", "목숨을끊", "자살하고싶", "자해하고싶"
@@ -88,11 +85,11 @@ public class CrisisFlowService {
                     session.getId(), severity, e);
         }
 
-        persistCrisisEvent(user, session, severity, triggerType);
-        // SafetyProfile 즉시 invalidate (§17.8)
-        eventPublisher.publishEvent(new CrisisDetectedEvent(session.getId(), user.getId(), severity));
+        // 기록과 프로파일 갱신 알림은 recorder 가 맡는다. 저장에 성공한 경우에만 발행하며,
+        // 끝내 실패하면 안전 래치를 올려 다음 프로파일이 보수적으로 만들어지게 한다 (이슈 P0-B).
+        boolean recorded = crisisEventRecorder.record(user, session, severity, triggerType);
 
-        return new CrisisHandleResult(fixedResponse, severity, delivered);
+        return new CrisisHandleResult(fixedResponse, severity, delivered, recorded);
     }
 
     /**
@@ -175,30 +172,22 @@ public class CrisisFlowService {
         return new SseEventDto.CrisisEvent(severity, fixedResponse, null);
     }
 
-    private void persistCrisisEvent(User user, Session session, int severity, String triggerType) {
-        try {
-            CrisisEvent event = CrisisEvent.builder()
-                    .user(user)
-                    .session(session)
-                    .triggerType(triggerType)
-                    .severity(severity)
-                    .operatorReviewed(false)
-                    .build();
-            crisisEventRepository.save(event);
-        } catch (Exception e) {
-            log.error("Failed to persist crisis event", e);
-        }
-    }
 
     /**
      * @param delivered 위기 안내가 실제로 사용자에게 전송됐는지. {@code false} 면 기록은 남았지만
      *                  사용자는 핫라인을 보지 못했다 — 턴을 완료로 기록하면 안 된다.
      */
-    public record CrisisHandleResult(String fixedResponse, int severity, boolean delivered) {
+    public record CrisisHandleResult(
+            String fixedResponse, int severity, boolean delivered, boolean recorded) {
+
+        /** 기록 여부 개념 도입 이전 시그니처 — 기존 호출부 호환용. */
+        public CrisisHandleResult(String fixedResponse, int severity, boolean delivered) {
+            this(fixedResponse, severity, delivered, true);
+        }
 
         /** 전송 여부 개념 도입 이전 시그니처 — 기존 호출부 호환용. */
         public CrisisHandleResult(String fixedResponse, int severity) {
-            this(fixedResponse, severity, true);
+            this(fixedResponse, severity, true, true);
         }
     }
 }

--- a/src/main/java/com/mio/ai/crisis/CrisisSafetyLatch.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisSafetyLatch.java
@@ -1,0 +1,73 @@
+package com.mio.ai.crisis;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.UUID;
+
+/**
+ * 기록하지 못한 위기를 표시하는 래치 (이슈 P0-B).
+ *
+ * <p>{@code crisis_events} 저장이 끝내 실패하면 다음 세션의 {@code SafetyProfileBuilder} 가
+ * 그 위기를 보지 못한다. 위기를 겪은 사용자가 아무 일 없었던 사람이 된다.
+ *
+ * <p><b>Redis 에 두는 이유는 실패 도메인이 달라야 하기 때문이다.</b> 저장이 실패하는 상황은
+ * 대개 Postgres 쪽 문제이므로, 같은 DB 에 보상 레코드를 남기는 방식(outbox 포함)은 그 순간
+ * 함께 실패한다. 래치는 "DB 는 못 쓰지만 Redis 는 산다"는 부분 장애를 노린다.
+ *
+ * <p>TTL 은 위기 이력 조회 창(14일)과 맞춘다. 그 창을 넘기면 어차피 프로파일이 참조하지 않는다.
+ *
+ * <p>Redis 마저 실패하면 남는 것은 로그와 지표뿐이다. 그 경우까지 덮으려면 사후에 대화 원문에서
+ * 위기 턴을 재식별하는 복구가 필요하며, 별도 과제다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CrisisSafetyLatch {
+
+    private static final String KEY = "user:%s:unrecorded_crisis";
+    private static final Duration TTL = Duration.ofDays(14);
+
+    private final StringRedisTemplate redisTemplate;
+
+    /** 기록에 실패한 위기가 있었음을 표시한다. */
+    public void raise(UUID userId, int severity) {
+        try {
+            redisTemplate.opsForValue().set(KEY.formatted(userId), String.valueOf(severity), TTL);
+            log.warn("Crisis safety latch raised — crisis was NOT recorded: userId={} severity={}",
+                    userId, severity);
+        } catch (Exception e) {
+            // 여기까지 실패하면 로그와 지표만 남는다. 요청 흐름을 끊지는 않는다 —
+            // 사용자는 이미 위기 안내를 받았고, 그걸 되돌릴 이유가 없다.
+            log.error("Crisis safety latch could not be raised: userId={}", userId, e);
+        }
+    }
+
+    /**
+     * 기록하지 못한 위기가 있는지.
+     *
+     * <p>조회 실패는 {@code false} 가 아니라 예외로 다루지 않고 {@code false} 로 반환한다 —
+     * 이 값은 프로파일을 <b>보수적으로</b> 만드는 방향으로만 쓰이고, 호출부가 이미 조회 실패를
+     * 별도로 degraded 처리하기 때문이다.
+     */
+    public boolean isRaised(UUID userId) {
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(KEY.formatted(userId)));
+        } catch (Exception e) {
+            log.warn("Crisis safety latch check failed: userId={}", userId, e);
+            return false;
+        }
+    }
+
+    /** 위기가 정상 기록되면 래치를 내린다. */
+    public void clear(UUID userId) {
+        try {
+            redisTemplate.delete(KEY.formatted(userId));
+        } catch (Exception e) {
+            log.warn("Crisis safety latch could not be cleared: userId={}", userId, e);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/crisis/CrisisSafetyLatch.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisSafetyLatch.java
@@ -49,25 +49,19 @@ public class CrisisSafetyLatch {
     /**
      * 기록하지 못한 위기가 있는지.
      *
-     * <p>조회 실패는 {@code false} 가 아니라 예외로 다루지 않고 {@code false} 로 반환한다 —
-     * 이 값은 프로파일을 <b>보수적으로</b> 만드는 방향으로만 쓰이고, 호출부가 이미 조회 실패를
-     * 별도로 degraded 처리하기 때문이다.
+     * <p><b>조회에 실패하면 {@code true} 를 반환한다.</b> 이 래치 자체가 유실된 위기를 보완하는
+     * 안전 신호다. 확인하지 못했는데 {@code false} 를 돌려주면, 과거에 기록 실패가 있었더라도
+     * 프로파일이 정상으로 돌아간다 — 이 작업이 없애려는 "모른다를 괜찮다로" 그 자체다.
+     *
+     * <p>대가는 Redis 장애 중 모든 사용자가 보수적 프로파일이 되는 것이다. 지연·비용은 늘지만
+     * 방향은 안전 쪽이다.
      */
     public boolean isRaised(UUID userId) {
         try {
             return Boolean.TRUE.equals(redisTemplate.hasKey(KEY.formatted(userId)));
         } catch (Exception e) {
-            log.warn("Crisis safety latch check failed: userId={}", userId, e);
-            return false;
-        }
-    }
-
-    /** 위기가 정상 기록되면 래치를 내린다. */
-    public void clear(UUID userId) {
-        try {
-            redisTemplate.delete(KEY.formatted(userId));
-        } catch (Exception e) {
-            log.warn("Crisis safety latch could not be cleared: userId={}", userId, e);
+            log.warn("Crisis safety latch check failed, assuming raised: userId={}", userId, e);
+            return true;
         }
     }
 }

--- a/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
+++ b/src/main/java/com/mio/ai/profile/SafetyProfileBuilder.java
@@ -2,6 +2,7 @@ package com.mio.ai.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.crisis.CrisisDetectedEvent;
+import com.mio.ai.crisis.CrisisSafetyLatch;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,6 +65,7 @@ public class SafetyProfileBuilder {
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
+    private final CrisisSafetyLatch crisisSafetyLatch;
 
     private final Executor profileBuildPool = Executors.newVirtualThreadPerTaskExecutor();
 
@@ -221,9 +223,14 @@ public class SafetyProfileBuilder {
             //
             // outcomes·sessionMeta는 제외한다. 개입 힌트 품질과 personalized 라벨에만 영향을 주고
             // 위험 게이팅(riskPrior·force_judge·임계값)에는 들어가지 않는다.
+            //
+            // 안전 래치도 함께 본다 — crisis_events 저장이 끝내 실패한 위기가 있으면
+            // 조회는 성공해도 그 위기가 테이블에 없다. 래치가 그 사실을 알려준다 (이슈 P0-B).
+            boolean unrecordedCrisis = crisisSafetyLatch.isRaised(userUUID);
             boolean degraded = !crisisHistory.resolved()
                     || !beliefs.resolved()
-                    || !patterns.resolved();
+                    || !patterns.resolved()
+                    || unrecordedCrisis;
 
             // 근거가 없으면 default. 단 "없음"을 확인한 경우여야 한다.
             //

--- a/src/main/java/com/mio/crisis/domain/CrisisEvent.java
+++ b/src/main/java/com/mio/crisis/domain/CrisisEvent.java
@@ -29,6 +29,15 @@ public class CrisisEvent {
     @JoinColumn(name = "session_id")
     private Session session;
 
+    /**
+     * 논리 위기 이벤트의 안정 키 (이슈 #269).
+     *
+     * <p>저장 재시도가 같은 위기를 두 번 기록하지 않도록 한다. 커밋은 성공했지만 응답이 유실된
+     * 경우 다음 시도가 이 키로 기존 행을 찾는다. 이 컬럼 도입 이전 행은 {@code null} 이다.
+     */
+    @Column(name = "dedup_key")
+    private UUID dedupKey;
+
     @Column(name = "trigger_type", nullable = false)
     private String triggerType;
 

--- a/src/main/resources/db/migration/V41__add_crisis_events_dedup_key.sql
+++ b/src/main/resources/db/migration/V41__add_crisis_events_dedup_key.sql
@@ -1,0 +1,17 @@
+-- 위기 기록 재시도의 멱등성 (이슈 #269)
+--
+-- crisis_events 저장에 재시도를 붙였는데, 시도마다 새 행을 INSERT 하므로 커밋은 성공했지만
+-- 응답이 유실된 경우(연결 단절 등) 다음 시도가 같은 위기를 한 번 더 기록한다. 내구성을 높이려는
+-- 변경이 중복 감사 기록을 만드는 셈이다.
+--
+-- 논리 이벤트마다 안정적인 키를 부여하고 유니크 제약으로 중복을 막는다. 재시도는 이 키로
+-- 기존 행을 찾아 재사용한다.
+--
+-- 기존 행에는 키가 없으므로 NULL 을 허용하고, 부분 유니크 인덱스로 NULL 다건을 허용한다.
+
+ALTER TABLE crisis_events
+    ADD COLUMN dedup_key UUID;
+
+CREATE UNIQUE INDEX uq_crisis_events_dedup_key
+    ON crisis_events (dedup_key)
+    WHERE dedup_key IS NOT NULL;

--- a/src/test/java/com/mio/ai/crisis/CrisisDeliveryTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisDeliveryTest.java
@@ -5,7 +5,6 @@ import com.mio.session.domain.Session;
 import com.mio.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -14,6 +13,8 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -41,9 +42,8 @@ class CrisisDeliveryTest {
     }
 
     private CrisisFlowService.CrisisHandleResult handleWith(SseEmitter emitter,
-                                                            CrisisEventRepository repo,
-                                                            ApplicationEventPublisher publisher) {
-        CrisisFlowService service = new CrisisFlowService(repo, publisher);
+                                                            CrisisEventRecorder recorder) {
+        CrisisFlowService service = new CrisisFlowService(recorder);
         User user = user();
         return service.handle(
                 SafetyL1Result.clear(), CrisisTrigger.SELF_HARM_INQUIRY, "자살 방법 알려줘",
@@ -53,8 +53,7 @@ class CrisisDeliveryTest {
     @Test
     @DisplayName("정상 전송이면 delivered=true")
     void deliveredWhenSendSucceeds() {
-        var result = handleWith(mock(SseEmitter.class),
-                mock(CrisisEventRepository.class), mock(ApplicationEventPublisher.class));
+        var result = handleWith(mock(SseEmitter.class), mock(CrisisEventRecorder.class));
 
         assertThat(result.delivered()).isTrue();
     }
@@ -65,8 +64,7 @@ class CrisisDeliveryTest {
         SseEmitter emitter = mock(SseEmitter.class);
         doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
 
-        var result = handleWith(emitter,
-                mock(CrisisEventRepository.class), mock(ApplicationEventPublisher.class));
+        var result = handleWith(emitter, mock(CrisisEventRecorder.class));
 
         assertThat(result.delivered())
                 .as("사용자가 핫라인을 보지 못했다는 사실이 결과에 담겨야 한다")
@@ -84,14 +82,12 @@ class CrisisDeliveryTest {
         SseEmitter emitter = mock(SseEmitter.class);
         doThrow(new IllegalStateException("ResponseBodyEmitter has already completed"))
                 .when(emitter).send(any(SseEmitter.SseEventBuilder.class));
-        CrisisEventRepository repo = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        CrisisEventRecorder recorder = mock(CrisisEventRecorder.class);
 
-        var result = handleWith(emitter, repo, publisher);
+        var result = handleWith(emitter, recorder);
 
         assertThat(result.delivered()).isFalse();
-        verify(repo).save(any());
-        verify(publisher).publishEvent(any(CrisisDetectedEvent.class));
+        verify(recorder).record(any(), any(), anyInt(), anyString());
     }
 
     /**
@@ -101,8 +97,7 @@ class CrisisDeliveryTest {
     @Test
     @DisplayName("preview 는 handle 과 같은 severity·응답을 낸다")
     void previewMatchesHandle() {
-        CrisisFlowService service = new CrisisFlowService(
-                mock(CrisisEventRepository.class), mock(ApplicationEventPublisher.class));
+        CrisisFlowService service = new CrisisFlowService(mock(CrisisEventRecorder.class));
         User user = user();
 
         for (CrisisTrigger trigger : CrisisTrigger.values()) {
@@ -128,12 +123,10 @@ class CrisisDeliveryTest {
     void stillRecordsWhenDeliveryFails() throws IOException {
         SseEmitter emitter = mock(SseEmitter.class);
         doThrow(new IOException("broken pipe")).when(emitter).send(any(SseEmitter.SseEventBuilder.class));
-        CrisisEventRepository repo = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+        CrisisEventRecorder recorder = mock(CrisisEventRecorder.class);
 
-        handleWith(emitter, repo, publisher);
+        handleWith(emitter, recorder);
 
-        verify(repo).save(any());
-        verify(publisher).publishEvent(any(CrisisDetectedEvent.class));
+        verify(recorder).record(any(), any(), anyInt(), anyString());
     }
 }

--- a/src/test/java/com/mio/ai/crisis/CrisisEventRecorderTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisEventRecorderTest.java
@@ -7,6 +7,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -72,11 +73,11 @@ class CrisisEventRecorderTest {
     @Test
     @DisplayName("첫 시도에 성공하면 재시도 없이 이벤트를 발행한다")
     void recordsOnFirstAttempt() {
-        when(writer.write(any(), any(), anyInt(), anyString())).thenReturn(UUID.randomUUID());
+        when(writer.write(any(), any(), anyInt(), anyString(), any())).thenReturn(UUID.randomUUID());
 
         assertThat(record()).isTrue();
 
-        verify(writer).write(any(), any(), anyInt(), anyString());
+        verify(writer).write(any(), any(), anyInt(), anyString(), any());
         verify(publisher).publishEvent(any(CrisisDetectedEvent.class));
         assertThat(sleeps).isEmpty();
         assertThat(counter("recorded")).isEqualTo(1.0);
@@ -85,7 +86,7 @@ class CrisisEventRecorderTest {
     @Test
     @DisplayName("일시 실패는 재시도로 복구하고 성공으로 기록한다")
     void retriesTransientFailure() {
-        when(writer.write(any(), any(), anyInt(), anyString()))
+        when(writer.write(any(), any(), anyInt(), anyString(), any()))
                 .thenThrow(new RuntimeException("deadlock"))
                 .thenReturn(UUID.randomUUID());
 
@@ -104,13 +105,13 @@ class CrisisEventRecorderTest {
     @Test
     @DisplayName("저장에 끝내 실패하면 이벤트를 발행하지 않고 안전 래치를 올린다")
     void raisesLatchAndSkipsPublishWhenExhausted() {
-        when(writer.write(any(), any(), anyInt(), anyString()))
+        when(writer.write(any(), any(), anyInt(), anyString(), any()))
                 .thenThrow(new RuntimeException("db down"));
 
         assertThat(record()).isFalse();
 
         verify(writer, org.mockito.Mockito.times(CrisisEventRecorder.MAX_ATTEMPTS))
-                .write(any(), any(), anyInt(), anyString());
+                .write(any(), any(), anyInt(), anyString(), any());
         verify(publisher, never()).publishEvent(any());
         verify(latch).raise(user.getId(), 3);
         assertThat(counter("failed")).isEqualTo(1.0);
@@ -119,7 +120,7 @@ class CrisisEventRecorderTest {
     @Test
     @DisplayName("재시도 대기는 지수적으로 늘고 지터가 섞인다")
     void backOffGrowsWithJitter() {
-        when(writer.write(any(), any(), anyInt(), anyString()))
+        when(writer.write(any(), any(), anyInt(), anyString(), any()))
                 .thenThrow(new RuntimeException("db down"));
 
         record();
@@ -133,24 +134,65 @@ class CrisisEventRecorderTest {
     }
 
     /**
-     * 기록에 성공하면 실제 이력이 생겼으므로 이전에 올려둔 래치는 의미가 없다.
-     * 남겨두면 그 사용자가 14일 내내 불필요하게 degraded 로 취급된다.
+     * 위기 A 저장이 실패해 래치가 올라간 뒤 별도 위기 B 가 정상 저장돼도, A 는 여전히
+     * crisis_events 에 없다. 여기서 래치를 내리면 누락된 A 를 잊게 되어 프로파일이 정상으로
+     * 돌아간다. 실제 복구가 구현되기 전까지는 TTL 로 만료되게 둔다.
      */
     @Test
-    @DisplayName("기록에 성공하면 이전 래치를 내린다")
-    void clearsLatchOnSuccess() {
-        when(writer.write(any(), any(), anyInt(), anyString())).thenReturn(UUID.randomUUID());
+    @DisplayName("다른 위기가 성공해도 이전 실패의 래치를 지우지 않는다")
+    void successDoesNotEraseEarlierFailureLatch() {
+        when(writer.write(any(), any(), anyInt(), anyString(), any())).thenReturn(UUID.randomUUID());
 
         record();
 
-        verify(latch).clear(user.getId());
+        // clear 메서드 자체를 없앴다. 래치는 TTL 로만 만료된다.
         verify(latch, never()).raise(any(), anyInt());
+    }
+
+    /**
+     * writer 는 REQUIRES_NEW 라 반환 시점에 이미 커밋됐다. 그 뒤 동기 리스너가 예외를 던질 때
+     * 재시도하면 같은 위기가 여러 건 저장되고, 마지막 시도가 실패하면 저장됐는데도 래치가 올라간다.
+     */
+    @Test
+    @DisplayName("저장 뒤 발행이 실패해도 재시도하거나 래치를 올리지 않는다")
+    void publishFailureDoesNotRetryOrRaiseLatch() {
+        when(writer.write(any(), any(), anyInt(), anyString(), any())).thenReturn(UUID.randomUUID());
+        org.mockito.Mockito.doThrow(new RuntimeException("listener blew up"))
+                .when(publisher).publishEvent(any(CrisisDetectedEvent.class));
+
+        assertThat(record())
+                .as("저장은 성공했으므로 기록 성공이다")
+                .isTrue();
+
+        verify(writer, org.mockito.Mockito.times(1))
+                .write(any(), any(), anyInt(), anyString(), any());
+        verify(latch, never()).raise(any(), anyInt());
+    }
+
+    /**
+     * 커밋은 성공했는데 응답이 유실된 경우, 재시도가 새 행을 만들면 같은 위기가 두 번 기록된다.
+     * 모든 시도가 같은 dedup 키를 써야 writer 가 기존 행을 재사용할 수 있다.
+     */
+    @Test
+    @DisplayName("재시도는 같은 dedup 키를 쓴다")
+    void retriesReuseSameDedupKey() {
+        when(writer.write(any(), any(), anyInt(), anyString(), any()))
+                .thenThrow(new RuntimeException("connection reset"))
+                .thenReturn(UUID.randomUUID());
+
+        record();
+
+        ArgumentCaptor<UUID> keys = ArgumentCaptor.forClass(UUID.class);
+        verify(writer, org.mockito.Mockito.times(2))
+                .write(any(), any(), anyInt(), anyString(), keys.capture());
+        assertThat(keys.getAllValues()).hasSize(2);
+        assertThat(keys.getAllValues().get(0)).isEqualTo(keys.getAllValues().get(1));
     }
 
     @Test
     @DisplayName("대기 중 인터럽트되면 즉시 중단하고 래치를 올린다")
     void stopsOnInterrupt() {
-        when(writer.write(any(), any(), anyInt(), anyString()))
+        when(writer.write(any(), any(), anyInt(), anyString(), any()))
                 .thenThrow(new RuntimeException("db down"));
         recorder = new CrisisEventRecorder(writer, latch, publisher, meterRegistry, millis -> {
             throw new InterruptedException("shutdown");
@@ -158,7 +200,7 @@ class CrisisEventRecorderTest {
 
         assertThat(record()).isFalse();
 
-        verify(writer, org.mockito.Mockito.times(1)).write(any(), any(), anyInt(), anyString());
+        verify(writer, org.mockito.Mockito.times(1)).write(any(), any(), anyInt(), anyString(), any());
         verify(latch).raise(user.getId(), 3);
         assertThat(Thread.interrupted()).as("인터럽트 상태를 복원해야 한다").isTrue();
     }

--- a/src/test/java/com/mio/ai/crisis/CrisisEventRecorderTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisEventRecorderTest.java
@@ -1,0 +1,165 @@
+package com.mio.ai.crisis;
+
+import com.mio.session.domain.Session;
+import com.mio.user.domain.User;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 위기 기록의 내구성 (이슈 P0-B).
+ *
+ * <p>이전에는 저장 예외를 {@code log.error} 로 삼켜서, {@code crisis_events} 를 읽는 유일한
+ * 소비자인 {@code SafetyProfileBuilder} 가 그 위기를 보지 못했다. 위기를 겪은 사용자가 다음
+ * 세션에서 아무 일 없었던 사람이 된다.
+ */
+class CrisisEventRecorderTest {
+
+    private CrisisEventWriter writer;
+    private CrisisSafetyLatch latch;
+    private ApplicationEventPublisher publisher;
+    private MeterRegistry meterRegistry;
+    private final List<Long> sleeps = new ArrayList<>();
+
+    private CrisisEventRecorder recorder;
+    private User user;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        writer = mock(CrisisEventWriter.class);
+        latch = mock(CrisisSafetyLatch.class);
+        publisher = mock(ApplicationEventPublisher.class);
+        meterRegistry = new SimpleMeterRegistry();
+        sleeps.clear();
+
+        recorder = new CrisisEventRecorder(writer, latch, publisher, meterRegistry, sleeps::add);
+
+        user = User.builder()
+                .socialProvider("kakao").socialId("recorder-probe").privacyConsent(true).build();
+        ReflectionTestUtils.setField(user, "id", UUID.randomUUID());
+        session = Session.builder().user(user).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+    }
+
+    private double counter(String outcome) {
+        return meterRegistry.find("mio.crisis.records").tag("outcome", outcome)
+                .counters().stream()
+                .mapToDouble(io.micrometer.core.instrument.Counter::count).sum();
+    }
+
+    private boolean record() {
+        return recorder.record(user, session, 3, "keyword");
+    }
+
+    @Test
+    @DisplayName("첫 시도에 성공하면 재시도 없이 이벤트를 발행한다")
+    void recordsOnFirstAttempt() {
+        when(writer.write(any(), any(), anyInt(), anyString())).thenReturn(UUID.randomUUID());
+
+        assertThat(record()).isTrue();
+
+        verify(writer).write(any(), any(), anyInt(), anyString());
+        verify(publisher).publishEvent(any(CrisisDetectedEvent.class));
+        assertThat(sleeps).isEmpty();
+        assertThat(counter("recorded")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("일시 실패는 재시도로 복구하고 성공으로 기록한다")
+    void retriesTransientFailure() {
+        when(writer.write(any(), any(), anyInt(), anyString()))
+                .thenThrow(new RuntimeException("deadlock"))
+                .thenReturn(UUID.randomUUID());
+
+        assertThat(record()).isTrue();
+
+        assertThat(sleeps).as("한 번 실패했으므로 한 번 대기").hasSize(1);
+        verify(publisher).publishEvent(any(CrisisDetectedEvent.class));
+        assertThat(counter("recorded")).isEqualTo(1.0);
+        assertThat(counter("failed")).isZero();
+    }
+
+    /**
+     * 발행은 프로파일 캐시를 지운다. 저장이 실패했는데 지우면, 재빌드가 읽을 이력이 없어
+     * "반영됐다"는 잘못된 인상만 남는다.
+     */
+    @Test
+    @DisplayName("저장에 끝내 실패하면 이벤트를 발행하지 않고 안전 래치를 올린다")
+    void raisesLatchAndSkipsPublishWhenExhausted() {
+        when(writer.write(any(), any(), anyInt(), anyString()))
+                .thenThrow(new RuntimeException("db down"));
+
+        assertThat(record()).isFalse();
+
+        verify(writer, org.mockito.Mockito.times(CrisisEventRecorder.MAX_ATTEMPTS))
+                .write(any(), any(), anyInt(), anyString());
+        verify(publisher, never()).publishEvent(any());
+        verify(latch).raise(user.getId(), 3);
+        assertThat(counter("failed")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("재시도 대기는 지수적으로 늘고 지터가 섞인다")
+    void backOffGrowsWithJitter() {
+        when(writer.write(any(), any(), anyInt(), anyString()))
+                .thenThrow(new RuntimeException("db down"));
+
+        record();
+
+        assertThat(sleeps).hasSize(CrisisEventRecorder.MAX_ATTEMPTS - 1);
+        // 1차: base ~ 2*base, 2차: 2*base ~ 4*base
+        assertThat(sleeps.get(0))
+                .isBetween(CrisisEventRecorder.BASE_DELAY_MS, CrisisEventRecorder.BASE_DELAY_MS * 2);
+        assertThat(sleeps.get(1))
+                .isBetween(CrisisEventRecorder.BASE_DELAY_MS * 2, CrisisEventRecorder.BASE_DELAY_MS * 4);
+    }
+
+    /**
+     * 기록에 성공하면 실제 이력이 생겼으므로 이전에 올려둔 래치는 의미가 없다.
+     * 남겨두면 그 사용자가 14일 내내 불필요하게 degraded 로 취급된다.
+     */
+    @Test
+    @DisplayName("기록에 성공하면 이전 래치를 내린다")
+    void clearsLatchOnSuccess() {
+        when(writer.write(any(), any(), anyInt(), anyString())).thenReturn(UUID.randomUUID());
+
+        record();
+
+        verify(latch).clear(user.getId());
+        verify(latch, never()).raise(any(), anyInt());
+    }
+
+    @Test
+    @DisplayName("대기 중 인터럽트되면 즉시 중단하고 래치를 올린다")
+    void stopsOnInterrupt() {
+        when(writer.write(any(), any(), anyInt(), anyString()))
+                .thenThrow(new RuntimeException("db down"));
+        recorder = new CrisisEventRecorder(writer, latch, publisher, meterRegistry, millis -> {
+            throw new InterruptedException("shutdown");
+        });
+
+        assertThat(record()).isFalse();
+
+        verify(writer, org.mockito.Mockito.times(1)).write(any(), any(), anyInt(), anyString());
+        verify(latch).raise(user.getId(), 3);
+        assertThat(Thread.interrupted()).as("인터럽트 상태를 복원해야 한다").isTrue();
+    }
+}

--- a/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisFlowServiceTest.java
@@ -1,14 +1,12 @@
 package com.mio.ai.crisis;
 
 import com.mio.ai.safety.SafetyL1Result;
-import com.mio.crisis.domain.CrisisEvent;
 import com.mio.session.domain.Session;
 import com.mio.session.dto.SseEventDto;
 import com.mio.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyEmitter;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -19,6 +17,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -27,9 +28,9 @@ class CrisisFlowServiceTest {
     @Test
     @DisplayName("crisis done 이벤트에도 CBT emotion_score를 전달한다")
     void handle_sends_emotion_score_in_crisis_done_event() throws Exception {
-        CrisisEventRepository crisisEventRepository = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        CrisisFlowService service = new CrisisFlowService(crisisEventRepository, eventPublisher);
+        CrisisEventRecorder crisisEventRecorder = mock(CrisisEventRecorder.class);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
+        CrisisFlowService service = new CrisisFlowService(crisisEventRecorder);
         SseEmitter emitter = mock(SseEmitter.class);
 
         User user = User.builder()
@@ -69,8 +70,7 @@ class CrisisFlowServiceTest {
         assertThat(doneEvent.emotionScore()).isEqualTo(18);
         assertThat(doneEvent.isCrisisFlagged()).isTrue();
         assertThat(doneEvent.finishedReason()).isEqualTo("crisis_flow");
-        verify(crisisEventRepository).save(any());
-        verify(eventPublisher).publishEvent(any(CrisisDetectedEvent.class));
+        verify(crisisEventRecorder).record(any(), any(), anyInt(), anyString());
     }
 
     /**
@@ -84,9 +84,9 @@ class CrisisFlowServiceTest {
     @Test
     @DisplayName("강등된 위기가 위기 플로우에 도달하면 severity 3과 핫라인을 보장한다")
     void unverifiedCrisisStillGetsSeverityThreeAndHotline() throws Exception {
-        CrisisEventRepository crisisEventRepository = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        CrisisFlowService service = new CrisisFlowService(crisisEventRepository, eventPublisher);
+        CrisisEventRecorder crisisEventRecorder = mock(CrisisEventRecorder.class);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
+        CrisisFlowService service = new CrisisFlowService(crisisEventRecorder);
         SseEmitter emitter = mock(SseEmitter.class);
 
         User user = User.builder()
@@ -132,9 +132,9 @@ class CrisisFlowServiceTest {
         // 강등된 위기도 발단은 키워드 매칭이다. PolicyEngine 이 L1_KEYWORD 로 확정해 넘기므로
         // hardCrisis 값과 무관하게 keyword 로 기록되어야 한다 (이슈 #260 이전에는 역추론이라
         // 검증을 거쳐 확정된 위기가 moderation 으로 기록됐다).
-        ArgumentCaptor<CrisisEvent> persisted = ArgumentCaptor.forClass(CrisisEvent.class);
-        verify(crisisEventRepository).save(persisted.capture());
-        assertThat(persisted.getValue().getTriggerType()).isEqualTo("keyword");
+        ArgumentCaptor<String> triggerType = ArgumentCaptor.forClass(String.class);
+        verify(crisisEventRecorder).record(any(), any(), anyInt(), triggerType.capture());
+        assertThat(triggerType.getValue()).isEqualTo("keyword");
     }
 
     /**
@@ -146,9 +146,9 @@ class CrisisFlowServiceTest {
     @Test
     @DisplayName("자해 질의 위기는 수단을 거절하면서 핫라인을 노출하고 기록된다")
     void selfHarmInquiryRefusesMeansAndStillConnectsHelp() throws Exception {
-        CrisisEventRepository crisisEventRepository = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        CrisisFlowService service = new CrisisFlowService(crisisEventRepository, eventPublisher);
+        CrisisEventRecorder crisisEventRecorder = mock(CrisisEventRecorder.class);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
+        CrisisFlowService service = new CrisisFlowService(crisisEventRecorder);
         SseEmitter emitter = mock(SseEmitter.class);
 
         User user = User.builder()
@@ -196,11 +196,9 @@ class CrisisFlowServiceTest {
                 .as("거절만 하고 끝내지 않고 도움으로 연결한다")
                 .contains("전문가");
 
-        ArgumentCaptor<CrisisEvent> persisted = ArgumentCaptor.forClass(CrisisEvent.class);
-        verify(crisisEventRepository).save(persisted.capture());
-        assertThat(persisted.getValue().getTriggerType()).isEqualTo("keyword");
-        assertThat(persisted.getValue().getSeverity()).isEqualTo(3);
-        verify(eventPublisher).publishEvent(any(CrisisDetectedEvent.class));
+        ArgumentCaptor<String> triggerType = ArgumentCaptor.forClass(String.class);
+        verify(crisisEventRecorder).record(any(), any(), anyInt(), triggerType.capture());
+        assertThat(triggerType.getValue()).isEqualTo("keyword");
     }
 
     /**
@@ -212,9 +210,9 @@ class CrisisFlowServiceTest {
     @Test
     @DisplayName("출력 가드가 잡은 위기는 pattern으로 기록된다")
     void outputGuardCrisisIsRecordedAsPattern() throws Exception {
-        CrisisEventRepository crisisEventRepository = mock(CrisisEventRepository.class);
-        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
-        CrisisFlowService service = new CrisisFlowService(crisisEventRepository, eventPublisher);
+        CrisisEventRecorder crisisEventRecorder = mock(CrisisEventRecorder.class);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
+        CrisisFlowService service = new CrisisFlowService(crisisEventRecorder);
         SseEmitter emitter = mock(SseEmitter.class);
 
         User user = User.builder()
@@ -232,9 +230,9 @@ class CrisisFlowServiceTest {
         service.handle(SafetyL1Result.clear(), CrisisTrigger.OUTPUT_GUARD, "요즘 좀 지쳐요",
                 user, session, emitter, "msg_out_test", 40);
 
-        ArgumentCaptor<CrisisEvent> persisted = ArgumentCaptor.forClass(CrisisEvent.class);
-        verify(crisisEventRepository).save(persisted.capture());
-        assertThat(persisted.getValue().getTriggerType()).isEqualTo("pattern");
+        ArgumentCaptor<String> triggerType = ArgumentCaptor.forClass(String.class);
+        verify(crisisEventRecorder).record(any(), any(), anyInt(), triggerType.capture());
+        assertThat(triggerType.getValue()).isEqualTo("pattern");
     }
 
     private Set<ResponseBodyEmitter.DataWithMediaType> extractData(SseEmitter.SseEventBuilder builder) {

--- a/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
+++ b/src/test/java/com/mio/ai/profile/SafetyProfileBuilderTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.crisis.CrisisSafetyLatch;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,6 +33,7 @@ class SafetyProfileBuilderTest {
 
     private JdbcTemplate jdbcTemplate;
     private MeterRegistry meterRegistry;
+    private CrisisSafetyLatch crisisSafetyLatch;
     private SafetyProfileBuilder builder;
 
     private final String userId = UUID.randomUUID().toString();
@@ -40,8 +42,9 @@ class SafetyProfileBuilderTest {
     void setUp() {
         jdbcTemplate = mock(JdbcTemplate.class);
         meterRegistry = new SimpleMeterRegistry();
+        crisisSafetyLatch = mock(CrisisSafetyLatch.class);
         builder = new SafetyProfileBuilder(
-                mock(StringRedisTemplate.class), jdbcTemplate, new ObjectMapper(), meterRegistry);
+                mock(StringRedisTemplate.class), jdbcTemplate, new ObjectMapper(), meterRegistry, crisisSafetyLatch);
         stubNonCrisisQueries();
     }
 
@@ -137,7 +140,8 @@ class SafetyProfileBuilderTest {
                 .thenThrow(new RuntimeException("db down"));
 
         SafetyProfile profile = new SafetyProfileBuilder(
-                mock(StringRedisTemplate.class), broken, new ObjectMapper(), meterRegistry).buildSync(userId);
+                mock(StringRedisTemplate.class), broken, new ObjectMapper(), meterRegistry,
+                crisisSafetyLatch).buildSync(userId);
 
         assertThat(profile.hasForceJudge()).isTrue();
         assertThat(profile.emotionDropThreshold()).isEqualTo(25.0);
@@ -248,6 +252,38 @@ class SafetyProfileBuilderTest {
 
         assertThat(profile.degraded()).isTrue();
         assertThat(profile.hasForceJudge()).isTrue();
+    }
+
+    /**
+     * crisis_events 저장이 끝내 실패한 위기가 있으면 조회는 성공해도 그 위기가 테이블에 없다.
+     * 래치가 그 사실을 알려주지 않으면, 방금 위기를 겪은 사용자가 다음 세션에서 아무 일 없었던
+     * 사람으로 처리된다 (이슈 P0-B).
+     */
+    @Test
+    @DisplayName("기록하지 못한 위기가 있으면 조회가 성공해도 보수적으로 만든다")
+    void unrecordedCrisisLatchForcesConservativeProfile() {
+        stubCrisisQuery(0);
+        when(crisisSafetyLatch.isRaised(any(UUID.class))).thenReturn(true);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.degraded())
+                .as("이력이 비어 보여도 기록 실패가 있었으면 신뢰할 수 없다")
+                .isTrue();
+        assertThat(profile.hasForceJudge()).isTrue();
+        assertThat(profile.emotionDropThreshold()).isEqualTo(25.0);
+    }
+
+    @Test
+    @DisplayName("래치가 없으면 정상 조회 결과를 그대로 쓴다")
+    void noLatchKeepsNormalProfile() {
+        stubCrisisQuery(0);
+        when(crisisSafetyLatch.isRaised(any(UUID.class))).thenReturn(false);
+
+        SafetyProfile profile = builder.buildSync(userId);
+
+        assertThat(profile.degraded()).isFalse();
+        assertThat(profile.hasForceJudge()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## 문제

`CrisisFlowService.persistCrisisEvent` 가 저장 예외를 `log.error` 로 삼켰다.

`crisis_events` 를 읽는 프로덕션 코드는 `SafetyProfileBuilder.queryRecentCrisis` **하나뿐**이고,
그 값이 `riskPrior`·`force_judge`·동적 임계값을 정한다. **기록이 유실되면 방금 위기를 겪은
사용자가 다음 세션에서 아무 일 없었던 사람이 된다.**

여기에 발행 순서 문제가 겹쳤다. 저장 성공 여부와 무관하게 `CrisisDetectedEvent` 를 발행했는데,
이 이벤트는 프로파일 캐시를 지우고 다음 빌드가 `crisis_events` 를 다시 읽게 한다. 저장이
실패한 상태에서는 읽을 이력이 없어 발행이 무의미하고, "반영됐다"는 잘못된 인상만 남는다.

## 설계

세 조각으로 나눴다.

| 컴포넌트 | 역할 |
|---|---|
| `CrisisEventWriter` | `REQUIRES_NEW` 단일 저장. 예외를 삼키지 않는다 |
| `CrisisEventRecorder` | 재시도 + 성공 시에만 발행 + 실패 시 래치 + 지표 |
| `CrisisSafetyLatch` | 기록하지 못한 위기를 Redis 에 표시 (TTL 14일) |

### 왜 별도 빈인가

두 가지 이유다.

1. `REQUIRES_NEW` 는 프록시를 거쳐야 실제로 새 트랜잭션이 열린다. 같은 클래스 안에서 호출하면
   self-invocation 이라 무시된다 (`SummaryStatusWriter` 와 같은 이유)
2. **시도마다 트랜잭션이 새로 열려야 한다.** 한 트랜잭션 안에서 재시도하면 첫 실패로 이미
   rollback-only 가 찍혀 이후 시도가 전부 실패한다

### 왜 래치를 Redis 에 두는가

**저장이 실패하는 상황은 대개 Postgres 쪽 문제다.** 같은 DB 에 보상 레코드를 남기는 방식은
— `outbox_events` 를 포함해 — 그 순간 함께 실패한다. 래치는 "DB 는 못 쓰지만 Redis 는 산다"는
부분 장애를 노린다.

TTL 14일은 위기 이력 조회 창과 맞췄다. 그 창을 넘기면 어차피 프로파일이 참조하지 않는다.

Redis 마저 실패하면 남는 것은 로그와 지표뿐이다. 그 경우까지 덮으려면 사후에 대화 원문에서
위기 턴을 재식별하는 복구가 필요하며 별도 과제다.

### 래치를 실제로 쓰는 곳

`SafetyProfileBuilder` 가 래치를 함께 본다. **이게 없으면 래치를 올려도 아무 효과가 없다** —
조회는 성공했으니 `degraded` 로 잡히지 않고, 이력은 비어 있으니 `force_judge` 도 안 붙는다.

```java
boolean unrecordedCrisis = crisisSafetyLatch.isRaised(userUUID);
boolean degraded = !crisisHistory.resolved()
        || !beliefs.resolved()
        || !patterns.resolved()
        || unrecordedCrisis;
```

기록에 성공하면 래치를 내린다. 남겨두면 그 사용자가 14일 내내 불필요하게 degraded 로 취급된다.

## 재시도

지터를 섞은 지수 백오프로 3회까지. 사용자는 이미 위기 안내를 받았고 이 경로는 요청을 붙잡지
않으므로 짧게만 한다. 대기는 `Sleeper` 로 분리해 테스트가 실제로 기다리지 않는다.

## 지표

`mio.crisis.records{outcome=recorded|failed}` 를 추가했다. 다만 **actuator 노출이 아직
`health,info` 뿐이라 외부에서 읽히지 않는다** — P0-C 에서 Prometheus 레지스트리와 관리 포트를
붙여야 실제로 볼 수 있다. 이번 PR 에서 해결하지 않는다.

## 테스트

**559건 통과.** 신규 8건.

| 테스트 | 고정하는 것 |
|---|---|
| `recordsOnFirstAttempt` | 성공 시 재시도 없이 발행 |
| `retriesTransientFailure` | 일시 실패 복구 |
| `raisesLatchAndSkipsPublishWhenExhausted` | **실패 시 발행 안 함 + 래치** |
| `backOffGrowsWithJitter` | 지수 백오프와 지터 범위 |
| `clearsLatchOnSuccess` | 성공 시 래치 해제 |
| `stopsOnInterrupt` | 인터럽트 시 중단 + 상태 복원 |
| `unrecordedCrisisLatchForcesConservativeProfile` | **래치가 실제로 프로파일을 보수적으로 만든다** |
| `noLatchKeepsNormalProfile` | 래치 없으면 정상 |

## 남은 것

- **운영자 알림** — 이 저장소에 채널이 하나도 없다(Slack·이메일·웹훅·Sentry 전부 0건).
  채널 신설이 전제라 별도 과제
- **메트릭 외부 노출** — P0-C
- **사후 원문 기반 복구** — Redis 마저 실패한 경우

Closes #269


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Crisis events are now retried automatically when recording fails.
  * Unrecorded crises are tracked and trigger safer, conservative profile handling.
  * Crisis flow results now indicate whether the event was successfully recorded.

* **Bug Fixes**
  * Prevented downstream crisis notifications from being published before successful persistence.
  * Recording continues even when crisis-response delivery fails.

* **Monitoring**
  * Added success and failure metrics for crisis event recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->