### PR TITLE
feat: 세션 감사 로그·통합 조회 구현 (#277)

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminCrisisEventController.java
+++ b/src/main/java/com/mio/admin/controller/AdminCrisisEventController.java
@@ -1,0 +1,38 @@
+package com.mio.admin.controller;
+
+import com.mio.admin.dto.CrisisEventReviewRequest;
+import com.mio.admin.service.AdminCrisisEventService;
+import com.mio.common.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 운영자용 위기 이벤트 검토 처리.
+ *
+ * <p><b>인증 미포함 — Sprint01 범위 밖 결정.</b> 내부 개발팀 전용 전제. Admin 로그인 시스템이
+ * 생기면 이 위에 인증 필터만 얹는 구조로 지금부터 설계해둔다.
+ */
+@RestController
+@RequestMapping("/v1/admin/crisis-events")
+@RequiredArgsConstructor
+public class AdminCrisisEventController {
+
+    private final AdminCrisisEventService adminCrisisEventService;
+
+    @PostMapping("/{eventId}/review")
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> review(
+            @PathVariable UUID eventId,
+            @Valid @RequestBody CrisisEventReviewRequest request) {
+        adminCrisisEventService.review(eventId, request);
+        return ResponseEntity.ok(ApiResponse.ok(Map.of("reviewed", true)));
+    }
+}

--- a/src/main/java/com/mio/admin/controller/AdminSessionController.java
+++ b/src/main/java/com/mio/admin/controller/AdminSessionController.java
@@ -1,0 +1,33 @@
+package com.mio.admin.controller;
+
+import com.mio.admin.dto.SessionTimelineResponse;
+import com.mio.admin.service.AdminSessionService;
+import com.mio.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * 운영자용 세션 통합 조회 — 한 세션의 대화·안전판정·위기·감사기록을 시간순으로 반환한다.
+ *
+ * <p><b>인증 미포함 — Sprint01 범위 밖 결정.</b> 내부 개발팀 전용 전제로 대화 원문도 마스킹 없이
+ * 그대로 노출한다. Admin 로그인 시스템이 생기면 이 위에 인증 필터만 얹는 구조로 지금부터
+ * 설계해둔다 (컨트롤러 로직과 인증을 분리).
+ */
+@RestController
+@RequestMapping("/v1/admin/sessions")
+@RequiredArgsConstructor
+public class AdminSessionController {
+
+    private final AdminSessionService adminSessionService;
+
+    @GetMapping("/{sessionId}")
+    public ResponseEntity<ApiResponse<SessionTimelineResponse>> getTimeline(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminSessionService.getTimeline(sessionId)));
+    }
+}

--- a/src/main/java/com/mio/admin/dto/CrisisEventReviewRequest.java
+++ b/src/main/java/com/mio/admin/dto/CrisisEventReviewRequest.java
@@ -1,0 +1,13 @@
+package com.mio.admin.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record CrisisEventReviewRequest(
+        @NotBlank
+        @Pattern(regexp = "no_action_needed|user_contacted|escalated")
+        String action,
+
+        String note
+) {
+}

--- a/src/main/java/com/mio/admin/dto/SessionTimelineResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionTimelineResponse.java
@@ -1,0 +1,16 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record SessionTimelineResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("user_id") UUID userId,
+        @JsonProperty("session_cost_usd") BigDecimal sessionCostUsd,
+        List<Map<String, Object>> timeline
+) {
+}

--- a/src/main/java/com/mio/admin/service/AdminCrisisEventService.java
+++ b/src/main/java/com/mio/admin/service/AdminCrisisEventService.java
@@ -25,11 +25,10 @@ public class AdminCrisisEventService {
         CrisisEvent event = crisisEventRepository.findById(eventId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.CRISIS_EVENT_NOT_FOUND));
 
