### PR TITLE
feat: AI 파이프라인 계측 — 지표 노출·LLM usage 파싱·비용 기록

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,12 +102,20 @@ Flyway가 시작 시 자동으로 DB 마이그레이션을 수행합니다.
 ### 6. 동작 확인
 
 ```bash
-# Health check
-curl http://localhost:8080/actuator/health
+# Health check (liveness — 프로세스가 응답 가능한지만 확인)
+curl http://localhost:8080/health
 
 # Swagger UI
 open http://localhost:8080/swagger-ui.html
+
+# 의존성까지 포함한 상태·메트릭은 관리 포트(9090)에 있다.
+# 운영에서는 publish 하지 않으므로 컨테이너 밖에서 도달할 수 없다.
+curl http://localhost:9090/actuator/health
+curl http://localhost:9090/actuator/prometheus | grep '^mio_'
 ```
+
+> 운영 서버에서 스크레이프하려면:
+> `docker compose exec app curl -s localhost:9090/actuator/prometheus`
 
 ---
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,10 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
 
+    // Metrics — Micrometer 카운터를 Prometheus 포맷으로 스크레이프 가능하게 만든다.
+    // 이 레지스트리가 없으면 코드가 기록하는 지표를 프로세스 밖에서 읽을 방법이 없다.
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+
     // Database
     runtimeOnly("org.postgresql:postgresql")
     implementation("org.flywaydb:flyway-database-postgresql")

--- a/src/main/java/com/mio/MioApplication.java
+++ b/src/main/java/com/mio/MioApplication.java
@@ -2,10 +2,12 @@ package com.mio;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 @EnableAsync
 @EnableScheduling
 public class MioApplication {

--- a/src/main/java/com/mio/ai/llm/LlmClient.java
+++ b/src/main/java/com/mio/ai/llm/LlmClient.java
@@ -10,9 +10,10 @@ public interface LlmClient {
      *
      * @param request      the LLM request
      * @param chunkHandler called for each content chunk
-     * @return time to first token in milliseconds
+     * @return time to first token and token usage; usage is
+     *         {@link LlmUsage#unresolved(String)} when the provider did not report it
      */
-    long stream(LlmRequest request, Consumer<String> chunkHandler);
+    LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler);
 
     /** Sends a non-streaming request for a natural-language response. */
     String completeText(LlmRequest request);

--- a/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
+++ b/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
@@ -1,0 +1,65 @@
+package com.mio.ai.llm;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+
+/**
+ * 토큰 사용량을 USD 비용으로 환산한다.
+ *
+ * <p>환산할 수 없으면 {@code null} 을 돌려준다. 0 을 돌려주지 않는 이유는
+ * {@link LlmUsage} 와 같다 — "비용이 0" 과 "비용을 모른다" 가 같은 값이 되면
+ * 단가 미등록·사용량 미수신을 사후에 구분할 수 없다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LlmCostCalculator {
+
+    private static final BigDecimal TOKENS_PER_PRICE_UNIT = new BigDecimal("1000000");
+    /**
+     * 한 호출의 비용은 아주 작을 수 있다. 임베딩 24 토큰은 $0.02/1M 기준 4.8e-7 달러라
+     * 마이크로달러(1e-6)에서 끊으면 <b>0 으로 반올림돼 임베딩 비용이 영원히 0 으로 누적된다.</b>
+     * 가장 싼 모델의 1 토큰(2e-8)도 살아남도록 잡는다.
+     */
+    private static final int COST_SCALE = 10;
+
+    private final LlmPricingProperties pricing;
+
+    /**
+     * @return 비용(USD). 사용량을 못 받았거나 단가가 등록되지 않은 모델이면 {@code null}
+     */
+    public BigDecimal costUsd(LlmUsage usage) {
+        if (usage == null || !usage.resolved()) {
+            return null;
+        }
+        LlmPricingProperties.ModelPrice price = pricing.getModels().get(usage.model());
+        if (price == null || !price.isValid()) {
+            log.warn("LLM 단가 미등록 모델이라 비용을 계산하지 못했다: model={}. "
+                    + "openai.pricing.models 에 추가해야 비용 집계가 맞는다", usage.model());
+            return null;
+        }
+
+        BigDecimal inputCost = price.input()
+                .multiply(BigDecimal.valueOf(usage.promptTokens()))
+                .divide(TOKENS_PER_PRICE_UNIT, MathContext.DECIMAL64);
+        BigDecimal outputCost = price.output()
+                .multiply(BigDecimal.valueOf(usage.completionTokens()))
+                .divide(TOKENS_PER_PRICE_UNIT, MathContext.DECIMAL64);
+
+        // stripTrailingZeros 로 0.0004500000 대신 0.00045 를 남긴다.
+        return inputCost.add(outputCost)
+                .setScale(COST_SCALE, RoundingMode.HALF_UP)
+                .stripTrailingZeros();
+    }
+
+    /** 단가가 등록된 모델인지. 메트릭에서 미등록 모델을 별도 태그로 세기 위해 쓴다. */
+    public boolean hasPrice(String model) {
+        LlmPricingProperties.ModelPrice price = pricing.getModels().get(model);
+        return price != null && price.isValid();
+    }
+}

--- a/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
+++ b/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
@@ -7,6 +7,8 @@ import org.springframework.stereotype.Component;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * 토큰 사용량을 USD 비용으로 환산한다.
@@ -29,6 +31,7 @@ public class LlmCostCalculator {
     private static final int COST_SCALE = 10;
 
     private final LlmPricingProperties pricing;
+    private final Set<String> warnedModels = ConcurrentHashMap.newKeySet();
 
     /**
      * @return 비용(USD). 사용량을 못 받았거나 단가가 등록되지 않은 모델이면 {@code null}
@@ -39,8 +42,12 @@ public class LlmCostCalculator {
         }
         LlmPricingProperties.ModelPrice price = pricing.getModels().get(usage.model());
         if (price == null || !price.isValid()) {
-            log.warn("LLM 단가 미등록 모델이라 비용을 계산하지 못했다: model={}. "
-                    + "openai.pricing.models 에 추가해야 비용 집계가 맞는다", usage.model());
+            // 모델당 한 번만 경고한다. 매 호출마다 찍으면 요청 속도로 로그가 쏟아져
+            // 정작 읽어야 할 다른 경고를 덮는다. 발생 횟수는 mio.llm.cost.unpriced 가 센다.
+            if (warnedModels.add(usage.model())) {
+                log.warn("LLM 단가 미등록 모델이라 비용을 계산하지 못했다: model={}. "
+                        + "openai.pricing.models 에 추가해야 비용 집계가 맞는다", usage.model());
+            }
             return null;
         }
 
@@ -55,11 +62,5 @@ public class LlmCostCalculator {
         return inputCost.add(outputCost)
                 .setScale(COST_SCALE, RoundingMode.HALF_UP)
                 .stripTrailingZeros();
-    }
-
-    /** 단가가 등록된 모델인지. 메트릭에서 미등록 모델을 별도 태그로 세기 위해 쓴다. */
-    public boolean hasPrice(String model) {
-        LlmPricingProperties.ModelPrice price = pricing.getModels().get(model);
-        return price != null && price.isValid();
     }
 }

--- a/src/main/java/com/mio/ai/llm/LlmPricingProperties.java
+++ b/src/main/java/com/mio/ai/llm/LlmPricingProperties.java
@@ -1,0 +1,40 @@
+package com.mio.ai.llm;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * 모델별 토큰 단가. 단위는 <b>100만 토큰당 USD</b> — OpenAI 가격표 표기와 같은 단위를 써서
+ * 설정값을 가격표에서 그대로 옮길 수 있게 한다.
+ *
+ * <p>여기 없는 모델은 비용을 <b>0 이 아니라 '미상'</b> 으로 처리한다
+ * ({@link LlmCostCalculator}). 모델을 새로 도입하면서 단가 등록을 잊었을 때
+ * 비용이 0 으로 집계되면 그 사실 자체를 알아챌 방법이 없기 때문이다.
+ */
+@ConfigurationProperties(prefix = "openai.pricing")
+public class LlmPricingProperties {
+
+    private Map<String, ModelPrice> models = new LinkedHashMap<>();
+
+    public Map<String, ModelPrice> getModels() {
+        return Map.copyOf(models);
+    }
+
+    public void setModels(Map<String, ModelPrice> models) {
+        this.models = models != null ? new LinkedHashMap<>(models) : new LinkedHashMap<>();
+    }
+
+    /**
+     * @param input  입력 토큰 100만 개당 USD
+     * @param output 출력 토큰 100만 개당 USD
+     */
+    public record ModelPrice(BigDecimal input, BigDecimal output) {
+        public boolean isValid() {
+            return input != null && output != null
+                    && input.signum() >= 0 && output.signum() >= 0;
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/llm/LlmStreamResult.java
+++ b/src/main/java/com/mio/ai/llm/LlmStreamResult.java
@@ -1,0 +1,10 @@
+package com.mio.ai.llm;
+
+/**
+ * 스트리밍 호출 한 번의 결과.
+ *
+ * @param ttftMs 첫 토큰까지 걸린 시간(ms). 토큰이 하나도 오지 않았으면 전체 소요 시간
+ * @param usage  토큰 사용량. 받지 못했으면 {@link LlmUsage#unresolved(String)}
+ */
+public record LlmStreamResult(long ttftMs, LlmUsage usage) {
+}

--- a/src/main/java/com/mio/ai/llm/LlmUsage.java
+++ b/src/main/java/com/mio/ai/llm/LlmUsage.java
@@ -1,0 +1,34 @@
+package com.mio.ai.llm;
+
+/**
+ * LLM 한 번 호출의 토큰 사용량.
+ *
+ * <p>{@code resolved} 는 <b>"사용량을 실제로 받아왔는가"</b> 를 뜻한다. 응답에 {@code usage} 가
+ * 없었거나 스트림이 중간에 끊겨 사용량을 못 읽은 경우 {@link #unresolved(String)} 로 남기고,
+ * 토큰 수를 0 으로 채우지 않는다. 0 으로 채우면 "토큰을 안 썼다" 와 "얼마나 썼는지 모른다" 가
+ * 같은 값이 되어 비용 집계가 조용히 과소 계상된다.
+ *
+ * @param model            요청에 사용한 모델. 응답이 실제 서빙 모델을 알려주면 그 값
+ * @param promptTokens     입력 토큰. {@code resolved=false} 면 의미 없음
+ * @param completionTokens 출력 토큰. {@code resolved=false} 면 의미 없음
+ * @param resolved         사용량을 실제로 받아왔는지
+ */
+public record LlmUsage(
+        String model,
+        long promptTokens,
+        long completionTokens,
+        boolean resolved
+) {
+    public static LlmUsage of(String model, long promptTokens, long completionTokens) {
+        return new LlmUsage(model, promptTokens, completionTokens, true);
+    }
+
+    /** 사용량을 받지 못했다. 모델은 알 수 있으므로 함께 남긴다. */
+    public static LlmUsage unresolved(String model) {
+        return new LlmUsage(model, 0L, 0L, false);
+    }
+
+    public long totalTokens() {
+        return promptTokens + completionTokens;
+    }
+}

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -69,9 +69,13 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         long startMs = System.currentTimeMillis();
         AtomicLong ttft = new AtomicLong(0);
         AtomicReference<LlmUsage> usage = new AtomicReference<>();
-        // 이 호출의 결말을 이미 셌는지. 아래 catch 는 우리가 던진 예외와 청크 핸들러가 던진
-        // 예외를 함께 받는데, 전자는 이미 세어져 있어 이 표시가 없으면 이중 계상된다.
-        boolean outcomeRecorded = false;
+        // 이 호출의 종료(outcome + usage)를 이미 기록했는지. 아래 catch 는 우리가 던진 예외와
+        // 청크 핸들러가 던진 예외를 함께 받는데, 전자는 이미 기록돼 있어 표시가 없으면 이중 계상된다.
+        //
+        // outcome 과 usage 를 이 표시 하나로 함께 묶는다. 둘을 따로 두면 "요청은 셌는데 usage 는
+        // 안 센" 경로가 생겨 mio.llm.requests 합계와 mio.llm.usage 합계가 어긋나고,
+        // 그러면 계측 자체를 대사할 수 없다. 모든 종료 경로는 둘 다 정확히 한 번씩 남긴다.
+        boolean terminalRecorded = false;
 
         int attempt = 0;
         while (true) {
@@ -95,7 +99,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     response.body().close();
                     if (attempt >= MAX_RETRIES) {
                         recordOutcome(request.model(), MODE_STREAM, "rate_limited");
-                        outcomeRecorded = true;
+                        recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                        terminalRecorded = true;
                         throw new RuntimeException("OpenAI API error: 429 (rate limited, max retries exceeded)");
                     }
                     // 재시도로 삼켜진 스로틀링은 결과가 success 라 mio.llm.requests 에 흔적이 없다.
@@ -118,7 +123,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 if (response.statusCode() != 200) {
                     response.body().close();
                     recordOutcome(request.model(), MODE_STREAM, "error");
-                    outcomeRecorded = true;
+                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                    terminalRecorded = true;
                     throw new RuntimeException("OpenAI API error: " + response.statusCode());
                 }
 
@@ -155,7 +161,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 // 청크 핸들러가 던진 예외가 여기로 온다 (오케스트레이터는 SSE IOException 을
                 // RuntimeException 으로 감싼다). 이 경로를 세지 않으면 과금은 됐는데 지표에는
                 // 아무것도 남지 않는다 — 실패가 "아무 일 없었던 것"이 되는 그 구조다.
-                if (!outcomeRecorded) {
+                if (!terminalRecorded) {
                     recordOutcome(request.model(), MODE_STREAM, "aborted");
                     recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
                 }
@@ -216,7 +222,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
     private String complete(LlmRequest request, boolean jsonResponse) {
         String mode = jsonResponse ? MODE_COMPLETE_JSON : MODE_COMPLETE_TEXT;
-        boolean outcomeRecorded = false;
+        boolean terminalRecorded = false;
         try {
             String requestBody = buildNonStreamingRequestBody(request, jsonResponse);
 
@@ -235,7 +241,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(request.model(), mode, "error");
-                outcomeRecorded = true;
+                recordUsage(mode, LlmUsage.unresolved(request.model()));
+                terminalRecorded = true;
                 throw new RuntimeException("OpenAI API error: " + response.statusCode());
             }
 
@@ -251,15 +258,18 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             recordOutcome(request.model(), mode, "interrupted");
+            recordUsage(mode, LlmUsage.unresolved(request.model()));
             throw new RuntimeException("LLM complete request interrupted", e);
         } catch (RuntimeException e) {
-            if (!outcomeRecorded) {
+            if (!terminalRecorded) {
                 recordOutcome(request.model(), mode, "aborted");
+                recordUsage(mode, LlmUsage.unresolved(request.model()));
             }
             throw e;
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());
             recordOutcome(request.model(), mode, "error");
+            recordUsage(mode, LlmUsage.unresolved(request.model()));
             throw new RuntimeException("LLM complete failed", e);
         }
     }
@@ -284,7 +294,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("embed() requires non-blank text");
         }
-        boolean outcomeRecorded = false;
+        boolean terminalRecorded = false;
         try {
             String requestBody = objectMapper.writeValueAsString(
                     Map.of("model", EMBEDDING_MODEL, "input", text));
@@ -302,7 +312,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                outcomeRecorded = true;
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+                terminalRecorded = true;
                 throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
             }
 
@@ -310,7 +321,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             JsonNode embeddingNode = root.path("data").path(0).path("embedding");
             if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                outcomeRecorded = true;
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+                terminalRecorded = true;
                 throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
             }
             float[] result = new float[embeddingNode.size()];
@@ -327,15 +339,18 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "interrupted");
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
             throw new RuntimeException("Embeddings request interrupted", e);
         } catch (RuntimeException e) {
-            if (!outcomeRecorded) {
+            if (!terminalRecorded) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "aborted");
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
             }
             throw e;
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
             throw new RuntimeException("Embeddings request failed", e);
         }
     }

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -36,6 +36,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private static final String TOKENS_METRIC = "mio.llm.tokens";
     private static final String COST_METRIC = "mio.llm.cost.usd";
     private static final String UNPRICED_METRIC = "mio.llm.cost.unpriced";
