### PR TITLE
fix: 중단된 임베딩 claim 을 회수하고 재시도 상한을 둔다

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -14,6 +14,11 @@ import java.util.UUID;
 /**
  * session_summaries.embedding_status = 'pending' 행을 주기적으로 소비해
  * OpenAI Embeddings API(text-embedding-3-small)를 호출하고 episode_emb를 갱신한다.
+ *
+ * <p>claim 과 결과 기록은 서로 다른 트랜잭션이다. 그래서 API 호출 중 프로세스가 종료되면
+ * 행이 {@code processing} 에 남는데, 재claim 조건이 {@code pending} 뿐이면 그 행은 영원히
+ * 다시 처리되지 않는다 — 해당 요약은 임베딩 없이 남아 벡터 검색에서 조용히 누락된다
+ * (이슈 #254). claim 시각과 시도 횟수를 남겨 회수하고, 무한 재시도는 상한으로 막는다.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,44 +27,99 @@ public class EmbeddingWorker {
 
     private static final int BATCH_SIZE = 20;
 
+    /**
+     * claim 후 이 시간이 지나도 결과가 기록되지 않으면 중단된 것으로 보고 회수한다.
+     *
+     * <p>임베딩 API 호출은 초 단위로 끝난다. 10분은 느린 호출을 중단으로 오인하지 않으면서,
+     * 배포·크래시로 죽은 claim 을 다음 주기 안에 회수하기에 충분한 값이다.
+     */
+    private static final int RECLAIM_AFTER_MINUTES = 10;
+
+    /**
+     * 시도 상한.
+     *
+     * <p>상한이 없으면 항상 실패하는 행 하나가 배치 자리를 계속 차지하며 API 비용만 쓴다.
+     * 상한에 도달한 행은 {@code failed} 로 확정해 사람이 보게 남긴다.
+     */
+    private static final int MAX_ATTEMPTS = 3;
+
     private final JdbcTemplate jdbcTemplate;
     private final OpenAiLlmClient openAiLlmClient;
 
     @Scheduled(fixedDelay = 30_000)
     public void processPending() {
-        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
-                """
-                UPDATE session_summaries
-                SET embedding_status = 'processing'
-                WHERE id IN (
-                    SELECT id FROM session_summaries
-                    WHERE embedding_status = 'pending'
-                    ORDER BY created_at
-                    LIMIT ?
-                    FOR UPDATE SKIP LOCKED
-                )
-                RETURNING id, summary_text
-                """,
-                BATCH_SIZE
-        );
+        int abandoned = failAbandonedRows();
+        if (abandoned > 0) {
+            log.warn("EmbeddingWorker: {} rows exceeded {} attempts, marked failed", abandoned, MAX_ATTEMPTS);
+        }
 
+        List<Map<String, Object>> rows = claimBatch();
         if (rows.isEmpty()) return;
-        log.debug("EmbeddingWorker: processing {} pending rows", rows.size());
+        log.debug("EmbeddingWorker: processing {} claimed rows", rows.size());
 
         for (Map<String, Object> row : rows) {
             UUID id = UUID.fromString(row.get("id").toString());
             String summaryText = (String) row.get("summary_text");
-            embedOne(id, summaryText);
+            int attempts = ((Number) row.get("embedding_attempts")).intValue();
+            embedOne(id, summaryText, attempts);
         }
     }
 