-        if (event.isOperatorReviewed()) {
+        int updated = crisisEventRepository.reviewIfNotAlready(eventId, request.action(), request.note());
+        if (updated == 0) {
             throw new BusinessException(ErrorCode.CRISIS_EVENT_ALREADY_REVIEWED);
         }
-
-        event.review(request.action(), request.note());
 
         auditLogService.record(
                 event.getUser().getId(),

--- a/src/main/java/com/mio/admin/service/AdminCrisisEventService.java
+++ b/src/main/java/com/mio/admin/service/AdminCrisisEventService.java
@@ -1,0 +1,45 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.CrisisEventReviewRequest;
+import com.mio.ai.crisis.CrisisEventRepository;
+import com.mio.common.audit.AuditLogService;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.crisis.domain.CrisisEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class AdminCrisisEventService {
+
+    private final CrisisEventRepository crisisEventRepository;
+    private final AuditLogService auditLogService;
+
+    @Transactional
+    public void review(UUID eventId, CrisisEventReviewRequest request) {
+        CrisisEvent event = crisisEventRepository.findById(eventId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CRISIS_EVENT_NOT_FOUND));
+
+        if (event.isOperatorReviewed()) {
+            throw new BusinessException(ErrorCode.CRISIS_EVENT_ALREADY_REVIEWED);
+        }
+
+        event.review(request.action(), request.note());
+
+        auditLogService.record(
+                event.getUser().getId(),
+                "CRISIS_EVENT_REVIEWED",
+                "crisis_event",
+                eventId.toString(),
+                Map.of(
+                        "action", request.action(),
+                        "note", request.note() != null ? request.note() : ""
+                )
+        );
+    }
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionService.java
@@ -1,0 +1,146 @@
+package com.mio.admin.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.admin.dto.SessionTimelineResponse;
+import com.mio.ai.crisis.CrisisEventRepository;
+import com.mio.ai.domain.AiPolicyDecision;
+import com.mio.ai.repository.AiPolicyDecisionRepository;
+import com.mio.common.audit.AuditLog;
+import com.mio.common.audit.AuditLogRepository;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.crisis.domain.CrisisEvent;
+import com.mio.session.domain.Message;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+/**
+ * 운영자가 세션 하나의 흐름·오류·Safety 사건을 시간순으로 통합 조회한다 (Sprint01 DoD).
+ *
+ * <p>4개 소스(messages, ai_policy_decisions, crisis_events, audit_logs)를 각각 조회한 뒤
+ * 애플리케이션 레벨에서 시간순 병합한다 — 소스별 컬럼 모양이 달라 SQL UNION으로는 묶기 어렵다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminSessionService {
+
+    private final SessionRepository sessionRepository;
+    private final MessageRepository messageRepository;
+    private final AiPolicyDecisionRepository aiPolicyDecisionRepository;
+    private final CrisisEventRepository crisisEventRepository;
+    private final AuditLogRepository auditLogRepository;
+    private final MessageEncryptor messageEncryptor;
+    private final ObjectMapper objectMapper;
+
+    private static final TypeReference<Map<String, Object>> JSON_MAP_TYPE = new TypeReference<>() {};
+
+    @Transactional(readOnly = true)
+    public SessionTimelineResponse getTimeline(UUID sessionId) {
+        var session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        List<CrisisEvent> crisisEvents = crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId);
+
+        // audit_logs.resource_id 는 행위 대상에 따라 session_id(탈퇴·동의)이거나
+        // crisis_event.id(위기검토)다 — 이 세션에 속한 위기 이벤트들의 검토 기록도 같이 모아야
+        // "세션의 흐름·Safety 사건을 처음부터 끝까지 추적"이 실제로 성립한다.
+        List<String> auditResourceIds = Stream.concat(
+                Stream.of(sessionId.toString()),
+                crisisEvents.stream().map(c -> c.getId().toString())
+        ).toList();
+
+        List<TimelineItem> items = Stream.of(
+                        messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId).stream()
+                                .map(this::messageItem),
+                        aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId).stream()
+                                .map(this::policyDecisionItem),
+                        crisisEvents.stream()
+                                .map(this::crisisEventItem),
+                        auditResourceIds.stream()
+                                .flatMap(resourceId -> auditLogRepository.findByResourceIdOrderByCreatedAtAsc(resourceId).stream())
+                                .map(this::auditLogItem)
+                )
+                .flatMap(s -> s)
+                .sorted(Comparator.comparing(TimelineItem::at))
+                .toList();
+
+        List<Map<String, Object>> timeline = items.stream().map(TimelineItem::data).toList();
+        BigDecimal sessionCostUsd = aiPolicyDecisionRepository.sumCostUsdBySessionId(sessionId);
+
+        return new SessionTimelineResponse(sessionId, session.getUser().getId(), sessionCostUsd, timeline);
+    }
+
+    private record TimelineItem(OffsetDateTime at, Map<String, Object> data) {
+    }
+
+    private TimelineItem messageItem(Message m) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "message");
+        data.put("at", m.getCreatedAt().toString());
+        data.put("role", m.getRole().name().toLowerCase());
+        data.put("content", new String(messageEncryptor.decrypt(m.getContentCiphertext()), StandardCharsets.UTF_8));
+        data.put("emotion_score", m.getEmotionScore());
+        data.put("bias_type", m.getBiasType());
+        data.put("is_crisis_flagged", m.isCrisisFlagged());
+        return new TimelineItem(m.getCreatedAt(), data);
+    }
+
+    private TimelineItem policyDecisionItem(AiPolicyDecision d) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "policy_decision");
+        data.put("at", d.getCreatedAt().toString());
+        data.put("risk_level", d.getRiskLevel());
+        data.put("action", d.getAction());
+        data.put("delivery_mode", d.getDeliveryMode());
+        data.put("trace", parseJson(d.getTrace(), "ai_policy_decisions.trace", d.getId()));
+        return new TimelineItem(d.getCreatedAt(), data);
+    }
+
+    private TimelineItem crisisEventItem(CrisisEvent c) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "crisis_event");
+        data.put("at", c.getCreatedAt().toString());
+        data.put("trigger_type", c.getTriggerType());
+        data.put("severity", c.getSeverity());
+        data.put("operator_reviewed", c.isOperatorReviewed());
+        data.put("review_action", c.getReviewAction());
+        data.put("operator_note", c.getOperatorNote());
+        return new TimelineItem(c.getCreatedAt(), data);
+    }
+
+    private TimelineItem auditLogItem(AuditLog a) {
+        Map<String, Object> data = new LinkedHashMap<>();
+        data.put("type", "audit_log");
+        data.put("at", a.getCreatedAt().toString());
+        data.put("action", a.getAction());
+        data.put("details", parseJson(a.getDetails(), "audit_logs.details", a.getId()));
+        return new TimelineItem(a.getCreatedAt(), data);
+    }
+
+    private Map<String, Object> parseJson(String json, String fieldDescription, UUID rowId) {
+        try {
+            return objectMapper.readValue(json, JSON_MAP_TYPE);
+        } catch (JsonProcessingException e) {
+            log.warn("Failed to parse {} for session timeline: id={}", fieldDescription, rowId, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
@@ -3,6 +3,7 @@ package com.mio.ai.crisis;
 import com.mio.crisis.domain.CrisisEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -10,4 +11,6 @@ public interface CrisisEventRepository extends JpaRepository<CrisisEvent, UUID> 
 
     /** 재시도가 같은 논리 이벤트를 다시 만들지 않도록 기존 행을 찾는다 (이슈 #269). */
     Optional<CrisisEvent> findByDedupKey(UUID dedupKey);
+
+    List<CrisisEvent> findBySession_IdOrderByCreatedAtAsc(UUID sessionId);
 }

--- a/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
@@ -2,6 +2,9 @@ package com.mio.ai.crisis;
 
 import com.mio.crisis.domain.CrisisEvent;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +16,23 @@ public interface CrisisEventRepository extends JpaRepository<CrisisEvent, UUID> 
     Optional<CrisisEvent> findByDedupKey(UUID dedupKey);
 
     List<CrisisEvent> findBySession_IdOrderByCreatedAtAsc(UUID sessionId);
+
+    /**
+     * 원자적 조건부 검토 처리 (이슈 #277 리뷰 반영).
+     *
+     * <p>read-then-write(findById → isOperatorReviewed 확인 → review())로 하면 동시 요청
+     * 둘 다 검사를 통과해 서로 덮어쓸 수 있다. WHERE 절에 operator_reviewed = false 를 걸어
+     * DB 가 동시성을 직렬화하게 한다 — SessionRepository.endSessionIfActive 와 동일 패턴.
+     *
+     * @return 1 = 이번 호출이 검토 처리함, 0 = 이미 다른 요청이 먼저 처리함(호출자가 409 판단)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE CrisisEvent c
+            SET c.operatorReviewed = true, c.reviewAction = :action, c.operatorNote = :note
+            WHERE c.id = :eventId AND c.operatorReviewed = false
+            """)
+    int reviewIfNotAlready(@Param("eventId") UUID eventId,
+                           @Param("action") String action,
+                           @Param("note") String note);
 }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -63,6 +63,7 @@ import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -140,6 +141,10 @@ public class ConversationOrchestrator {
         // 결말이 이미 저장됐는지. done 을 보내기 전에 저장하는 것이 이 작업의 핵심 순서다.
         AtomicBoolean turnPersisted = new AtomicBoolean(false);
         String outboundMsgId = "msg_out_" + shortId();
+
+        // CloudWatch 등 원시 로그를 session_id 로 교차 검색하기 위한 상관관계 키 (Sprint01, 이슈 #277).
+        // TraceIdFilter 의 traceId 는 요청 단위라 세션 단위 상관관계를 주지 않는다.
+        MDC.put("sessionId", sessionId.toString());
 
         try {
             Session session = sessionRepository.findById(sessionId)
@@ -513,6 +518,8 @@ public class ConversationOrchestrator {
             //    보낼 대상이 없다. 저장이 보장 대상이고 전송은 최선 노력이다.
             sendFallbackDone(emitter, outboundMsgId);
             emitter.completeWithError(e);
+        } finally {
+            MDC.remove("sessionId");
         }
     }
 

--- a/src/main/java/com/mio/ai/repository/AiPolicyDecisionRepository.java
+++ b/src/main/java/com/mio/ai/repository/AiPolicyDecisionRepository.java
@@ -13,10 +13,13 @@ public interface AiPolicyDecisionRepository extends JpaRepository<AiPolicyDecisi
 
     List<AiPolicyDecision> findBySessionIdOrderByCreatedAtAsc(UUID sessionId);
 
+    // llm_cost_usd 가 숫자가 아닌 값(예: 파싱 실패로 문자열이 남는 경우)이면 ::numeric 캐스팅이
+    // 예외를 던져 전체 세션 조회가 500 으로 죽는다. jsonb_typeof 로 숫자 행만 걸러 방어한다.
     @Query(value = """
             SELECT COALESCE(SUM((trace->>'llm_cost_usd')::numeric), 0)
             FROM ai_policy_decisions
             WHERE session_id = :sessionId
+              AND jsonb_typeof(trace->'llm_cost_usd') = 'number'
             """, nativeQuery = true)
     BigDecimal sumCostUsdBySessionId(@Param("sessionId") UUID sessionId);
 }

--- a/src/main/java/com/mio/ai/repository/AiPolicyDecisionRepository.java
+++ b/src/main/java/com/mio/ai/repository/AiPolicyDecisionRepository.java
@@ -2,8 +2,21 @@ package com.mio.ai.repository;
 
 import com.mio.ai.domain.AiPolicyDecision;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 
 public interface AiPolicyDecisionRepository extends JpaRepository<AiPolicyDecision, UUID> {
+
+    List<AiPolicyDecision> findBySessionIdOrderByCreatedAtAsc(UUID sessionId);
+
+    @Query(value = """
+            SELECT COALESCE(SUM((trace->>'llm_cost_usd')::numeric), 0)
+            FROM ai_policy_decisions
+            WHERE session_id = :sessionId
+            """, nativeQuery = true)
+    BigDecimal sumCostUsdBySessionId(@Param("sessionId") UUID sessionId);
 }

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -46,6 +46,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if ("/error".equals(request.getRequestURI())) {
             return true;
         }
+        // Sprint01 범위 결정: 내부 개발팀 전용 축소판, 인증 계층 미포함 (이슈 #277).
+        // SecurityConfig.PUBLIC_ENDPOINTS 와 별개로 이 필터가 먼저 실행되므로 여기서도 제외해야
+        // 한다. Admin 로그인 시스템이 생기면 이 조건부터 걷어내고 인증을 앞단에 둔다.
+        if (request.getRequestURI().startsWith("/v1/admin/")) {
+            return true;
+        }
         String key = request.getMethod() + " " + request.getRequestURI();
         return WHITELIST.contains(key);
     }

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.mio.auth.service;
 
 import com.mio.auth.dto.*;
 import com.mio.auth.provider.SocialAuthProvider;
+import com.mio.common.audit.AuditLogService;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.user.domain.SignupStep;
@@ -20,6 +21,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -35,6 +37,9 @@ public class AuthService {
     private final UserDeviceRepository userDeviceRepository;
     private final JwtTokenService jwtTokenService;
     private final RefreshTokenService refreshTokenService;
+    private final AuditLogService auditLogService;
+
+    private static final int WITHDRAW_RETENTION_DAYS = 30;
 
     @Transactional
     public LoginResponse login(LoginRequest request) {
@@ -148,6 +153,11 @@ public class AuthService {
                 .toList();
         userConsentRepository.saveAll(consents);
 
+        auditLogService.record(userId, "CONSENT_AGREED", "user_consent", userId.toString(), Map.of(
+                "consent_types", request.consents().stream().map(ConsentRequest.ConsentItem::type).toList(),
+                "marketing_agreed", marketingAgreed
+        ));
+
         return new ConsentResponse(user.getSignupStep());
     }
 
@@ -205,6 +215,11 @@ public class AuthService {
         // PII 비식별화 정책 — social_id를 해시로 대체해 재가입 방지 키만 유지
         String anonymizedSocialId = sha256(user.getSocialId());
         user.softDelete(anonymizedSocialId);
+
+        auditLogService.record(userId, "USER_WITHDRAW", "user", userId.toString(), Map.of(
+                "anonymized_at", user.getDeletedAt().toString(),
+                "hard_delete_scheduled_at", user.getDeletedAt().plusDays(WITHDRAW_RETENTION_DAYS).toString()
+        ));
 
         return new WithdrawResponse(user.getDeletedAt());
     }

--- a/src/main/java/com/mio/common/audit/AuditLogRepository.java
+++ b/src/main/java/com/mio/common/audit/AuditLogRepository.java
@@ -1,0 +1,11 @@
+package com.mio.common.audit;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface AuditLogRepository extends JpaRepository<AuditLog, UUID> {
+
+    List<AuditLog> findByResourceIdOrderByCreatedAtAsc(String resourceId);
+}

--- a/src/main/java/com/mio/common/audit/AuditLogService.java
+++ b/src/main/java/com/mio/common/audit/AuditLogService.java
@@ -1,0 +1,42 @@
+package com.mio.common.audit;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 컴플라이언스 감사 기록 계층. 탈퇴·동의·위기검토 등 "누가 무엇을 했는가"를 남긴다.
+ *
+ * <p>성장분석 이벤트 로그(CC·리텐션)와는 별개 파이프라인이다 — 혼용하지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuditLogService {
+
+    private final AuditLogRepository auditLogRepository;
+    private final ObjectMapper objectMapper;
+
+    public void record(UUID userId, String action, String resourceType, String resourceId,
+                        Map<String, Object> details) {
+        try {
+            AuditLog entry = AuditLog.builder()
+                    .userId(userId)
+                    .action(action)
+                    .resourceType(resourceType)
+                    .resourceId(resourceId)
+                    .details(objectMapper.writeValueAsString(details))
+                    .build();
+            auditLogRepository.save(entry);
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize audit log details: action={}, resourceId={}", action, resourceId, e);
+        } catch (Exception e) {
+            log.error("Failed to persist audit log: action={}, resourceId={}", action, resourceId, e);
+        }
+    }
+}

--- a/src/main/java/com/mio/common/audit/AuditLogService.java
+++ b/src/main/java/com/mio/common/audit/AuditLogService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.UUID;
@@ -22,6 +24,15 @@ public class AuditLogService {
     private final AuditLogRepository auditLogRepository;
     private final ObjectMapper objectMapper;
 
+    /**
+     * 호출자 트랜잭션과 분리된 독립 트랜잭션으로 기록한다.
+     *
+     * <p>같은 트랜잭션에서 실행하면, 여기서 예외를 잡아 삼켜도 JPA 구현체가 이미 트랜잭션을
+     * rollback-only 로 표시해뒀을 수 있다 — 그러면 감사 로그 실패가 호출자의 실제 작업(탈퇴 등)
+     * 커밋까지 {@code UnexpectedRollbackException} 으로 무너뜨린다. 감사 기록 실패가 원 작업을
+     * 막아서는 안 되므로 REQUIRES_NEW 로 분리한다.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void record(UUID userId, String action, String resourceType, String resourceId,
                         Map<String, Object> details) {
         try {

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -69,6 +69,10 @@ public enum ErrorCode {
     // Report
     REPORT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버 오류로 리포트 조회에 실패했습니다."),
 
+    // Admin
+    CRISIS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "존재하지 않는 위기 이벤트입니다."),
+    CRISIS_EVENT_ALREADY_REVIEWED(HttpStatus.CONFLICT, "CONFLICT", "이미 검토된 위기 이벤트입니다."),
+
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", "요청 한도를 초과했습니다."),
 

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -31,7 +31,11 @@ public class SecurityConfig {
             "/v1/auth/**",
             "/api-docs/**",
             "/swagger-ui/**",
-            "/swagger-ui.html"
+            "/swagger-ui.html",
+            // Sprint01 범위 결정: 내부 개발팀 전용 축소판, 인증 계층 미포함 (이슈 #277).
+            // Nginx 가 8080 을 프록시하므로 인터넷에 노출된다 — Admin 로그인 시스템이 생기면
+            // 반드시 이 줄부터 걷어내고 인증을 앞단에 둔다.
+            "/v1/admin/**"
     };
 
     /**

--- a/src/main/java/com/mio/crisis/domain/CrisisEvent.java
+++ b/src/main/java/com/mio/crisis/domain/CrisisEvent.java
@@ -67,10 +67,4 @@ public class CrisisEvent {
     protected void onCreate() {
         createdAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
-
-    public void review(String action, String note) {
-        this.reviewAction = action;
-        this.operatorNote = note;
-        this.operatorReviewed = true;
-    }
 }

--- a/src/main/java/com/mio/crisis/domain/CrisisEvent.java
+++ b/src/main/java/com/mio/crisis/domain/CrisisEvent.java
@@ -56,11 +56,21 @@ public class CrisisEvent {
     @Column(name = "operator_note")
     private String operatorNote;
 
+    /** no_action_needed / user_contacted / escalated */
+    @Column(name = "review_action")
+    private String reviewAction;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 
     @PrePersist
     protected void onCreate() {
         createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    public void review(String action, String note) {
+        this.reviewAction = action;
+        this.operatorNote = note;
+        this.operatorReviewed = true;
     }
 }

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -27,4 +27,6 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
     List<Message> findRecentBySessionAndRole(@Param("sessionId") UUID sessionId,
                                              @Param("role") MessageRole role,
                                              Pageable pageable);
+
+    List<Message> findBySession_IdOrderByCreatedAtAsc(UUID sessionId);
 }

