### PR TITLE
fix: 세션 통합 조회의 audit_logs 타임라인이 항상 빈 배열이던 버그 수정 (#287)

### DIFF
--- a/src/main/java/com/mio/admin/service/AdminSessionService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionService.java
@@ -59,11 +59,12 @@ public class AdminSessionService {
 
         List<CrisisEvent> crisisEvents = crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId);
 
-        // audit_logs.resource_id 는 행위 대상에 따라 session_id(탈퇴·동의)이거나
-        // crisis_event.id(위기검토)다 — 이 세션에 속한 위기 이벤트들의 검토 기록도 같이 모아야
-        // "세션의 흐름·Safety 사건을 처음부터 끝까지 추적"이 실제로 성립한다.
+        // audit_logs.resource_id 는 session_id 를 쓰는 action 이 없다 — 행위 대상에 따라
+        // userId(USER_WITHDRAW·CONSENT_AGREED, AuthService 참고) 이거나 crisis_event.id(위기검토)다.
+        // 이 세션에 속한 위기 이벤트들의 검토 기록도 같이 모아야 "세션의 흐름·Safety 사건을 처음부터
+        // 끝까지 추적"이 실제로 성립한다 (#287 — 이전에는 sessionId 로만 조회해 항상 빈 배열이었음).
         List<String> auditResourceIds = Stream.concat(
-                Stream.of(sessionId.toString()),
+                Stream.of(session.getUser().getId().toString()),
                 crisisEvents.stream().map(c -> c.getId().toString())
         ).toList();
 

--- a/src/test/java/com/mio/admin/service/AdminSessionServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionServiceTest.java
@@ -1,0 +1,113 @@
+package com.mio.admin.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.admin.dto.SessionTimelineResponse;
+import com.mio.ai.crisis.CrisisEventRepository;
+import com.mio.ai.repository.AiPolicyDecisionRepository;
+import com.mio.common.audit.AuditLog;
+import com.mio.common.audit.AuditLogRepository;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.crisis.domain.CrisisEvent;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * #287 — audit_logs.resource_id 는 session_id 를 쓰는 action 이 없어(userId 또는
+ * crisis_event.id) 세션 타임라인 조회가 구조적으로 항상 빈 배열이었던 버그의 회귀 방지 테스트.
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminSessionServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private AiPolicyDecisionRepository aiPolicyDecisionRepository;
+    @Mock private CrisisEventRepository crisisEventRepository;
+    @Mock private AuditLogRepository auditLogRepository;
+    @Mock private MessageEncryptor messageEncryptor;
+
+    private AdminSessionService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminSessionService(
+                sessionRepository, messageRepository, aiPolicyDecisionRepository,
+                crisisEventRepository, auditLogRepository, messageEncryptor, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("audit_logs는 session_id가 아니라 유저 id + 세션의 crisis_event id로 조회한다")
+    void getTimeline_queriesAuditLogsByUserIdAndCrisisEventIds_notSessionId() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        UUID crisisEventId = UUID.randomUUID();
+        CrisisEvent crisisEvent = CrisisEvent.builder()
+                .id(crisisEventId).user(user).session(session)
+                .triggerType("keyword").severity(2).operatorReviewed(false)
+                .createdAt(OffsetDateTime.now())
+                .build();
+        when(crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                .thenReturn(List.of(crisisEvent));
+
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.sumCostUsdBySessionId(sessionId)).thenReturn(BigDecimal.ZERO);
+        when(auditLogRepository.findByResourceIdOrderByCreatedAtAsc(any())).thenReturn(List.of());
+
+        SessionTimelineResponse response = service.getTimeline(sessionId);
+
+        assertThat(response.userId()).isEqualTo(userId);
+        verify(auditLogRepository).findByResourceIdOrderByCreatedAtAsc(userId.toString());
+        verify(auditLogRepository).findByResourceIdOrderByCreatedAtAsc(crisisEventId.toString());
+        verify(auditLogRepository, never()).findByResourceIdOrderByCreatedAtAsc(sessionId.toString());
+    }
+
+    @Test
+    @DisplayName("USER_WITHDRAW 감사 로그가 세션 타임라인에 실제로 포함된다 (회귀 방지)")
+    void getTimeline_includesUserWithdrawAuditLog() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.sumCostUsdBySessionId(sessionId)).thenReturn(BigDecimal.ZERO);
+
+        AuditLog withdrawLog = AuditLog.builder()
+                .userId(userId).action("USER_WITHDRAW").resourceType("user")
+                .resourceId(userId.toString()).details("{}")
+                .createdAt(OffsetDateTime.now())
+                .build();
+        when(auditLogRepository.findByResourceIdOrderByCreatedAtAsc(userId.toString()))
+                .thenReturn(List.of(withdrawLog));
+
+        SessionTimelineResponse response = service.getTimeline(sessionId);
+
+        assertThat(response.timeline()).hasSize(1);
+        assertThat(response.timeline().get(0))
+                .containsEntry("type", "audit_log")
+                .containsEntry("action", "USER_WITHDRAW");
+    }
+}


