### PR TITLE
feat: 세션 종료 후 놓친 위기를 사후 승격한다

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisEpisodePromoter.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEpisodePromoter.java
@@ -1,0 +1,72 @@
+package com.mio.ai.crisis;
+
+import com.mio.session.domain.Session;
+import com.mio.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 세션 종료 후 ExtractorLLM 이 위기로 판정한 세션을 위기 이벤트로 승격한다 (이슈 #256).
+ *
+ * <p>이 경로가 필요한 이유는 구조적이다. {@code InputJudge} 는 {@code SafetySignalCombiner} 가
+ * 검증을 요구할 때만 호출되고, 그 조건은 전적으로 룰 레이어 결과로 정해진다. 즉 <b>Judge 의
+ * 회수율 상한은 룰의 회수율과 같고</b>, 룰이 정상으로 본 발화는 어떤 LLM 도 보지 못한다.
+ * ExtractorLLM 은 세션 전체를 읽고 독립적으로 판정하므로 그 한계를 넘는 유일한 기존 경로다.
+ *
+ * <p>승격의 효과는 학습 루프 복구다. {@code SafetyProfileBuilder} 는 {@code crisis_events} 를
+ * 읽어 다음 세션의 임계값과 {@code force_judge} 를 정한다. 미탐이면 행이 생기지 않아 같은
+ * 사용자가 같은 이유로 계속 미탐되는데, 이 승격이 그 고리를 끊는다.
+ *
+ * <p>추가 비용은 없다. ExtractorLLM 호출은 이미 세션마다 발생하고 그 결과를 읽기만 한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class CrisisEpisodePromoter {
+
+    private static final String CRISIS_EPISODE = "crisis";
+
+    /** 사후 판정이므로 {@code pattern} 이다 — 키워드·moderation 근거로 잡힌 것이 아니다. */
+    private static final String TRIGGER_TYPE = "pattern";
+
+    /**
+     * 승격 이벤트의 심각도.
+     *
+     * <p>실시간 위기 플로우는 발화 근거로 1~3을 가른다. 사후 승격은 그 근거가 없다 — 세션
+     * 전체를 요약한 판정이라 즉시성과 계획 여부를 확인할 수 없다. 그래서 최고 등급은 쓰지
+     * 않고, 동시에 프로파일이 무시하지 않도록 최저 등급보다는 높게 둔다.
+     */
+    private static final int PROMOTED_SEVERITY = 2;
+
+    private final CrisisEventRepository crisisEventRepository;
+    private final CrisisEventRecorder crisisEventRecorder;
+
+    /**
+     * @param episodeType ExtractorLLM 이 판정한 세션 유형
+     * @return 이번 호출이 승격을 기록했는지. 이미 위기로 기록된 세션이면 {@code false}
+     */
+    public boolean promoteIfCrisis(User user, Session session, String episodeType) {
+        if (user == null || session == null || !CRISIS_EPISODE.equalsIgnoreCase(episodeType)) {
+            return false;
+        }
+        // 실시간 플로우가 이미 기록한 세션은 건너뛴다. 같은 위기를 두 번 세면 프로파일의
+        // 위기 빈도가 부풀고, 운영자 검토 큐에도 중복이 쌓인다.
+        if (crisisEventRepository.existsBySession_Id(session.getId())) {
+            log.debug("CrisisEpisodePromoter: sessionId={} already has a crisis event, skipping",
+                    session.getId());
+            return false;
+        }
+
+        boolean recorded = crisisEventRecorder.record(user, session, PROMOTED_SEVERITY, TRIGGER_TYPE);
+        if (recorded) {
+            // 실시간 하네스가 놓친 위기다. 사람이 볼 수 있게 경고로 남긴다.
+            log.warn("CrisisEpisodePromoter: promoted missed crisis sessionId={} severity={}",
+                    session.getId(), PROMOTED_SEVERITY);
+        } else {
+            log.error("CrisisEpisodePromoter: failed to record promoted crisis sessionId={}",
+                    session.getId());
+        }
+        return recorded;
+    }
+}

--- a/src/main/java/com/mio/ai/crisis/CrisisEpisodePromoter.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEpisodePromoter.java
@@ -1,10 +1,15 @@
 package com.mio.ai.crisis;
 
 import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
+
+import java.util.UUID;
 
 /**
  * 세션 종료 후 ExtractorLLM 이 위기로 판정한 세션을 위기 이벤트로 승격한다 (이슈 #256).
@@ -18,7 +23,9 @@ import org.springframework.stereotype.Component;
  * 읽어 다음 세션의 임계값과 {@code force_judge} 를 정한다. 미탐이면 행이 생기지 않아 같은
  * 사용자가 같은 이유로 계속 미탐되는데, 이 승격이 그 고리를 끊는다.
  *
- * <p>추가 비용은 없다. ExtractorLLM 호출은 이미 세션마다 발생하고 그 결과를 읽기만 한다.
+ * <p><b>이 클래스는 예외를 밖으로 내보내지 않는다.</b> 호출부는 이미 커밋된 세션 요약 뒤에서
+ * 돌기 때문이다. 승격 경로의 DB 실패가 위로 전파되면 사용자가 LLM 비용을 치르고 받은 요약이
+ * 함께 사라진다 — 이슈 #219 에서 한 번 겪은 사고다.
  */
 @Component
 @RequiredArgsConstructor
@@ -35,26 +42,51 @@ public class CrisisEpisodePromoter {
      *
      * <p>실시간 위기 플로우는 발화 근거로 1~3을 가른다. 사후 승격은 그 근거가 없다 — 세션
      * 전체를 요약한 판정이라 즉시성과 계획 여부를 확인할 수 없다. 그래서 최고 등급은 쓰지
-     * 않고, 동시에 프로파일이 무시하지 않도록 최저 등급보다는 높게 둔다.
+     * 않는다. 반대로 1은 {@code SafetyProfileBuilder} 의 {@code crisisMax >= 2} 조건을
+     * 넘지 못해 {@code force_judge} 도 민감 임계값도 켜지지 않는다 — 승격의 목적이 사라진다.
      */
     private static final int PROMOTED_SEVERITY = 2;
 
     private final CrisisEventRepository crisisEventRepository;
     private final CrisisEventRecorder crisisEventRecorder;
+    private final UserRepository userRepository;
+    private final SessionRepository sessionRepository;
 
     /**
      * @param episodeType ExtractorLLM 이 판정한 세션 유형
-     * @return 이번 호출이 승격을 기록했는지. 이미 위기로 기록된 세션이면 {@code false}
+     * @return 이번 호출이 승격을 기록했는지. 이미 위기로 기록된 세션이거나 실패면 {@code false}
      */
-    public boolean promoteIfCrisis(User user, Session session, String episodeType) {
-        if (user == null || session == null || !CRISIS_EPISODE.equalsIgnoreCase(episodeType)) {
+    public boolean promoteIfCrisis(UUID userId, UUID sessionId, String episodeType) {
+        if (userId == null || sessionId == null || !CRISIS_EPISODE.equalsIgnoreCase(episodeType)) {
             return false;
         }
-        // 실시간 플로우가 이미 기록한 세션은 건너뛴다. 같은 위기를 두 번 세면 프로파일의
-        // 위기 빈도가 부풀고, 운영자 검토 큐에도 중복이 쌓인다.
-        if (crisisEventRepository.existsBySession_Id(session.getId())) {
-            log.debug("CrisisEpisodePromoter: sessionId={} already has a crisis event, skipping",
-                    session.getId());
+        try {
+            return promote(userId, sessionId);
+        } catch (DataIntegrityViolationException e) {
+            // 같은 세션에 대한 승격이 동시에 두 번 들어온 경우다. DB 의 부분 유니크 인덱스가
+            // 두 번째를 막았으므로 이미 목적은 달성됐다.
+            log.debug("CrisisEpisodePromoter: sessionId={} already promoted concurrently", sessionId);
+            return false;
+        } catch (Exception e) {
+            // 여기서 던지면 이미 커밋된 요약 뒤의 후처리가 실패로 기록된다. 승격은 사후
+            // 안전망이므로 실패해도 요약과 나머지 후처리를 막지 않는다.
+            log.error("CrisisEpisodePromoter: promotion failed sessionId={}", sessionId, e);
+            return false;
+        }
+    }
+
+    private boolean promote(UUID userId, UUID sessionId) {
+        // 실시간 플로우가 이미 기록한 세션은 건너뛴다. 같은 위기를 두 번 기록하면 운영자
+        // 검토 큐에 중복이 쌓이고, 사후 승격인지 실시간 감지인지 구분이 흐려진다.
+        if (crisisEventRepository.existsBySession_Id(sessionId)) {
+            log.debug("CrisisEpisodePromoter: sessionId={} already has a crisis event, skipping", sessionId);
+            return false;
+        }
+
+        User user = userRepository.findById(userId).orElse(null);
+        Session session = sessionRepository.findById(sessionId).orElse(null);
+        if (user == null || session == null) {
+            log.warn("CrisisEpisodePromoter: user or session not found userId={} sessionId={}", userId, sessionId);
             return false;
         }
 
@@ -62,10 +94,9 @@ public class CrisisEpisodePromoter {
         if (recorded) {
             // 실시간 하네스가 놓친 위기다. 사람이 볼 수 있게 경고로 남긴다.
             log.warn("CrisisEpisodePromoter: promoted missed crisis sessionId={} severity={}",
-                    session.getId(), PROMOTED_SEVERITY);
+                    sessionId, PROMOTED_SEVERITY);
         } else {
-            log.error("CrisisEpisodePromoter: failed to record promoted crisis sessionId={}",
-                    session.getId());
+            log.error("CrisisEpisodePromoter: failed to record promoted crisis sessionId={}", sessionId);
         }
         return recorded;
     }

--- a/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisEventRepository.java
@@ -17,6 +17,9 @@ public interface CrisisEventRepository extends JpaRepository<CrisisEvent, UUID> 
 
     List<CrisisEvent> findBySession_IdOrderByCreatedAtAsc(UUID sessionId);
 
+    /** 세션에 위기 이벤트가 이미 있는지 (이슈 #256). 사후 승격이 같은 위기를 두 번 세지 않게 한다. */
+    boolean existsBySession_Id(UUID sessionId);
+
     /**
      * 원자적 조건부 검토 처리 (이슈 #277 리뷰 반영).
      *

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.domain.CbtPattern;
 import com.mio.ai.domain.EmotionalState;
 import com.mio.ai.domain.MemoryEmbedding;
+import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.ai.llm.LlmRequest;
@@ -97,6 +98,7 @@ public class SessionConsolidator {
     private final OntologyValidator ontologyValidator;
     private final TodoRecommendationService todoRecommendationService;
     private final SummaryStatusWriter summaryStatusWriter;
+    private final CrisisEpisodePromoter crisisEpisodePromoter;
     // 메모리 보강을 별도 트랜잭션(REQUIRES_NEW)으로 호출하기 위한 self 프록시.
     // self-invocation으로는 프록시 어드바이스(@Transactional)가 적용되지 않으므로 ObjectProvider로 우회.
     private final ObjectProvider<SessionConsolidator> self;
@@ -240,6 +242,10 @@ public class SessionConsolidator {
 
         log.info("SessionConsolidator: summary persisted sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
                 sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
+
+        // ExtractorLLM 이 위기로 판정했는데 실시간 하네스가 놓친 세션을 사후 승격한다 (이슈 #256).
+        // 요약 영속화가 끝난 뒤에 한다 — 승격이 실패해도 요약은 남아야 한다.
+        crisisEpisodePromoter.promoteIfCrisis(user, session, extracted.episodeType());
 
         return new EnrichmentInput(userId, sessionId, validThoughts, dominantEmotion, distortionCodes,
                 extracted.triggerTags(), summaryText);

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -136,6 +136,18 @@ public class SessionConsolidator {
         // 2단계: thoughts/beliefs/cbt_patterns/todos 등 메모리 보강은 별도 트랜잭션(REQUIRES_NEW)에서
         // best-effort로 실행한다. 1단계 요약은 이미 커밋되었으므로 보강 실패가 요약에 영향을 주지 않는다.
         if (enrichInput != null) {
+            // 실시간 하네스가 놓친 위기를 사후 승격한다 (이슈 #256).
+            // 요약 트랜잭션이 커밋된 뒤 best-effort 로 실행한다 — 승격 경로의 실패가 이미 성공한
+            // 요약을 롤백시키면, 사용자는 LLM 비용을 치른 요약을 영구히 받지 못한다 (이슈 #219와
+            // 같은 계열의 사고다).
+            try {
+                crisisEpisodePromoter.promoteIfCrisis(
+                        enrichInput.userId(), enrichInput.sessionId(), enrichInput.episodeType());
+            } catch (Exception e) {
+                log.error("SessionConsolidator: crisis promotion failed but summary preserved sessionId={}",
+                        event.sessionId(), e);
+            }
+
             try {
                 self.getObject().enrichMemory(enrichInput);
             } catch (Exception e) {
@@ -243,12 +255,9 @@ public class SessionConsolidator {
         log.info("SessionConsolidator: summary persisted sessionId={} episodeType={} cbtIntervened={} thoughts={} emotion={}",
                 sessionId, extracted.episodeType(), cbtIntervened, validThoughts.size(), dominantEmotion);
 
-        // ExtractorLLM 이 위기로 판정했는데 실시간 하네스가 놓친 세션을 사후 승격한다 (이슈 #256).
-        // 요약 영속화가 끝난 뒤에 한다 — 승격이 실패해도 요약은 남아야 한다.
-        crisisEpisodePromoter.promoteIfCrisis(user, session, extracted.episodeType());
 
         return new EnrichmentInput(userId, sessionId, validThoughts, dominantEmotion, distortionCodes,
-                extracted.triggerTags(), summaryText);
+                extracted.triggerTags(), summaryText, extracted.episodeType());
     }
 
     /**
@@ -293,7 +302,8 @@ public class SessionConsolidator {
             String dominantEmotion,
             List<String> distortionCodes,
             List<String> triggerTags,
-            String summaryText
+            String summaryText,
+            String episodeType
     ) {}
 
     // ── 대화 컨텍스트 구성 ────────────────────────────────────────

--- a/src/main/resources/db/migration/V49__unique_promoted_crisis_per_session.sql
+++ b/src/main/resources/db/migration/V49__unique_promoted_crisis_per_session.sql
@@ -1,0 +1,13 @@
+-- [issue #256] 사후 승격은 "이미 위기 이벤트가 있는지" 확인한 뒤 INSERT 한다. 확인과 쓰기
+-- 사이에 잠금이 없어, 같은 세션에 대한 승격이 동시에 두 번 들어오면 둘 다 통과할 수 있다.
+-- dedup_key 는 호출 한 건의 재시도만 막을 뿐 서로 다른 두 호출은 막지 못한다.
+--
+-- 승격은 세션당 한 번뿐이므로 DB 가 직렬화하게 한다. 실시간 감지(keyword/moderation/
+-- user_sos)는 한 세션에서 여러 번 발생할 수 있으므로 제약 대상이 아니다.
+
+CREATE UNIQUE INDEX uq_crisis_events_promoted_per_session
+    ON crisis_events (session_id)
+    WHERE trigger_type = 'pattern' AND session_id IS NOT NULL;
+
+COMMENT ON INDEX uq_crisis_events_promoted_per_session IS
+    'One retrospective promotion per session. Real-time detections are not constrained - a session can legitimately trigger several.';

--- a/src/test/java/com/mio/ai/crisis/CrisisEpisodePromoterTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisEpisodePromoterTest.java
@@ -1,0 +1,110 @@
+package com.mio.ai.crisis;
+
+import com.mio.session.domain.Session;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #256 — 실시간 하네스가 놓친 위기를 세션 종료 후 승격한다. */
+class CrisisEpisodePromoterTest {
+
+    private CrisisEventRepository crisisEventRepository;
+    private CrisisEventRecorder crisisEventRecorder;
+    private CrisisEpisodePromoter promoter;
+
+    private User user;
+    private Session session;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        crisisEventRepository = mock(CrisisEventRepository.class);
+        crisisEventRecorder = mock(CrisisEventRecorder.class);
+        promoter = new CrisisEpisodePromoter(crisisEventRepository, crisisEventRecorder);
+
+        user = mock(User.class);
+        session = mock(Session.class);
+        sessionId = UUID.randomUUID();
+        when(session.getId()).thenReturn(sessionId);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("위기 세션인데 기록이 없으면 승격한다")
+    void promotesCrisisEpisodeWithoutExistingEvent() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
+
+        boolean promoted = promoter.promoteIfCrisis(user, session, "crisis");
+
+        assertThat(promoted)
+                .as("룰이 정상으로 본 발화는 어떤 LLM 도 보지 못한다 — 이 경로가 유일한 회수 지점이다")
+                .isTrue();
+        verify(crisisEventRecorder).record(eq(user), eq(session), eq(2), eq("pattern"));
+    }
+
+    @Test
+    @DisplayName("이미 위기로 기록된 세션은 승격하지 않는다")
+    void doesNotPromoteWhenSessionAlreadyHasCrisisEvent() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(true);
+
+        boolean promoted = promoter.promoteIfCrisis(user, session, "crisis");
+
+        assertThat(promoted)
+                .as("같은 위기를 두 번 세면 프로파일의 위기 빈도가 부풀고 검토 큐에도 중복이 쌓인다")
+                .isFalse();
+        verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
+    }
+
+    @Test
+    @DisplayName("위기가 아닌 세션 유형은 무시한다")
+    void ignoresNonCrisisEpisodeTypes() {
+        for (String episodeType : new String[]{"regular", "cbt_success", "cbt_partial", "support_only"}) {
+            assertThat(promoter.promoteIfCrisis(user, session, episodeType)).isFalse();
+        }
+
+        verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
+        verify(crisisEventRepository, never()).existsBySession_Id(any());
+    }
+
+    @Test
+    @DisplayName("판정값이 없거나 엔티티가 없으면 아무 일도 하지 않는다")
+    void ignoresMissingInputs() {
+        assertThat(promoter.promoteIfCrisis(user, session, null)).isFalse();
+        assertThat(promoter.promoteIfCrisis(null, session, "crisis")).isFalse();
+        assertThat(promoter.promoteIfCrisis(user, null, "crisis")).isFalse();
+
+        verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
+    }
+
+    @Test
+    @DisplayName("대소문자가 달라도 위기 판정으로 인식한다")
+    void episodeTypeMatchingIsCaseInsensitive() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
+
+        assertThat(promoter.promoteIfCrisis(user, session, "CRISIS")).isTrue();
+    }
+
+    @Test
+    @DisplayName("기록에 실패하면 승격도 실패로 보고한다")
+    void reportsFailureWhenRecordingFails() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(false);
+
+        assertThat(promoter.promoteIfCrisis(user, session, "crisis"))
+                .as("기록되지 않은 승격을 성공으로 세면 다음 세션의 보호 근거가 없는데 있다고 믿게 된다")
+                .isFalse();
+    }
+}

--- a/src/test/java/com/mio/ai/crisis/CrisisEpisodePromoterTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisEpisodePromoterTest.java
@@ -1,7 +1,9 @@
 package com.mio.ai.crisis;
 
 import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
 import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,22 +25,30 @@ class CrisisEpisodePromoterTest {
 
     private CrisisEventRepository crisisEventRepository;
     private CrisisEventRecorder crisisEventRecorder;
+    private UserRepository userRepository;
+    private SessionRepository sessionRepository;
     private CrisisEpisodePromoter promoter;
 
     private User user;
     private Session session;
+    private UUID userId;
     private UUID sessionId;
 
     @BeforeEach
     void setUp() {
         crisisEventRepository = mock(CrisisEventRepository.class);
         crisisEventRecorder = mock(CrisisEventRecorder.class);
-        promoter = new CrisisEpisodePromoter(crisisEventRepository, crisisEventRecorder);
+        userRepository = mock(UserRepository.class);
+        sessionRepository = mock(SessionRepository.class);
+        promoter = new CrisisEpisodePromoter(
+                crisisEventRepository, crisisEventRecorder, userRepository, sessionRepository);
 
         user = mock(User.class);
         session = mock(Session.class);
+        userId = UUID.randomUUID();
         sessionId = UUID.randomUUID();
-        when(session.getId()).thenReturn(sessionId);
+        when(userRepository.findById(userId)).thenReturn(java.util.Optional.of(user));
+        when(sessionRepository.findById(sessionId)).thenReturn(java.util.Optional.of(session));
         when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(true);
     }
 
@@ -47,7 +57,7 @@ class CrisisEpisodePromoterTest {
     void promotesCrisisEpisodeWithoutExistingEvent() {
         when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
 
-        boolean promoted = promoter.promoteIfCrisis(user, session, "crisis");
+        boolean promoted = promoter.promoteIfCrisis(userId, sessionId, "crisis");
 
         assertThat(promoted)
                 .as("룰이 정상으로 본 발화는 어떤 LLM 도 보지 못한다 — 이 경로가 유일한 회수 지점이다")
@@ -60,10 +70,10 @@ class CrisisEpisodePromoterTest {
     void doesNotPromoteWhenSessionAlreadyHasCrisisEvent() {
         when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(true);
 
-        boolean promoted = promoter.promoteIfCrisis(user, session, "crisis");
+        boolean promoted = promoter.promoteIfCrisis(userId, sessionId, "crisis");
 
         assertThat(promoted)
-                .as("같은 위기를 두 번 세면 프로파일의 위기 빈도가 부풀고 검토 큐에도 중복이 쌓인다")
+                .as("같은 위기를 두 번 기록하면 운영자 검토 큐에 중복이 쌓이고 감지 경로 구분이 흐려진다")
                 .isFalse();
         verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
     }
@@ -72,7 +82,7 @@ class CrisisEpisodePromoterTest {
     @DisplayName("위기가 아닌 세션 유형은 무시한다")
     void ignoresNonCrisisEpisodeTypes() {
         for (String episodeType : new String[]{"regular", "cbt_success", "cbt_partial", "support_only"}) {
-            assertThat(promoter.promoteIfCrisis(user, session, episodeType)).isFalse();
+            assertThat(promoter.promoteIfCrisis(userId, sessionId, episodeType)).isFalse();
         }
 
         verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
@@ -82,9 +92,9 @@ class CrisisEpisodePromoterTest {
     @Test
     @DisplayName("판정값이 없거나 엔티티가 없으면 아무 일도 하지 않는다")
     void ignoresMissingInputs() {
-        assertThat(promoter.promoteIfCrisis(user, session, null)).isFalse();
-        assertThat(promoter.promoteIfCrisis(null, session, "crisis")).isFalse();
-        assertThat(promoter.promoteIfCrisis(user, null, "crisis")).isFalse();
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, null)).isFalse();
+        assertThat(promoter.promoteIfCrisis(null, sessionId, "crisis")).isFalse();
+        assertThat(promoter.promoteIfCrisis(userId, null, "crisis")).isFalse();
 
         verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
     }
@@ -94,7 +104,38 @@ class CrisisEpisodePromoterTest {
     void episodeTypeMatchingIsCaseInsensitive() {
         when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
 
-        assertThat(promoter.promoteIfCrisis(user, session, "CRISIS")).isTrue();
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, "CRISIS")).isTrue();
+    }
+
+    @Test
+    @DisplayName("조회가 실패해도 예외를 밖으로 내보내지 않는다")
+    void doesNotPropagateRepositoryFailure() {
+        when(crisisEventRepository.existsBySession_Id(sessionId))
+                .thenThrow(new org.springframework.dao.QueryTimeoutException("db down"));
+
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, "crisis"))
+                .as("여기서 예외가 나가면 이미 커밋된 세션 요약 뒤의 후처리가 통째로 실패한다 (이슈 #219)")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("동시 승격이 유니크 제약에 막히면 조용히 넘어간다")
+    void treatsUniqueViolationAsAlreadyPromoted() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
+        when(crisisEventRecorder.record(any(), any(), anyInt(), anyString()))
+                .thenThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate"));
+
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, "crisis")).isFalse();
+    }
+
+    @Test
+    @DisplayName("사용자나 세션을 찾지 못하면 기록하지 않는다")
+    void skipsWhenEntitiesAreMissing() {
+        when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
+        when(sessionRepository.findById(sessionId)).thenReturn(java.util.Optional.empty());
+
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, "crisis")).isFalse();
+        verify(crisisEventRecorder, never()).record(any(), any(), anyInt(), anyString());
     }
 
     @Test
