### PR TITLE
feat: 성장분석 이벤트 수집 API 구현 (#285)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -8,6 +8,13 @@ services:
       - .env
     environment:
       SPRING_PROFILES_ACTIVE: prod
+      # 이슈 #285 — 강민석 인프라 명세 §1 EVENT_FILE 그대로. 컨테이너 안에서만 쓰면 호스트의
+      # CloudWatch Agent가 못 읽으므로 아래 volumes로 호스트 경로에 마운트한다.
+      EVENTS_LOG_FILE_PATH: /var/log/mio/journey-events.jsonl
+    volumes:
+      # 호스트에 /var/log/mio 디렉터리·권한이 먼저 준비돼 있어야 한다
+      # (강민석 인프라 명세 §4-B: mkdir + 앱 실행 유저 소유 + cwagent 그룹 추가).
+      - /var/log/mio:/var/log/mio
     logging:
       driver: awslogs
       options:

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -35,7 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             "POST /v1/auth/refresh",
             "POST /v1/auth/dev/token",
             // actuator 는 관리 포트로 분리됐다. 8080 의 liveness 는 HealthController 가 담당한다.
-            "GET /health"
+            "GET /health",
+            // 이슈 #285: 성장분석 이벤트 수집 API. SecurityConfig.PUBLIC_ENDPOINTS 와 별개로
+            // 이 필터가 먼저 실행되므로 여기서도 제외해야 한다.
+            "POST /v1/events"
     );
 
     private final JwtTokenService jwtTokenService;

--- a/src/main/java/com/mio/config/SecurityConfig.java
+++ b/src/main/java/com/mio/config/SecurityConfig.java
@@ -31,7 +31,9 @@ public class SecurityConfig {
             "/v1/auth/**",
             "/api-docs/**",
             "/swagger-ui/**",
-            "/swagger-ui.html"
+            "/swagger-ui.html",
+            // 이슈 #285: 로그인 전 익명 이벤트도 받아야 하는 성장분석 수집 API.
+            "/v1/events"
     };
 
     /**

--- a/src/main/java/com/mio/events/config/EventWhitelist.java
+++ b/src/main/java/com/mio/events/config/EventWhitelist.java
@@ -1,0 +1,45 @@
+package com.mio.events.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 강민석 "mio 이벤트 로그 명세 v3.4" §4 카탈로그를 설정 파일로 관리한다 (하드코딩 금지 —
+ * 명세 §5 요구사항). 온보딩 개편 같은 카탈로그 변경은 event-whitelist.yml 한 곳만 고치면 된다.
+ */
+@Component
+public class EventWhitelist {
+
+    private static final String RESOURCE_PATH = "event-whitelist.yml";
+
+    private Map<String, List<String>> allowedPropertiesByEvent;
+
+    @PostConstruct
+    @SuppressWarnings("unchecked")
+    void load() {
+        Yaml yaml = new Yaml();
+        try (InputStream in = new ClassPathResource(RESOURCE_PATH).getInputStream()) {
+            Map<String, Object> root = yaml.load(in);
+            allowedPropertiesByEvent = (Map<String, List<String>>) root.get("events");
+        } catch (IOException e) {
+            throw new IllegalStateException("event-whitelist.yml 로드 실패", e);
+        }
+    }
+
+    public boolean isKnownEvent(String eventName) {
+        return allowedPropertiesByEvent.containsKey(eventName);
+    }
+
+    public Set<String> allowedProperties(String eventName) {
+        List<String> keys = allowedPropertiesByEvent.get(eventName);
+        return keys == null ? Set.of() : Set.copyOf(keys);
+    }
+}