+    private static final String RETRIES_METRIC = "mio.llm.retries";
 
     private static final String MODE_STREAM = "stream";
     private static final String MODE_COMPLETE_TEXT = "complete_text";
@@ -68,6 +69,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         long startMs = System.currentTimeMillis();
         AtomicLong ttft = new AtomicLong(0);
         AtomicReference<LlmUsage> usage = new AtomicReference<>();
+        // 이 호출의 결말을 이미 셌는지. 아래 catch 는 우리가 던진 예외와 청크 핸들러가 던진
+        // 예외를 함께 받는데, 전자는 이미 세어져 있어 이 표시가 없으면 이중 계상된다.
+        boolean outcomeRecorded = false;
 
         int attempt = 0;
         while (true) {
@@ -91,8 +95,14 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     response.body().close();
                     if (attempt >= MAX_RETRIES) {
                         recordOutcome(request.model(), MODE_STREAM, "rate_limited");
+                        outcomeRecorded = true;
                         throw new RuntimeException("OpenAI API error: 429 (rate limited, max retries exceeded)");
                     }
+                    // 재시도로 삼켜진 스로틀링은 결과가 success 라 mio.llm.requests 에 흔적이 없다.
+                    // 요청 수를 시도 수로 오염시키지 않도록 별도 지표로 센다.
+                    meterRegistry.counter(RETRIES_METRIC,
+                            "model", request.model(), "mode", MODE_STREAM, "reason", "rate_limited")
+                            .increment();
                     long delayMs = streamRetryDelayMs(response, attempt);
                     log.warn("OpenAI rate limited (429), retrying in {}ms (attempt {}/{})",
                             delayMs, attempt + 1, MAX_RETRIES + 1);
@@ -108,6 +118,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 if (response.statusCode() != 200) {
                     response.body().close();
                     recordOutcome(request.model(), MODE_STREAM, "error");
+                    outcomeRecorded = true;
                     throw new RuntimeException("OpenAI API error: " + response.statusCode());
                 }
 
@@ -138,20 +149,27 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 recordOutcome(request.model(), MODE_STREAM, "interrupted");
+                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
                 throw new RuntimeException("LLM streaming request interrupted", e);
             } catch (RuntimeException e) {
+                // 청크 핸들러가 던진 예외가 여기로 온다 (오케스트레이터는 SSE IOException 을
+                // RuntimeException 으로 감싼다). 이 경로를 세지 않으면 과금은 됐는데 지표에는
+                // 아무것도 남지 않는다 — 실패가 "아무 일 없었던 것"이 되는 그 구조다.
+                if (!outcomeRecorded) {
+                    recordOutcome(request.model(), MODE_STREAM, "aborted");
+                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                }
                 throw e;
             } catch (Exception e) {
                 log.error("LLM streaming error: {}", e.getMessage());
                 recordOutcome(request.model(), MODE_STREAM, "error");
+                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
                 throw new RuntimeException("LLM streaming failed", e);
             }
         }
 
         recordOutcome(request.model(), MODE_STREAM, "success");