@@ -103,7 +144,7 @@ class CrisisEpisodePromoterTest {
         when(crisisEventRepository.existsBySession_Id(sessionId)).thenReturn(false);
         when(crisisEventRecorder.record(any(), any(), anyInt(), anyString())).thenReturn(false);
 
-        assertThat(promoter.promoteIfCrisis(user, session, "crisis"))
+        assertThat(promoter.promoteIfCrisis(userId, sessionId, "crisis"))
                 .as("기록되지 않은 승격을 성공으로 세면 다음 세션의 보호 근거가 없는데 있다고 믿게 된다")
                 .isFalse();
     }

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.episodic.ThoughtRepository;
 import com.mio.ai.memory.episodic.UserBelief;
@@ -86,6 +87,7 @@ class SessionConsolidatorTest {
                 mock(OntologyValidator.class),
                 todoRecommendationService,
                 summaryStatusWriter,
+                mock(CrisisEpisodePromoter.class),
                 selfProvider
         );
     }

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -50,6 +50,7 @@ class SessionConsolidatorTest {
     private SessionRepository sessionRepository;
     private TodoRecommendationService todoRecommendationService;
     private SummaryStatusWriter summaryStatusWriter;
+    private CrisisEpisodePromoter crisisEpisodePromoter;
     private ObjectProvider<SessionConsolidator> self;
 
     private SessionConsolidator newConsolidator() {
@@ -62,6 +63,7 @@ class SessionConsolidatorTest {
         sessionRepository = mock(SessionRepository.class);
         todoRecommendationService = mock(TodoRecommendationService.class);
         summaryStatusWriter = mock(SummaryStatusWriter.class);
+        crisisEpisodePromoter = mock(CrisisEpisodePromoter.class);
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
         when(beliefIdentityHasher.hash(any(), anyString(), anyShort())).thenReturn(new byte[]{9});
@@ -87,7 +89,7 @@ class SessionConsolidatorTest {
                 mock(OntologyValidator.class),
                 todoRecommendationService,
                 summaryStatusWriter,
-                mock(CrisisEpisodePromoter.class),
+                crisisEpisodePromoter,
                 selfProvider
         );
     }
@@ -110,8 +112,7 @@ class SessionConsolidatorTest {
         UUID userId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
-                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약"
-        );
+                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약", "regular");
         when(self.getObject()).thenReturn(proxy);
         when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
         when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any()))
