### PR TITLE
fix: LLM 출력 토큰 상한 설정 — 응답 폭주 노출 제거

### DIFF
--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -18,6 +18,8 @@ import java.util.List;
 public class CbtMetadataClassifier {
 
     private static final String MODEL = "gpt-4o-mini";
+    // JSON 분류 출력 상한. 예상 ~90 토큰.
+    private static final int MAX_COMPLETION_TOKENS = 400;
 
     private static final String SYSTEM_PROMPT = """
             You classify CBT Socratic intervention state for a mental health coaching chat.
@@ -64,7 +66,8 @@ public class CbtMetadataClassifier {
                     userMessage,
                     assistantResponse,
                     userSignal,
-                    socraticQuestionsUsed));
+                    socraticQuestionsUsed))
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS);
             String responseJson = llmClient.completeJson(request);
             return parse(responseJson, CbtInterventionState.fromWireValue(previousState), userSignal);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -22,6 +22,9 @@ import java.util.List;
 public class InputJudge {
 
     private static final String JUDGE_MODEL = "gpt-4o-mini";
+    // JSON 판정 출력 상한. 예상 ~130 토큰이지만 여유를 크게 둔다 — JSON 은 잘리면 파싱이
+    // 통째로 실패하고, 그러면 안전 판정이 사라진다 (fallback CLEAR_LOW + failed).
+    private static final int JUDGE_MAX_COMPLETION_TOKENS = 500;
 
     private static final String SYSTEM_PROMPT = """
             You are a safety classifier for a mental health coaching app.
@@ -64,7 +67,8 @@ public class InputJudge {
     public InputJudgeResult judge(String message, CombinedSignal combined, SafetyProfile profile) {
         try {
             String contextPrompt = buildContextPrompt(profile, message);
-            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt);
+            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt)
+                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS);
             String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Component;
 public class OutputJudge {
 
     private static final String JUDGE_MODEL = "gpt-4o-mini";
+    // JSON 판정 출력 상한. 잘리면 파싱 실패 → REPLACE 로 떨어져 정상 응답이 대체된다.
+    private static final int JUDGE_MAX_COMPLETION_TOKENS = 400;
 
     private static final String SYSTEM_PROMPT = """
             You are a safety reviewer for a mental health coaching AI.
@@ -42,7 +44,8 @@ public class OutputJudge {
     public OutputJudgeResult judge(String aiResponse, OutputPreFilterResult preFilterResult) {
         try {
             String userContent = buildJudgePrompt(aiResponse, preFilterResult);
-            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent);
+            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent)
+                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS);
             String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -14,8 +14,13 @@ import org.springframework.stereotype.Component;
 public class OutputJudge {
 
     private static final String JUDGE_MODEL = "gpt-4o-mini";
-    // JSON 판정 출력 상한. 잘리면 파싱 실패 → REPLACE 로 떨어져 정상 응답이 대체된다.
-    private static final int JUDGE_MAX_COMPLETION_TOKENS = 400;
+    // JSON 판정 출력 상한.
+    //
+    // REWRITE 판정은 rewritten_content 에 <b>본문을 다시 써서</b> 돌려준다. 본문 자체가
+    // 생성 상한(400)까지 갈 수 있으므로 판정 상한도 400 이면 정작 다시 써야 할 긴 응답에서
+    // 잘린다 — 그러면 파싱이 실패하고 REPLACE 로 떨어져, 고쳐 쓸 수 있었던 응답이 통째로
+    // 안전 문구로 대체된다. 본문 400 + JSON 키·이스케이프 오버헤드 + 여유로 잡는다.
+    private static final int JUDGE_MAX_COMPLETION_TOKENS = 800;
 
     private static final String SYSTEM_PROMPT = """
             You are a safety reviewer for a mental health coaching AI.

--- a/src/main/java/com/mio/ai/llm/LlmRequest.java
+++ b/src/main/java/com/mio/ai/llm/LlmRequest.java
@@ -5,17 +5,41 @@ import com.mio.ai.memory.working.WorkingMessage;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * @param maxCompletionTokens 출력 토큰 상한. {@code null} 이면 상한을 보내지 않는다 —
+ *                            모델 기본 한도까지 생성될 수 있다는 뜻이므로, 새 호출부는
+ *                            {@link #withMaxCompletionTokens(int)} 로 명시하는 것을 권한다.
+ *                            <p>상한은 그 자체로 새 실패 모드를 만든다. 초과하면 응답이
+ *                            <b>잘린 채</b> {@code finish_reason=length} 로 끝나고, JSON 모드에서는
+ *                            파싱이 통째로 실패한다. 그래서 상한값은 프롬프트가 요구하는 길이 옆에
+ *                            두어 둘이 함께 바뀌게 하고, 실제 절단 발생은
+ *                            {@code mio.llm.truncated} 로 관측한다.
+ */
 public record LlmRequest(
         String model,
-        List<Message> messages
+        List<Message> messages,
+        Integer maxCompletionTokens
 ) {
     public record Message(String role, String content) {}
+
+    public LlmRequest {
+        if (maxCompletionTokens != null && maxCompletionTokens <= 0) {
+            throw new IllegalArgumentException(
+                    "maxCompletionTokens must be positive: " + maxCompletionTokens);
+        }
+        messages = messages != null ? List.copyOf(messages) : List.of();
+    }
+
+    /** 상한을 지정한 복사본. 원본은 그대로 둔다. */
+    public LlmRequest withMaxCompletionTokens(int maxCompletionTokens) {
+        return new LlmRequest(model, messages, maxCompletionTokens);
+    }
 
     public static LlmRequest of(String model, String systemPrompt, String userMessage) {
         return new LlmRequest(model, List.of(
                 new Message("system", systemPrompt),
                 new Message("user", userMessage)
-        ));
+        ), null);
     }
 
     public static LlmRequest of(String model, String systemPrompt,
@@ -28,6 +52,6 @@ public record LlmRequest(
             }
         }
         messages.add(new Message("user", userMessage));
-        return new LlmRequest(model, List.copyOf(messages));
+        return new LlmRequest(model, messages, null);
     }
 }

