### PR TITLE
chore: develop → main 승격 — docker-compose.prod.yml awslogs-stream-prefix 수정 반영 (#309)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,9 @@ services:
       options:
         awslogs-region: ap-northeast-2
         awslogs-group: /mio/app
-        awslogs-stream-prefix: app
+        # awslogs-stream-prefix: EC2(mio_backend)의 Docker 엔진이 "unknown log opt"로 거부해
+        # 컨테이너 생성 자체가 실패했다(#309, 2026-08-05 배포 장애) — 스트림 이름을 보기 좋게
+        # 만드는 optional 필드일 뿐이라 제거. 없어도 CloudWatch 전송 자체엔 영향 없음.
         # 로그 그룹이 미리 없으면 자동 생성 — 이미 있으면 무해한 no-op.
         # 보존기간(30일)은 aws logs put-retention-policy로 별도 설정 필요 (자동 생성 시 기본이 무기한 보관).
         awslogs-create-group: "true"


### PR DESCRIPTION
## 요약
2026-08-05 이전 develop→main 승격(#308) 배포 중 발생한 실제 장애(app 컨테이너 생성 실패, DB 연결 끊김)의 원인 수정(#309/#310)을 main에 반영합니다. 서버는 이미 수동 조치로 복구된 상태지만, main의 git 파일이 여전히 옛날 버전이라 다음 배포 때 같은 장애가 재발하는 것을 막기 위한 승격입니다.

## 관련 이슈
- Closes #309

## 변경 사항
- docker-compose.prod.yml app 서비스 logging.options에서 awslogs-stream-prefix 제거 (EC2 Docker 엔진이 unknown log opt로 거부하던 옵션)

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (docker-compose.prod.yml)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (CloudWatch 로그 스트림 이름 방식만 변경, 전송 자체는 동일)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
# EC2 서버에서 이미 실제 검증 완료
docker compose -f docker-compose.prod.yml up -d --remove-orphans
```

### 확인 내용
- #310에서 이미 서버 실동작으로 검증 완료 (app 정상 기동, 마이그레이션 적용, health UP, 이벤트 파이프라인 전체 도달 확인)

## 중점 리뷰 포인트
- 이 PR 머지 후 CD가 다시 배포를 도는데, 이번엔 이미 정상 상태인 서버에 같은 내용을 다시 배포하는 것이라 문제 없이 지나갈 것으로 예상됩니다. 그래도 배포 로그는 한 번 더 확인 예정입니다.

## 배포 / 롤백
- Rollout: 머지 시 CD 자동 트리거. 배포 후 컨테이너 상태 재확인 예정.
- Rollback: 문제 시 이전 main 커밋으로 되돌리기. DB 마이그레이션 없음.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.