@@ -126,6 +127,9 @@ class SessionConsolidatorTest {
         inOrder.verify(summaryStatusWriter).markDone(sessionId);
         verify(sessionRepository, never()).updateSummaryStatus(sessionId, SummaryStatus.DONE);
         verify(summaryStatusWriter, never()).markFailed(sessionId);
+
+        // 승격 호출이 통째로 빠져도 나머지 단언은 통과한다 — 배선 자체를 고정한다 (이슈 #256).
+        verify(crisisEpisodePromoter).promoteIfCrisis(userId, sessionId, "regular");
     }
 
     @Test
@@ -136,8 +140,7 @@ class SessionConsolidatorTest {
         UUID userId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
-                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약"
-        );
+                userId, sessionId, List.of(), null, List.of(), List.of(), "세션 요약", "regular");
         when(self.getObject()).thenReturn(proxy);
         when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
         when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any()))


### PR DESCRIPTION
## 요약

`ExtractorLLM` 이 이미 판정하고 있는 `episodeType = "crisis"` 를 위기 이벤트로 승격해, 실시간 하네스(룰 + InputJudge)가 놓친 위기를 사후에 회수한다. 판정 결과가 지금까지 `session_summaries` 에 저장된 뒤 아무도 읽지 않고 버려지고 있었다.