--- a/src/main/java/com/mio/ai/llm/LlmStreamResult.java
+++ b/src/main/java/com/mio/ai/llm/LlmStreamResult.java
@@ -3,8 +3,12 @@ package com.mio.ai.llm;
 /**
  * 스트리밍 호출 한 번의 결과.
  *
- * @param ttftMs 첫 토큰까지 걸린 시간(ms). 토큰이 하나도 오지 않았으면 전체 소요 시간
- * @param usage  토큰 사용량. 받지 못했으면 {@link LlmUsage#unresolved(String)}
+ * @param ttftMs    첫 토큰까지 걸린 시간(ms). 토큰이 하나도 오지 않았으면 전체 소요 시간
+ * @param usage     토큰 사용량. 받지 못했으면 {@link LlmUsage#unresolved(String)}
+ * @param truncated 출력 토큰 상한에 걸려 응답이 잘렸는지. {@code true} 면 <b>내용이 불완전하다</b> —
+ *                  요약처럼 결과를 정본으로 저장하는 호출부는 이 값을 반드시 확인해야 한다.
+ *                  잘린 텍스트를 그대로 저장하면 이후 턴의 기억 맥락이 문장 중간에서 끊긴 채
+ *                  쓰이고, 그 사실이 데이터에는 남지 않는다.
  */
-public record LlmStreamResult(long ttftMs, LlmUsage usage) {
+public record LlmStreamResult(long ttftMs, LlmUsage usage, boolean truncated) {
 }

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -16,6 +16,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -72,6 +73,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         long startMs = System.currentTimeMillis();
         AtomicLong ttft = new AtomicLong(0);
         AtomicReference<LlmUsage> usage = new AtomicReference<>();
+        AtomicBoolean truncated = new AtomicBoolean(false);
         // 이 호출의 종료(outcome + usage)를 이미 기록했는지. 아래 catch 는 우리가 던진 예외와
         // 청크 핸들러가 던진 예외를 함께 받는데, 전자는 이미 기록돼 있어 표시가 없으면 이중 계상된다.
         //
@@ -120,6 +122,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     // 사용량이 남아 최종 결과에 섞이거나 중복 집계된다.
                     ttft.set(0);
                     usage.set(null);
+                    truncated.set(false);
                     continue;
                 }
 
@@ -144,7 +147,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                                 if (chunkUsage != null) {
                                     usage.set(chunkUsage);
                                 }
