### PR TITLE
feat: 이벤트 배치 응답 개선 - rejected.index, 배치 내 중복 통지, 토큰-user_id 대조 (#324)

### DIFF
--- a/src/main/java/com/mio/events/controller/EventsController.java
+++ b/src/main/java/com/mio/events/controller/EventsController.java
@@ -1,5 +1,6 @@
 package com.mio.events.controller;
 
+import com.mio.auth.service.JwtTokenService;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.common.response.ApiResponse;
@@ -7,8 +8,10 @@ import com.mio.events.dto.EventEnvelope;
 import com.mio.events.dto.EventsIngestResponse;
 import com.mio.events.service.EventIngestService;
 import com.mio.events.service.EventRateLimiter;
+import io.jsonwebtoken.JwtException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,18 +31,22 @@ import java.util.List;
 @RestController
 @RequestMapping("/v1/events")
 @RequiredArgsConstructor
+@Slf4j
 public class EventsController {
 
     private static final int MAX_BATCH_SIZE = 100;
     private static final long MAX_REQUEST_BYTES = 1024L * 1024L;
+    private static final String BEARER_PREFIX = "Bearer ";
 
     private final EventIngestService eventIngestService;
     private final EventRateLimiter eventRateLimiter;
+    private final JwtTokenService jwtTokenService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<EventsIngestResponse>> ingest(
             HttpServletRequest request,
             @RequestHeader("X-Device-Id") String deviceId,
+            @RequestHeader(value = "Authorization", required = false) String authorization,
             @RequestBody List<EventEnvelope> events) {
 
         if (events.size() > MAX_BATCH_SIZE) {
@@ -53,7 +60,29 @@ public class EventsController {
         eventRateLimiter.check(deviceId);
 
         String requestId = String.valueOf(request.getAttribute("traceId"));
-        EventsIngestResponse response = eventIngestService.ingest(events, requestId);
+        List<EventEnvelope> reconciled = reconcileUserId(events, authorization);
+        EventsIngestResponse response = eventIngestService.ingest(reconciled, requestId);
         return ResponseEntity.status(HttpStatus.ACCEPTED).body(ApiResponse.ok(response));
+    }
+
+    /**
+     * 이슈 #324 — 무인증 엔드포인트라 envelope의 user_id는 자기 신고다. Authorization
+     * 헤더가 있으면 토큰 sub로 덮어써서 임의 user_id로 타인의 지표를 오염시키는 걸 막는다.
+     * 헤더가 없거나 파싱에 실패해도 요청 자체는 막지 않는다 — 익명 허용은 그대로 유지한다.
+     */
+    private List<EventEnvelope> reconcileUserId(List<EventEnvelope> events, String authorization) {
+        if (authorization == null || !authorization.startsWith(BEARER_PREFIX)) {
+            return events;
+        }
+        String tokenUserId;
+        try {
+            tokenUserId = jwtTokenService.parseToken(authorization.substring(BEARER_PREFIX.length())).getSubject();
+        } catch (JwtException e) {
+            log.debug("이벤트 수집 요청의 Authorization 토큰이 유효하지 않아 무시함: {}", e.getMessage());
+            return events;
+        }
+        return events.stream()
+                .map(event -> tokenUserId.equals(event.userId()) ? event : event.withUserId(tokenUserId))
+                .toList();
     }
 }

--- a/src/main/java/com/mio/events/dto/EventEnvelope.java
+++ b/src/main/java/com/mio/events/dto/EventEnvelope.java
@@ -21,4 +21,10 @@ public record EventEnvelope(
         @JsonProperty("os_version") String osVersion,
         Map<String, Object> properties
 ) {
+
+    /** 이슈 #324 — Authorization 토큰의 sub와 대조해 서버 값으로 덮어쓸 때 쓴다. */
+    public EventEnvelope withUserId(String newUserId) {
+        return new EventEnvelope(eventId, eventName, schemaVersion, tsClient, anonymousId, newUserId,
+                appSessionId, appVersion, platform, osVersion, properties);
+    }
 }

--- a/src/main/java/com/mio/events/dto/RejectedEvent.java
+++ b/src/main/java/com/mio/events/dto/RejectedEvent.java
@@ -2,7 +2,13 @@ package com.mio.events.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+/**
+ * 이슈 #324 — event_id가 없어서(MISSING_EVENT_ID) 거부된 건은 event_id가 null로 돌아온다.
+ * index(배치 내 0-base 위치) 없이는 앱이 큐에서 어느 항목을 지울지 몰라 영구 재전송 루프에
+ * 빠질 수 있다.
+ */
 public record RejectedEvent(
+        int index,
         @JsonProperty("event_id") String eventId,
         @JsonProperty("event_name") String eventName,
         String reason

--- a/src/main/java/com/mio/events/service/EventIngestService.java
+++ b/src/main/java/com/mio/events/service/EventIngestService.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Service;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * POST /v1/events 배치 검증 + 기록 (이슈 #285). 부분 성공 모델 — 개별 이벤트 검증 실패는
@@ -29,13 +31,23 @@ public class EventIngestService {
 
     public EventsIngestResponse ingest(List<EventEnvelope> events, String requestId) {
         List<RejectedEvent> rejected = new ArrayList<>();
+        Set<String> seenEventIds = new HashSet<>();
         int acceptedCount = 0;
 
-        for (EventEnvelope event : events) {
+        for (int index = 0; index < events.size(); index++) {
+            EventEnvelope event = events.get(index);
             EventRejectionReason reason = validate(event);
             if (reason != null) {
-                rejected.add(new RejectedEvent(event.eventId(), event.eventName(), reason.name()));
+                rejected.add(new RejectedEvent(index, event.eventId(), event.eventName(), reason.name()));
                 log.warn("journey_event_rejected reason={} event_name={}", reason, event.eventName());
+                continue;
+            }
+            // 이슈 #324 — 배치 안 event_id 중복은 거부가 아니라 통지다. 지표는 투영
+            // dedup으로 안전하지만, 통지 없이 그대로 적재하면 "이벤트 수신 건수" 알람이
+            // 부풀어 계측 생존 판정이 낙관 편향된다.
+            if (!seenEventIds.add(event.eventId())) {
+                rejected.add(new RejectedEvent(index, event.eventId(), event.eventName(),
+                        EventRejectionReason.DUPLICATE_IN_BATCH.name()));
                 continue;
             }
             // 이슈 #322 — 앱 버전은 항상 혼재한다. schema_version이 허용 집합 밖이어도

--- a/src/main/java/com/mio/events/service/EventRejectionReason.java
+++ b/src/main/java/com/mio/events/service/EventRejectionReason.java
@@ -8,5 +8,7 @@ public enum EventRejectionReason {
     MISSING_ANONYMOUS_ID,
     MISSING_APP_SESSION_ID,
     TS_CLIENT_INVALID_FORMAT,
-    UNKNOWN_EVENT_NAME
+    UNKNOWN_EVENT_NAME,
+    /** 이슈 #324 — 거부가 아니라 통지. 지표는 투영 dedup으로 안전하다. */
+    DUPLICATE_IN_BATCH
 }

--- a/src/test/java/com/mio/events/controller/EventsControllerTest.java
+++ b/src/test/java/com/mio/events/controller/EventsControllerTest.java
@@ -1,0 +1,85 @@
+package com.mio.events.controller;
+
+import com.mio.auth.service.JwtTokenService;
+import com.mio.events.dto.EventEnvelope;
+import com.mio.events.dto.EventsIngestResponse;
+import com.mio.events.service.EventIngestService;
+import com.mio.events.service.EventRateLimiter;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/** 이슈 #324 — Authorization 토큰 sub와 envelope user_id 대조(reconcileUserId) 검증. */
+@ExtendWith(MockitoExtension.class)
+class EventsControllerTest {
+
+    @Mock private EventIngestService eventIngestService;
+    @Mock private EventRateLimiter eventRateLimiter;
+    @Mock private HttpServletRequest request;
+
+    private EventsController controller;
+    private JwtTokenService jwtTokenService;
+
+    private static final String VALID_TS = "2026-08-06T21:13:02+09:00";
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenService = new JwtTokenService("test-secret-key-32-bytes-minimum!!", 900);
+        controller = new EventsController(eventIngestService, eventRateLimiter, jwtTokenService);
+        when(eventIngestService.ingest(any(), any())).thenReturn(new EventsIngestResponse(1, List.of()));
+    }
+
+    private EventEnvelope eventWithUserId(String userId) {
+        return new EventEnvelope("e1", "chat_message_sent", 3, VALID_TS,
+                "anon-1", userId, "session-1", "1.0.0", "ios", "17.0", Map.of());
+    }
+
+    @Test
+    @DisplayName("Authorization 토큰이 있고 user_id가 다르면 서버가 토큰 sub로 덮어쓴다")
+    void ingest_tokenMismatch_overridesUserId() {
+        String token = jwtTokenService.generateAccessToken("token-user-id", "device-1", false, false);
+        EventEnvelope event = eventWithUserId("client-claimed-user-id");
+
+        controller.ingest(request, "device-1", "Bearer " + token, List.of(event));
+
+        ArgumentCaptor<List<EventEnvelope>> captor = ArgumentCaptor.forClass(List.class);
+        verify(eventIngestService).ingest(captor.capture(), any());
+        assertThat(captor.getValue().get(0).userId()).isEqualTo("token-user-id");
+    }
+
+    @Test
+    @DisplayName("Authorization 헤더가 없으면 user_id를 그대로 둔다 (익명 허용 유지)")
+    void ingest_noAuthorizationHeader_passesThrough() {
+        EventEnvelope event = eventWithUserId("client-claimed-user-id");
+
+        controller.ingest(request, "device-1", null, List.of(event));
+
+        ArgumentCaptor<List<EventEnvelope>> captor = ArgumentCaptor.forClass(List.class);
+        verify(eventIngestService).ingest(captor.capture(), any());
+        assertThat(captor.getValue().get(0).userId()).isEqualTo("client-claimed-user-id");
+    }
+
+    @Test
+    @DisplayName("Authorization 토큰이 유효하지 않으면 요청을 막지 않고 그대로 수용한다")
+    void ingest_invalidToken_doesNotBlockRequest() {
+        EventEnvelope event = eventWithUserId("client-claimed-user-id");
+
+        controller.ingest(request, "device-1", "Bearer not-a-real-token", List.of(event));
+
+        ArgumentCaptor<List<EventEnvelope>> captor = ArgumentCaptor.forClass(List.class);
+        verify(eventIngestService).ingest(captor.capture(), any());
+        assertThat(captor.getValue().get(0).userId()).isEqualTo("client-claimed-user-id");
+    }
+}

--- a/src/test/java/com/mio/events/service/EventIngestServiceTest.java
+++ b/src/test/java/com/mio/events/service/EventIngestServiceTest.java
@@ -76,6 +76,35 @@ class EventIngestServiceTest {
     }
 
     @Test
+    @DisplayName("#324 — rejected 항목에 배치 내 index가 정확히 포함된다")
+    void ingest_rejectedEvent_includesBatchIndex() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(true);
+        EventEnvelope valid = validEvent("e0");
+        EventEnvelope missingId = new EventEnvelope(null, "chat_message_sent", 3, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", Map.of());
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(valid, missingId), "req-1");
+
+        assertThat(response.rejected().get(0).index()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("#324 — 배치 내 event_id 중복은 첫 건만 기록되고 DUPLICATE_IN_BATCH로 통지된다")
+    void ingest_duplicateEventIdInBatch_secondNotified() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(true);
+        EventEnvelope first = validEvent("dup-1");
+        EventEnvelope duplicate = validEvent("dup-1");
+
+        EventsIngestResponse response = eventIngestService.ingest(List.of(first, duplicate), "req-1");
+
+        assertThat(response.acceptedCount()).isEqualTo(1);
+        assertThat(response.rejected()).hasSize(1);
+        assertThat(response.rejected().get(0).index()).isEqualTo(1);
+        assertThat(response.rejected().get(0).reason()).isEqualTo("DUPLICATE_IN_BATCH");
+        verify(eventLogWriter, times(1)).write(any(), eq("req-1"));
+    }
+
+    @Test
     @DisplayName("#322 — schema_version이 허용 집합 밖이어도 거부하지 않고 그대로 수락한다")
     void ingest_schemaVersionMismatch_stillAccepted() {
         when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(true);


### PR DESCRIPTION
## 요약
`POST /v1/events` 배치 응답을 개선한다 — rejected 항목에 배치 내 index 추가, 배치 안 event_id 중복을 거부가 아닌 통지로 처리, Authorization 토큰의 sub와 envelope user_id를 대조해 불일치 시 서버가 덮어쓴다.

## 관련 이슈
Closes #324

## 변경 사항
- `RejectedEvent`에 `index`(int, 첫 필드) 추가 — 클라이언트가 원본 배치와 거부 항목을 위치로 매칭 가능
- `EventIngestService.ingest()`가 인덱스 기반 루프로 전환, `seenEventIds`로 배치 내 event_id 중복 추적
- 배치 내 event_id 중복은 `DUPLICATE_IN_BATCH`로 통지 (거부 아님 — 첫 건만 기록, 지표는 투영 dedup으로 안전)
- `EventEnvelope.withUserId()` 추가
- `EventsController`가 `JwtTokenService`를 주입받아 선택적 `Authorization` 헤더를 파싱, 토큰 `sub`와 envelope `user_id`가 다르면 토큰 값으로 덮어씀 (헤더 없음/토큰 무효 시 요청은 막지 않고 그대로 통과 — 익명 허용 유지)

## 영향 범위
- `POST /v1/events` 요청/응답 스키마 (rejected 배열에 index 필드 추가 — 클라이언트 추가 대응 불필요, 필드 추가는 non-breaking)
- 인증된 클라이언트가 다른 user_id로 이벤트를 보내던 기존 동작이 바뀜 (서버가 토큰 sub로 강제 — 의도된 변경)

## 테스트
- `EventIngestServiceTest`: index 정확성, 배치 내 중복 시 첫 건만 accepted+기록되고 둘째는 DUPLICATE_IN_BATCH로 통지되는지 검증 (신규 2건 포함 총 9건)
- `EventsControllerTest` (신규): 실제 `JwtTokenService` 인스턴스로 토큰 sub-user_id 불일치 시 덮어쓰기, 헤더 없을 때 통과, 토큰 무효 시 통과 검증 (3건)
- `./gradlew compileJava compileTestJava` 통과, `./gradlew test --tests "com.mio.events.*"` 전체 통과

## 배포 / 롤백
- 스키마 마이그레이션 없음, 설정 변경 없음 — 코드 배포만으로 적용/롤백 가능
- 롤백 시 rejected.index 필드가 응답에서 사라지는 것 외 클라이언트 영향 없음

## 체크리스트
- [x] 로컬 테스트 통과
- [x] 관련 이슈 연결
- [ ] 코드 리뷰 반영
