### PR TITLE
feat: CloudWatch Logs 연동 — awslogs 드라이버 추가 (#281)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,15 @@ services:
       - .env
     environment:
       SPRING_PROFILES_ACTIVE: prod
+    logging:
+      driver: awslogs
+      options:
+        awslogs-region: ap-northeast-2
+        awslogs-group: /mio/app
+        awslogs-stream-prefix: app
+        # 로그 그룹이 미리 없으면 자동 생성 — 이미 있으면 무해한 no-op.
+        # 보존기간(30일)은 aws logs put-retention-policy로 별도 설정 필요 (자동 생성 시 기본이 무기한 보관).
+        awslogs-create-group: "true"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
---
요약

CloudWatch Logs 연동. 컨테이너 로그를 /mio/app 로그 그룹(30일 보존)으로 전송해 session_id 기준 원시 에러 로그 교차검색을 가능하게 한다.

관련 이슈

- Closes #281

변경 사항

- docker-compose.prod.yml의 app 서비스에 awslogs 로깅 드라이버 추가
- 로그 그룹 /mio/app 사전 생성 + 30일 보존기간 설정 완료 (IAM 권한 승인 후 직접 확인)

영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (EC2 인스턴스 IAM Role에 CloudWatch 쓰기 권한 필요 — 완료됨)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

테스트

확인 내용

- aws logs create-log-group, put-retention-policy 실제 실행 완료, describe-log-groups로 retentionInDays: 30 확인

배포 / 롤백

- Rollout: main push 시 CD가 새 이미지로 재기동 → awslogs 드라이버로 즉시 로그 전송 시작
- Rollback: 로깅 드라이버만 되돌리면 됨, 로그 그룹 자체는 남겨둬도 무해

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AWS CloudWatch Logs integration for the application service.
  * Configured log regions, log groups, stream prefixes, and automatic log-group creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->