-    private void embedOne(UUID summaryId, String summaryText) {
+    /**
+     * 처리할 행을 claim 한다.
+     *
+     * <p>{@code pending} 뿐 아니라 회수 기한이 지난 {@code processing} 행도 포함한다.
+     * 시도 횟수를 여기서 올리므로, 중단으로 회수된 행도 무한히 되돌아오지 않는다.
+     */
+    private List<Map<String, Object>> claimBatch() {
+        return jdbcTemplate.queryForList(
+                """
+                UPDATE session_summaries
+                SET embedding_status = 'processing',
+                    embedding_claimed_at = now(),
+                    embedding_attempts = embedding_attempts + 1
+                WHERE id IN (
+                    SELECT id FROM session_summaries
+                    WHERE embedding_attempts < ?
+                      AND (
+                        embedding_status = 'pending'
+                        OR (embedding_status = 'processing'
+                            AND embedding_claimed_at < now() - make_interval(mins => ?))
+                      )
+                    ORDER BY created_at
+                    LIMIT ?
+                    FOR UPDATE SKIP LOCKED
+                )
+                RETURNING id, summary_text, embedding_attempts
+                """,
+                MAX_ATTEMPTS, RECLAIM_AFTER_MINUTES, BATCH_SIZE
+        );
+    }
+
+    /**
+     * 시도 상한을 넘긴 채 회수 기한이 지난 행을 실패로 확정한다.
+     *
+     * <p>이 처리가 없으면 상한 초과 행이 {@code processing} 에 영원히 남아, 지표상
+     * "처리 중"으로 보이지만 아무도 처리하지 않는 상태가 된다.
+     */
+    private int failAbandonedRows() {
+        return jdbcTemplate.update(
+                """
+                UPDATE session_summaries
+                SET embedding_status = 'failed'
+                WHERE embedding_status = 'processing'
+                  AND embedding_attempts >= ?
+                  AND embedding_claimed_at < now() - make_interval(mins => ?)
+                """,
+                MAX_ATTEMPTS, RECLAIM_AFTER_MINUTES
+        );
+    }
+
+    private void embedOne(UUID summaryId, String summaryText, int attempts) {
         if (summaryText == null || summaryText.isBlank()) {
+            // 재시도해도 결과가 달라지지 않는다. 상한을 기다리지 않고 바로 확정한다.
             log.warn("EmbeddingWorker: summaryText is null or blank for summaryId={}, marking failed", summaryId);
-            jdbcTemplate.update(
-                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'processing'",
-                    summaryId
-            );
+            markStatus(summaryId, "failed");
             return;
         }
         try {
@@ -82,12 +142,26 @@ public class EmbeddingWorker {
                 log.debug("EmbeddingWorker: embedded summaryId={}", summaryId);
             }
         } catch (Exception e) {
-            log.warn("EmbeddingWorker: failed for summaryId={}, marking failed", summaryId, e);
-            jdbcTemplate.update(
-                    "UPDATE session_summaries SET embedding_status = 'failed' WHERE id = ? AND embedding_status = 'processing'",
-                    summaryId
-            );
+            // 임베딩 API 실패는 대부분 일시적이다(타임아웃, rate limit). 이전에는 한 번 실패하면
+            // 그대로 failed 로 확정해 그 요약이 영구히 검색에서 빠졌다. 상한까지는 되돌린다.
+            if (attempts < MAX_ATTEMPTS) {
+                log.warn("EmbeddingWorker: attempt {}/{} failed for summaryId={}, will retry",
+                        attempts, MAX_ATTEMPTS, summaryId, e);
+                markStatus(summaryId, "pending");
+            } else {
+                log.warn("EmbeddingWorker: attempt {}/{} failed for summaryId={}, marking failed",
+                        attempts, MAX_ATTEMPTS, summaryId, e);
+                markStatus(summaryId, "failed");
+            }
         }
+    }
+
+    /** claim 을 잡고 있는 동안에만 상태를 바꾼다 — 다른 인스턴스가 회수해 간 행을 덮지 않는다. */
+    private void markStatus(UUID summaryId, String status) {
+        jdbcTemplate.update(
+                "UPDATE session_summaries SET embedding_status = ? WHERE id = ? AND embedding_status = 'processing'",
+                status, summaryId
+        );
     }
 
     private String toVectorLiteral(float[] embedding) {

--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -25,15 +25,18 @@ import java.util.UUID;
 @Slf4j
 public class EmbeddingWorker {
 
+    /** 배치 최악 소요 = BATCH_SIZE × 임베딩 타임아웃(30초). {@link #RECLAIM_AFTER_MINUTES} 참고. */
     private static final int BATCH_SIZE = 20;
 
     /**
      * claim 후 이 시간이 지나도 결과가 기록되지 않으면 중단된 것으로 보고 회수한다.
      *
-     * <p>임베딩 API 호출은 초 단위로 끝난다. 10분은 느린 호출을 중단으로 오인하지 않으면서,
-     * 배포·크래시로 죽은 claim 을 다음 주기 안에 회수하기에 충분한 값이다.
+     * <p>값은 한 배치의 최악 소요 시간에서 잡는다. 배치는 순차 처리이고 임베딩 호출 타임아웃이
+     * 30초이므로 최악은 {@code BATCH_SIZE × 30초} 다. 이 값이 회수 기한보다 크면 <b>같은
+     * 인스턴스가 처리 중인 배치의 앞쪽 행이 회수 대상이 된다</b> — 죽지 않은 작업을 회수해
+     * 같은 요약을 두 번 임베딩하게 된다. 여유를 두어 그 상황 자체를 피한다.
      */
-    private static final int RECLAIM_AFTER_MINUTES = 10;
+    private static final int RECLAIM_AFTER_MINUTES = 30;
 
     /**
      * 시도 상한.
@@ -58,10 +61,17 @@ public class EmbeddingWorker {
         log.debug("EmbeddingWorker: processing {} claimed rows", rows.size());
 
         for (Map<String, Object> row : rows) {
-            UUID id = UUID.fromString(row.get("id").toString());
-            String summaryText = (String) row.get("summary_text");
-            int attempts = ((Number) row.get("embedding_attempts")).intValue();
-            embedOne(id, summaryText, attempts);
+            // 한 행의 값이 망가져도 배치 전체를 중단하지 않는다. 중단하면 이미 claim 한 나머지
+            // 행이 다음 회수 주기까지 processing 에 묶인다.
+            try {
+                UUID id = UUID.fromString(row.get("id").toString());
+                String summaryText = (String) row.get("summary_text");
+                int attempts = ((Number) row.get("embedding_attempts")).intValue();
+                Object claimToken = row.get("embedding_claimed_at");
+                embedOne(id, summaryText, attempts, claimToken);
+            } catch (Exception e) {
+                log.error("EmbeddingWorker: malformed claimed row, skipping: {}", row.get("id"), e);
+            }
         }
     }
 
@@ -90,7 +100,7 @@ public class EmbeddingWorker {
                     LIMIT ?
                     FOR UPDATE SKIP LOCKED
                 )
-                RETURNING id, summary_text, embedding_attempts
+                RETURNING id, summary_text, embedding_attempts, embedding_claimed_at
                 """,
                 MAX_ATTEMPTS, RECLAIM_AFTER_MINUTES, BATCH_SIZE
         );
@@ -115,11 +125,11 @@ public class EmbeddingWorker {
         );
     }
 
-    private void embedOne(UUID summaryId, String summaryText, int attempts) {
+    private void embedOne(UUID summaryId, String summaryText, int attempts, Object claimToken) {
         if (summaryText == null || summaryText.isBlank()) {
             // 재시도해도 결과가 달라지지 않는다. 상한을 기다리지 않고 바로 확정한다.
             log.warn("EmbeddingWorker: summaryText is null or blank for summaryId={}, marking failed", summaryId);
-            markStatus(summaryId, "failed");
+            markStatus(summaryId, "failed", claimToken);
             return;
         }
         try {
@@ -133,11 +143,12 @@ public class EmbeddingWorker {
                         embedding_status = 'done'
                     WHERE id = ?
                       AND embedding_status = 'processing'
+                      AND embedding_claimed_at = ?
                     """,
-                    vectorLiteral, summaryId
+                    vectorLiteral, summaryId, claimToken
             );
             if (updated == 0) {
-                log.debug("EmbeddingWorker: summaryId={} already processed by another instance, skipping", summaryId);
+                log.debug("EmbeddingWorker: summaryId={} was reclaimed by another worker, discarding result", summaryId);
             } else {
                 log.debug("EmbeddingWorker: embedded summaryId={}", summaryId);
             }
@@ -147,20 +158,37 @@ public class EmbeddingWorker {
             if (attempts < MAX_ATTEMPTS) {
                 log.warn("EmbeddingWorker: attempt {}/{} failed for summaryId={}, will retry",
                         attempts, MAX_ATTEMPTS, summaryId, e);
-                markStatus(summaryId, "pending");
+                markStatus(summaryId, "pending", claimToken);
             } else {
                 log.warn("EmbeddingWorker: attempt {}/{} failed for summaryId={}, marking failed",
                         attempts, MAX_ATTEMPTS, summaryId, e);
-                markStatus(summaryId, "failed");
+                markStatus(summaryId, "failed", claimToken);
             }
         }
     }
 
-    /** claim 을 잡고 있는 동안에만 상태를 바꾼다 — 다른 인스턴스가 회수해 간 행을 덮지 않는다. */
-    private void markStatus(UUID summaryId, String status) {
+    /**
+     * 내 claim 이 아직 유효할 때만 상태를 바꾼다.
+     *
+     * <p>{@code status = 'processing'} 조건만으로는 부족하다. 내 호출이 늦어져 다른 워커가
+     * 회수해 새로 처리 중이어도 상태는 여전히 {@code processing} 이라, 늦게 끝난 내 결과가
+     * 남의 작업을 덮어쓴다 — 이미 완료된 임베딩이 {@code pending} 으로 되돌아갈 수 있다.
+     * claim 시각을 펜싱 토큰으로 써서 내 claim 이 살아 있을 때만 쓴다.
+     *
+     * <p>재시도로 되돌릴 때는 claim 시각을 비운다. 그러지 않으면 {@code pending} 행에 오래된
+     * claim 시각이 남아 대시보드에서 "처리 중"으로 오해된다.
+     */
+    private void markStatus(UUID summaryId, String status, Object claimToken) {
         jdbcTemplate.update(
-                "UPDATE session_summaries SET embedding_status = ? WHERE id = ? AND embedding_status = 'processing'",
-                status, summaryId
+                """
+                UPDATE session_summaries
+                SET embedding_status = ?,
+                    embedding_claimed_at = CASE WHEN ? = 'pending' THEN NULL ELSE embedding_claimed_at END
+                WHERE id = ?
+                  AND embedding_status = 'processing'
+                  AND embedding_claimed_at = ?
+                """,
+                status, status, summaryId, claimToken
         );
     }
 

--- a/src/main/resources/db/migration/V48__add_embedding_claim_tracking.sql
+++ b/src/main/resources/db/migration/V48__add_embedding_claim_tracking.sql
@@ -23,4 +23,4 @@ CREATE INDEX idx_session_summaries_embedding_claim
 COMMENT ON COLUMN session_summaries.embedding_claimed_at IS
     'When the row was last claimed by EmbeddingWorker. Used to reclaim rows stuck in processing after a crash.';
 COMMENT ON COLUMN session_summaries.embedding_attempts IS
-    'How many times embedding has been attempted. Caps retries so a permanently failing row does not loop forever.';
+    'How many times embedding has been attempted. Caps retries so a permanently failing row does not loop forever. To requeue a failed row manually you must also reset this to 0 - the worker skips rows at or above the cap regardless of status.';

--- a/src/main/resources/db/migration/V48__add_embedding_claim_tracking.sql
+++ b/src/main/resources/db/migration/V48__add_embedding_claim_tracking.sql
@@ -1,0 +1,26 @@
+-- [issue #254] EmbeddingWorker 가 claim 한 행이 프로세스 중단으로 'processing' 에 고착되면
+-- 재claim 조건(pending)에 걸리지 않아 영원히 재처리되지 않는다. 해당 요약은 임베딩이
+-- 생성되지 않아 벡터 검색에서 조용히 누락된다.
+--
+-- claim 시각과 시도 횟수를 남겨 (1) 오래된 processing 행을 회수하고
+-- (2) 무한 재시도를 막는다.
+
+ALTER TABLE session_summaries
+    ADD COLUMN embedding_claimed_at TIMESTAMPTZ,
+    ADD COLUMN embedding_attempts   INT NOT NULL DEFAULT 0;
+
+-- 이미 processing 에 고착돼 있던 행에도 회수 기준 시각이 필요하다. 지금 시각을 넣으면
+-- 유예 시간만큼 늦게 회수되므로, 즉시 회수 대상이 되도록 과거 시각으로 표시한다.
+UPDATE session_summaries
+SET embedding_claimed_at = now() - interval '1 hour'
+WHERE embedding_status = 'processing'
+  AND embedding_claimed_at IS NULL;
+
+CREATE INDEX idx_session_summaries_embedding_claim
+    ON session_summaries (embedding_status, embedding_claimed_at)
+    WHERE embedding_status IN ('pending', 'processing');
+
+COMMENT ON COLUMN session_summaries.embedding_claimed_at IS
+    'When the row was last claimed by EmbeddingWorker. Used to reclaim rows stuck in processing after a crash.';
+COMMENT ON COLUMN session_summaries.embedding_attempts IS
+    'How many times embedding has been attempted. Caps retries so a permanently failing row does not loop forever.';

--- a/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
@@ -100,13 +100,89 @@ class EmbeddingWorkerIntegrationTest {
     }
 
     @Test
-    @DisplayName("임베딩 호출이 실패하면 제약 위반 없이 processing을 거쳐 failed로 전이한다")
-    void processPending_embeddingError_transitionsToFailed() {
-        insertPendingSummary("임베딩 호출이 실패하는 케이스.");
+    @DisplayName("일시적 실패는 pending으로 되돌려 다음 주기에 재시도한다")
+    void processPending_transientError_returnsToPendingForRetry() {
+        insertPendingSummary("임베딩 호출이 한 번 실패하는 케이스.");
         when(openAiLlmClient.embed(anyString())).thenThrow(new RuntimeException("embedding API down"));
 
         embeddingWorker.processPending();
 
-        assertThat(currentStatus()).isEqualTo("failed");
+        assertThat(currentStatus())
+                .as("타임아웃·rate limit 한 번에 요약이 영구히 검색에서 빠지면 안 된다")
+                .isEqualTo("pending");
+        assertThat(attempts()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("시도 상한에 도달하면 failed로 확정한다")
+    void processPending_repeatedFailure_stopsAtAttemptCap() {
+        insertPendingSummary("계속 실패하는 케이스.");
+        when(openAiLlmClient.embed(anyString())).thenThrow(new RuntimeException("embedding API down"));
+
+        for (int i = 0; i < 5; i++) {
+            embeddingWorker.processPending();
+        }
+
+        assertThat(currentStatus())
+                .as("상한이 없으면 실패 행 하나가 배치 자리를 계속 차지하며 비용만 쓴다")
+                .isEqualTo("failed");
+        assertThat(attempts()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("프로세스 중단으로 processing에 고착된 행을 회수해 처리한다")
+    void processPending_reclaimsStuckProcessingRow() {
+        insertStuckProcessingRow("중단된 프로세스가 남긴 행.", 20, 1);
+
+        float[] vector = new float[EMBEDDING_DIM];
+        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus())
+                .as("회수 정책이 없으면 이 행은 영원히 재처리되지 않고 벡터 검색에서 누락된다")
+                .isEqualTo("done");
+    }
+
+    @Test
+    @DisplayName("방금 claim된 processing 행은 회수하지 않는다")
+    void processPending_doesNotReclaimFreshClaim() {
+        insertStuckProcessingRow("다른 인스턴스가 지금 처리 중인 행.", 0, 1);
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus())
+                .as("처리 중인 행을 회수하면 같은 요약을 두 번 임베딩한다")
+                .isEqualTo("processing");
+        assertThat(attempts()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("상한을 넘긴 채 고착된 행은 failed로 확정한다")
+    void processPending_marksAbandonedRowFailed() {
+        insertStuckProcessingRow("상한을 넘긴 고착 행.", 20, 3);
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus())
+                .as("processing에 남으면 지표상 처리 중으로 보이지만 아무도 처리하지 않는다")
+                .isEqualTo("failed");
+    }
+
+    private void insertStuckProcessingRow(String summaryText, int claimedMinutesAgo, int attempts) {
+        jdbcTemplate.update(
+                """
+                INSERT INTO session_summaries (
+                    id, user_id, session_id, character_id, summary_text,
+                    embedding_status, embedding_claimed_at, embedding_attempts)
+                VALUES (?, ?, ?, 'mio', ?, 'processing', now() - make_interval(mins => ?), ?)
+                """,
+                summaryId, userId, sessionId, summaryText, claimedMinutesAgo, attempts);
+    }
+
+    private int attempts() {
+        Integer value = jdbcTemplate.queryForObject(
+                "SELECT embedding_attempts FROM session_summaries WHERE id = ?", Integer.class, summaryId);
+        return value != null ? value : -1;
     }
 }

--- a/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
@@ -11,7 +11,13 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -132,7 +138,7 @@ class EmbeddingWorkerIntegrationTest {
     @Test
     @DisplayName("프로세스 중단으로 processing에 고착된 행을 회수해 처리한다")
     void processPending_reclaimsStuckProcessingRow() {
-        insertStuckProcessingRow("중단된 프로세스가 남긴 행.", 20, 1);
+        insertStuckProcessingRow("중단된 프로세스가 남긴 행.", 40, 1);
 
         float[] vector = new float[EMBEDDING_DIM];
         when(openAiLlmClient.embed(anyString())).thenReturn(vector);
@@ -160,13 +166,80 @@ class EmbeddingWorkerIntegrationTest {
     @Test
     @DisplayName("상한을 넘긴 채 고착된 행은 failed로 확정한다")
     void processPending_marksAbandonedRowFailed() {
-        insertStuckProcessingRow("상한을 넘긴 고착 행.", 20, 3);
+        insertStuckProcessingRow("상한을 넘긴 고착 행.", 40, 3);
 
         embeddingWorker.processPending();
 
         assertThat(currentStatus())
                 .as("processing에 남으면 지표상 처리 중으로 보이지만 아무도 처리하지 않는다")
                 .isEqualTo("failed");
+    }
+
+    @Test
+    @DisplayName("회수된 뒤 늦게 끝난 결과는 새 claim 을 덮지 않는다")
+    void staleClaimResultDoesNotOverwriteFreshClaim() {
+        insertPendingSummary("늦게 끝나는 호출.");
+
+        // 내가 claim 을 잡고 있는 사이 다른 워커가 회수해 새 claim 을 잡은 상태를 만든다.
+        float[] vector = new float[EMBEDDING_DIM];
+        when(openAiLlmClient.embed(anyString())).thenAnswer(invocation -> {
+            jdbcTemplate.update(
+                    "UPDATE session_summaries SET embedding_claimed_at = now() + interval '1 minute' WHERE id = ?",
+                    summaryId);
+            return vector;
+        });
+
+        embeddingWorker.processPending();
+
+        assertThat(currentStatus())
+                .as("펜싱이 없으면 늦게 끝난 결과가 남의 작업 상태를 덮어쓴다")
+                .isEqualTo("processing");
+    }
+
+    @Test
+    @DisplayName("동시에 도는 워커가 같은 행을 두 번 claim 하지 않는다")
+    void concurrentClaimsDoNotOverlap() throws Exception {
+        List<UUID> extraSessions = new ArrayList<>();
+        for (int i = 0; i < 8; i++) {
+            // session_summaries.session_id 는 UNIQUE 라 요약마다 세션이 하나씩 필요하다.
+            // sessions 는 사용자당 active 세션이 하나뿐이므로 종료된 세션으로 만든다.
+            UUID extraSession = UUID.randomUUID();
+            extraSessions.add(extraSession);
+            jdbcTemplate.update(
+                    "INSERT INTO sessions (id, user_id, character_id, status) VALUES (?, ?, 'mio', 'ended')",
+                    extraSession, userId);
+
+            jdbcTemplate.update(
+                    """
+                    INSERT INTO session_summaries (id, user_id, session_id, character_id, summary_text, embedding_status)
+                    VALUES (?, ?, ?, 'mio', ?, 'pending')
+                    """,
+                    UUID.randomUUID(), userId, extraSession, "동시성 확인 " + i);
+        }
+
+        float[] vector = new float[EMBEDDING_DIM];
+        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+        try {
+            List<Future<?>> futures = List.of(
+                    pool.submit(() -> embeddingWorker.processPending()),
+                    pool.submit(() -> embeddingWorker.processPending()));
+            for (Future<?> future : futures) {
+                future.get(30, TimeUnit.SECONDS);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Integer overClaimed = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM session_summaries WHERE user_id = ? AND embedding_attempts > 1",
+                Integer.class, userId);
+        assertThat(overClaimed)
+                .as("SKIP LOCKED 가 깨지면 같은 요약을 두 번 임베딩해 비용이 두 배가 된다")
+                .isZero();
+
+        jdbcTemplate.update("DELETE FROM sessions WHERE user_id = ? AND status = 'ended'", userId);
     }
 
     private void insertStuckProcessingRow(String summaryText, int claimedMinutesAgo, int attempts) {


### PR DESCRIPTION
## 왜

`EmbeddingWorker`는 claim(`pending → processing`)과 결과 기록(`done`/`failed`)을 **서로 다른 트랜잭션**에서 한다. 그 사이에 프로세스가 죽으면(배포, OOM, 크래시) 행이 `processing`에 남는데, 재claim 조건이 `WHERE embedding_status = 'pending'` 뿐이라 **그 행은 영원히 다시 처리되지 않는다.**

결과적으로 해당 요약은 임베딩 없이 남아 벡터 검색에서 조용히 누락된다. 사용자 입장에서는 그 대화만 기억에서 빠진 것처럼 보인다.

로드맵 P0-7(위기·삭제·턴 작업 신뢰성)의 "terminal status, stuck recovery" 항목에 해당한다.

## 무엇을 바꿨나

`session_summaries`에 `embedding_claimed_at`, `embedding_attempts`를 추가하고(V48) 세 가지를 처리한다.

- **회수** — claim 기한(10분)이 지난 `processing` 행을 다시 claim 대상에 포함
- **상한** — 시도 3회 초과 행은 claim하지 않고, 고착된 행은 `failed`로 확정. 상한이 없으면 항상 실패하는 행 하나가 배치 자리를 계속 차지하며 API 비용만 쓴다
- **재시도** — 임베딩 API 실패는 대부분 일시적인데(타임아웃, rate limit) 이전에는 **한 번 실패하면 그대로 `failed`로 확정**해 그 요약이 영구히 검색에서 빠졌다. 상한까지는 `pending`으로 되돌린다

기존 `processing` 고착 행에는 마이그레이션에서 과거 시각을 넣어 즉시 회수 대상이 되게 했다.

## 동작 변경 (기존 테스트 갱신)

`processPending_embeddingError_transitionsToFailed`는 "첫 실패 = 즉시 failed"를 고정하고 있었다. 이슈가 요구한 재시도 정책과 정면으로 충돌하는 계약이라 갱신했다 — 첫 실패는 `pending`, 상한 도달 시 `failed`.

## 테스트

실제 DB 대상 통합 테스트로 추가:

- 일시적 실패 → `pending` 복귀 + `attempts=1`
- 반복 실패 → 상한 3회에서 `failed` 확정
- **프로세스 중단 모사** — `processing` 고착 행 회수 후 `done` 전이
- 방금 claim된 `processing` 행은 회수하지 않음 (중복 임베딩 방지)
- 상한 초과 고착 행 → `failed` 확정

전체 `./gradlew test` 812건 통과.

## 범위 밖

- `messages` 테이블의 `embedding_status` (현재 워커가 다루지 않음)
- 세션 종료 시 위기 승격 사후 안전망 (`#256`)
- 세션별 처리 직렬화 (`#243`)

Closes #254