--- a/src/main/java/com/mio/events/controller/EventsController.java
+++ b/src/main/java/com/mio/events/controller/EventsController.java
@@ -1,0 +1,59 @@
+package com.mio.events.controller;
+
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.common.response.ApiResponse;
+import com.mio.events.dto.EventEnvelope;
+import com.mio.events.dto.EventsIngestResponse;
+import com.mio.events.service.EventIngestService;
+import com.mio.events.service.EventRateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 성장분석 이벤트 수집 API (이슈 #285). 강민석 대시보드 파이프라인의 입구 —
+ * #277 세션 감사/조회와는 완전히 별개 시스템이다 (Notion "15_Events_이벤트수집" 참고).
+ *
+ * <p>인증 불필요 — 로그인 전 익명 이벤트도 받아야 한다.
+ */
+@RestController
+@RequestMapping("/v1/events")
+@RequiredArgsConstructor
+public class EventsController {
+
+    private static final int MAX_BATCH_SIZE = 100;
+    private static final long MAX_REQUEST_BYTES = 1024L * 1024L;
+
+    private final EventIngestService eventIngestService;
+    private final EventRateLimiter eventRateLimiter;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<EventsIngestResponse>> ingest(
+            HttpServletRequest request,
+            @RequestHeader("X-Device-Id") String deviceId,
+            @RequestBody List<EventEnvelope> events) {
+
+        if (events.size() > MAX_BATCH_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        long contentLength = request.getContentLengthLong();
+        if (contentLength > MAX_REQUEST_BYTES) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        eventRateLimiter.check(deviceId);
+
+        String requestId = String.valueOf(request.getAttribute("traceId"));
+        EventsIngestResponse response = eventIngestService.ingest(events, requestId);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.ok(response));
+    }
+}

--- a/src/main/java/com/mio/events/dto/EventEnvelope.java
+++ b/src/main/java/com/mio/events/dto/EventEnvelope.java
@@ -1,0 +1,24 @@
+package com.mio.events.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Map;
+
+/**
+ * 강민석 "mio 이벤트 로그 명세 v3.4" §2 공통 envelope. 전역 snake_case 전략이 없는 프로젝트라
+ * 필드마다 {@code @JsonProperty}를 명시한다 (LoginRequest와 동일 컨벤션).
+ */
+public record EventEnvelope(
+        @JsonProperty("event_id") String eventId,
+        @JsonProperty("event_name") String eventName,
+        @JsonProperty("schema_version") Integer schemaVersion,
+        @JsonProperty("ts_client") String tsClient,
+        @JsonProperty("anonymous_id") String anonymousId,
+        @JsonProperty("user_id") String userId,
+        @JsonProperty("app_session_id") String appSessionId,
+        @JsonProperty("app_version") String appVersion,
+        String platform,
+        @JsonProperty("os_version") String osVersion,
+        Map<String, Object> properties
+) {
+}

--- a/src/main/java/com/mio/events/dto/EventsIngestResponse.java
+++ b/src/main/java/com/mio/events/dto/EventsIngestResponse.java
@@ -1,0 +1,11 @@
+package com.mio.events.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+public record EventsIngestResponse(
+        @JsonProperty("accepted_count") int acceptedCount,
+        List<RejectedEvent> rejected
+) {
+}

--- a/src/main/java/com/mio/events/dto/RejectedEvent.java
+++ b/src/main/java/com/mio/events/dto/RejectedEvent.java
@@ -1,0 +1,10 @@
+package com.mio.events.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record RejectedEvent(
+        @JsonProperty("event_id") String eventId,
+        @JsonProperty("event_name") String eventName,
+        String reason
+) {
+}

--- a/src/main/java/com/mio/events/service/EventIngestService.java
+++ b/src/main/java/com/mio/events/service/EventIngestService.java
@@ -1,0 +1,75 @@
+package com.mio.events.service;
+
+import com.mio.events.config.EventWhitelist;
+import com.mio.events.dto.EventEnvelope;
+import com.mio.events.dto.EventsIngestResponse;
+import com.mio.events.dto.RejectedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * POST /v1/events 배치 검증 + 기록 (이슈 #285). 부분 성공 모델 — 개별 이벤트 검증 실패는
+ * 배치 전체를 막지 않고 거부 목록에만 담는다 (강민석 명세 §5 ③).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class EventIngestService {
+
+    /** 강민석 명세 §2 — "현재 3 고정". */
+    private static final int CURRENT_SCHEMA_VERSION = 3;
+
+    private final EventWhitelist eventWhitelist;
+    private final EventLogWriter eventLogWriter;
+
+    public EventsIngestResponse ingest(List<EventEnvelope> events, String requestId) {
+        List<RejectedEvent> rejected = new ArrayList<>();
+        int acceptedCount = 0;
+
+        for (EventEnvelope event : events) {
+            EventRejectionReason reason = validate(event);
+            if (reason != null) {
+                rejected.add(new RejectedEvent(event.eventId(), event.eventName(), reason.name()));
+                log.warn("journey_event_rejected reason={} event_name={}", reason, event.eventName());
+                continue;
+            }
+            eventLogWriter.write(event, requestId);
+            acceptedCount++;
+        }
+
+        return new EventsIngestResponse(acceptedCount, rejected);
+    }
+
+    private EventRejectionReason validate(EventEnvelope event) {
+        if (isBlank(event.eventId())) return EventRejectionReason.MISSING_EVENT_ID;
+        if (isBlank(event.eventName())) return EventRejectionReason.MISSING_EVENT_NAME;
+        if (isBlank(event.tsClient())) return EventRejectionReason.MISSING_TS_CLIENT;
+        if (isBlank(event.anonymousId())) return EventRejectionReason.MISSING_ANONYMOUS_ID;
+        if (isBlank(event.appSessionId())) return EventRejectionReason.MISSING_APP_SESSION_ID;
+        if (event.schemaVersion() == null || event.schemaVersion() != CURRENT_SCHEMA_VERSION) {
+            return EventRejectionReason.INVALID_SCHEMA_VERSION;
+        }
+        if (!isValidIso8601(event.tsClient())) return EventRejectionReason.TS_CLIENT_INVALID_FORMAT;
+        if (!eventWhitelist.isKnownEvent(event.eventName())) return EventRejectionReason.UNKNOWN_EVENT_NAME;
+        return null;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    private boolean isValidIso8601(String tsClient) {
+        try {
+            OffsetDateTime.parse(tsClient);
+            return true;
+        } catch (DateTimeParseException e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/mio/events/service/EventLogWriter.java
+++ b/src/main/java/com/mio/events/service/EventLogWriter.java
@@ -1,0 +1,65 @@
+package com.mio.events.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventWhitelist;
+import com.mio.events.dto.EventEnvelope;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * 전용 로거 "journey-events"에 순수 JSON 한 줄을 남긴다 — logback-spring.xml에서
+ * additivity=false로 콘솔/앱 일반 로그(#281, /mio/app)와 물리적으로 분리한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class EventLogWriter {
+
+    private static final Logger JOURNEY_LOG = LoggerFactory.getLogger("journey-events");
+
+    private final EventWhitelist eventWhitelist;
+    private final ObjectMapper objectMapper;
+
+    public void write(EventEnvelope event, String requestId) {
+        Set<String> allowedKeys = eventWhitelist.allowedProperties(event.eventName());
+        Map<String, Object> filteredProperties = new LinkedHashMap<>();
+        if (event.properties() != null) {
+            event.properties().forEach((key, value) -> {
+                if (allowedKeys.contains(key)) {
+                    filteredProperties.put(key, value);
+                }
+            });
+        }
+
+        Map<String, Object> line = new LinkedHashMap<>();
+        line.put("event_id", event.eventId());
+        line.put("event_name", event.eventName());
+        line.put("schema_version", event.schemaVersion());
+        line.put("ts_client", event.tsClient());
+        line.put("ts_server", Instant.now().toString());
+        line.put("request_id", requestId);
+        line.put("anonymous_id", event.anonymousId());
+        line.put("user_id", event.userId());
+        line.put("app_session_id", event.appSessionId());
+        line.put("app_version", event.appVersion());
+        line.put("platform", event.platform());
+        line.put("os_version", event.osVersion());
+        line.put("properties", filteredProperties);
+
+        try {
+            JOURNEY_LOG.info(objectMapper.writeValueAsString(line));
+        } catch (JsonProcessingException e) {
+            // 이벤트 로그 기록 실패는 통계적 손실일 뿐 — 요청 자체를 막지 않는다 (감사로그와 다른 성격)
+            log.error("Failed to serialize journey event: event_id={}", event.eventId(), e);
+        }
+    }
+}

--- a/src/main/java/com/mio/events/service/EventRateLimiter.java
+++ b/src/main/java/com/mio/events/service/EventRateLimiter.java
@@ -1,0 +1,39 @@
+package com.mio.events.service;
+
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * X-Device-Id 기준 속도 제한 — 익명 허용의 대가 (강민석 명세 §5 ③).
+ *
+ * <p>임계치는 명세에 구체적 수치가 없어 SessionService의 메시지 rate limit(60/분)과
+ * 같은 자릿수로 잠정 설정했다. 실사용량 보고 조정 필요.
+ */
+@Component
+@RequiredArgsConstructor
+public class EventRateLimiter {
+
+    private static final int MAX_REQUESTS_PER_MINUTE = 60;
+    private static final long TTL_SECONDS = 60L;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void check(String deviceId) {
+        String key = "events:ratelimit:" + deviceId;
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count == null) {
+            return;
+        }
+        if (count == 1) {
+            redisTemplate.expire(key, TTL_SECONDS, TimeUnit.SECONDS);
+        }
+        if (count > MAX_REQUESTS_PER_MINUTE) {
+            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        }
+    }
+}

--- a/src/main/java/com/mio/events/service/EventRejectionReason.java
+++ b/src/main/java/com/mio/events/service/EventRejectionReason.java
@@ -1,0 +1,13 @@
+package com.mio.events.service;
+
+/** 이슈 #285 — 강민석 인프라 명세 §4-H가 이 이름을 CloudWatch 메트릭 필터로 센다. */
+public enum EventRejectionReason {
+    MISSING_EVENT_ID,
+    MISSING_EVENT_NAME,
+    MISSING_TS_CLIENT,
+    MISSING_ANONYMOUS_ID,
+    MISSING_APP_SESSION_ID,
+    INVALID_SCHEMA_VERSION,
+    TS_CLIENT_INVALID_FORMAT,
+    UNKNOWN_EVENT_NAME
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -137,3 +137,8 @@ openai:
 logging:
   level:
     com.mio: INFO
+
+events:
+  # 성장분석 이벤트 전용 로그 파일 경로 (이슈 #285). prod는 docker-compose.prod.yml에서
+  # /var/log/mio/journey-events.jsonl로 덮어쓴다 — 강민석 인프라 명세 §1 EVENT_FILE 그대로.
+  log-file-path: ${EVENTS_LOG_FILE_PATH:./logs/journey-events.jsonl}

--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -1,0 +1,126 @@
+# 강민석 "mio 이벤트 로그 명세 v3.4" §4 카탈로그 전체 반영 (이슈 #285).
+# 이벤트 카탈로그가 바뀌면 이 파일만 고치면 된다 — 인프라/코드 변경 불필요.
+# 값이 빈 배열([])인 이벤트는 properties가 없거나 원문 위험 때문에 전부 거른다는 뜻이다.
+
+events:
+  # §4-A 세션 백본
+  app_session_started:
+    - entry_point
+    - is_first_session
+    - days_since_last_session
+  app_session_ended:
+    - last_screen
+    - duration_ms
+    - screen_count
+  screen_viewed:
+    - screen_name
+    - referrer_screen
+  app_installed: []
+
+  # §4-B 가입·온보딩 퍼널
+  consent_agreed:
+    - consent_version
+    - marketing_agree
+  profile_submitted:
+    - age_range
+    - gender
+  signup_completed: []
+  onboarding_step_completed:
+    - step
+    - selected_emotion
+    - concern_types
+    - preferred_style
+  onboarding_step_skipped:
+    - step
+  character_selected:
+    - character_id
+  onboarding_completed: []
+  identify:
+    - previous_anonymous_id
+    - user_id
+  login_succeeded:
+    - provider
+
+  # §4-C Core Action 5종 (최우선)
+  checkin_completed:
+    - condition_score
+    - has_memo
+    - emotion_type
+    - time_of_day
+  chat_message_sent:
+    - chat_session_id
+    - message_index
+    - char_count
+    - ai_emotion_score
+    - is_socratic
+    - cbt_intervention_state
+    - is_crisis_flagged
+  session_summary_viewed:
+    - chat_session_id
+  todo_checked_in:
+    - todo_id
+    - task_status
+    - chat_session_id
+    - emotion_before
+    - emotion_after
+    - emotion_delta
+    - has_feedback
+    - days_since_suggested
+  report_viewed:
+    - period
+
+  # §4-D 대화 세션 부속 (session_summarized·todo_suggested는 서버 발행, 이번 이슈 범위 밖)
+  session_summarized:
+    - chat_session_id
+    - duration_seconds
+    - message_count
+    - bias_types_detected
+    - socratic_count
+    - problem_type
+    - classifier_version
+    - dominant_emotion
+    - cbt_intervened
+    - avg_emotion_score
+    - todo_suggested_count
+  todo_suggested:
+    - chat_session_id
+    - count
+    - categories
+    - difficulty_avg
+  chat_session_created:
+    - chat_session_id
+  chat_session_ended:
+    - duration_ms
+    - message_count
+    - chat_session_id
+    - completion_reason
+    - socratic_count
+  emotion_score_recorded:
+    - score
+    - chat_session_id
+    - reconstruction_id
+    - score_before
+    - score_delta
+
+  # §4-E 알림·보조 기능
+  notification_opened:
+    - notification_type
+  account_withdrawn: []
+  logout: []
+  checkin_started: []
+  checkin_updated: []
+  todo_list_viewed:
+    - todo_count
+  emotion_trend_viewed:
+    - period
+    - days
+  daily_test_viewed: []
+  daily_test_answered:
+    - test_id
+  notification_settings_changed:
+    - setting_key
+    - enabled
+  character_changed:
+    - from_id
+    - to_id
+  crisis_flow_triggered: []

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <!--
+        이슈 #285: 성장분석 이벤트 전용 로거. #281의 앱 일반 로그(콘솔 → /mio/app)와
+        물리적으로 분리한다 — additivity=false로 루트/콘솔 appender에 전파되지 않는다.
+        경로는 환경별로 다르다 (강민석 인프라 명세 §4-B "app.log와 같은 파일 금지" 참고):
+          local/test → ./logs/journey-events.jsonl
+          prod       → /var/log/mio/journey-events.jsonl (docker-compose.prod.yml에서 지정)
+    -->
+    <springProperty scope="context" name="journeyEventsLogFile"
+                     source="events.log-file-path" defaultValue="./logs/journey-events.jsonl"/>
+
+    <appender name="JOURNEY_EVENTS" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${journeyEventsLogFile}</file>
+        <encoder>
+            <!-- 순수 JSON 한 줄만 — 접두 타임스탬프·로그레벨 문자열 금지 (명세 §5 ①) -->
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${journeyEventsLogFile}.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="journey-events" level="INFO" additivity="false">
+        <appender-ref ref="JOURNEY_EVENTS"/>
+    </logger>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/src/test/java/com/mio/events/config/EventWhitelistTest.java
+++ b/src/test/java/com/mio/events/config/EventWhitelistTest.java
@@ -1,0 +1,54 @@
+package com.mio.events.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EventWhitelistTest {
+
+    private EventWhitelist whitelist;
+
+    @BeforeEach
+    void setUp() {
+        whitelist = new EventWhitelist();
+        whitelist.load();
+    }
+
+    @Test
+    @DisplayName("카탈로그에 있는 이벤트는 known으로 판정한다")
+    void isKnownEvent_catalogued_returnsTrue() {
+        assertThat(whitelist.isKnownEvent("chat_message_sent")).isTrue();
+        assertThat(whitelist.isKnownEvent("checkin_completed")).isTrue();
+        assertThat(whitelist.isKnownEvent("crisis_flow_triggered")).isTrue();
+    }
+
+    @Test
+    @DisplayName("카탈로그에 없는 이벤트는 unknown으로 판정한다")
+    void isKnownEvent_uncatalogued_returnsFalse() {
+        assertThat(whitelist.isKnownEvent("totally_made_up_event")).isFalse();
+    }
+
+    @Test
+    @DisplayName("chat_message_sent의 허용 property 키를 정확히 반환한다")
+    void allowedProperties_returnsExactKeys() {
+        assertThat(whitelist.allowedProperties("chat_message_sent"))
+                .containsExactlyInAnyOrder(
+                        "chat_session_id", "message_index", "char_count",
+                        "ai_emotion_score", "is_socratic", "cbt_intervention_state", "is_crisis_flagged"
+                );
+    }
+
+    @Test
+    @DisplayName("property가 없는 이벤트(app_installed)는 빈 집합을 반환한다")
+    void allowedProperties_noPropertiesEvent_returnsEmpty() {
+        assertThat(whitelist.allowedProperties("app_installed")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("모르는 이벤트의 허용 property를 물으면 빈 집합을 반환한다")
+    void allowedProperties_unknownEvent_returnsEmpty() {
+        assertThat(whitelist.allowedProperties("totally_made_up_event")).isEmpty();
+    }
+}

--- a/src/test/java/com/mio/events/service/EventIngestServiceTest.java
+++ b/src/test/java/com/mio/events/service/EventIngestServiceTest.java
@@ -1,0 +1,113 @@
+package com.mio.events.service;
+
+import com.mio.events.config.EventWhitelist;
+import com.mio.events.dto.EventEnvelope;
+import com.mio.events.dto.EventsIngestResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class EventIngestServiceTest {
+
+    @Mock private EventWhitelist eventWhitelist;
+    @Mock private EventLogWriter eventLogWriter;
+
+    private EventIngestService eventIngestService;
+
+    private static final String VALID_TS = "2026-08-04T21:13:02+09:00";
+
+    @BeforeEach
+    void setUp() {
+        eventIngestService = new EventIngestService(eventWhitelist, eventLogWriter);
+    }
+
+    private EventEnvelope validEvent(String eventId) {
+        return new EventEnvelope(eventId, "chat_message_sent", 3, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+    }
+
+    @Test
+    @DisplayName("유효한 이벤트는 기록되고 accepted_count에 반영된다")
+    void ingest_validEvent_accepted() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(true);
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(validEvent("e1")), "req-1");
+
+        assertThat(response.acceptedCount()).isEqualTo(1);
+        assertThat(response.rejected()).isEmpty();
+        verify(eventLogWriter).write(any(), eq("req-1"));
+    }
+
+    @Test
+    @DisplayName("카탈로그에 없는 event_name은 UNKNOWN_EVENT_NAME으로 거부된다")
+    void ingest_unknownEventName_rejected() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(false);
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(validEvent("e1")), "req-1");
+
+        assertThat(response.acceptedCount()).isZero();
+        assertThat(response.rejected()).hasSize(1);
+        assertThat(response.rejected().get(0).reason()).isEqualTo("UNKNOWN_EVENT_NAME");
+        verifyNoInteractions(eventLogWriter);
+    }
+
+    @Test
+    @DisplayName("event_id 누락은 MISSING_EVENT_ID로 거부되고 화이트리스트 조회까지 안 간다")
+    void ingest_missingEventId_rejected() {
+        EventEnvelope event = new EventEnvelope(null, "chat_message_sent", 3, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(event), "req-1");
+
+        assertThat(response.rejected().get(0).reason()).isEqualTo("MISSING_EVENT_ID");
+        verifyNoInteractions(eventWhitelist);
+    }
+
+    @Test
+    @DisplayName("schema_version이 3이 아니면 INVALID_SCHEMA_VERSION으로 거부된다")
+    void ingest_wrongSchemaVersion_rejected() {
+        EventEnvelope event = new EventEnvelope("e1", "chat_message_sent", 2, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(event), "req-1");
+
+        assertThat(response.rejected().get(0).reason()).isEqualTo("INVALID_SCHEMA_VERSION");
+    }
+
+    @Test
+    @DisplayName("ts_client가 ISO8601 형식이 아니면 TS_CLIENT_INVALID_FORMAT으로 거부된다")
+    void ingest_malformedTsClient_rejected() {
+        EventEnvelope event = new EventEnvelope("e1", "chat_message_sent", 3, "not-a-date",
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(event), "req-1");
+
+        assertThat(response.rejected().get(0).reason()).isEqualTo("TS_CLIENT_INVALID_FORMAT");
+    }
+
+    @Test
+    @DisplayName("부분 성공 — 배치 안에서 유효한 것과 거부된 것이 섞여도 전체가 막히지 않는다")
+    void ingest_mixedBatch_partialSuccess() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(true);
+        EventEnvelope valid = validEvent("e1");
+        EventEnvelope invalid = new EventEnvelope("e2", null, 3, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(valid, invalid), "req-1");
+
+        assertThat(response.acceptedCount()).isEqualTo(1);
+        assertThat(response.rejected()).hasSize(1);
+        assertThat(response.rejected().get(0).eventId()).isEqualTo("e2");
+    }
+}


### PR DESCRIPTION
강민석 성장분석 대시보드의 데이터 원천이 될 POST /v1/events를 추가한다.
화이트리스트 기본 deny로 검증하고 전용 로거(journey-events)에 순수 JSON 한 줄로 기록하며, 앱 일반 로그와는 additivity=false로 물리적으로 분리한다. DB 테이블은 두지 않는다(ADR-010, CloudWatch 단독 이벤트 스토어).

## 요약
강민석님 성장분석 대시보드(mio-dashboard.pages.dev)는 CloudWatch → Lambda → S3/CloudFront 파이프라인으로 이벤트 원본 행을 직접 읽어 활성화·리텐션·퍼널을 브라우저에서 계산한다. 그 파이프라인의 입구(POST /v1/events)가 없으면 대시보드 전체가 빈 상태로 남는다. 이 PR은 그 수집 API만 구현한다 — CloudWatch Agent 설정·Lambda 투영·S3/CloudFront는 인프라(강민석) 담당으로 이 PR 범위 밖이다.

## 관련 이슈
- Closes #285

## 변경 사항
- `POST /v1/events` 배치 수집 엔드포인트 추가 — 인증 불필요(로그인 전 익명 이벤트도 수집), 배치 100건/1MB 상한, 부분 성공 `202` + 거부 목록 응답
- 화이트리스트 검증(`event-whitelist.yml`) — 강민석 "mio 이벤트 로그 명세 v3.4" §4-A~E 카탈로그 전체(35개 이벤트) 반영, 하드코딩 없이 설정 파일로 관리
- 전용 로거 `journey-events` 신설(`logback-spring.xml`) — `additivity=false`로 앱 일반 로그(#281, `/mio/app`)와 물리적으로 완전히 분리, 순수 JSON 한 줄 포맷
- `X-Device-Id` 기준 Redis rate limit(`EventRateLimiter`) — 기존 `SessionService` 메시지 rate limit과 동일 패턴 재사용
- `SecurityConfig`·`JwtAuthenticationFilter` 양쪽에 `/v1/events` 화이트리스트 추가 (두 필터가 별도로 동작하는 구조라 한쪽만 고치면 401이 남는다 — #279에서 확인된 패턴)
- 로그 파일 경로 환경별 분기 — local `./logs/journey-events.jsonl`, prod `/var/log/mio/journey-events.jsonl`(`docker-compose.prod.yml` 볼륨 마운트)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (신규 엔드포인트 추가, 기존 API 변경 없음)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (`EVENTS_LOG_FILE_PATH`, prod에서 `/var/log/mio` 호스트 디렉터리 사전 준비 필요 — 아래 배포 참고)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (`journey-events` 전용 로거·파일 신설)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.events.*"
./gradlew compileJava compileTestJava
```

### 확인 내용
- `EventWhitelistTest`(5) — 카탈로그 내/외 이벤트 판정, property 화이트리스트 정확성
- `EventIngestServiceTest`(6) — 정상 수락, 미상 이벤트명 거부, 필수 필드 누락 거부, 스키마 버전 불일치 거부, ts_client 포맷 오류 거부, 배치 내 부분 성공(성공/실패 혼재)
- 전체 컴파일 클린 확인
- EC2 실배포 후 CloudWatch까지의 실적재 확인은 인프라(Agent/IAM) 조율 이후 별도 진행 예정 — 이 PR엔 미포함

## 중점 리뷰 포인트
- `EventRateLimiter`의 분당 60건 임계치는 명세에 구체 수치가 없어 잠정 설정한 값입니다 — 실사용량 보고 조정이 필요할 수 있습니다.
- prod 배포 시 컨테이너가 non-root(`app`, uid 100/gid 101)로 도는데, 호스트 `/var/log/mio` 디렉터리를 미리 그 uid로 chown해두지 않으면 이벤트가 에러 없이 조용히 유실됩니다(`EventLogWriter`가 쓰기 실패를 요청 실패로 전파하지 않도록 의도적으로 설계됨). CD 워크플로우엔 이 준비 단계가 자동화돼 있지 않습니다.
- `SecurityConfig`와 `JwtAuthenticationFilter` 양쪽 다 고쳤는지 확인 부탁드립니다 — 한쪽만 고치면 필터 체인 순서상 401이 남습니다.

## 배포 / 롤백
- Rollout: `develop` 머지 → EC2에서 `sudo mkdir -p /var/log/mio && sudo chown 100:101 /var/log/mio && sudo chmod 750 /var/log/mio` 선행 → 배포. CloudWatch 적재까지 확인하려면 강민석/인프라 쪽 Agent·IAM 설정 완료가 선행돼야 합니다(§4-A~B, 이 PR 범위 밖).
- Rollback: 이 PR을 되돌리면 `/v1/events`가 404로 사라질 뿐, DB 마이그레이션이 없어 별도 롤백 절차가 필요 없습니다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion "15_Events_이벤트수집" v1.0.0에 이미 반영됨, DB 변경 없음)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