이 경로가 필요한 이유는 구조적이다. `InputJudge` 는 `SafetySignalCombiner.determineRequiresJudge()` 가 true 일 때만 호출되고 그 조건은 전적으로 룰 결과로 정해진다. 즉 **Judge 의 회수율 상한은 룰의 회수율과 같고, 룰이 정상으로 본 발화는 어떤 LLM 도 보지 못한다.** 출력 하네스의 `CRISIS_MISMATCH` 검사도 입력 신호를 전제로 하므로 입력 미탐이면 비활성이다. `ExtractorLLM` 은 세션 전체를 읽고 독립 판정하는 유일한 기존 경로다.

## 관련 이슈

- Closes #256

## 변경 사항

- `CrisisEpisodePromoter` 추가 — `episodeType == "crisis"` 이고 해당 세션에 위기 이벤트가 없으면 `trigger_type = 'pattern'`, `severity = 2` 로 기록하고 기존 `CrisisEventRecorder` 를 통해 `CrisisDetectedEvent` 발행
- `SessionConsolidator` 가 **요약 트랜잭션 커밋 이후** best-effort 로 호출 (`enrichMemory` 와 같은 단계)
- `crisis_events` 에 세션당 승격 1회 부분 유니크 인덱스 추가 (V49)
- `CrisisEventRepository.existsBySession_Id` 추가

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. — V49 부분 유니크 인덱스 (`crisis_events`)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `SessionConsolidator.onSessionEnded` 후처리 단계 추가
- [x] 로깅 / 모니터링 포인트가 변경됩니다. — 승격 시 `WARN` 로그(놓친 위기), 실패 시 `ERROR`
- [ ] Breaking change 가 있습니다.

