### PR TITLE
feat: event-whitelist.yml에 employment_status 추가 (#291)

### DIFF
--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -24,6 +24,7 @@ events:
   profile_submitted:
     - age_range
     - gender
+    - employment_status
   signup_completed: []
   onboarding_step_completed:
     - step

--- a/src/test/java/com/mio/events/config/EventWhitelistTest.java
+++ b/src/test/java/com/mio/events/config/EventWhitelistTest.java
@@ -41,6 +41,13 @@ class EventWhitelistTest {
     }
 
     @Test
+    @DisplayName("profile_submitted의 허용 property에 employment_status가 포함된다 (#291)")
+    void allowedProperties_profileSubmitted_includesEmploymentStatus() {
+        assertThat(whitelist.allowedProperties("profile_submitted"))
+                .containsExactlyInAnyOrder("age_range", "gender", "employment_status");
+    }
+
+    @Test
     @DisplayName("property가 없는 이벤트(app_installed)는 빈 집합을 반환한다")
     void allowedProperties_noPropertiesEvent_returnsEmpty() {
         assertThat(whitelist.allowedProperties("app_installed")).isEmpty();


### PR DESCRIPTION
## 요약
Auth API v1.2.3(온보딩 간소화)로 POST /v1/auth/signup/profile에 employment_status 필드가 추가됐는데, 이벤트 화이트리스트(event-whitelist.yml)엔 반영이 안 돼 있어서 profile_submitted 이벤트에서 이 값이 조용히 제거되고 있었습니다.

## 관련 이슈
- Closes #291

## 변경 사항
- event-whitelist.yml의 profile_submitted에 employment_status 추가
- EventWhitelistTest에 employment_status 포함 검증 케이스 추가

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (profile_submitted 이벤트 로그에 employment_status 필드가 이제 남음)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.events.config.EventWhitelistTest"
./gradlew compileJava compileTestJava
```

### 확인 내용
- allowedProperties_profileSubmitted_includesEmploymentStatus — profile_submitted의 허용 property에 employment_status가 포함됨을 검증
- 기존 5개 테스트 포함 6/6 통과, 전체 컴파일 클린

## 중점 리뷰 포인트
- 설정 파일 한 줄 추가라 리스크 낮음 — 화이트리스트 구조상 하드코딩 없이 이 파일만 고치면 되는 설계(§4-C 명세)와 일치하는지만 확인 부탁드려요.

## 배포 / 롤백
- Rollout: develop 머지만으로 충분, 별도 배포 절차 불필요
- Rollback: 이 PR을 되돌리면 employment_status가 다시 조용히 제거되는 이전 상태로 돌아갈 뿐, 다른 부작용 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion "15_Events_이벤트수집" 카탈로그 갱신 이력에 이미 반영)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `employment_status` property in `profile_submitted` events.

* **Tests**
  * Added coverage confirming that `employment_status` is accepted alongside existing profile properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->