--- a/src/main/resources/db/migration/V42__add_crisis_events_review_action.sql
+++ b/src/main/resources/db/migration/V42__add_crisis_events_review_action.sql
@@ -1,0 +1,6 @@
+-- 위기 이벤트 검토 처리 (POST /v1/admin/crisis-events/{id}/review) 결과 저장
+-- operator_note 는 자유 텍스트라 검토 액션(no_action_needed/user_contacted/escalated) 자체를
+-- 별도 값으로 조회·집계하려면 전용 컬럼이 필요하다.
+
+ALTER TABLE crisis_events
+    ADD COLUMN review_action TEXT;

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -2,6 +2,7 @@ package com.mio.auth.service;
 
 import com.mio.auth.dto.*;
 import com.mio.auth.provider.SocialAuthProvider;
+import com.mio.common.audit.AuditLogService;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.user.domain.SignupStep;
@@ -35,6 +36,7 @@ class AuthServiceTest {
     @Mock private UserDeviceRepository userDeviceRepository;
     @Mock private JwtTokenService jwtTokenService;
     @Mock private RefreshTokenService refreshTokenService;
+    @Mock private AuditLogService auditLogService;
 
     private AuthService authService;
 
@@ -49,7 +51,7 @@ class AuthServiceTest {
                 .thenReturn(Optional.empty());
         authService = new AuthService(
                 List.of(kakaoProvider), userRepository, userConsentRepository,
-                userDeviceRepository, jwtTokenService, refreshTokenService
+                userDeviceRepository, jwtTokenService, refreshTokenService, auditLogService
         );
     }
 


### PR DESCRIPTION
## 요약
Sprint01 완료조건 — 운영자가 세션 하나의 흐름·오류·Safety 사건을 처음부터 끝까지 추적 가능해야
하고, 삭제·동의 철회 반영 여부를 확인 가능해야 함. audit_logs 테이블은 존재만 하고 코드에서
전혀 쓰이지 않았고, 세션 통합 조회 방법도 없었다.

## 관련 이슈
- Closes #277

## 변경 사항
- AuditLogRepository/AuditLogService 신설 + AuthService(withdraw/agreeConsent) 연동
- GET /v1/admin/sessions/{sessionId} — 메시지·안전판정·위기·감사로그 시간순 통합 조회
- POST /v1/admin/crisis-events/{id}/review — 위기 이벤트 검토 처리 + 감사로그 연쇄 기록
- 세션 단위 AI 비용 집계(session_cost_usd)
- ConversationOrchestrator에 MDC sessionId 추가 (원시 로그 상관관계 대비)
- crisis_events.review_action 컬럼 추가 (V42)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (신규 API 2개 추가, 기존 API 변경 없음)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (V42, crisis_events.review_action 컬럼 추가)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (MDC sessionId 추가)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test

확인 내용

- 유닛/통합 테스트 593/594 통과 (실패 1건은 로컬 환경의 무관한 Flyway V18 체크섬 드리프트, 이 PR과 무관)
- 로컬 Postgres/Redis 띄우고 실제 앱 기동 후 API 직접 호출로 검증:
  - DELETE /v1/auth/withdraw 호출 → audit_logs에 USER_WITHDRAW 실제 기록 확인
  - POST /v1/auth/signup/consent → CONSENT_AGREED 기록 확인 (AuthIntegrationTest)
  - GET /v1/admin/sessions/{id} → 메시지·안전판정·위기·감사로그가 시간순으로 정확히 병합됨, 존재하지 않는 세션 404 확인
  - POST /v1/admin/crisis-events/{id}/review → DB 반영 + 감사로그 연쇄 기록 확인, 재검토 409·존재하지 않는 이벤트 404·잘못된 값 400 확인
  - 위 검토 기록이 세션 타임라인에도 반영되는지 재조회로 확인

중점 리뷰 포인트

- /v1/admin/**가 인증 없이 열려 있습니다 (SecurityConfig.PUBLIC_ENDPOINTS + JwtAuthenticationFilter 양쪽 모두). Sprint01 범위상 내부 개발팀 전용 전제로 의도적으로 그렇게 했지만, Nginx가 8080을 프록시하므로 인터넷에 그대로 노출됩니다. 프로덕션/베타 오픈 전 반드시 인증 계층 추가 필요 — 별도 이슈로 트래킹 권장.
- 대화 원문도 마스킹 없이 그대로 노출합니다 (AdminSessionService.messageItem) — 위와 같은 이유로 내부 전용 전제.

배포 / 롤백

- Rollout: DB 마이그레이션(V42) 자동 적용, 코드 배포만으로 완료. 다운타임 없음.
- Rollback: 이전 배포로 롤백 시 V42 컬럼(crisis_events.review_action)은 남아있어도 무해 (nullable, 미사용 컬럼으로만 남음).

체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. (기존 AuthServiceTest 업데이트, 신규 admin 서비스는 실제 API 호출로 수동 검증)
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added administrative tools to review crisis events with supported actions and optional notes.
  * Added session timeline retrieval, combining messages, policy decisions, crisis events, and audit activity.
  * Added session cost reporting and chronological event display.
  * Added audit logging for crisis reviews, consent updates, and account withdrawal actions.

* **Bug Fixes**
  * Improved handling of malformed timeline data without interrupting session retrieval.
  * Added clearer errors for missing or previously reviewed crisis events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->