### PR TITLE
feat: 회원가입 온보딩 간소화 — 취준생/취업자 필드 추가, 캐릭터 선택 진입조건 완화 (#282)

### DIFF
--- a/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
@@ -6,5 +6,6 @@ import jakarta.validation.constraints.Size;
 public record SignupCompleteRequest(
         @NotBlank @Size(min = 2, max = 13) String nickname,
         String ageRange,
-        String gender
+        String gender,
+        String employmentStatus
 ) {}

--- a/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
+++ b/src/main/java/com/mio/auth/dto/SignupCompleteRequest.java
@@ -1,5 +1,6 @@
 package com.mio.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -7,5 +8,5 @@ public record SignupCompleteRequest(
         @NotBlank @Size(min = 2, max = 13) String nickname,
         String ageRange,
         String gender,
-        String employmentStatus
+        @JsonProperty("employment_status") String employmentStatus
 ) {}

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -173,7 +173,7 @@ public class AuthService {
             throw new BusinessException(ErrorCode.NICKNAME_DUPLICATE);
         }
 
-        user.completeProfile(request.nickname(), request.ageRange(), request.gender());
+        user.completeProfile(request.nickname(), request.ageRange(), request.gender(), request.employmentStatus());
 
         return new SignupCompleteResponse(user.getSignupStep(), user.getOnboardingStep(), user.getNickname());
     }

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -115,7 +115,9 @@ public class OnboardingService {
         }
 
         User user = findUser(userId);