-                                recordIfTruncated(chunk, request.model(), MODE_STREAM);
+                                if (recordIfTruncated(chunk, request.model(), MODE_STREAM)) {
+                                    truncated.set(true);
+                                }
                                 String content = extractDeltaContent(chunk);
                                 if (content != null && !content.isEmpty()) {
                                     if (ttft.get() == 0) {
@@ -183,7 +188,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         recordUsage(MODE_STREAM, resolved);
 
         long ttftMs = ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
-        return new LlmStreamResult(ttftMs, resolved);
+        return new LlmStreamResult(ttftMs, resolved, truncated.get());
     }
 
     private long streamRetryDelayMs(HttpResponse<?> response, int attempt) {
@@ -410,12 +415,14 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
      * 파싱 실패로 이어져 판정이 통째로 사라지는데, 그건 로그에 "파싱 실패"로만 보이고 원인이
      * 상한이었다는 사실은 드러나지 않는다.
      */
-    private void recordIfTruncated(JsonNode root, String model, String mode) {
+    private boolean recordIfTruncated(JsonNode root, String model, String mode) {
         String finishReason = root.path("choices").path(0).path("finish_reason").asText(null);
-        if (FINISH_REASON_LENGTH.equals(finishReason)) {
-            log.warn("LLM 응답이 출력 토큰 상한에 걸려 잘렸다: model={} mode={}", model, mode);
-            meterRegistry.counter(TRUNCATED_METRIC, "model", model, "mode", mode).increment();
+        if (!FINISH_REASON_LENGTH.equals(finishReason)) {
+            return false;
         }
+        log.warn("LLM 응답이 출력 토큰 상한에 걸려 잘렸다: model={} mode={}", model, mode);
+        meterRegistry.counter(TRUNCATED_METRIC, "model", model, "mode", mode).increment();
+        return true;
     }
 
     /** 사용량을 못 받았으면 0 짜리 사용량이 아니라 '미상' 으로 만든다. */

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -37,6 +37,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private static final String COST_METRIC = "mio.llm.cost.usd";
     private static final String UNPRICED_METRIC = "mio.llm.cost.unpriced";
     private static final String RETRIES_METRIC = "mio.llm.retries";
+    private static final String TRUNCATED_METRIC = "mio.llm.truncated";
+
+    private static final String FINISH_REASON_LENGTH = "length";
 
     private static final String MODE_STREAM = "stream";
     private static final String MODE_COMPLETE_TEXT = "complete_text";
@@ -141,6 +144,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                                 if (chunkUsage != null) {
                                     usage.set(chunkUsage);
                                 }
+                                recordIfTruncated(chunk, request.model(), MODE_STREAM);
                                 String content = extractDeltaContent(chunk);
                                 if (content != null && !content.isEmpty()) {
                                     if (ttft.get() == 0) {
@@ -206,6 +210,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         body.put("stream", true);
         // 이걸 켜지 않으면 스트리밍 응답에는 usage 가 아예 오지 않는다.
         body.put("stream_options", Map.of("include_usage", true));
+        putMaxCompletionTokens(body, request);
 
         return objectMapper.writeValueAsString(body);
     }
@@ -250,6 +255,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             // 비스트리밍 응답에는 usage 가 항상 실려 오는데 지금까지 읽지 않고 버렸다.
             // 호출부가 12곳이라 반환 타입은 그대로 두고 메트릭으로만 남긴다.
             LlmUsage usage = extractUsage(root, request.model());
+            recordIfTruncated(root, request.model(), mode);
             recordOutcome(request.model(), mode, "success");
             recordUsage(mode, usage != null ? usage : LlmUsage.unresolved(request.model()));
 
@@ -286,6 +292,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         if (jsonResponse) {
             body.put("response_format", Map.of("type", "json_object"));
         }
+        putMaxCompletionTokens(body, request);
 
         return objectMapper.writeValueAsString(body);
     }
@@ -381,6 +388,34 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         // 임베딩 응답에는 completion_tokens 가 없다. 출력 토큰이 실제로 0 인 경우다.
         return LlmUsage.of(requestedModel, prompt.asLong(),
                 completion.isNumber() ? completion.asLong() : 0L);
+    }
+
+    /**
+     * 출력 토큰 상한을 싣는다. 지정되지 않았으면 아무것도 보내지 않는다 (모델 기본 한도).
+     *
+     * <p>{@code max_tokens} 가 아니라 {@code max_completion_tokens} 를 쓴다. 실제 API 프로브에서
+     * gpt-4o 는 둘 다 받지만, 최신 모델은 전자를 거부하므로 모델을 올릴 때 같이 깨지지 않는 쪽을
+     * 고른다.
+     */
+    private void putMaxCompletionTokens(Map<String, Object> body, LlmRequest request) {
+        if (request.maxCompletionTokens() != null) {
+            body.put("max_completion_tokens", request.maxCompletionTokens());
+        }
+    }
+
+    /**
+     * 상한에 걸려 응답이 잘렸는지 센다.
+     *
+     * <p>이걸 세지 않으면 상한이 너무 빡빡해도 알 방법이 없다. 특히 JSON 모드에서는 절단이
+     * 파싱 실패로 이어져 판정이 통째로 사라지는데, 그건 로그에 "파싱 실패"로만 보이고 원인이
+     * 상한이었다는 사실은 드러나지 않는다.
+     */
+    private void recordIfTruncated(JsonNode root, String model, String mode) {
+        String finishReason = root.path("choices").path(0).path("finish_reason").asText(null);
+        if (FINISH_REASON_LENGTH.equals(finishReason)) {
+            log.warn("LLM 응답이 출력 토큰 상한에 걸려 잘렸다: model={} mode={}", model, mode);
+            meterRegistry.counter(TRUNCATED_METRIC, "model", model, "mode", mode).increment();
+        }
     }
 
     /** 사용량을 못 받았으면 0 짜리 사용량이 아니라 '미상' 으로 만든다. */

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -39,6 +39,8 @@ public class ConversationCheckpointService {
 
     static final int CHECKPOINT_INTERVAL = 20;
     private static final String CHECKPOINT_MODEL = "gpt-4o-mini";
+    // 체크포인트 요약 출력 상한. 프롬프트가 200자를 요구한다 (~142 토큰).
+    private static final int CHECKPOINT_MAX_COMPLETION_TOKENS = 400;
     private static final String CHECKPOINT_SYSTEM_PROMPT = """
             당신은 CBT 코칭 대화의 중간 요약 전문가입니다.
             아래 대화를 200자 이내로 간결하게 요약하세요.
@@ -165,7 +167,8 @@ public class ConversationCheckpointService {
         StringBuilder sb = new StringBuilder();
         try {
             llmClient.stream(
-                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines)),
+                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines))
+                            .withMaxCompletionTokens(CHECKPOINT_MAX_COMPLETION_TOKENS),
                     sb::append
             );
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -3,6 +3,7 @@ package com.mio.ai.memory.consolidation;
 import com.mio.ai.AiCacheKeys;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionCheckpoint;
@@ -166,11 +167,18 @@ public class ConversationCheckpointService {
     private String generateSummary(List<String> lines) {
         StringBuilder sb = new StringBuilder();
         try {
-            llmClient.stream(
+            LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines))
                             .withMaxCompletionTokens(CHECKPOINT_MAX_COMPLETION_TOKENS),
                     sb::append
             );
+            // 잘린 요약은 저장하지 않는다. 체크포인트는 이후 턴의 프롬프트에 그대로 실리므로,
+            // 문장 중간에서 끊긴 텍스트를 정본으로 남기면 그 사실이 데이터에 남지 않은 채
+            // 계속 재사용된다. 없는 편이 낫다 — 호출부가 null 을 이미 건너뛴다.
+            if (result.truncated()) {
+                log.warn("ConversationCheckpointService: 요약이 출력 상한에 걸려 잘려 저장하지 않는다");
+                return null;
+            }
         } catch (Exception e) {
             log.warn("ConversationCheckpointService: summary generation failed", e);
             return null;

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -3,6 +3,7 @@ package com.mio.ai.memory.consolidation;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -98,11 +99,23 @@ public class ExtractorLlmClient {
 
         StringBuilder responseBuilder = new StringBuilder();
         try {
-            llmClient.stream(
+            LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary)
                             .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
                     responseBuilder::append
             );
+            // 잘린 응답은 파싱하지 않는다. "파싱이 실패할 테니 괜찮다"에 기댈 수 없다 —
+            // objectMapper.readTree 는 FAIL_ON_TRAILING_TOKENS 가 기본 off 라서 선행 객체만
+            // 읽고 뒤에 붙은 잘린 내용을 조용히 버린다. 실측 확인:
+            //   {"dominantEmotion":"sadness"} + 잘린 후속 텍스트  → 파싱 성공
+            // 이때 thoughts·episodeType·emotionScore 가 '부재'로 처리되어 아래 파서의
+            // 기본값(List.of() / "regular" / null)으로 채워지고, 그 값이 session_summaries 에
+            // 그대로 저장된다. episodeType 이 "regular" 로 굳으면 위기 세션이 일반 세션으로
+            // 기록되고, 사후 안전망(#256)이 그 세션을 다시 볼 근거도 사라진다.
+            if (result.truncated()) {
+                log.warn("ExtractorLLM 응답이 출력 상한에 걸려 잘렸다 — 부분 추출을 저장하지 않고 비운다");
+                return ExtractorResult.empty();
+            }
             return parseResponse(responseBuilder.toString());
         } catch (Exception e) {
             log.warn("ExtractorLLM failed, returning empty result", e);

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -20,6 +20,8 @@ import java.util.Set;
 public class ExtractorLlmClient {
 
     private static final String MODEL = "gpt-4o-mini";
+    // JSON 추출 출력 상한. 항목 최대 3개라 여유를 둔다.
+    private static final int MAX_COMPLETION_TOKENS = 600;
 
     private static final String SYSTEM_PROMPT = """
             당신은 CBT(인지행동치료) 전문 분석가입니다.
@@ -97,7 +99,8 @@ public class ExtractorLlmClient {
         StringBuilder responseBuilder = new StringBuilder();
         try {
             llmClient.stream(
-                    LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary),
+                    LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary)
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
                     responseBuilder::append
             );
             return parseResponse(responseBuilder.toString());

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -7,6 +7,7 @@ import com.mio.ai.domain.MemoryEmbedding;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.memory.episodic.Thought;
 import com.mio.ai.memory.episodic.ThoughtRepository;
 import com.mio.ai.memory.episodic.UserBelief;
@@ -362,11 +363,18 @@ public class SessionConsolidator {
 
     private String generateSummary(String conversationText) {
         StringBuilder sb = new StringBuilder();
-        llmClient.stream(
+        LlmStreamResult result = llmClient.stream(
                 LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText)
                         .withMaxCompletionTokens(SUMMARY_MAX_COMPLETION_TOKENS),
                 sb::append
         );
+        // 잘린 요약을 그대로 쓰면 암호화·저장을 거쳐 세션의 정본 기억이 되고, ExtractorLLM 이
+        // 그 불완전한 텍스트에서 사고·감정을 뽑아낸다. 잘렸다는 사실은 어디에도 남지 않는다.
+        // 상위 consolidate() 의 catch 가 받아 로그를 남기고 이번 컨솔리데이션만 중단한다.
+        if (result.truncated()) {
+            throw new IllegalStateException(
+                    "세션 요약이 출력 토큰 상한에 걸려 잘렸다 — 불완전한 요약을 정본으로 저장하지 않는다");
+        }
         return sb.toString().trim();
     }
 

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -61,6 +61,9 @@ import java.util.stream.Collectors;
 public class SessionConsolidator {
 
     private static final String SUMMARY_MODEL = "gpt-4o-mini";
+    // 요약 출력 상한. 프롬프트가 500자를 요구하고 한국어 1자 ≈ 0.71 토큰이라 ~355 토큰,
+    // 2배 이상 여유를 둔다. 잘리면 세션 요약이 문장 중간에서 끊긴 채 저장된다.
+    private static final int SUMMARY_MAX_COMPLETION_TOKENS = 800;
     private static final String SUMMARY_SYSTEM_PROMPT = """
             당신은 CBT 코칭 세션 분석 전문가입니다.
             사용자와 AI 캐릭터 간의 대화 내용을 바탕으로 세션 요약을 300~500자 이내로 작성하세요.
@@ -360,7 +363,8 @@ public class SessionConsolidator {
     private String generateSummary(String conversationText) {
         StringBuilder sb = new StringBuilder();
         llmClient.stream(
-                LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText),
+                LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText)
+                        .withMaxCompletionTokens(SUMMARY_MAX_COMPLETION_TOKENS),
                 sb::append
         );
         return sb.toString().trim();

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
@@ -25,6 +25,8 @@ import java.util.List;
 public class TodoActionPersonalizer {
 
     private static final String MODEL = "gpt-4o-mini";
+    // 템플릿 개인화 출력 상한. 템플릿 수만큼 문장을 만들어야 해 여유를 둔다.
+    private static final int MAX_COMPLETION_TOKENS = 600;
     private static final int MAX_ACTION_LENGTH = 120;
 
     private static final String SYSTEM_PROMPT = """
@@ -61,7 +63,8 @@ public class TodoActionPersonalizer {
         try {
             StringBuilder response = new StringBuilder();
             llmClient.stream(
-                    LlmRequest.of(MODEL, SYSTEM_PROMPT, buildUserMessage(sessionSummary, triggerTags, templates)),
+                    LlmRequest.of(MODEL, SYSTEM_PROMPT, buildUserMessage(sessionSummary, triggerTags, templates))
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
                     response::append
             );
             List<String> personalized = parse(response.toString(), templates.size());

--- a/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
@@ -32,6 +32,9 @@ import java.util.*;
 @RequiredArgsConstructor
 public class WeeklyReflectionJob {
 
+    // 주간 회고 출력 상한. 프롬프트가 500자를 요구한다 (~355 토큰).
+    private static final int REFLECTION_MAX_COMPLETION_TOKENS = 800;
+
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
     private static final String NARRATIVE_SYSTEM = """
             당신은 CBT 기반 감정 코칭 AI입니다.
@@ -175,7 +178,8 @@ public class WeeklyReflectionJob {
 
     private String generateText(String systemPrompt, String context) {
         try {
-            return llmClient.completeText(LlmRequest.of("gpt-4o-mini", systemPrompt, context));
+            return llmClient.completeText(LlmRequest.of("gpt-4o-mini", systemPrompt, context)
+                    .withMaxCompletionTokens(REFLECTION_MAX_COMPLETION_TOKENS));
         } catch (Exception e) {
             log.warn("[WeeklyReflectionJob] LLM call failed: {}", e.getMessage());
             return null;

--- a/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
@@ -18,6 +18,8 @@ import org.springframework.stereotype.Component;
 public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
 
     private static final String MODEL = "gpt-4o-mini";
+    // JSON 추출 출력 상한. 예상 ~40 토큰. 잘리면 파싱 실패로 추출이 비어 반환된다.
+    private static final int MAX_COMPLETION_TOKENS = 400;
     private static final String SYSTEM_PROMPT = """
             당신은 CBT 대화에서 현재 사용자의 발화만 분류합니다.
             반드시 아래 JSON 객체만 반환하세요.
@@ -38,7 +40,8 @@ public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
             return TurnOntologySignal.empty();
         }
         try {
-            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
             JsonNode node = objectMapper.readTree(stripCodeFence(response));
             return new TurnOntologySignal(
                     nullableText(node, "distortionCode"),

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -87,6 +87,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class ConversationOrchestrator {
 
     private static final String LLM_MODEL = "gpt-4o";
+    // 출력 상한. 프롬프트가 "2-4문장"을 요구하고 실측 출력이 49~150 토큰이라 2.7배 여유다.
+    // 상한이 없으면 폭주 응답 하나가 턴당 비용을 8.1배로 올린다 (기준선 문서 §5.7 R-1).
+    private static final int LLM_MAX_COMPLETION_TOKENS = 400;
     private static final int EARLY_PREFILTER_THRESHOLD = 200;
 
     private final InputNormalizer inputNormalizer;
@@ -278,7 +281,8 @@ public class ConversationOrchestrator {
                 List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
-                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage);
+                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage)
+                        .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS);
                 StringBuilder contentBuilder = new StringBuilder();
 
                 DeliveryMode deliveryMode = decision.deliveryMode();

--- a/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
+++ b/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 public class CheckinAiResponseGenerator {
 
     private static final String MODEL = "gpt-4o-mini";
+    // 체크인 응답 출력 상한. 프롬프트가 150자를 요구한다 (~107 토큰).
+    private static final int MAX_COMPLETION_TOKENS = 400;
     private static final String SYSTEM_PROMPT = """
             당신은 감정 코칭 AI 캐릭터입니다.
             사용자의 현재 감정 상태와 강도를 바탕으로 따뜻하고 공감적인 짧은 코멘트를 작성하세요.
@@ -38,7 +40,8 @@ public class CheckinAiResponseGenerator {
     public void generateAndSave(UUID checkinId, String emotionType, int conditionScore, String timeOfDay) {
         try {
             String userMessage = buildPrompt(emotionType, conditionScore, timeOfDay);
-            String response = llmClient.completeText(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            String response = llmClient.completeText(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
 
             if (response == null || response.isBlank()) {
                 log.debug("[CheckinAiResponseGenerator] no response for checkinId={}", checkinId);

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -16,6 +16,8 @@ import java.util.List;
 public class ReportNarrativeService {
 
     private static final String MODEL = "gpt-4o-mini";
+    // 리포트 서술 출력 상한. 프롬프트가 3문장·100자를 요구한다.
+    private static final int MAX_COMPLETION_TOKENS = 400;
 
     private static final String SYSTEM_PROMPT = """
             당신은 CBT 기반 심리 코칭 전문가입니다.
@@ -41,7 +43,8 @@ public class ReportNarrativeService {
                                     List<DistortionDto> distortionTop3) {
         String userMessage = buildUserMessage(periodLabel, checkinCount, avgEmotionScore, distortionTop3);
         try {
-            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage));
+            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
             return parseResponse(response);
         } catch (Exception e) {
             log.warn("ReportNarrative generation failed: period={} error={}", periodLabel, e.getClass().getSimpleName());

--- a/src/test/java/com/mio/ai/llm/LlmRequestTest.java
+++ b/src/test/java/com/mio/ai/llm/LlmRequestTest.java
@@ -1,0 +1,38 @@
+package com.mio.ai.llm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class LlmRequestTest {
+
+    @Test
+    @DisplayName("기본 팩토리는 상한을 지정하지 않는다")
+    void factoryLeavesMaxCompletionTokensUnset() {
+        assertThat(LlmRequest.of("gpt-4o", "system", "user").maxCompletionTokens()).isNull();
+    }
+
+    @Test
+    @DisplayName("withMaxCompletionTokens는 원본을 바꾸지 않고 복사본을 만든다")
+    void witherDoesNotMutateOriginal() {
+        LlmRequest original = LlmRequest.of("gpt-4o", "system", "user");
+
+        LlmRequest capped = original.withMaxCompletionTokens(400);
+
+        assertThat(capped.maxCompletionTokens()).isEqualTo(400);
+        assertThat(original.maxCompletionTokens()).isNull();
+        assertThat(capped.messages()).isEqualTo(original.messages());
+        assertThat(capped.model()).isEqualTo(original.model());
+    }
+
+    @Test
+    @DisplayName("0 이하 상한은 거부한다 — 조용히 빈 응답을 만드느니 즉시 실패한다")
+    void rejectsNonPositiveLimit() {
+        assertThatThrownBy(() -> LlmRequest.of("gpt-4o", "s", "u").withMaxCompletionTokens(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new LlmRequest("gpt-4o", java.util.List.of(), -1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -303,6 +303,88 @@ class OpenAiLlmClientTest {
         assertThat(counter("mio.llm.cost.usd", "mode", "embed")).isEqualTo(4.8e-7);
     }
 
+    @Test
+    @DisplayName("상한을 지정하면 max_completion_tokens로 보낸다 — max_tokens는 최신 모델이 거부한다")
+    void sendsMaxCompletionTokensWhenSpecified() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of("data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).stream(
+                LlmRequest.of(MODEL, "system", "user").withMaxCompletionTokens(400),
+                chunk -> { });
+
+        assertThat(requestBody(capturedRequest(httpClient)))
+                .contains("\"max_completion_tokens\":400")
+                .doesNotContain("\"max_tokens\"");
+    }
+
+    @Test
+    @DisplayName("상한을 지정하지 않으면 아무것도 보내지 않는다")
+    void omitsMaxCompletionTokensWhenUnspecified() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = successfulResponse();
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).completeJson(LlmRequest.of(MODEL, "system", "user"));
+
+        assertThat(requestBody(capturedRequest(httpClient)))
+                .doesNotContain("max_completion_tokens");
+    }
+
+    @Test
+    @DisplayName("상한에 걸려 잘리면 계측한다 — 안 세면 상한이 빡빡해도 알 수 없다")
+    void recordsTruncationOnNonStreaming() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<String> response = mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(200);
+        when(response.body()).thenReturn("{\"choices\":[{\"finish_reason\":\"length\","
+                + "\"message\":{\"content\":\"{\\\"a\\\": \\\"잘린\"}}],"
+                + "\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":400}}");
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).completeJson(
+                LlmRequest.of(MODEL, "system", "user").withMaxCompletionTokens(400));
+
+        assertThat(counter("mio.llm.truncated", "mode", "complete_json")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("스트리밍 절단도 계측한다 — 실측상 스트리밍도 finish_reason=length를 준다")
+    void recordsTruncationOnStreaming() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"인지행동\"}}]}",
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).stream(
+                LlmRequest.of(MODEL, "system", "user").withMaxCompletionTokens(400),
+                chunk -> { });
+
+        assertThat(counter("mio.llm.truncated", "mode", "stream")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("정상 종료는 절단으로 세지 않는다")
+    void doesNotRecordTruncationOnNormalStop() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"안녕\"},\"finish_reason\":\"stop\"}]}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+
+        assertThat(meterRegistry.find("mio.llm.truncated").counters()).isEmpty();
+    }
+
     // ── helpers ────────────────────────────────────────────────────
 
     private OpenAiLlmClient client(HttpClient httpClient) {

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -371,6 +371,42 @@ class OpenAiLlmClientTest {
     }
 
     @Test
+    @DisplayName("절단 여부를 결과로 돌려준다 — 호출부가 잘린 텍스트를 정본으로 저장하지 않게")
+    void streamResultExposesTruncation() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"요약 앞부분\"}}]}",
+                "data: {\"choices\":[{\"delta\":{},\"finish_reason\":\"length\"}]}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        LlmStreamResult result = client(httpClient).stream(
+                LlmRequest.of(MODEL, "system", "user").withMaxCompletionTokens(400),
+                chunk -> { });
+
+        assertThat(result.truncated())
+                .as("지표만 올리고 결과에 안 알려주면 잘린 요약이 그대로 저장된다")
+                .isTrue();
+    }
+
+    @Test
+    @DisplayName("정상 종료면 truncated=false")
+    void streamResultIsNotTruncatedOnNormalStop() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[{\"delta\":{\"content\":\"완결된 요약\"},\"finish_reason\":\"stop\"}]}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        LlmStreamResult result =
+                client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+
+        assertThat(result.truncated()).isFalse();
+    }
+
+    @Test
     @DisplayName("정상 종료는 절단으로 세지 않는다")
     void doesNotRecordTruncationOnNormalStop() throws Exception {
         HttpClient httpClient = mock(HttpClient.class);

--- a/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
@@ -1,0 +1,76 @@
+package com.mio.ai.memory.consolidation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.LlmUsage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 절단된 추출 응답이 부분 결과로 저장되지 않는지 확인한다.
+ *
+ * <p>"파싱이 실패할 테니 괜찮다"에 기댈 수 없다는 것이 핵심이다.
+ * {@code ObjectMapper.readTree} 는 {@code FAIL_ON_TRAILING_TOKENS} 가 기본 off 라서
+ * 선행 JSON 객체만 읽고 뒤에 붙은 잘린 내용을 조용히 버린다. 그래서 절단된 응답이
+ * <b>파싱에 성공하고</b> 누락 필드가 기본값으로 채워질 수 있다.
+ */
+class ExtractorLlmClientTruncationTest {
+
+    /** 잘렸지만 선행 객체가 완결돼 파싱은 성공하는 응답. 실측으로 확인된 형태다. */
+    private static final String TRUNCATED_BUT_PARSEABLE =
+            "{\"dominantEmotion\":\"sadness\"} 그리고 이 세션에서 사용자는 반복적으로";
+
+    @Test
+    @DisplayName("절단된 응답은 파싱 가능해도 비운다 — 누락 필드가 기본값으로 굳는 것을 막는다")
+    void truncatedResponseYieldsEmptyResult() {
+        ExtractorLlmClient client = new ExtractorLlmClient(
+                stubClient(TRUNCATED_BUT_PARSEABLE, true), new ObjectMapper());
+
+        ExtractorResult result = client.extract("세션 요약 본문");
+
+        assertThat(result.dominantEmotion())
+                .as("잘린 응답에서 읽은 감정을 저장하면 부분 분석 결과가 정본이 된다")
+                .isNull();
+        assertThat(result.thoughts()).isEmpty();
+        assertThat(result.triggerTags()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 응답이 절단되지 않았다면 그대로 파싱한다 — 절단 여부만이 차이다")
+    void sameResponseIsParsedWhenNotTruncated() {
+        ExtractorLlmClient client = new ExtractorLlmClient(
+                stubClient(TRUNCATED_BUT_PARSEABLE, false), new ObjectMapper());
+
+        ExtractorResult result = client.extract("세션 요약 본문");
+
+        assertThat(result.dominantEmotion())
+                .as("절단이 아니면 기존 동작을 바꾸지 않는다 — 이 값이 null 이면 회귀다")
+                .isEqualTo("sadness");
+    }
+
+    private LlmClient stubClient(String response, boolean truncated) {
+        return new LlmClient() {
+            @Override
+            public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
+                chunkHandler.accept(response);
+                return new LlmStreamResult(10L, LlmUsage.unresolved(request.model()), truncated);
+            }
+
+            @Override
+            public String completeText(LlmRequest request) {
+                throw new UnsupportedOperationException();
+            }
+
+            @Override
+            public String completeJson(LlmRequest request) {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+}


### PR DESCRIPTION
Closes #273

## 왜

출력 길이를 제어하는 것이 프롬프트의 `"응답은 2-4문장으로 간결하게 유지합니다."` 한 줄뿐이었다. **지시일 뿐 강제가 아니라서**, 모델이 지시를 벗어나면 막을 수단이 없었다.

기준선 문서 `plans/ai-quality-safety-escalation-cost-baseline.md` §5.7 **R-1**:

| 상황 | 출력 토큰 | 턴당 비용 |
|---|---|---|
| 정상 (문서 가정) | 150 | $0.00547 |
| 실측 (실제 턴) | 49~296 | $0.00089~ |
| 폭주 | 4,000 | **$0.0443 (8.1배)** |

## 파라미터는 추정하지 않고 실측했다

실제 OpenAI API 프로브 결과:

| 파라미터 | gpt-4o |
|---|---|
| `max_tokens` | 200 (동작) |
| `max_completion_tokens` | 200 (동작) |

둘 다 되지만 **`max_completion_tokens`를 쓴다** — 최신 모델은 `max_tokens`를 거부하므로 모델을 올릴 때 같이 깨지지 않는 쪽을 고른다.

## 새 안전장치의 실패 경로 (먼저 적고 시작)

상한은 그 자체로 새 실패 모드(절단)를 만든다. 실측 결과:

| 실패 경로 | 실측 | 처리 |
|---|---|---|
| 산문 절단 | `finish_reason=length`, 문장 중간 끊김 | 한도 400 (가정치 150의 2.7배) |
| **JSON 절단** | **파싱 전체 실패** (`Unterminated string`) | JSON 호출은 여유를 더 크게 |
| 한도 과소 | 정상 응답이 상시 절단 | **`mio.llm.truncated` 계측** |
| 스트리밍 절단 | `finish_reason=length` 전달됨 | 스트리밍도 계측 |

**판정 실패 경로 자체는 이미 안전하다** — `InputJudge`는 `risk_level` 부재 시 fail-closed, `OutputJudge`는 `REPLACE`. 절단이 안전 판정을 뒤집지는 않는다. 다만 절단이 늘면 판정 실패율이 조용히 올라가므로 계측이 필수다.

## 설계 판단 두 가지

**① 상한값을 설정 파일이 아니라 프롬프트 옆에 뒀다**

설정으로 빼면 `"500자 이내로 요약"`이라는 프롬프트와 상한값이 다른 파일에 있게 되고, **프롬프트를 늘려도 상한이 그대로인 걸 아무도 못 본다.** 잘못된 상한의 결과가 절단(= JSON이면 판정 소실)이라 이 결합은 눈에 보여야 한다.

호출부 12곳 전부 모델 상수 옆에 근거 주석과 함께 선언했다.

| 호출부 | 프롬프트 요구 | 상한 |
|---|---|---|
| ConversationOrchestrator (main, gpt-4o) | 2-4문장 (~150tok) | 400 |
| InputJudge | JSON (~130tok) | 500 |
| OutputJudge / CbtMetadataClassifier / OntologyExtractor | JSON | 400 |
| ExtractorLlmClient / TodoActionPersonalizer | JSON, 항목 최대 3 | 600 |
| SessionConsolidator / WeeklyReflectionJob | 500자 (~355tok) | 800 |
| ConversationCheckpointService / CheckinAiResponse / ReportNarrative | 100~200자 | 400 |

JSON 생성 호출은 절단이 파싱 전체 실패로 이어지므로 여유를 더 줬다.

**② 절단을 계측한다**

상한이 너무 빡빡해도 알 방법이 없으면 "모른다"가 침묵이 된다. 특히 JSON 절단은 로그에 "파싱 실패"로만 보이고 **원인이 상한이었다는 사실이 드러나지 않는다.**

## 검증

**단위 테스트 589건 통과** (기존 581 + 신규 8).

**실측 — 상한을 20으로 임시로 낮춰 실제 턴 실행:**
```
mio_llm_tokens_total{mode="stream",model="gpt-4o",type="completion"}  20.0   ← 정확히 상한에서 정지
mio_llm_truncated_total{mode="stream",model="gpt-4o"}                  1.0
WARN  LLM 응답이 출력 토큰 상한에 걸려 잘렸다: model=gpt-4o mode=stream
```
정상값(400) 복원 후 실제 턴 2건에서 출력이 56·296 토큰 → 절단 없음, `mio_llm_truncated` 미생성.

## 비용 관점에서 정확히 말하면

**이건 비용 절감이 아니라 테일 리스크 방어다.** 문서도 절감 효과를 "평시 0"으로 적어뒀다.

gpt-4o 턴당 비용은 입력 71% / 출력 29% 구조라 돈은 입력 쪽에 있다. 실제 절감은 C-1(CLEAR_LOW → mini, −54%)이나 C-3(프롬프트 캐싱, −23%) 항목이다. 이 PR은 **상한 없는 출력이라는 무방비 노출을 없애는 것**이 목적이다.

남은 비용 노출: **R-2 일일 사용량 상한 없음** (분당 60건만 존재, 1사용자 24시간 = $473/일). C-4로 별도 진행 필요.

## 테스트 플랜

- [x] `./gradlew build` — 589건 통과
- [x] 실제 API로 파라미터명·절단 동작 프로브
- [x] 상한 20으로 낮춰 절단 계측 end-to-end 확인
- [x] 정상값에서 절단 미발생 확인
- [ ] 배포 후 `mio_llm_truncated_total` 관측 — 올라가면 해당 호출부 상한이 빡빡한 것

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum output lengths across AI-generated classifications, summaries, reports, check-ins, personalized actions, and ontology extraction.
  * Added truncation detection for LLM outputs and surfaced it in streaming results.
* **Bug Fixes**
  * Improved protection against incomplete/truncated AI responses by avoiding persisting or trusting partial results in consolidation and extraction flows.
  * Added validation to reject non-positive response-length limits.
* **Tests**
  * Added/expanded coverage for max-completion handling and truncation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->