### PR TITLE
feat: 이벤트 화이트리스트를 값 도메인 검증까지 확장 (#320)

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -179,8 +179,10 @@ public class AuthService {
         }
 
         String employmentStatus = request.employmentStatus();
-        if (employmentStatus != null && !employmentStatus.isBlank()
-                && !VALID_EMPLOYMENT_STATUSES.contains(employmentStatus)) {
+        if (employmentStatus != null && employmentStatus.isBlank()) {
+            employmentStatus = null;
+        }
+        if (employmentStatus != null && !VALID_EMPLOYMENT_STATUSES.contains(employmentStatus)) {
             throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
 

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -30,6 +31,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AuthService {
 
     private static final int JWT_EXPIRY_SECONDS = 900;
+
+    // #320 — 이벤트 화이트리스트(event-whitelist.yml)에만 enum 검증을 걸면 DB엔 오염값이
+    // 남아 나중에 백필이 불가능하다. 코호트 축이라 여기서도 막는다. 선택 필드라 null/blank는 통과.
+    private static final Set<String> VALID_EMPLOYMENT_STATUSES = Set.of("job_seeker", "employed");
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;
@@ -173,7 +178,13 @@ public class AuthService {
             throw new BusinessException(ErrorCode.NICKNAME_DUPLICATE);
         }
 
-        user.completeProfile(request.nickname(), request.ageRange(), request.gender(), request.employmentStatus());
+        String employmentStatus = request.employmentStatus();
+        if (employmentStatus != null && !employmentStatus.isBlank()
+                && !VALID_EMPLOYMENT_STATUSES.contains(employmentStatus)) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        user.completeProfile(request.nickname(), request.ageRange(), request.gender(), employmentStatus);
 
         return new SignupCompleteResponse(user.getSignupStep(), user.getOnboardingStep(), user.getNickname());
     }

--- a/src/main/java/com/mio/events/config/EventWhitelist.java
+++ b/src/main/java/com/mio/events/config/EventWhitelist.java
@@ -34,11 +34,11 @@ public class EventWhitelist {
                 return true;
             }
             return switch (type) {
-                case ENUM -> enumValues.contains(String.valueOf(value));
-                case INT -> value instanceof Number;
+                case ENUM -> value instanceof String s && enumValues.contains(s);
+                case INT -> value instanceof Integer || value instanceof Long;
                 case BOOL -> value instanceof Boolean;
                 case ID -> value instanceof String s && !s.isBlank();
-                case STRING -> true;
+                case STRING -> value instanceof String;
             };
         }
     }

--- a/src/main/java/com/mio/events/config/EventWhitelist.java
+++ b/src/main/java/com/mio/events/config/EventWhitelist.java
@@ -7,20 +7,43 @@ import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 /**
- * 강민석 "mio 이벤트 로그 명세 v3.4" §4 카탈로그를 설정 파일로 관리한다 (하드코딩 금지 —
+ * 강민석 "mio 이벤트 로그 명세" §4 카탈로그를 설정 파일로 관리한다 (하드코딩 금지 —
  * 명세 §5 요구사항). 온보딩 개편 같은 카탈로그 변경은 event-whitelist.yml 한 곳만 고치면 된다.
+ *
+ * <p>#320 — 키 목록뿐 아니라 값 도메인(enum/type)까지 검증한다. 키만 검증하면 enum 자리에
+ * 자유 문자열이 실려도 통과했다(예: employment_status).
  */
 @Component
 public class EventWhitelist {
 
     private static final String RESOURCE_PATH = "event-whitelist.yml";
 
-    private Map<String, List<String>> allowedPropertiesByEvent;
+    public enum PropertyType { ENUM, INT, BOOL, ID, STRING }
+
+    public record PropertySpec(PropertyType type, Set<String> enumValues) {
+
+        /** null은 항상 통과시킨다 — nullable property(예: ai_emotion_score)가 정상 값이다. */
+        boolean accepts(Object value) {
+            if (value == null) {
+                return true;
+            }
+            return switch (type) {
+                case ENUM -> enumValues.contains(String.valueOf(value));
+                case INT -> value instanceof Number;
+                case BOOL -> value instanceof Boolean;
+                case ID -> value instanceof String s && !s.isBlank();
+                case STRING -> true;
+            };
+        }
+    }
+
+    private Map<String, Map<String, PropertySpec>> catalog;
 
     @PostConstruct
     @SuppressWarnings("unchecked")
@@ -28,18 +51,55 @@ public class EventWhitelist {
         Yaml yaml = new Yaml();
         try (InputStream in = new ClassPathResource(RESOURCE_PATH).getInputStream()) {
             Map<String, Object> root = yaml.load(in);
-            allowedPropertiesByEvent = (Map<String, List<String>>) root.get("events");
+            Map<String, Object> events = (Map<String, Object>) root.get("events");
+            catalog = new LinkedHashMap<>();
+            events.forEach((eventName, rawProperties) -> catalog.put(eventName, parseProperties(rawProperties)));
         } catch (IOException e) {
             throw new IllegalStateException("event-whitelist.yml 로드 실패", e);
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, PropertySpec> parseProperties(Object rawProperties) {
+        if (!(rawProperties instanceof Map<?, ?> propertiesMap)) {
+            return Map.of();
+        }
+        Map<String, PropertySpec> specs = new LinkedHashMap<>();
+        propertiesMap.forEach((key, spec) -> specs.put((String) key, parseSpec((Map<String, Object>) spec)));
+        return specs;
+    }
+
+    @SuppressWarnings("unchecked")
+    private PropertySpec parseSpec(Map<String, Object> spec) {
+        if (spec.containsKey("enum")) {
+            List<String> values = (List<String>) spec.get("enum");
+            return new PropertySpec(PropertyType.ENUM, Set.copyOf(values));
+        }
+        PropertyType type = switch (String.valueOf(spec.get("type"))) {
+            case "int" -> PropertyType.INT;
+            case "bool" -> PropertyType.BOOL;
+            case "id" -> PropertyType.ID;
+            default -> PropertyType.STRING;
+        };
+        return new PropertySpec(type, Set.of());
+    }
+
     public boolean isKnownEvent(String eventName) {
-        return allowedPropertiesByEvent.containsKey(eventName);
+        return catalog.containsKey(eventName);
     }
 
     public Set<String> allowedProperties(String eventName) {
-        List<String> keys = allowedPropertiesByEvent.get(eventName);
-        return keys == null ? Set.of() : Set.copyOf(keys);
+        Map<String, PropertySpec> specs = catalog.get(eventName);
+        return specs == null ? Set.of() : Set.copyOf(specs.keySet());
+    }
+
+    /** 키가 카탈로그에 없거나, 있어도 값이 도메인 밖이면 false. */
+    public boolean isValidPropertyValue(String eventName, String key, Object value) {
+        Map<String, PropertySpec> specs = catalog.get(eventName);
+        if (specs == null) {
+            return false;
+        }
+        PropertySpec spec = specs.get(key);
+        return spec != null && spec.accepts(value);
     }
 }

--- a/src/main/java/com/mio/events/service/EventLogWriter.java
+++ b/src/main/java/com/mio/events/service/EventLogWriter.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Component;
 import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
 
 /**
  * 전용 로거 "journey-events"에 순수 JSON 한 줄을 남긴다 — logback-spring.xml에서
@@ -30,11 +29,12 @@ public class EventLogWriter {
     private final ObjectMapper objectMapper;
 
     public void write(EventEnvelope event, String requestId) {
-        Set<String> allowedKeys = eventWhitelist.allowedProperties(event.eventName());
+        // #320 — 키만 보면 enum 자리에 자유 문자열이 실려도 통과했다(예: employment_status).
+        // 값이 도메인 밖이면 그 property만 드롭한다 — 이벤트 자체는 통과시킨다.
         Map<String, Object> filteredProperties = new LinkedHashMap<>();
         if (event.properties() != null) {
             event.properties().forEach((key, value) -> {
-                if (allowedKeys.contains(key)) {
+                if (eventWhitelist.isValidPropertyValue(event.eventName(), key, value)) {
                     filteredProperties.put(key, value);
                 }
             });

--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -4,9 +4,9 @@
 # #320 개편: 키 목록이 아니라 "키 -> 값 도메인" 맵이다. 값이 도메인 밖이면 그 property만
 # 조용히 드롭한다(이벤트 자체는 통과) — 키만 검증하면 enum 자리에 자유 문자열이 실려도
 # 통과했다(예: employment_status). 도메인 종류:
-#   enum: [...]       -> 문자열이 목록 안에 있어야 함
-#   type: enum         -> id(빈 문자열 아닌 문자열), int(숫자), bool(true/false),
-#                          string(자유 문자열 — screen_name류 예외만 여기 씀)
+#   enum: [...]                -> 문자열이 목록 안에 있어야 함
+#   type: <int|bool|id|string> -> int(정수), bool(true/false), id(빈 문자열 아닌 문자열),
+#                                  string(자유 문자열 — screen_name류 예외만 여기 씀)
 # properties가 없는 이벤트는 빈 맵으로 둔다(어떤 property를 보내도 전부 드롭됨).
 
 events:

--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -1,127 +1,143 @@
-# 강민석 "mio 이벤트 로그 명세 v3.4" §4 카탈로그 전체 반영 (이슈 #285).
+# 강민석 "mio 이벤트 로그 명세" §4 카탈로그 전체 반영 (이슈 #285, 개편 #320).
 # 이벤트 카탈로그가 바뀌면 이 파일만 고치면 된다 — 인프라/코드 변경 불필요.
-# 값이 빈 배열([])인 이벤트는 properties가 없거나 원문 위험 때문에 전부 거른다는 뜻이다.
+#
+# #320 개편: 키 목록이 아니라 "키 -> 값 도메인" 맵이다. 값이 도메인 밖이면 그 property만
+# 조용히 드롭한다(이벤트 자체는 통과) — 키만 검증하면 enum 자리에 자유 문자열이 실려도
+# 통과했다(예: employment_status). 도메인 종류:
+#   enum: [...]       -> 문자열이 목록 안에 있어야 함
+#   type: enum         -> id(빈 문자열 아닌 문자열), int(숫자), bool(true/false),
+#                          string(자유 문자열 — screen_name류 예외만 여기 씀)
+# properties가 없는 이벤트는 빈 맵으로 둔다(어떤 property를 보내도 전부 드롭됨).
 
 events:
   # §4-A 세션 백본
   app_session_started:
-    - entry_point
-    - is_first_session
-    - days_since_last_session
+    entry_point: {enum: [cold_start, push_notification, background_resume, deep_link]}
+    is_first_session: {type: bool}
+    days_since_last_session: {type: int}
   app_session_ended:
-    - last_screen
-    - duration_ms
-    - screen_count
+    last_screen: {type: string}
+    duration_ms: {type: int}
+    screen_count: {type: int}
   screen_viewed:
-    - screen_name
-    - referrer_screen
-  app_installed: []
+    screen_name: {type: string}
+    referrer_screen: {type: string}
+  app_installed: {}
 
   # §4-B 가입·온보딩 퍼널
   consent_agreed:
-    - consent_version
-    - marketing_agree
+    consent_version: {type: string}
+    marketing_agree: {type: bool}
+    sensitive_info_agreed: {type: bool}
   profile_submitted:
-    - age_range
-    - gender
-    - employment_status
-  signup_completed: []
+    age_range: {enum: ["10대", "20대", "30대", "40대+"]}
+    gender: {enum: [male, female, other]}
+    employment_status: {enum: [job_seeker, employed]}
+  signup_completed: {}
   onboarding_step_completed:
-    - step
-    - selected_emotion
-    - concern_types
-    - preferred_style
+    step: {type: int}
+    selected_emotion: {enum: [happy, calm, anxious, sad, angry, ashamed, numb, tired, confused]}
+    concern_types: {type: string}
+    preferred_style: {enum: [empathetic, analytical, solution, balanced]}
   onboarding_step_skipped:
-    - step
+    step: {type: int}
   character_selected:
-    - character_id
-  onboarding_completed: []
+    character_id: {enum: [mio, bau, rumi, momo, chichi]}
+    is_auto_assigned: {type: bool}
+  onboarding_completed: {}
+  push_permission_prompted:
+    trigger: {enum: [signup_flow, settings, re_prompt]}
+  push_permission_result:
+    granted: {type: bool}
+    trigger: {enum: [signup_flow, settings, re_prompt]}
   identify:
-    - previous_anonymous_id
-    - user_id
+    previous_anonymous_id: {type: string}
+    user_id: {type: id}
   login_succeeded:
-    - provider
+    provider: {enum: [kakao, apple]}
+    is_new_user: {type: bool}
+    is_new_device: {type: bool}
 
   # §4-C Core Action 5종 (최우선)
   checkin_completed:
-    - condition_score
-    - has_memo
-    - emotion_type
-    - time_of_day
+    condition_score: {type: int}
+    has_memo: {type: bool}
+    emotion_type: {enum: [happy, calm, anxious, sad, angry, ashamed, numb, tired, confused]}
+    time_of_day: {enum: [morning, afternoon, evening]}
   chat_message_sent:
-    - chat_session_id
-    - message_index
-    - char_count
-    - ai_emotion_score
-    - is_socratic
-    - cbt_intervention_state
-    - is_crisis_flagged
+    chat_session_id: {type: id}
+    message_index: {type: int}
+    char_count: {type: int}
+    ai_emotion_score: {type: int}
+    is_socratic: {type: bool}
+    cbt_intervention_state: {enum: [none, socratic_asked, followup_needed, completed]}
+    is_crisis_flagged: {type: bool}
   session_summary_viewed:
-    - chat_session_id
+    chat_session_id: {type: id}
   todo_checked_in:
-    - todo_id
-    - task_status
-    - chat_session_id
-    - emotion_before
-    - emotion_after
-    - emotion_delta
-    - has_feedback
-    - days_since_suggested
+    todo_id: {type: id}
+    task_status: {enum: [completed, partial_completed, skipped, expired]}
+    chat_session_id: {type: id}
+    emotion_before: {type: int}
+    emotion_after: {type: int}
+    emotion_delta: {type: int}
+    has_feedback: {type: bool}
+    days_since_suggested: {type: int}
   report_viewed:
-    - period
+    period: {enum: [weekly, monthly]}
 
-  # §4-D 대화 세션 부속 (session_summarized·todo_suggested는 서버 발행, 이번 이슈 범위 밖)
+  # §4-D 대화 세션 부속 (session_summarized·todo_suggested는 서버 발행)
   session_summarized:
-    - chat_session_id
-    - duration_seconds
-    - message_count
-    - bias_types_detected
-    - socratic_count
-    - problem_type
-    - classifier_version
-    - dominant_emotion
-    - cbt_intervened
-    - avg_emotion_score
-    - todo_suggested_count
+    chat_session_id: {type: id}
+    duration_seconds: {type: int}
+    message_count: {type: int}
+    bias_types_detected: {type: string}
+    socratic_count: {type: int}
+    problem_type: {enum: [loneliness, burnout, fear, comparison, other]}
+    classifier_version: {type: string}
+    dominant_emotion: {enum: [happy, calm, anxious, sad, angry, ashamed, numb, tired, confused]}
+    cbt_intervened: {type: bool}
+    avg_emotion_score: {type: int}
+    todo_suggested_count: {type: int}
   todo_suggested:
-    - chat_session_id
-    - count
-    - categories
-    - difficulty_avg
+    chat_session_id: {type: id}
+    count: {type: int}
+    categories: {type: string}
+    difficulty_avg: {type: int}
   chat_session_created:
-    - chat_session_id
+    chat_session_id: {type: id}
   chat_session_ended:
-    - duration_ms
-    - message_count
-    - chat_session_id
-    - completion_reason
-    - socratic_count
+    duration_ms: {type: int}
+    message_count: {type: int}
+    chat_session_id: {type: id}
+    completion_reason: {enum: [user_reframed_thought, user_declined, max_questions_reached, stabilized, not_applicable]}
+    socratic_count: {type: int}
   emotion_score_recorded:
-    - score
-    - chat_session_id
-    - reconstruction_id
-    - score_before
-    - score_delta
+    score: {type: int}
+    chat_session_id: {type: id}
+    reconstruction_id: {type: id}
+    score_before: {type: int}
+    score_delta: {type: int}
 
   # §4-E 알림·보조 기능
   notification_opened:
-    - notification_type
-  account_withdrawn: []
-  logout: []
-  checkin_started: []
-  checkin_updated: []
+    notification_type: {enum: [checkin_reminder_morning, checkin_reminder_afternoon, checkin_reminder_evening, todo_incomplete, negative_emotion_streak, report_weekly, crisis_detected]}
+  account_withdrawn: {}
+  logout: {}
+  checkin_started: {}
+  checkin_updated: {}
   todo_list_viewed:
-    - todo_count
+    todo_count: {type: int}
   emotion_trend_viewed:
-    - period
-    - days
-  daily_test_viewed: []
+    period: {enum: [week, month, all]}
+    days: {type: int}
+  daily_test_viewed: {}
   daily_test_answered:
-    - test_id
+    test_id: {type: id}
   notification_settings_changed:
-    - setting_key
-    - enabled
+    setting_key: {enum: [checkin_enabled, checkin_time, character_enabled, report_enabled]}
+    enabled: {type: bool}
   character_changed:
-    - from_id
-    - to_id
-  crisis_flow_triggered: []
+    from_id: {enum: [mio, bau, rumi, momo, chichi]}
+    to_id: {enum: [mio, bau, rumi, momo, chichi]}
+  crisis_flow_triggered: {}

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -279,6 +279,33 @@ class AuthServiceTest {
                         .isEqualTo(ErrorCode.NICKNAME_DUPLICATE));
     }
 
+    @Test
+    @DisplayName("#320 — employment_status가 job_seeker/employed 외 값이면 INVALID_INPUT을 던진다")
+    void completeSignup_invalidEmploymentStatus_throwsInvalidInput() {
+        User user = buildUser(USER_ID, "kakao", "social-123", SignupStep.CONSENT_AGREED, "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("닉네임")).thenReturn(false);
+        SignupCompleteRequest request = new SignupCompleteRequest("닉네임", "20대", "male", "JOB_SEEKER");
+
+        assertThatThrownBy(() -> authService.completeSignup(USER_ID, request))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+
+    @Test
+    @DisplayName("#320 — employment_status가 없으면(선택 필드) 그대로 통과한다")
+    void completeSignup_nullEmploymentStatus_succeeds() {
+        User user = buildUser(USER_ID, "kakao", "social-123", SignupStep.CONSENT_AGREED, "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("닉네임")).thenReturn(false);
+        SignupCompleteRequest request = new SignupCompleteRequest("닉네임", "20대", "male", null);
+
+        SignupCompleteResponse response = authService.completeSignup(USER_ID, request);
+
+        assertThat(response.nickname()).isEqualTo("닉네임");
+    }
+
     // ──────────────── checkNicknameDuplicate ────────────────
 
     @Test

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -294,6 +294,19 @@ class AuthServiceTest {
     }
 
     @Test
+    @DisplayName("#320 리뷰 반영 — employment_status가 공백 문자열이면 null로 정규화해 저장한다")
+    void completeSignup_blankEmploymentStatus_normalizesToNull() {
+        User user = buildUser(USER_ID, "kakao", "social-123", SignupStep.CONSENT_AGREED, "PENDING");
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(userRepository.existsByNickname("닉네임")).thenReturn(false);
+        SignupCompleteRequest request = new SignupCompleteRequest("닉네임", "20대", "male", "   ");
+
+        authService.completeSignup(USER_ID, request);
+
+        assertThat(user.getEmploymentStatus()).isNull();
+    }
+
+    @Test
     @DisplayName("#320 — employment_status가 없으면(선택 필드) 그대로 통과한다")
     void completeSignup_nullEmploymentStatus_succeeds() {
         User user = buildUser(USER_ID, "kakao", "social-123", SignupStep.CONSENT_AGREED, "PENDING");

--- a/src/test/java/com/mio/events/config/EventWhitelistTest.java
+++ b/src/test/java/com/mio/events/config/EventWhitelistTest.java
@@ -92,4 +92,25 @@ class EventWhitelistTest {
     void isValidPropertyValue_unknownKey_returnsFalse() {
         assertThat(whitelist.isValidPropertyValue("profile_submitted", "totally_made_up_key", "x")).isFalse();
     }
+
+    @Test
+    @DisplayName("#320 리뷰 반영 — INT는 Integer/Long만 허용, Double은 거부한다")
+    void isValidPropertyValue_intField_rejectsDouble() {
+        assertThat(whitelist.isValidPropertyValue("chat_message_sent", "message_index", 3.5)).isFalse();
+        assertThat(whitelist.isValidPropertyValue("chat_message_sent", "message_index", 3L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("#320 리뷰 반영 — STRING은 실제 문자열만 허용, 중첩 객체/배열은 거부한다")
+    void isValidPropertyValue_stringField_rejectsNestedStructures() {
+        assertThat(whitelist.isValidPropertyValue("app_session_ended", "last_screen", java.util.Map.of("a", 1))).isFalse();
+        assertThat(whitelist.isValidPropertyValue("app_session_ended", "last_screen", java.util.List.of("a"))).isFalse();
+        assertThat(whitelist.isValidPropertyValue("app_session_ended", "last_screen", "home")).isTrue();
+    }
+
+    @Test
+    @DisplayName("#320 리뷰 반영 — ENUM은 문자열 강제 변환 없이 실제 문자열만 비교한다")
+    void isValidPropertyValue_enumField_rejectsNonStringCoercion() {
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "gender", true)).isFalse();
+    }
 }

--- a/src/test/java/com/mio/events/config/EventWhitelistTest.java
+++ b/src/test/java/com/mio/events/config/EventWhitelistTest.java
@@ -58,4 +58,38 @@ class EventWhitelistTest {
     void allowedProperties_unknownEvent_returnsEmpty() {
         assertThat(whitelist.allowedProperties("totally_made_up_event")).isEmpty();
     }
+
+    @Test
+    @DisplayName("#320 — enum 값이 도메인 안이면 유효하다")
+    void isValidPropertyValue_enumInDomain_returnsTrue() {
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "employment_status", "job_seeker")).isTrue();
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "age_range", "40대+")).isTrue();
+    }
+
+    @Test
+    @DisplayName("#320 — enum 값이 도메인 밖이면 무효하다 (오타·구표기 등)")
+    void isValidPropertyValue_enumOutOfDomain_returnsFalse() {
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "employment_status", "JOB_SEEKER")).isFalse();
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "age_range", "50대+")).isFalse();
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "age_range", "40대")).isFalse();
+    }
+
+    @Test
+    @DisplayName("#320 — null 값은 nullable property에서 항상 통과한다")
+    void isValidPropertyValue_nullValue_alwaysValid() {
+        assertThat(whitelist.isValidPropertyValue("chat_message_sent", "ai_emotion_score", null)).isTrue();
+    }
+
+    @Test
+    @DisplayName("#320 — 타입이 안 맞으면(int 자리에 문자열) 무효하다")
+    void isValidPropertyValue_wrongType_returnsFalse() {
+        assertThat(whitelist.isValidPropertyValue("chat_message_sent", "message_index", "not-a-number")).isFalse();
+        assertThat(whitelist.isValidPropertyValue("chat_message_sent", "message_index", 3)).isTrue();
+    }
+
+    @Test
+    @DisplayName("#320 — 카탈로그에 없는 키는 무효하다")
+    void isValidPropertyValue_unknownKey_returnsFalse() {
+        assertThat(whitelist.isValidPropertyValue("profile_submitted", "totally_made_up_key", "x")).isFalse();
+    }
 }


### PR DESCRIPTION
## 요약
event-whitelist.yml이 "허용된 키 목록"만 검증해서, enum 자리에 자유 문자열이 실려도 통과했습니다. employment_status가 그 예입니다 - Auth API는 값 검증 없이 저장하는 자유 문자열이고, MVP 코호트 2분할(취업 준비생/초기 취업 적응자)의 축이라 오염되면 앱 버전·오타에 따라 job_seeker/jobseeker/JOB_SEEKER가 섞여 대시보드 코호트 facet이 쪼개집니다.

## 관련 이슈
- Closes #320

## 변경 사항
- event-whitelist.yml을 "키: 값목록" -> "키: {enum:[...]}/{type:int|bool|id|string}" 구조로 전면 개편 (35개 이벤트 전부)
- EventWhitelist에 isValidPropertyValue() 추가 - 값이 도메인 밖이면 그 property만 드롭, 이벤트 자체는 통과
- AuthService.completeSignup()에 employment_status 서버 enum 검증 추가
- age_range 도메인을 4종(10대/20대/30대/40대+)으로 명시

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (employment_status가 job_seeker/employed 외 값이면 400 VALIDATION_ERROR 신규 발생)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (도메인 밖 값이 이제 조용히 드롭됨 - 기존엔 키만 맞으면 그대로 로그에 실렸음)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test
```

### 확인 내용
- EventWhitelistTest 11개(신규 5개 포함) - enum 도메인 안/밖, null 통과, 타입 불일치, 모르는 키 케이스
- AuthServiceTest 17개(신규 2개 포함) - employment_status 잘못된 값 400, null(선택 필드) 통과
- EventIngestServiceTest 6개 전부 통과(EventWhitelist가 Mock이라 영향 없음)
- 전체 스위트 832개 중 831개 통과. 실패 1개(MioApplicationTests.contextLoads)는 로컬 Postgres Flyway 마이그레이션 체크섬 불일치로, 이 PR과 무관한 환경 문제입니다.

## 중점 리뷰 포인트
- event-whitelist.yml 전체를 다시 썼습니다(35개 이벤트) - 강민석 이벤트 로그 명세 v3.5 §4·§8 기준으로 값 도메인을 채웠는데, 특히 concern_types·bias_types_detected·categories 같은 **배열형 enum**은 이번 범위에서 type:string(무검증)으로 남겨뒀습니다 - 스칼라 enum(employment_status 등) 검증이 우선순위였고 배열 검증은 후속 작업으로 미룸.
- int 타입 검증에 min 값 경계는 안 넣었습니다(예: message_index >= 0) - 타입 일치만 확인, 범위 검증은 범위 밖으로 판단했습니다.

## 배포 / 롤백
- Rollout: develop 머지만으로 충분, 별도 배포 절차 불필요
- Rollback: 이 PR을 되돌리면 값 검증이 다시 키 목록만 보는 이전 상태로 돌아갈 뿐, 다른 부작용 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for employment status during signup, supporting `job_seeker` and `employed`.
  * Expanded event tracking with typed property validation for enums, numbers, booleans, IDs, and text.
  * Added support for push-permission events and related metadata.

* **Bug Fixes**
  * Invalid event properties are now excluded while valid events continue to be recorded.
  * Optional blank or missing employment status values remain accepted.

* **Tests**
  * Added coverage for signup and event-property validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->