## 테스트

### 실행 커맨드

```bash
./gradlew test
```

### 확인 내용

- `CrisisEpisodePromoterTest` 9건 — 승격 / 중복 스킵 / 비crisis 무시 / 입력 누락 / 대소문자 / 기록 실패 보고 / **DB 예외 비전파** / 유니크 위반 처리 / 엔티티 부재
- `SessionConsolidatorTest` — 승격 호출 배선 검증 (호출이 빠져도 통과하던 공백 보완)
- 전체 823건 통과

수동 검증은 하지 않았다. 실 세션 종료 흐름은 `@TransactionalEventListener(AFTER_COMMIT)` + `@Async` 경로라 통합 재현 비용이 커, 트랜잭션 격리 속성은 코드 경계와 단위 테스트로 고정했다.

## 중점 리뷰 포인트

1. **트랜잭션 경계** — 초기 구현에서 승격 호출이 요약과 같은 `REQUIRES_NEW` 안에 있어, `existsBySession_Id` 의 `DataAccessException` 이 이미 저장된 요약까지 롤백시킬 수 있었다(이슈 #219 와 같은 계열). 요약 커밋 이후 best-effort 로 옮기고 promoter 내부에서도 예외를 삼키도록 고쳤다. 이 경계가 맞는지 확인 부탁드린다.
2. **심각도 2의 근거** — `SafetyProfileBuilder` 의 `crisisMax >= 2` 를 넘어야 `force_judge` 와 민감 임계값이 켜진다. 1이면 승격의 목적이 사라지고, 3은 발화 근거 없는 사후 판정에 과하다고 판단했다.
3. **오탐 비용** — `queryRecentCrisis` 가 `operator_reviewed` 를 보지 않아, 운영자가 오탐으로 검토해도 14일간 프로파일에 남는다. 기존 갭이지만 이번 변경이 비용을 키우므로 #315 로 분리했다.

## 배포 / 롤백

- Rollout: V49 인덱스는 `crisis_events` 대상이며 현재 행 수가 적어 잠금 영향이 작다. 코드 배포 후 다음 세션 종료부터 승격이 동작한다.
- Rollback: 이전 커밋으로 되돌리면 승격이 중단된다. 인덱스는 남아도 동작에 영향이 없으므로 되돌리지 않아도 된다. 이미 생성된 `pattern` 이벤트는 운영자 검토 큐에서 확인 가능하다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.