-        if (user.getOnboardingStep() < 3) {
+        // 2026-08 개편(이슈 #282): 온보딩 step1~3 완료가 더 이상 캐릭터 선택의 진입 조건이 아니다.
+        // 프로필 완료 직후 바로 캐릭터를 고를 수 있다 — step1~3은 선택적 레거시 경로로 남는다.
+        if (user.getSignupStep().ordinal() < SignupStep.PROFILE_COMPLETED.ordinal()) {
             throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
         }
 

--- a/src/main/java/com/mio/onboarding/service/OnboardingService.java
+++ b/src/main/java/com/mio/onboarding/service/OnboardingService.java
@@ -117,7 +117,12 @@ public class OnboardingService {
         User user = findUser(userId);
         // 2026-08 개편(이슈 #282): 온보딩 step1~3 완료가 더 이상 캐릭터 선택의 진입 조건이 아니다.
         // 프로필 완료 직후 바로 캐릭터를 고를 수 있다 — step1~3은 선택적 레거시 경로로 남는다.
-        if (user.getSignupStep().ordinal() < SignupStep.PROFILE_COMPLETED.ordinal()) {
+        //
+        // signupStep은 정확히 PROFILE_COMPLETED여야 한다 — 범위(>=)로 열어두면 이미
+        // ONBOARDING_COMPLETED/COMPLETED인 유저도 이 API를 다시 통과해 completeOnboarding()이
+        // signupStep을 ONBOARDING_COMPLETED로 되돌려버린다(가입 완료 상태의 강등). 가입 이후
+        // 캐릭터를 바꾸는 경로는 CharacterService.changeCharacter()가 별도로 있다.
+        if (user.getSignupStep() != SignupStep.PROFILE_COMPLETED) {
             throw new BusinessException(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED);
         }
 

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -39,6 +39,10 @@ public class User {
     @Column(name = "gender")
     private String gender;
 
+    /** 취준생/취업자 구분. 값 검증 없음 — gender/ageRange와 동일한 자유 문자열 (이슈 #282). */
+    @Column(name = "employment_status")
+    private String employmentStatus;
+
     /** 가입 시 초기 동의값 (이후 변경은 notification_settings 참조) */
     @Column(name = "notification_agree", nullable = false)
     @Builder.Default
@@ -125,10 +129,11 @@ public class User {
         this.marketingAgree = marketingAgree;
         this.signupStep = SignupStep.CONSENT_AGREED;
     }
-    public void completeProfile(String nickname, String ageRange, String gender) {
+    public void completeProfile(String nickname, String ageRange, String gender, String employmentStatus) {
         this.nickname = nickname;
         this.ageRange = ageRange;
         this.gender = gender;
+        this.employmentStatus = employmentStatus;
         this.signupStep = SignupStep.PROFILE_COMPLETED;
     }
 

--- a/src/main/resources/db/migration/V44__add_users_employment_status.sql
+++ b/src/main/resources/db/migration/V44__add_users_employment_status.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD COLUMN employment_status TEXT;

--- a/src/test/java/com/mio/auth/dto/SignupCompleteRequestJsonTest.java
+++ b/src/test/java/com/mio/auth/dto/SignupCompleteRequestJsonTest.java
@@ -1,0 +1,26 @@
+package com.mio.auth.dto;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SignupCompleteRequestJsonTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void employmentStatus_bindsFromSnakeCaseWireName() throws Exception {
+        String json = """
+                {
+                  "nickname": "닉네임",
+                  "gender": "male",
+                  "employment_status": "job_seeker"
+                }
+                """;
+
+        SignupCompleteRequest request = objectMapper.readValue(json, SignupCompleteRequest.class);
+
+        assertThat(request.employmentStatus()).isEqualTo("job_seeker");
+    }
+}

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -323,6 +323,6 @@ class AuthServiceTest {
     }
 
     private SignupCompleteRequest buildCompleteRequest(String nickname) {
-        return new SignupCompleteRequest(nickname, "20대", "male");
+        return new SignupCompleteRequest(nickname, "20대", "male", "job_seeker");
     }
 }

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -52,7 +52,7 @@ class OnboardingServiceTest {
     @Test
     @DisplayName("1단계 제출 성공 시 onboarding_step이 1을 반환한다")
     void submitStep1_success_returnsStep1() {
-        mockUser.completeProfile("테스트", null, null);
+        mockUser.completeProfile("테스트", null, null, null);
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
         when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));
@@ -209,6 +209,7 @@ class OnboardingServiceTest {
     @Test
     @DisplayName("캐릭터 선택 성공 시 preferred_character_id와 signup_step을 반환한다")
     void selectCharacter_success_returnsResponse() {
+        mockUser.completeProfile("테스트", null, null, null);
         mockUser.updateOnboardingStep(3);
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
 
@@ -273,7 +274,7 @@ class OnboardingServiceTest {
     @Test
     @DisplayName("이미 완료한 단계를 다시 제출해도 onboarding_step은 낮아지지 않는다")
     void submitStep1_resubmit_doesNotRegressStep() {
-        mockUser.completeProfile("테스트", null, null);
+        mockUser.completeProfile("테스트", null, null, null);
         mockUser.updateOnboardingStep(2);
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
@@ -287,7 +288,7 @@ class OnboardingServiceTest {
     @Test
     @DisplayName("step 1 skip 성공 시 onboarding_step이 1을 반환한다")
     void skipStep1_success_returnsStep1() {
-        mockUser.completeProfile("테스트", null, null);
+        mockUser.completeProfile("테스트", null, null, null);
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(onboardingAnswerRepository.findByUser_Id(any())).thenReturn(Optional.empty());
         when(onboardingAnswerRepository.save(any())).thenAnswer(i -> i.getArgument(0));

--- a/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
+++ b/src/test/java/com/mio/onboarding/service/OnboardingServiceTest.java
@@ -233,6 +233,39 @@ class OnboardingServiceTest {
     }
 
     @Test
+    @DisplayName("이미 ONBOARDING_COMPLETED인 사용자가 다시 선택하면 COMPLETED로 강등되지 않고 예외를 발생시킨다")
+    void selectCharacter_alreadyOnboardingCompleted_throwsAndDoesNotDowngrade() {
+        mockUser.completeProfile("테스트", null, null, null);
+        mockUser.completeOnboarding("mio");
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.selectCharacter(
+                userId, new CharacterSelectRequest("bau")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+        assertThat(mockUser.getPreferredCharacterId()).isEqualTo("mio");
+    }
+
+    @Test
+    @DisplayName("이미 COMPLETED인 사용자가 다시 선택하면 ONBOARDING_COMPLETED로 강등되지 않고 예외를 발생시킨다")
+    void selectCharacter_alreadyCompleted_throwsAndDoesNotDowngrade() {
+        mockUser.completeProfile("테스트", null, null, null);
+        mockUser.completeOnboarding("mio");
+        mockUser.finalizeSignup();
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+
+        assertThatThrownBy(() -> onboardingService.selectCharacter(
+                userId, new CharacterSelectRequest("bau")
+        ))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.ONBOARDING_STEP_NOT_COMPLETED));
+        assertThat(mockUser.getSignupStep()).isEqualTo(SignupStep.COMPLETED);
+    }
+
+    @Test
     @DisplayName("캐릭터 선택은 3단계 미완료 시 ONBOARDING_STEP_NOT_COMPLETED 예외를 발생시킨다")
     void selectCharacter_step3NotCompleted_throws() {
         mockUser.updateOnboardingStep(2);


### PR DESCRIPTION
---
요약

새 디자인 목업(닉네임+성별+나이 → 캐릭터 선택)에 맞춰 회원가입 온보딩을 간소화합니다. 프로필 설정 단계에 취준생/취업자 구분 필드를 추가하고, 캐릭터 선택이 더 이상 온보딩 3단계(감정상태·고민유형·상담스타일) 완료를 요구하지 않도록 진입조건을 완화합니다.

관련 이슈

- Closes #282

변경 사항

- users 테이블에 employment_status 컬럼 추가 (V44, 값 검증 없는 자유 문자열)
- SignupCompleteRequest에 employment_status 필드 추가, User.completeProfile()에 반영
- OnboardingService.selectCharacter() 진입조건을 onboarding_step >= 3 → signup_step >= PROFILE_COMPLETED로 완화
- step1~3 엔드포인트, CharacterRecommender, UserOnboardingAnswer는 삭제하지 않고 선택적 레거시 경로로 유지

영향 범위

- [x] API 스펙 또는 응답 형식이 변경됩니다. (POST /v1/auth/signup/profile 요청 바디에 필드 추가, POST /v1/onboarding/character 진입조건 완화)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (users.employment_status 컬럼 추가)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다. (기존 필드는 그대로, 신규 필드는 옵셔널이라 하위 호환)

테스트

실행 커맨드

./gradlew test
확인 내용

- 전체 테스트 620개 중 619개 통과. 실패 1건(MioApplicationTests.contextLoads)은 로컬 DB의 기존 V18 Flyway 체크섬 불일치로 이번 변경과 무관.
- 진입조건 변경으로 깨진 기존 테스트 1건(selectCharacter_success_returnsResponse)을 프로필 완료 상태를 먼저 세팅하도록 수정.
- 생성자/메서드 시그니처 변경(SignupCompleteRequest, User.completeProfile)에 따라 호출부 테스트 4곳 갱신.

중점 리뷰 포인트

- step1~3(감정상태·고민유형·상담스타일)과 CharacterRecommender를 삭제하지 않고 레거시 경로로 남겨뒀습니다 — 팀 결정상 아직 삭제 시점이 아니라 판단했는데, 이 판단이 맞는지 확인 부탁드립니다.
- employment_status는 gender/age_range처럼 서버 값 검증이 없습니다. 프론트에서 잘못된 값을 보내도 그대로 저장됩니다.

배포 / 롤백

- Rollout: develop 머지만으로 배포 트리거 없음(CD는 main push 전용)
- Rollback: 되돌리면 캐릭터 선택 시 다시 온보딩 3단계 완료가 필요해짐 — 프론트가 이미 새 플로우로 배포됐다면 롤백 전 프론트와 조율 필요

체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion 4개 문서 사전 반영: 01. Auth, Auth 구현문서, 02_Onboarding, Onboarding 구현문서)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added employment status to the signup profile, allowing users to provide additional personal information.
  - Employment status is saved as part of the user profile.
  - Users can select a character after completing their profile, without needing to finish all earlier onboarding steps.

- **Bug Fixes**
  - Updated signup and onboarding flows to consistently handle the new employment status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->