-        LlmUsage resolved = usage.get() != null
-                ? usage.get()
-                : LlmUsage.unresolved(request.model());
+        LlmUsage resolved = resolveUsage(usage, request.model());
         recordUsage(MODE_STREAM, resolved);
 
         long ttftMs = ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
@@ -198,6 +216,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
     private String complete(LlmRequest request, boolean jsonResponse) {
         String mode = jsonResponse ? MODE_COMPLETE_JSON : MODE_COMPLETE_TEXT;
+        boolean outcomeRecorded = false;
         try {
             String requestBody = buildNonStreamingRequestBody(request, jsonResponse);
 
@@ -216,6 +235,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(request.model(), mode, "error");
+                outcomeRecorded = true;
                 throw new RuntimeException("OpenAI API error: " + response.statusCode());
             }
 
@@ -233,6 +253,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             recordOutcome(request.model(), mode, "interrupted");
             throw new RuntimeException("LLM complete request interrupted", e);
         } catch (RuntimeException e) {
+            if (!outcomeRecorded) {
+                recordOutcome(request.model(), mode, "aborted");
+            }
             throw e;
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());
@@ -261,6 +284,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("embed() requires non-blank text");
         }
+        boolean outcomeRecorded = false;
         try {
             String requestBody = objectMapper.writeValueAsString(
                     Map.of("model", EMBEDDING_MODEL, "input", text));
@@ -278,6 +302,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
+                outcomeRecorded = true;
                 throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
             }
 
@@ -285,6 +310,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             JsonNode embeddingNode = root.path("data").path(0).path("embedding");
             if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
+                outcomeRecorded = true;
                 throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
             }
             float[] result = new float[embeddingNode.size()];
@@ -303,6 +329,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "interrupted");
             throw new RuntimeException("Embeddings request interrupted", e);
         } catch (RuntimeException e) {
+            if (!outcomeRecorded) {
+                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "aborted");
+            }
             throw e;
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
@@ -337,6 +366,12 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         // 임베딩 응답에는 completion_tokens 가 없다. 출력 토큰이 실제로 0 인 경우다.
         return LlmUsage.of(requestedModel, prompt.asLong(),
                 completion.isNumber() ? completion.asLong() : 0L);
+    }
+
+    /** 사용량을 못 받았으면 0 짜리 사용량이 아니라 '미상' 으로 만든다. */
+    private LlmUsage resolveUsage(AtomicReference<LlmUsage> usage, String model) {
+        LlmUsage parsed = usage.get();
+        return parsed != null ? parsed : LlmUsage.unresolved(model);
     }
 
     private void recordOutcome(String model, String mode, String outcome) {

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -2,10 +2,12 @@ package com.mio.ai.llm;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -15,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -28,25 +31,43 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private static final String DONE_MARKER = "data: [DONE]";
     private static final String DATA_PREFIX = "data: ";
 
+    private static final String REQUESTS_METRIC = "mio.llm.requests";
+    private static final String USAGE_METRIC = "mio.llm.usage";
+    private static final String TOKENS_METRIC = "mio.llm.tokens";
+    private static final String COST_METRIC = "mio.llm.cost.usd";
+    private static final String UNPRICED_METRIC = "mio.llm.cost.unpriced";
+
+    private static final String MODE_STREAM = "stream";
+    private static final String MODE_COMPLETE_TEXT = "complete_text";
+    private static final String MODE_COMPLETE_JSON = "complete_json";
+    private static final String MODE_EMBED = "embed";
+
     private final String apiKey;
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
+    private final LlmCostCalculator costCalculator;
 
     public OpenAiLlmClient(
             @Value("${openai.api-key}") String apiKey,
             HttpClient httpClient,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            MeterRegistry meterRegistry,
+            LlmCostCalculator costCalculator) {
         this.apiKey = apiKey;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistry;
+        this.costCalculator = costCalculator;
     }
 
     private static final int MAX_RETRIES = 4;
 
     @Override
-    public long stream(LlmRequest request, Consumer<String> chunkHandler) {
+    public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
         long startMs = System.currentTimeMillis();
         AtomicLong ttft = new AtomicLong(0);
+        AtomicReference<LlmUsage> usage = new AtomicReference<>();
 
         int attempt = 0;
         while (true) {
@@ -69,6 +90,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 if (response.statusCode() == 429) {
                     response.body().close();
                     if (attempt >= MAX_RETRIES) {
+                        recordOutcome(request.model(), MODE_STREAM, "rate_limited");
                         throw new RuntimeException("OpenAI API error: 429 (rate limited, max retries exceeded)");
                     }
                     long delayMs = streamRetryDelayMs(response, attempt);
@@ -76,12 +98,16 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                             delayMs, attempt + 1, MAX_RETRIES + 1);
                     Thread.sleep(delayMs);
                     attempt++;
+                    // 재시도는 앞선 시도의 결과를 버린다. 리셋하지 않으면 실패한 시도의
+                    // 사용량이 남아 최종 결과에 섞이거나 중복 집계된다.
                     ttft.set(0);
+                    usage.set(null);
                     continue;
                 }
 
                 if (response.statusCode() != 200) {
                     response.body().close();
+                    recordOutcome(request.model(), MODE_STREAM, "error");
                     throw new RuntimeException("OpenAI API error: " + response.statusCode());
                 }
 
@@ -89,8 +115,16 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     lines.filter(line -> line.startsWith(DATA_PREFIX))
                             .takeWhile(line -> !line.equals(DONE_MARKER))
                             .forEach(line -> {
-                                String json = line.substring(DATA_PREFIX.length());
-                                String content = extractDeltaContent(json);
+                                JsonNode chunk = readChunk(line.substring(DATA_PREFIX.length()));
+                                if (chunk == null) {
+                                    return;
+                                }
+                                // include_usage 를 켜면 마지막 청크가 choices=[] + usage 로 온다.
+                                LlmUsage chunkUsage = extractUsage(chunk, request.model());
+                                if (chunkUsage != null) {
+                                    usage.set(chunkUsage);
+                                }
+                                String content = extractDeltaContent(chunk);
                                 if (content != null && !content.isEmpty()) {
                                     if (ttft.get() == 0) {
                                         ttft.set(System.currentTimeMillis() - startMs);
@@ -103,16 +137,25 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
+                recordOutcome(request.model(), MODE_STREAM, "interrupted");
                 throw new RuntimeException("LLM streaming request interrupted", e);
             } catch (RuntimeException e) {
                 throw e;
             } catch (Exception e) {
                 log.error("LLM streaming error: {}", e.getMessage());
+                recordOutcome(request.model(), MODE_STREAM, "error");
                 throw new RuntimeException("LLM streaming failed", e);
             }
         }
 
-        return ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
+        recordOutcome(request.model(), MODE_STREAM, "success");
+        LlmUsage resolved = usage.get() != null
+                ? usage.get()
+                : LlmUsage.unresolved(request.model());
+        recordUsage(MODE_STREAM, resolved);
+
+        long ttftMs = ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
+        return new LlmStreamResult(ttftMs, resolved);
     }
 
     private long streamRetryDelayMs(HttpResponse<?> response, int attempt) {
@@ -137,6 +180,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         body.put("model", request.model());
         body.put("messages", messages);
         body.put("stream", true);
+        // 이걸 켜지 않으면 스트리밍 응답에는 usage 가 아예 오지 않는다.
+        body.put("stream_options", Map.of("include_usage", true));
 
         return objectMapper.writeValueAsString(body);
     }
@@ -152,6 +197,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     }
 
     private String complete(LlmRequest request, boolean jsonResponse) {
+        String mode = jsonResponse ? MODE_COMPLETE_JSON : MODE_COMPLETE_TEXT;
         try {
             String requestBody = buildNonStreamingRequestBody(request, jsonResponse);
 
@@ -169,17 +215,28 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             );
 
             if (response.statusCode() != 200) {
+                recordOutcome(request.model(), mode, "error");
                 throw new RuntimeException("OpenAI API error: " + response.statusCode());
             }
 
             JsonNode root = objectMapper.readTree(response.body());
+            // 비스트리밍 응답에는 usage 가 항상 실려 오는데 지금까지 읽지 않고 버렸다.
+            // 호출부가 12곳이라 반환 타입은 그대로 두고 메트릭으로만 남긴다.
+            LlmUsage usage = extractUsage(root, request.model());
+            recordOutcome(request.model(), mode, "success");
+            recordUsage(mode, usage != null ? usage : LlmUsage.unresolved(request.model()));
+
             return root.path("choices").path(0).path("message").path("content").asText();
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            recordOutcome(request.model(), mode, "interrupted");
             throw new RuntimeException("LLM complete request interrupted", e);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());
+            recordOutcome(request.model(), mode, "error");
             throw new RuntimeException("LLM complete failed", e);
         }
     }
@@ -220,37 +277,111 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     httpRequest, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() != 200) {
+                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
                 throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
             }
 
             JsonNode root = objectMapper.readTree(response.body());
             JsonNode embeddingNode = root.path("data").path(0).path("embedding");
             if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
+                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
                 throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
             }
             float[] result = new float[embeddingNode.size()];
             for (int i = 0; i < result.length; i++) {
                 result[i] = (float) embeddingNode.get(i).asDouble();
             }
+
+            // 임베딩도 과금 대상이다. 빼면 mio.llm.cost.usd 가 실제 지출보다 낮게 나온다.
+            LlmUsage usage = extractUsage(root, EMBEDDING_MODEL);
+            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "success");
+            recordUsage(MODE_EMBED, usage != null ? usage : LlmUsage.unresolved(EMBEDDING_MODEL));
+
             return result;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
+            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "interrupted");
             throw new RuntimeException("Embeddings request interrupted", e);
