### PR TITLE
fix: docker-compose.prod.yml에서 awslogs-stream-prefix 제거 (#309)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,9 @@ services:
       options:
         awslogs-region: ap-northeast-2
         awslogs-group: /mio/app
-        awslogs-stream-prefix: app
+        # awslogs-stream-prefix: EC2(mio_backend)의 Docker 엔진이 "unknown log opt"로 거부해
+        # 컨테이너 생성 자체가 실패했다(#309, 2026-08-05 배포 장애) — 스트림 이름을 보기 좋게
+        # 만드는 optional 필드일 뿐이라 제거. 없어도 CloudWatch 전송 자체엔 영향 없음.
         # 로그 그룹이 미리 없으면 자동 생성 — 이미 있으면 무해한 no-op.
         # 보존기간(30일)은 aws logs put-retention-policy로 별도 설정 필요 (자동 생성 시 기본이 무기한 보관).
         awslogs-create-group: "true"


### PR DESCRIPTION
## 요약
2026-08-05 develop→main 승격 배포 중 실제 장애가 발생했습니다. EC2(mio_backend)의 Docker 엔진이 docker-compose.prod.yml의 awslogs-stream-prefix 옵션을 "unknown log opt"로 거부해 app 컨테이너 생성 자체가 실패했고, 그 여파로 postgres/redis도 Created 상태에서 멈추고 app은 12일 전 옛날 컨테이너로 방치됐습니다. 서버에는 이미 수동으로 같은 조치를 적용해 서비스 복구했고, 이 PR로 레포 원본을 정식으로 고쳐 재발을 막습니다.

## 관련 이슈
- Closes #309

## 변경 사항
- docker-compose.prod.yml app 서비스의 logging.options에서 awslogs-stream-prefix 라인 제거

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (docker-compose.prod.yml 로깅 설정)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (CloudWatch 로그 스트림 이름이 prefix 없이 컨테이너 ID 기반으로 생성됨 — 로그 전송 자체는 동일)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
# EC2 서버에서 실제로 검증 완료 (2026-08-05)
docker compose -f docker-compose.prod.yml up -d --remove-orphans
```

### 확인 내용
- 서버에서 동일한 라인을 수동으로 제거하고 재배포해 app 컨테이너가 정상 Recreate/Start됨을 실제로 확인
- Flyway 마이그레이션 8건 정상 적용, /health 엔드포인트 UP 확인
- POST /v1/events 스모크 테스트 → 파일 적재 → CloudWatch 로그 그룹(/mio/journey-events) 도달까지 전체 파이프라인 확인
- 이 PR은 서버에서 이미 검증된 변경을 레포에 그대로 반영하는 것이라 별도 유닛 테스트 없음(YAML 설정 한 줄 제거)

## 중점 리뷰 포인트
- CI에서 이 종류의 장애(GitHub Actions는 success로 끝났지만 실제 컨테이너는 안 뜬 상태)를 못 잡아낸다는 게 근본적인 문제로 남아있습니다 — cd.yml에 배포 후 컨테이너 상태 확인 스텝을 추가할지는 이 PR 범위 밖이라 별도 논의가 필요할 것 같습니다.

## 배포 / 롤백
- Rollout: develop 머지 후 다음 main 승격 때 자동 반영. 서버는 이미 수동 조치로 복구된 상태라 긴급도는 낮음.
- Rollback: 이 한 줄을 되돌리면 다시 같은 장애가 날 수 있으므로 롤백 비권장.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. (서버에서 이미 실동작 검증됨)
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed production container creation failures related to AWS CloudWatch logging configuration.
  * Production logs continue to be delivered to CloudWatch without the unnecessary stream prefix setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->