### PR DESCRIPTION
## 요약
`GET /v1/admin/sessions/{sessionId}` 응답의 `audit_logs` 타임라인이 어떤 세션을 조회해도 항상 빈 배열이었습니다. `audit_logs.resource_id`는 session_id를 쓰는 action이 없는데(USER_WITHDRAW/CONSENT_AGREED=userId, CRISIS_EVENT_REVIEWED=crisis_event.id) 조회 코드는 sessionId로만 조회하고 있어서였습니다.

## 관련 이슈
- Closes #287

## 변경 사항
- `AdminSessionService.getTimeline()`의 `auditResourceIds` 구성을 `sessionId` → `session.getUser().getId()`로 수정 (crisis_event.id 매칭은 원래도 맞았음, userId 매칭만 빠져있었음)
- `AdminSessionServiceTest` 신규 추가 — audit_logs가 유저 id + 세션의 crisis_event id로만 조회되고 sessionId로는 조회되지 않음을 검증, USER_WITHDRAW 감사로그가 실제로 타임라인에 포함되는 회귀 테스트

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (`GET /v1/admin/sessions/{sessionId}` 응답의 `timeline` 배열에 `audit_log` 타입 항목이 이제 실제로 채워짐 — 스키마 변경 아님, 버그 수정)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.admin.service.AdminSessionServiceTest"
./gradlew compileJava compileTestJava

확인 내용

- getTimeline_queriesAuditLogsByUserIdAndCrisisEventIds_notSessionId — audit_logs 조회가 userId.toString()·crisisEventId.toString()로는 호출되고 sessionId.toString()로는 호출되지 않음을 검증
- getTimeline_includesUserWithdrawAuditLog — USER_WITHDRAW 감사로그가 실제로 응답 timeline에 type=audit_log, action=USER_WITHDRAW로 포함되는지 검증
- 전체 컴파일 클린 확인

중점 리뷰 포인트

- USER_WITHDRAW/CONSENT_AGREED는 세션과 무관하게 그 유저의 모든 세션 타임라인에 동일하게 노출됩니다 (userId 매칭이라 세션 단위 정보가 없음). 원 설계 문서("session_id 또는 user_id 매칭")와 일치하는 의도된 동작으로 확인했으나, 실제 운영자 UX 관점에서 이 부분 한 번 더 봐주시면 좋겠습니다.
- #277에서 "A~D 실제 API 호출로 검증 완료"라고 적었던 검증이 이 버그를 놓쳤던 케이스입니다 — 이번엔 유닛 테스트로 회귀 방지를 걸었습니다.

배포 / 롤백

- Rollout: develop 머지만으로 충분, 별도 배포 절차 불필요 (DB 마이그레이션 없음)
- Rollback: 이 PR을 되돌리면 이전처럼 audit_logs 타임라인이 빈 배열로 돌아갈 뿐, 다른 부작용 없음

체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion 개인초안 A·B·I·J섹션 갱신 완료)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session timeline audit logs now correctly include user- and crisis-related records, providing comprehensive visibility of all relevant audit events associated with a session.

* **Tests**
  * Added regression tests to verify audit log querying behavior and ensure session timelines accurately reflect all related audit events, including user withdrawal actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->