+        } catch (RuntimeException e) {
+            throw e;
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
+            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
             throw new RuntimeException("Embeddings request failed", e);
         }
     }
 
-    private String extractDeltaContent(String json) {
+    // ── usage 파싱·계측 ────────────────────────────────────────────
+
+    /**
+     * 응답(또는 스트리밍 청크)에서 usage 를 읽는다.
+     *
+     * <p>{@code usage} 가 없거나 null 이면 {@code null} 을 돌려준다 — 0 토큰짜리 사용량을
+     * 만들어내지 않는다. 스트리밍은 마지막 청크에만 usage 가 실려 오므로 중간 청크에서는
+     * 항상 {@code null} 이 나오는 게 정상이다.
+     *
+     * <p>모델 태그는 응답이 알려주는 실제 서빙 모델(예: {@code gpt-4o-2024-08-06})이 아니라
+     * <b>요청한 모델</b>을 쓴다. 날짜가 붙은 모델 ID 는 단가표 키와 어긋나고 태그 카디널리티만
+     * 늘린다.
+     */
+    private LlmUsage extractUsage(JsonNode root, String requestedModel) {
+        JsonNode usage = root.path("usage");
+        if (usage.isMissingNode() || usage.isNull()) {
+            return null;
+        }
+        JsonNode prompt = usage.path("prompt_tokens");
+        JsonNode completion = usage.path("completion_tokens");
+        if (!prompt.isNumber()) {
+            return null;
+        }
+        // 임베딩 응답에는 completion_tokens 가 없다. 출력 토큰이 실제로 0 인 경우다.
+        return LlmUsage.of(requestedModel, prompt.asLong(),
+                completion.isNumber() ? completion.asLong() : 0L);
+    }
+
+    private void recordOutcome(String model, String mode, String outcome) {
+        meterRegistry.counter(REQUESTS_METRIC, "model", model, "mode", mode, "outcome", outcome)
+                .increment();
+    }
+
+    private void recordUsage(String mode, LlmUsage usage) {
+        String model = usage.model();
+        if (!usage.resolved()) {
+            // "사용량을 못 받았다" 를 별도 값으로 남긴다. 토큰 0 으로 세면 조용히 과소 계상된다.
+            meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode, "outcome", "missing")
+                    .increment();
+            return;
+        }
+
+        meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode, "outcome", "resolved")
+                .increment();
+        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode, "type", "prompt")
+                .increment(usage.promptTokens());
+        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode, "type", "completion")
+                .increment(usage.completionTokens());
+
+        BigDecimal cost = costCalculator.costUsd(usage);
+        if (cost == null) {
+            meterRegistry.counter(UNPRICED_METRIC, "model", model, "mode", mode).increment();
+            return;
+        }
+        meterRegistry.counter(COST_METRIC, "model", model, "mode", mode)
+                .increment(cost.doubleValue());
+    }
+
+    private JsonNode readChunk(String json) {
         try {
-            JsonNode root = objectMapper.readTree(json);
-            JsonNode delta = root.path("choices").path(0).path("delta");
-            JsonNode content = delta.path("content");
-            if (!content.isMissingNode() && !content.isNull()) {
-                return content.asText();
-            }
-        } catch (Exception ignored) {
+            return objectMapper.readTree(json);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private String extractDeltaContent(JsonNode root) {
+        JsonNode delta = root.path("choices").path(0).path("delta");
+        JsonNode content = delta.path("content");
+        if (!content.isMissingNode() && !content.isNull()) {
+            return content.asText();
         }
         return null;
     }

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -6,6 +6,8 @@ import com.mio.ai.crisis.CrisisTrigger;
 import com.mio.ai.domain.AiPolicyDecision;
 import com.mio.ai.judge.OutputJudgeResult;
 import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.LlmUsage;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.policy.PolicyDecision;
 import com.mio.ai.repository.AiPolicyDecisionRepository;
@@ -16,9 +18,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
+import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.ToLongFunction;
 
 @Component
 @RequiredArgsConstructor
@@ -31,6 +35,7 @@ public class AiDecisionLogger {
 
     private final AiPolicyDecisionRepository repository;
     private final ObjectMapper objectMapper;
+    private final LlmCostCalculator costCalculator;
 
     @Async("aiDecisionLoggerExecutor")
     public void log(
@@ -50,7 +55,8 @@ public class AiDecisionLogger {
             boolean safetyProfileCacheHit,
             boolean memoryCacheHit,
             boolean safetyProfileDegraded,
-            CrisisTrigger appliedCrisisTrigger) {
+            CrisisTrigger appliedCrisisTrigger,
+            LlmUsage llmUsage) {
 
         try {
             Map<String, Object> trace = buildTrace(
@@ -58,7 +64,7 @@ public class AiDecisionLogger {
                     crisisFlowTriggered, decision,
                     inputJudgeCalled, preFilterResult, outputJudgeResult,
                     l1ThresholdSource, safetyProfileCacheHit, memoryCacheHit,
-                    safetyProfileDegraded, appliedCrisisTrigger);
+                    safetyProfileDegraded, appliedCrisisTrigger, llmUsage);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -98,7 +104,7 @@ public class AiDecisionLogger {
         log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered,
                 false, OutputPreFilterResult.pass(), null,
-                "default", false, false, false, decision.crisisTrigger());
+                "default", false, false, false, decision.crisisTrigger(), null);
     }
 
     private Map<String, Object> buildTrace(
@@ -115,7 +121,8 @@ public class AiDecisionLogger {
             boolean safetyProfileCacheHit,
             boolean memoryCacheHit,
             boolean safetyProfileDegraded,
-            CrisisTrigger appliedCrisisTrigger) {
+            CrisisTrigger appliedCrisisTrigger,
+            LlmUsage llmUsage) {
 
         Map<String, Object> l1Flags = new LinkedHashMap<>();
         l1Flags.put("crisis_keyword", l1Result.hardCrisis());
@@ -150,9 +157,19 @@ public class AiDecisionLogger {
         // 위기 이력을 확인하지 못한 턴은 임계값·force_judge 가 실제 이력과 무관하게 결정된다.
         trace.put("safety_profile_degraded", safetyProfileDegraded);
         trace.put("memory_cache_hit", memoryCacheHit);
-        trace.put("llm_model", "gpt-4o");
+        // LLM 관련 필드는 전부 null 이 될 수 있고, null 은 각각 다른 뜻이다.
+        //   llmUsage == null              → 이 턴은 LLM 을 호출하지 않았다 (보안 거절·위기·폴백)
+        //   llmUsage.resolved() == false  → 호출했지만 사용량을 받지 못했다
+        //   cost == null                  → 사용량을 모르거나 단가 미등록 모델이다
+        // 이전에는 세 경우 모두 model="gpt-4o", cost=0.0 으로 하드코딩돼 있어서
+        // "비용이 0" 과 "비용을 모른다" 가 구분되지 않았고, LLM 을 부르지도 않은 턴까지
+        // gpt-4o 를 쓴 것처럼 기록됐다.
+        trace.put("llm_model", llmUsage != null ? llmUsage.model() : null);
         trace.put("llm_ttft_ms", ttftMs);
-        trace.put("llm_cost_usd", 0.0);
+        trace.put("llm_usage_resolved", llmUsage != null ? llmUsage.resolved() : null);
+        trace.put("llm_prompt_tokens", resolvedTokens(llmUsage, LlmUsage::promptTokens));
+        trace.put("llm_completion_tokens", resolvedTokens(llmUsage, LlmUsage::completionTokens));
+        trace.put("llm_cost_usd", costUsd(llmUsage));
         trace.put("delivery_mode", decision.deliveryMode().name().toLowerCase());
         trace.put("output_pre_filter_result", preFilterResult != null
                 ? (preFilterResult.passed() ? "PASS" : "FAIL") : null);
@@ -173,5 +190,14 @@ public class AiDecisionLogger {
         trace.put("total_pipeline_ms", totalMs);
 
         return trace;
+    }
+
+    /** 사용량을 실제로 받았을 때만 토큰 수를 남긴다. 못 받았으면 0 이 아니라 null 이다. */
+    private Long resolvedTokens(LlmUsage usage, ToLongFunction<LlmUsage> field) {
+        return usage != null && usage.resolved() ? field.applyAsLong(usage) : null;
+    }
+
+    private BigDecimal costUsd(LlmUsage usage) {
+        return usage != null ? costCalculator.costUsd(usage) : null;
     }
 }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -24,6 +24,8 @@ import com.mio.ai.judge.OutputPreFilter;
 import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.LlmUsage;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.memory.working.WorkingMessage;
@@ -231,6 +233,9 @@ public class ConversationOrchestrator {
             // 7. Execute based on decision
             String assistantContent;
             long llmTtftMs = 0;
+            // LLM 을 호출하지 않은 턴(보안 거절·위기·폴백)에서는 null 로 남는다.
+            // 호출하지 않았다는 사실 자체가 기록돼야 하므로 빈 사용량으로 채우지 않는다.
+            LlmUsage llmUsage = null;
             boolean crisisFlowTriggered = false;
             // 실제로 위기 플로우를 발동시킨 경로. PolicyDecision 이 아니라 실행 결과를 따라간다 —
             // 출력 가드가 승격시킨 위기는 decision.action() 이 GENERATE 라 결정에 경로가 없다.
@@ -282,7 +287,10 @@ public class ConversationOrchestrator {
 
                 if (deliveryMode == DeliveryMode.BUFFER) {
                     // Buffer: complete first, then OutputGuard, then SSE
-                    llmTtftMs = llmClient.stream(llmRequest, withHeartbeat(turn, contentBuilder::append));
+                    LlmStreamResult streamResult =
+                            llmClient.stream(llmRequest, withHeartbeat(turn, contentBuilder::append));
+                    llmTtftMs = streamResult.ttftMs();
+                    llmUsage = streamResult.usage();
                     assistantContent = contentBuilder.toString();
 
                     preFilterResult = outputPreFilter.checkWithCrisisContext(assistantContent, inputHadRiskSignal);
@@ -317,7 +325,7 @@ public class ConversationOrchestrator {
                     AtomicReference<CompletableFuture<OutputJudgeResult>> earlyJudgeFutureRef = new AtomicReference<>();
                     AtomicReference<String> capturedSnapshotRef = new AtomicReference<>();
 
-                    llmTtftMs = llmClient.stream(llmRequest, withHeartbeat(turn, chunk -> {
+                    LlmStreamResult streamResult = llmClient.stream(llmRequest, withHeartbeat(turn, chunk -> {
                         contentBuilder.append(chunk);
                         if (!stopSendingDeltas.get()) {
                             int currentLen = contentBuilder.length();
@@ -346,6 +354,8 @@ public class ConversationOrchestrator {
                             }
                         }
                     }));
+                    llmTtftMs = streamResult.ttftMs();
+                    llmUsage = streamResult.usage();
 
                     assistantContent = contentBuilder.toString();
 
@@ -440,7 +450,7 @@ public class ConversationOrchestrator {
 
                 } else {
                     // SPECULATIVE: stream immediately, no post-guard
-                    llmTtftMs = llmClient.stream(llmRequest, withHeartbeat(turn, chunk -> {
+                    LlmStreamResult streamResult = llmClient.stream(llmRequest, withHeartbeat(turn, chunk -> {
                         contentBuilder.append(chunk);
                         try {
                             sendEvent(emitter, new SseEventDto.DeltaEvent(chunk, outboundMsgId));
@@ -448,6 +458,8 @@ public class ConversationOrchestrator {
                             throw new RuntimeException(e);
                         }
                     }));
+                    llmTtftMs = streamResult.ttftMs();
+                    llmUsage = streamResult.usage();
                     assistantContent = contentBuilder.toString();
                     sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                             userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
@@ -481,7 +493,7 @@ public class ConversationOrchestrator {
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
                     inputJudgeCalled, preFilterResult, judgeActionResult,
                     profile.source(), safetyProfileCacheHit, memoryCacheFallbackUsed,
-                    profile.degraded(), appliedCrisisTrigger);
+                    profile.degraded(), appliedCrisisTrigger, llmUsage);
 
             emitter.complete();
 

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -34,7 +34,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "POST /v1/auth/login",
             "POST /v1/auth/refresh",
             "POST /v1/auth/dev/token",
-            "GET /actuator/health"
+            // actuator 는 관리 포트로 분리됐다. 8080 의 liveness 는 HealthController 가 담당한다.
+            "GET /health"
     );
 
     private final JwtTokenService jwtTokenService;

--- a/src/main/java/com/mio/common/health/HealthController.java
+++ b/src/main/java/com/mio/common/health/HealthController.java
@@ -1,0 +1,33 @@
+package com.mio.common.health;
+
+import com.mio.common.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 메인 포트(8080)의 liveness 신호.
+ *
+ * <p>actuator 는 관리 포트로 분리돼 있어 8080 에서 도달할 수 없다. Nginx 는 8080 만 프록시하므로
+ * 외부 모니터가 확인할 수 있는 경로가 하나는 필요하다. Nginx 설정에도 이미 {@code /health} 가
+ * 헬스체크 경로로 잡혀 있는데, 지금까지 이 핸들러가 없어 401 을 반환하고 있었다.
+ *
+ * <p><b>이건 liveness 전용이다.</b> 프로세스가 요청을 받아 응답할 수 있다는 것만 뜻하며,
+ * DB·Redis·외부 API 상태는 보지 않는다. 의존성까지 포함한 판정은 관리 포트의
+ * {@code /actuator/health} 를 봐야 한다. 여기서 의존성을 확인하면 DB 순단마다 Nginx 헬스체크가
+ * 실패해 트래픽이 끊기므로, 두 신호를 의도적으로 분리한다.
+ */
+@RestController
+@Tag(name = "Health", description = "서비스 liveness 확인")
+public class HealthController {
+
+    @Operation(summary = "liveness 확인", description = "프로세스가 요청에 응답할 수 있는지만 확인한다. 의존성 상태는 포함하지 않는다.")
+    @GetMapping("/health")
+    public ResponseEntity<ApiResponse<Map<String, String>>> health() {
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("status", "UP")));
+    }
+}

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -3,8 +3,11 @@ package com.mio.config;
 import com.mio.auth.filter.JwtAuthenticationFilter;
 import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -22,13 +25,40 @@ public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private static final String[] PUBLIC_ENDPOINTS = {
-            "/actuator/health",
+            // actuator 는 관리 포트로 분리됐다. 8080 의 liveness 는 HealthController 가 담당한다.
+            "/health",
             "/error",
             "/v1/auth/**",
             "/api-docs/**",
             "/swagger-ui/**",
             "/swagger-ui.html"
     };
+
+    /**
+     * 관리 포트 전용 체인.
+     *
+     * <p>{@code EndpointRequest} 는 관리 포트가 메인 포트와 다르면 메인 포트 요청에는 매칭되지
+     * 않는다. 따라서 이 체인은 관리 포트에만 적용되고, 8080 의 {@code /actuator/**} 는 아래 메인
+     * 체인의 {@code anyRequest().authenticated()} 에 그대로 걸린다.
+     *
+     * <p>관리 포트를 인증 없이 여는 근거: Nginx 는 8080 만 프록시하고 관리 포트는
+     * {@code docker-compose.prod.yml} 에 publish 하지 않으므로 컨테이너 밖에서 도달할 수 없다.
+     * <b>이 포트를 publish 하게 되면 이 permitAll 부터 걷어내야 한다.</b>
+     */
+    @Bean
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    public SecurityFilterChain managementFilterChain(HttpSecurity http) throws Exception {
+        http
+                .securityMatcher(EndpointRequest.toAnyEndpoint())
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll());
+
+        return http.build();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,13 +68,22 @@ springdoc:
     disable-swagger-default-url: true
 
 management:
+  # 메인 포트(8080)와 분리한다. Nginx 는 8080 만 프록시하므로 관리 포트는 구조적으로
+  # 외부에서 도달할 수 없고, docker-compose.prod.yml 에도 publish 하지 않는다.
+  # 메인 포트에 노출하면 admin 롤이 없어 일반 로그인 사용자가 메트릭을 읽게 된다.
+  # 스크레이프: docker compose exec app curl -s localhost:9090/actuator/prometheus
+  server:
+    port: ${MANAGEMENT_PORT:9090}
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,metrics,prometheus
   endpoint:
     health:
-      show-details: when-authorized
+      show-details: always
+  metrics:
+    tags:
+      application: mio
 
 jwt:
   secret: ${JWT_SECRET}
@@ -109,6 +118,21 @@ notification:
 openai:
   api-key: ${OPENAI_API_KEY}
   base-url: https://api.openai.com
+  # 토큰 100만 개당 USD — OpenAI 가격표와 같은 단위라 값을 그대로 옮길 수 있다.
+  # 여기 없는 모델은 비용이 0 이 아니라 '미상'으로 기록되고 mio.llm.cost.unpriced 가 올라간다.
+  # 새 모델을 도입하면 여기에 단가를 같이 추가할 것.
+  pricing:
+    models:
+      "[gpt-4o]":
+        input: 2.50
+        output: 10.00
+      "[gpt-4o-mini]":
+        input: 0.15
+        output: 0.60
+      # 임베딩은 출력 토큰이 없다.
+      "[text-embedding-3-small]":
+        input: 0.02
+        output: 0.00
 
 logging:
   level:

--- a/src/test/java/com/mio/ai/judge/InputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/InputJudgeTest.java
@@ -84,7 +84,8 @@ class InputJudgeTest {
     private InputJudge judgeReturning(String responseJson) {
         LlmClient llmClient = new LlmClient() {
             @Override
-            public long stream(LlmRequest request, java.util.function.Consumer<String> chunkHandler) {
+            public com.mio.ai.llm.LlmStreamResult stream(
+                    LlmRequest request, java.util.function.Consumer<String> chunkHandler) {
                 throw new UnsupportedOperationException();
             }
 

--- a/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
+++ b/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
@@ -37,7 +37,6 @@ class LlmCostCalculatorTest {
         LlmCostCalculator calculator = calculator(Map.of());
 
         assertThat(calculator.costUsd(LlmUsage.of("gpt-5-future", 100, 50))).isNull();
-        assertThat(calculator.hasPrice("gpt-5-future")).isFalse();
     }
 
     @Test

--- a/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
+++ b/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
@@ -1,0 +1,81 @@
+package com.mio.ai.llm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LlmCostCalculatorTest {
+
+    @Test
+    @DisplayName("입력·출력 단가를 각각 적용해 합산한다")
+    void computesCostFromBothTokenKinds() {
+        LlmCostCalculator calculator = calculator(Map.of("gpt-4o",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), new BigDecimal("10.00"))));
+
+        // 2.50*2000/1e6 + 10.00*800/1e6 = 0.005 + 0.008
+        assertThat(calculator.costUsd(LlmUsage.of("gpt-4o", 2000, 800)))
+                .isEqualByComparingTo(new BigDecimal("0.013"));
+    }
+
+    @Test
+    @DisplayName("사용량을 못 받았으면 0이 아니라 null")
+    void unresolvedUsageHasNoCost() {
+        LlmCostCalculator calculator = calculator(Map.of("gpt-4o",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), new BigDecimal("10.00"))));
+
+        assertThat(calculator.costUsd(LlmUsage.unresolved("gpt-4o"))).isNull();
+        assertThat(calculator.costUsd(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("단가가 등록되지 않은 모델은 0이 아니라 null — 등록 누락을 묻지 않는다")
+    void unknownModelHasNoCost() {
+        LlmCostCalculator calculator = calculator(Map.of());
+
+        assertThat(calculator.costUsd(LlmUsage.of("gpt-5-future", 100, 50))).isNull();
+        assertThat(calculator.hasPrice("gpt-5-future")).isFalse();
+    }
+
+    @Test
+    @DisplayName("단가 설정이 깨져 있으면(누락·음수) 계산하지 않는다")
+    void invalidPriceIsTreatedAsUnknown() {
+        LlmCostCalculator calculator = calculator(Map.of(
+                "half-configured", new LlmPricingProperties.ModelPrice(new BigDecimal("1.00"), null),
+                "negative", new LlmPricingProperties.ModelPrice(new BigDecimal("-1.00"), BigDecimal.ONE)));
+
+        assertThat(calculator.costUsd(LlmUsage.of("half-configured", 100, 50))).isNull();
+        assertThat(calculator.costUsd(LlmUsage.of("negative", 100, 50))).isNull();
+    }
+
+    @Test
+    @DisplayName("출력 단가가 0인 임베딩 모델도 입력 비용은 계산한다")
+    void embeddingModelCostsInputOnly() {
+        LlmCostCalculator calculator = calculator(Map.of("text-embedding-3-small",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), new BigDecimal("0.00"))));
+
+        assertThat(calculator.costUsd(LlmUsage.of("text-embedding-3-small", 1_000_000, 0)))
+                .isEqualByComparingTo(new BigDecimal("0.02"));
+    }
+
+    @Test
+    @DisplayName("아주 작은 비용이 0으로 반올림되지 않는다 — 반올림되면 임베딩 비용이 영원히 0으로 쌓인다")
+    void tinyCostSurvivesRounding() {
+        LlmCostCalculator calculator = calculator(Map.of("text-embedding-3-small",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), new BigDecimal("0.00"))));
+
+        // 24 토큰 * $0.02/1M = 4.8e-7 — 실제 운영 스크레이프에서 0.0 으로 사라졌던 값이다.
+        assertThat(calculator.costUsd(LlmUsage.of("text-embedding-3-small", 24, 0)))
+                .isEqualByComparingTo(new BigDecimal("0.00000048"))
+                .isNotEqualByComparingTo(BigDecimal.ZERO);
+    }
+
+    private LlmCostCalculator calculator(Map<String, LlmPricingProperties.ModelPrice> models) {
+        LlmPricingProperties properties = new LlmPricingProperties();
+        properties.setModels(models);
+        return new LlmCostCalculator(properties);
+    }
+}

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -1,15 +1,24 @@
 package com.mio.ai.llm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,14 +27,27 @@ import static org.mockito.Mockito.when;
 
 class OpenAiLlmClientTest {
 
+    private static final String MODEL = "gpt-4o-mini";
+
+    private MeterRegistry meterRegistry;
+    private LlmPricingProperties pricing;
+
+    @BeforeEach
+    void setUp() {
+        meterRegistry = new SimpleMeterRegistry();
+        pricing = new LlmPricingProperties();
+        pricing.setModels(Map.of(MODEL, new LlmPricingProperties.ModelPrice(
+                new BigDecimal("0.15"), new BigDecimal("0.60"))));
+    }
+
     @Test
     void completeText_doesNotRequestJsonResponseFormat() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);
         HttpResponse<String> response = successfulResponse();
-        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
-        OpenAiLlmClient client = new OpenAiLlmClient("test-key", httpClient, new ObjectMapper());
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
 
-        client.completeText(LlmRequest.of("gpt-4o-mini", "system", "user"));
+        client(httpClient).completeText(LlmRequest.of(MODEL, "system", "user"));
 
         String body = requestBody(capturedRequest(httpClient));
         assertThat(body).contains("\"stream\":false");
@@ -36,19 +58,136 @@ class OpenAiLlmClientTest {
     void completeJson_requestsJsonObjectResponseFormat() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);
         HttpResponse<String> response = successfulResponse();
-        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(response);
-        OpenAiLlmClient client = new OpenAiLlmClient("test-key", httpClient, new ObjectMapper());
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
 
-        client.completeJson(LlmRequest.of("gpt-4o-mini", "system", "user"));
+        client(httpClient).completeJson(LlmRequest.of(MODEL, "system", "user"));
 
         assertThat(requestBody(capturedRequest(httpClient)))
                 .contains("\"response_format\":{\"type\":\"json_object\"}");
+    }
+
+    @Test
+    @DisplayName("스트리밍 요청에 include_usage를 넣는다 — 없으면 usage가 아예 오지 않는다")
+    void stream_requestsUsageInStreamOptions() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of("data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+
+        assertThat(requestBody(capturedRequest(httpClient)))
+                .contains("\"stream_options\":{\"include_usage\":true}");
+    }
+
+    @Test
+    @DisplayName("마지막 청크의 usage를 읽어 토큰·비용을 기록한다")
+    void stream_parsesUsageFromFinalChunk() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"안\"}}]}",
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"녕\"}}]}",
+                        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":40}}",
+                        "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        StringBuilder received = new StringBuilder();
+        LlmStreamResult result =
+                client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), received::append);
+
+        assertThat(received.toString()).isEqualTo("안녕");
+        assertThat(result.usage().resolved()).isTrue();
+        assertThat(result.usage().promptTokens()).isEqualTo(100);
+        assertThat(result.usage().completionTokens()).isEqualTo(40);
+
+        assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(100.0);
+        assertThat(counter("mio.llm.tokens", "type", "completion")).isEqualTo(40.0);
+        // 0.15*100/1e6 + 0.60*40/1e6 = 0.000015 + 0.000024
+        assertThat(counter("mio.llm.cost.usd", "mode", "stream")).isEqualTo(0.000039);
+        assertThat(counter("mio.llm.usage", "outcome", "resolved")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("usage 청크가 없으면 토큰 0이 아니라 '미상'으로 남긴다")
+    void stream_missingUsageIsUnresolvedNotZero() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                        "data: {\"choices\":[{\"delta\":{\"content\":\"안녕\"}}]}",
+                        "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        LlmStreamResult result =
+                client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+
+        assertThat(result.usage().resolved())
+                .as("사용량을 못 받은 것을 0 토큰으로 기록하면 비용이 조용히 과소 계상된다")
+                .isFalse();
+        assertThat(counter("mio.llm.usage", "outcome", "missing")).isEqualTo(1.0);
+        assertThat(meterRegistry.find("mio.llm.tokens").counters()).isEmpty();
+        assertThat(meterRegistry.find("mio.llm.cost.usd").counters()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("단가 미등록 모델은 비용 0이 아니라 unpriced로 센다")
+    void stream_unpricedModelDoesNotRecordZeroCost() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}",
+                        "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).stream(LlmRequest.of("gpt-unknown", "system", "user"), chunk -> { });
+
+        assertThat(counter("mio.llm.cost.unpriced", "model", "gpt-unknown")).isEqualTo(1.0);
+        assertThat(meterRegistry.find("mio.llm.cost.usd").counters())
+                .as("단가를 모르는데 0원으로 세면 미등록 사실이 묻힌다")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("비스트리밍 응답의 usage도 읽는다 — 반환 타입은 그대로 두고 메트릭으로만 남긴다")
+    void complete_recordsUsageFromResponse() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"choices\":[{\"message\":{\"content\":\"answer\"}}],"
+                + "\"usage\":{\"prompt_tokens\":7,\"completion_tokens\":3}}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).completeJson(LlmRequest.of(MODEL, "system", "user"));
+
+        assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(7.0);
+        assertThat(counter("mio.llm.usage", "mode", "complete_json")).isEqualTo(1.0);
+    }
+
+    // ── helpers ────────────────────────────────────────────────────
+
+    private OpenAiLlmClient client(HttpClient httpClient) {
+        return new OpenAiLlmClient("test-key", httpClient, new ObjectMapper(),
+                meterRegistry, new LlmCostCalculator(pricing));
+    }
+
+    private double counter(String name, String tagKey, String tagValue) {
+        Counter counter = meterRegistry.find(name).tag(tagKey, tagValue).counter();
+        return counter != null ? counter.count() : 0.0;
     }
 
     private HttpResponse<String> successfulResponse() {
         HttpResponse<String> response = mock(HttpResponse.class);
         when(response.statusCode()).thenReturn(200);
         when(response.body()).thenReturn("{\"choices\":[{\"message\":{\"content\":\"answer\"}}]}");
+        return response;
+    }
+
+    private HttpResponse<Stream<String>> streamingResponse(List<String> lines) {
+        HttpResponse<Stream<String>> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(lines.stream());
         return response;
     }
 

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Flow;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -163,6 +164,95 @@ class OpenAiLlmClientTest {
 
         assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(7.0);
         assertThat(counter("mio.llm.usage", "mode", "complete_json")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("429 재시도 시 앞선 시도의 usage가 최종 결과에 섞이지 않는다")
+    void stream_retryDiscardsPreviousAttemptUsage() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> throttled = mock(HttpResponse.class);
+        when(throttled.statusCode()).thenReturn(429);
+        when(throttled.body()).thenReturn(Stream.of(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":9999,\"completion_tokens\":9999}}"));
+        when(throttled.headers()).thenReturn(
+                java.net.http.HttpHeaders.of(Map.of("Retry-After", List.of("0")), (a, b) -> true));
+        HttpResponse<Stream<String>> ok = streamingResponse(List.of(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":11,\"completion_tokens\":7}}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(throttled, ok);
+
+        LlmStreamResult result =
+                client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+
+        assertThat(result.usage().promptTokens())
+                .as("버려진 시도의 사용량이 남으면 비용이 부풀려 계상된다")
+                .isEqualTo(11);
+        assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(11.0);
+        assertThat(counter("mio.llm.retries", "reason", "rate_limited"))
+                .as("재시도로 삼켜진 스로틀링은 결과가 success 라 별도 지표가 없으면 흔적이 없다")
+                .isEqualTo(1.0);
+        assertThat(counter("mio.llm.requests", "outcome", "success")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("청크 핸들러가 던지면 aborted로 센다 — 과금됐는데 지표에 없는 상태를 막는다")
+    void stream_recordsOutcomeWhenChunkHandlerThrows() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"안\"}}]}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        // 오케스트레이터는 SSE 전송 IOException 을 RuntimeException 으로 감싸 던진다.
+        assertThatThrownBy(() -> client(httpClient).stream(
+                LlmRequest.of(MODEL, "system", "user"),
+                chunk -> { throw new RuntimeException("SSE 전송 실패"); }))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(counter("mio.llm.requests", "outcome", "aborted")).isEqualTo(1.0);
+        assertThat(counter("mio.llm.usage", "outcome", "missing")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("HTTP 오류는 aborted가 아니라 error 한 번만 센다")
+    void stream_doesNotDoubleCountHttpError() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(500);
+        when(response.body()).thenReturn(Stream.of());
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        assertThatThrownBy(() -> client(httpClient)
+                .stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { }))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(counter("mio.llm.requests", "outcome", "error")).isEqualTo(1.0);
+        assertThat(counter("mio.llm.requests", "outcome", "aborted"))
+                .as("이미 센 실패를 catch 에서 또 세면 실패 수가 두 배가 된다")
+                .isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("임베딩도 토큰·비용을 계측한다 — 빼면 비용 합계가 실제 지출보다 낮다")
+    void embed_recordsUsageAndCost() throws Exception {
+        pricing.setModels(Map.of("text-embedding-3-small",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), BigDecimal.ZERO)));
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn(
+                "{\"data\":[{\"embedding\":[0.1,0.2]}],\"usage\":{\"prompt_tokens\":24}}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).embed("안녕하세요");
+
+        assertThat(counter("mio.llm.tokens", "mode", "embed")).isEqualTo(24.0);
+        // 24 * 0.02 / 1e6 = 4.8e-7 — 6자리로 끊으면 0 이 되던 값이다.
+        assertThat(counter("mio.llm.cost.usd", "mode", "embed")).isEqualTo(4.8e-7);
     }
 
     // ── helpers ────────────────────────────────────────────────────

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -215,6 +215,54 @@ class OpenAiLlmClientTest {
         assertThat(counter("mio.llm.usage", "outcome", "missing")).isEqualTo(1.0);
     }
 
+    /**
+     * 계측의 대사(reconcile) 불변식.
+     *
+     * <p>`mio.llm.requests` 합계와 `mio.llm.usage` 합계가 어긋나면 "요청은 셌는데 usage 는
+     * 안 센" 경로가 있다는 뜻이고, 그러면 지표만 보고 누락을 알아낼 수 없다. 성공·HTTP 오류·
+     * 중단 어느 경로로 끝나든 둘 다 정확히 한 번씩 올라가야 한다.
+     */
+    @Test
+    @DisplayName("모든 종료 경로가 requests와 usage를 정확히 한 번씩 남긴다")
+    void everyTerminalPathRecordsBothOutcomeAndUsage() throws Exception {
+        // 1) 성공
+        HttpClient ok = mock(HttpClient.class);
+        HttpResponse<Stream<String>> okResponse = streamingResponse(List.of(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2}}",
+                "data: [DONE]"));
+        when(ok.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class))).thenReturn(okResponse);
+        client(ok).stream(LlmRequest.of(MODEL, "s", "u"), chunk -> { });
+
+        // 2) HTTP 오류 — 요청은 보냈지만 usage 를 못 받았다
+        HttpClient failing = mock(HttpClient.class);
+        HttpResponse<Stream<String>> errorResponse = mock(HttpResponse.class);
+        when(errorResponse.statusCode()).thenReturn(500);
+        when(errorResponse.body()).thenReturn(Stream.of());
+        when(failing.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(errorResponse);
+        assertThatThrownBy(() -> client(failing).stream(LlmRequest.of(MODEL, "s", "u"), chunk -> { }))
+                .isInstanceOf(RuntimeException.class);
+
+        // 3) 청크 핸들러 중단
+        HttpClient aborting = mock(HttpClient.class);
+        HttpResponse<Stream<String>> abortResponse = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"x\"}}]}", "data: [DONE]"));
+        when(aborting.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(abortResponse);
+        assertThatThrownBy(() -> client(aborting).stream(LlmRequest.of(MODEL, "s", "u"),
+                chunk -> { throw new RuntimeException("SSE 전송 실패"); }))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(total("mio.llm.requests")).isEqualTo(3.0);
+        assertThat(total("mio.llm.usage"))
+                .as("실패 경로가 usage 를 남기지 않으면 두 합계가 어긋나 대사할 수 없다")
+                .isEqualTo(3.0);
+        assertThat(counter("mio.llm.usage", "outcome", "resolved")).isEqualTo(1.0);
+        assertThat(counter("mio.llm.usage", "outcome", "missing"))
+                .as("HTTP 오류와 중단 모두 '사용량 모름'으로 남아야 한다")
+                .isEqualTo(2.0);
+    }
+
     @Test
     @DisplayName("HTTP 오류는 aborted가 아니라 error 한 번만 센다")
     void stream_doesNotDoubleCountHttpError() throws Exception {
@@ -260,6 +308,11 @@ class OpenAiLlmClientTest {
     private OpenAiLlmClient client(HttpClient httpClient) {
         return new OpenAiLlmClient("test-key", httpClient, new ObjectMapper(),
                 meterRegistry, new LlmCostCalculator(pricing));
+    }
+
+    private double total(String name) {
+        return meterRegistry.find(name).counters().stream()
+                .mapToDouble(Counter::count).sum();
     }
 
     private double counter(String name, String tagKey, String tagValue) {

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -1,6 +1,9 @@
 package com.mio.ai.orchestrator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.LlmPricingProperties;
+import com.mio.ai.llm.LlmUsage;
 import com.mio.ai.crisis.CrisisTrigger;
 import com.mio.ai.domain.AiPolicyDecision;
 import com.mio.ai.judge.OutputPreFilterResult;
@@ -30,7 +33,8 @@ import static org.mockito.Mockito.verify;
 class AiDecisionLoggerTest {
 
     private final AiPolicyDecisionRepository repository = mock(AiPolicyDecisionRepository.class);
-    private final AiDecisionLogger logger = new AiDecisionLogger(repository, new ObjectMapper());
+    private final AiDecisionLogger logger = new AiDecisionLogger(repository, new ObjectMapper(),
+            new LlmCostCalculator(new LlmPricingProperties()));
 
     @Test
     @DisplayName("정책 결정의 risk_level을 집계 컬럼에도 저장한다")
@@ -66,7 +70,8 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 false,
-                decision.crisisTrigger()
+                decision.crisisTrigger(),
+                null
         );
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
@@ -120,7 +125,8 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 false,
-                decision.crisisTrigger()
+                decision.crisisTrigger(),
+                null
         );
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
@@ -175,7 +181,8 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 false,
-                CrisisTrigger.OUTPUT_GUARD
+                CrisisTrigger.OUTPUT_GUARD,
+                null
         );
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
@@ -219,6 +226,7 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 true,
+                null,
                 null
         );
 
@@ -253,6 +261,7 @@ class AiDecisionLoggerTest {
                 false,
                 false,
                 false,
+                null,
                 null
         );
 
@@ -262,6 +271,101 @@ class AiDecisionLoggerTest {
         assertThat(captor.getValue().getTrace())
                 .contains("\"l0_resolved\":true")
                 .contains("\"safety_profile_degraded\":false");
+    }
+
+    @Test
+    @DisplayName("LLM을 호출하지 않은 턴은 모델·비용을 null로 남긴다 — 하드코딩된 gpt-4o/0.0이 아니다")
+    void logLeavesLlmFieldsNullWhenNoLlmCall() {
+        logAndCapture(new LlmCostCalculator(pricedProperties()), null);
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .as("호출하지 않은 모델을 사용한 것처럼 남기면 비용·모델 집계가 통째로 틀어진다")
+                .contains("\"llm_model\":null")
+                .contains("\"llm_usage_resolved\":null")
+                .contains("\"llm_prompt_tokens\":null")
+                .contains("\"llm_cost_usd\":null");
+    }
+
+    @Test
+    @DisplayName("사용량을 받은 턴은 실제 토큰·비용을 남긴다")
+    void logWritesResolvedUsageAndCost() {
+        logAndCapture(new LlmCostCalculator(pricedProperties()),
+                LlmUsage.of("gpt-4o-mini", 1000, 500));
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        // 0.15*1000/1e6 + 0.60*500/1e6 = 0.00015 + 0.0003 = 0.000450
+        assertThat(captor.getValue().getTrace())
+                .contains("\"llm_model\":\"gpt-4o-mini\"")
+                .contains("\"llm_usage_resolved\":true")
+                .contains("\"llm_prompt_tokens\":1000")
+                .contains("\"llm_completion_tokens\":500")
+                .contains("\"llm_cost_usd\":0.00045");
+    }
+
+    @Test
+    @DisplayName("사용량을 못 받으면 토큰·비용은 0이 아니라 null, 모델은 남는다")
+    void logDistinguishesUnresolvedUsageFromZero() {
+        logAndCapture(new LlmCostCalculator(pricedProperties()),
+                LlmUsage.unresolved("gpt-4o-mini"));
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .as("0으로 남기면 '안 썼다'와 '모른다'가 같은 값이 된다")
+                .contains("\"llm_model\":\"gpt-4o-mini\"")
+                .contains("\"llm_usage_resolved\":false")
+                .contains("\"llm_prompt_tokens\":null")
+                .contains("\"llm_cost_usd\":null");
+    }
+
+    @Test
+    @DisplayName("단가 미등록 모델은 비용을 0이 아니라 null로 남긴다")
+    void logLeavesCostNullForUnpricedModel() {
+        logAndCapture(new LlmCostCalculator(new LlmPricingProperties()),
+                LlmUsage.of("gpt-4o-mini", 1000, 500));
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .contains("\"llm_prompt_tokens\":1000")
+                .contains("\"llm_cost_usd\":null");
+    }
+
+    private void logAndCapture(LlmCostCalculator calculator, LlmUsage usage) {
+        new AiDecisionLogger(repository, new ObjectMapper(), calculator).log(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                generateDecision("pd_llm"),
+                ModerationResult.clear(),
+                SafetyL1Result.clear(),
+                SecurityAssessment.clean(),
+                100,
+                10,
+                false,
+                false,
+                null,
+                null,
+                "default",
+                false,
+                false,
+                false,
+                null,
+                usage
+        );
+    }
+
+    private LlmPricingProperties pricedProperties() {
+        LlmPricingProperties properties = new LlmPricingProperties();
+        properties.setModels(Map.of("gpt-4o-mini", new LlmPricingProperties.ModelPrice(
+                new java.math.BigDecimal("0.15"), new java.math.BigDecimal("0.60"))));
+        return properties;
     }
 
     private PolicyDecision generateDecision(String decisionId) {

--- a/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
@@ -1,6 +1,9 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.LlmPricingProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import com.mio.ai.llm.OpenAiLlmClient;
 import com.mio.ai.memory.consolidation.ExtractorLlmClient;
 import com.mio.ai.memory.consolidation.ExtractorResult;
@@ -51,7 +54,8 @@ class ExtractorEpisodeTypeQaTest {
                 "OPENAI_API_KEY 미설정 또는 placeholder — LLM 통합 테스트 skip"
         );
         extractor = new ExtractorLlmClient(
-                new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper()),
+                new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
+                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties())),
                 new ObjectMapper()
         );
     }

--- a/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
@@ -1,6 +1,9 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.LlmPricingProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import com.mio.ai.llm.OpenAiLlmClient;
 import com.mio.ai.memory.consolidation.ExtractorLlmClient;
 import com.mio.ai.memory.consolidation.ExtractorResult;
@@ -32,7 +35,8 @@ class ExtractorLlmScaleTest {
         Assumptions.assumeTrue(apiKey != null && apiKey.startsWith("sk-"),
                 "OPENAI_API_KEY 미설정 또는 placeholder — LLM 통합 테스트 skip");
         extractor = new ExtractorLlmClient(
-                new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper()),
+                new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
+                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties())),
                 new ObjectMapper()
         );
     }


### PR DESCRIPTION
Closes #271

## 왜

안전 시리즈(#260·#261·#263·#267·#269)에서 지표 6개를 추가했지만 **전부 프로세스 밖에서 읽히지 않았다.** actuator 노출이 `health,info` 뿐이고 Prometheus 레지스트리도 없었다. 여기에 `AiDecisionLogger` 는 `llm_model="gpt-4o"`, `llm_cost_usd=0.0` 을 하드코딩하고 있어서 토큰·비용 데이터가 아예 존재하지 않았다.

이걸 하지 않으면 다음 단계(P1) 판단이 전부 추측이 된다.

## 무엇을

### 1. 지표를 밖에서 읽을 수 있게

- `micrometer-registry-prometheus` 추가
- 관리 포트 분리 (`management.server.port: 9090`) — `prometheus`·`metrics` 노출
- 8080 에 공개 `/health` 추가

**메인 포트에 열지 않은 이유**: admin 롤이 없어 일반 로그인 사용자가 메트릭을 그대로 읽는다.
**관리 포트가 안전한 이유**: Nginx 는 `127.0.0.1:8080` 만 프록시하고(운영 서버 실측), `docker-compose.prod.yml` 에 publish 하지 않으므로 컨테이너 밖에서 도달할 수 없다.

> 스크레이프: `docker compose exec app curl -s localhost:9090/actuator/prometheus`

### 2. LLM usage 파싱 + 비용

- 스트리밍에 `stream_options.include_usage` 추가 — 이게 없으면 usage 가 아예 오지 않는다
- 비스트리밍 응답의 usage 도 읽는다 (호출부 12곳이라 반환 타입은 유지, 메트릭으로만)
- 임베딩도 계측 — 빼면 비용 합계가 실제 지출보다 낮다
- 모델별 단가는 설정(`openai.pricing.models`), 100만 토큰당 USD

### 3. 하드코딩 제거

`AiDecisionLogger` 의 `llm_model`·`llm_cost_usd` 를 실제 값으로. **세 가지 '모름'을 값으로 구분한다:**

| 상태 | 뜻 |
|---|---|
| `llmUsage == null` | LLM 을 호출하지 않았다 (보안 거절·위기·폴백) |
| `resolved == false` | 호출했지만 사용량을 못 받았다 — 토큰 0 이 아니다 |
| `cost == null` | 사용량을 모르거나 단가 미등록 모델이다 |

단가 미등록은 `mio.llm.cost.unpriced` 로 따로 센다. 0 원으로 세면 새 모델 도입 시 단가 등록 누락이 그대로 묻힌다.

## 새 메커니즘의 실패 경로

| 메커니즘 | 실패 경로 | 처리 |
|---|---|---|
| 관리 포트 | 8080 에 actuator 가 남는가 | **실측** — 전부 401 |
| `/health` | DB 가 죽어도 200 | liveness 전용임을 명시. 의존성 판정은 9090. DB 순단마다 헬스체크가 죽으면 트래픽이 끊긴다 |
| usage 파싱 | 청크 미도착·스트림 중단 | `resolved=false`, 0 아님 |
| usage 파싱 | 429 재시도 시 중복 누적 | 재시도마다 `ttft` 와 함께 리셋 |
| 비용 계산 | 단가 미등록·설정 오류(음수·누락) | `null` + `unpriced` 카운터 |
| 비용 계산 | 소수점 반올림으로 0 | **실측에서 잡힘** — 아래 참조 |

## 실측으로 잡은 결함

로컬 스크레이프에서 `mio_llm_cost_usd_total{mode="embed"}` 가 **`0.0`** 이었다. 임베딩 24토큰 × $0.02/1M = 4.8e-7 인데 소수점 6자리에서 0 으로 반올림돼, **임베딩 비용이 영원히 0 으로 누적되는** 상태였다. 이 PR 이 막으려던 과소 계상 그 자체다. 정밀도를 10자리로 올려 `3.8E-7` 로 복구했고 회귀 테스트를 붙였다.

## 검증

**단위 테스트 576건 통과** (기존 561 + 신규 15).

**로컬 실측 — 실제 대화 턴 1회 후 `:9090/actuator/prometheus`:**

```
mio_llm_cost_usd_total{mode="stream",model="gpt-4o"}                    9.4E-4
mio_llm_cost_usd_total{mode="complete_json",model="gpt-4o-mini"}        1.026E-4
mio_llm_cost_usd_total{mode="embed",model="text-embedding-3-small"}     3.8E-7
mio_llm_tokens_total{mode="stream",model="gpt-4o",type="prompt"}        123.0
mio_llm_tokens_total{mode="stream",model="gpt-4o",type="completion"}    49.0
mio_llm_usage_total{mode="stream",model="gpt-4o",outcome="resolved"}    1.0
mio_moderation_requests_total{outcome="resolved"}                       1.0
mio_safety_profile_builds_total{outcome="resolved"}                     1.0
```

마지막 두 줄이 이 작업의 목적이다 — 죽어 있던 지표가 읽힌다.

**포트별 접근 실측:**

| 경로 | 8080 | 9090 |
|---|---|---|
| `/health` | 200 | (500 — 아래) |
| `/actuator/health` | 401 | 200 |
| `/actuator/prometheus` | 401 | 200 |
| `/actuator/env` (미노출) | 401 | 401 |

## 알려진 것 — 이 PR 범위 밖

9090 의 `/health` 가 500 이다. 관리 컨텍스트에 해당 핸들러가 없어 `NoResourceFoundException` 이 나는데, `GlobalExceptionHandler` 가 이걸 404 가 아니라 500 으로 매핑한다. **비공개 포트라 영향은 없지만 `GlobalExceptionHandler` 의 별개 결함이다.** 8080 에서는 JWT 필터가 먼저 401 을 내므로 드러나지 않는다. 예외 핸들러 수정은 상태 코드 전반에 영향이 있어 이 PR 에 섞지 않았다.

## 테스트 플랜

- [x] `./gradlew build` — 576건 통과
- [x] 로컬 기동 후 8080/9090 접근 권한 실측
- [x] 실제 대화 턴으로 `mio_*` 지표 스크레이프 확인
- [x] 임베딩 비용 반올림 회귀 테스트
- [ ] 배포 후 운영에서 `docker compose exec app curl -s localhost:9090/actuator/prometheus` 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public `/health` liveness endpoint returning service status.
  * Added management endpoints for health details, application metrics, and Prometheus monitoring on the management port.
  * Added per-request LLM token usage, response timing, outcome, and estimated cost metrics.
  * Added model-specific pricing configuration for cost estimation.
* **Documentation**
  * Updated local verification instructions for health checks, Swagger UI, and metrics collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->