### PR TITLE
feat: 거부 이벤트 로깅 강화 - journey-events-rejected.jsonl, 속성 drop/invalid 로그 (#326)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,9 @@ services:
       # 이슈 #285 — 강민석 인프라 명세 §1 EVENT_FILE 그대로. 컨테이너 안에서만 쓰면 호스트의
       # CloudWatch Agent가 못 읽으므로 아래 volumes로 호스트 경로에 마운트한다.
       EVENTS_LOG_FILE_PATH: /var/log/mio/journey-events.jsonl
+      # 이슈 #326 — 거부 이벤트 원본 로그. 같은 /var/log/mio 볼륨에 남기고, CloudWatch
+      # Agent 설정에 별도 로그 그룹으로 추가하는 건 이 PR과 분리된 인프라 작업이다.
+      EVENTS_REJECTED_LOG_FILE_PATH: /var/log/mio/journey-events-rejected.jsonl
     volumes:
       # 호스트에 /var/log/mio 디렉터리·권한이 먼저 준비돼 있어야 한다
       # (강민석 인프라 명세 §4-B: mkdir + 앱 실행 유저 소유 + cwagent 그룹 추가).

--- a/src/main/java/com/mio/events/config/EventWhitelist.java
+++ b/src/main/java/com/mio/events/config/EventWhitelist.java
@@ -102,4 +102,14 @@ public class EventWhitelist {
         PropertySpec spec = specs.get(key);
         return spec != null && spec.accepts(value);
     }
+
+    /**
+     * 이슈 #326 — {@link #isValidPropertyValue}는 "키가 없음"과 "키는 있는데 값이 도메인
+     * 밖"을 구분하지 않는다. drop(키 자체가 카탈로그 밖)과 invalid(알려진 키의 값 불일치)를
+     * 서로 다른 로그로 남기려면 이 구분이 필요하다.
+     */
+    public boolean isKnownProperty(String eventName, String key) {
+        Map<String, PropertySpec> specs = catalog.get(eventName);
+        return specs != null && specs.containsKey(key);
+    }
 }

--- a/src/main/java/com/mio/events/service/EventIngestService.java
+++ b/src/main/java/com/mio/events/service/EventIngestService.java
@@ -40,6 +40,7 @@ public class EventIngestService {
             if (reason != null) {
                 rejected.add(new RejectedEvent(index, event.eventId(), event.eventName(), reason.name()));
                 log.warn("journey_event_rejected reason={} event_name={}", reason, event.eventName());
+                eventLogWriter.writeRejected(event, index, reason.name(), requestId);
                 continue;
             }
             // 이슈 #324 — 배치 안 event_id 중복은 거부가 아니라 통지다. 지표는 투영

--- a/src/main/java/com/mio/events/service/EventLogWriter.java
+++ b/src/main/java/com/mio/events/service/EventLogWriter.java
@@ -24,6 +24,7 @@ import java.util.Map;
 public class EventLogWriter {
 
     private static final Logger JOURNEY_LOG = LoggerFactory.getLogger("journey-events");
+    private static final Logger JOURNEY_REJECTED_LOG = LoggerFactory.getLogger("journey-events-rejected");
 
     private final EventWhitelist eventWhitelist;
     private final ObjectMapper objectMapper;
@@ -31,12 +32,20 @@ public class EventLogWriter {
     public void write(EventEnvelope event, String requestId) {
         // #320 — 키만 보면 enum 자리에 자유 문자열이 실려도 통과했다(예: employment_status).
         // 값이 도메인 밖이면 그 property만 드롭한다 — 이벤트 자체는 통과시킨다.
+        // #326 — drop(카탈로그에 없는 키)과 invalid(아는 키인데 값이 도메인 밖)를 서로 다른
+        // 로그로 남긴다. 둘 다 조용히 사라지면 클라이언트 계측 결함을 감지할 방법이 없다.
         Map<String, Object> filteredProperties = new LinkedHashMap<>();
         if (event.properties() != null) {
             event.properties().forEach((key, value) -> {
-                if (eventWhitelist.isValidPropertyValue(event.eventName(), key, value)) {
-                    filteredProperties.put(key, value);
+                if (!eventWhitelist.isKnownProperty(event.eventName(), key)) {
+                    log.warn("journey_property_dropped event_name={} key={}", event.eventName(), key);
+                    return;
                 }
+                if (!eventWhitelist.isValidPropertyValue(event.eventName(), key, value)) {
+                    log.warn("journey_property_invalid event_name={} key={}", event.eventName(), key);
+                    return;
+                }
+                filteredProperties.put(key, value);
             });
         }
 
@@ -60,6 +69,37 @@ public class EventLogWriter {
         } catch (JsonProcessingException e) {
             // 이벤트 로그 기록 실패는 통계적 손실일 뿐 — 요청 자체를 막지 않는다 (감사로그와 다른 성격)
             log.error("Failed to serialize journey event: event_id={}", event.eventId(), e);
+        }
+    }
+
+    /**
+     * 이슈 #326 — 거부된 이벤트는 지금까지 {@code journey_event_rejected} 경고 로그 한 줄만
+     * 남고 원본 payload가 사라졌다. 사후에 "어떤 속성이 왜 거부됐는지" 확인할 수 있도록
+     * 원본 그대로 전용 로거("journey-events-rejected")에 남긴다 — journey-events와 물리적으로
+     * 분리해 정상 지표 집계 파이프라인을 오염시키지 않는다.
+     */
+    public void writeRejected(EventEnvelope event, int index, String reason, String requestId) {
+        Map<String, Object> line = new LinkedHashMap<>();
+        line.put("index", index);
+        line.put("reject_reason", reason);
+        line.put("event_id", event.eventId());
+        line.put("event_name", event.eventName());
+        line.put("schema_version", event.schemaVersion());
+        line.put("ts_client", event.tsClient());
+        line.put("ts_server", Instant.now().toString());
+        line.put("request_id", requestId);
+        line.put("anonymous_id", event.anonymousId());
+        line.put("user_id", event.userId());
+        line.put("app_session_id", event.appSessionId());
+        line.put("app_version", event.appVersion());
+        line.put("platform", event.platform());
+        line.put("os_version", event.osVersion());
+        line.put("properties", event.properties());
+
+        try {
+            JOURNEY_REJECTED_LOG.info(objectMapper.writeValueAsString(line));
+        } catch (JsonProcessingException e) {
+            log.error("Failed to serialize rejected journey event: event_id={}", event.eventId(), e);
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -142,6 +142,9 @@ events:
   # 성장분석 이벤트 전용 로그 파일 경로 (이슈 #285). prod는 docker-compose.prod.yml에서
   # /var/log/mio/journey-events.jsonl로 덮어쓴다 — 강민석 인프라 명세 §1 EVENT_FILE 그대로.
   log-file-path: ${EVENTS_LOG_FILE_PATH:./logs/journey-events.jsonl}
+  # 이슈 #326 — 거부 이벤트 원본 로그 파일. journey-events와 물리적으로 분리해
+  # 정상 지표 집계 파이프라인에 섞여 들어가지 않게 한다.
+  rejected-log-file-path: ${EVENTS_REJECTED_LOG_FILE_PATH:./logs/journey-events-rejected.jsonl}
   # 이슈 #322 — 앱 버전 혼재 시 구버전이 영구 소실되는 걸 막기 위해 거부가 아니라
   # 통과+태깅으로 처리한다. 명세 개정 시 [3, 4]로 잠시 병행한다.
   accepted-schema-versions: [3]

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -30,6 +30,30 @@
         <appender-ref ref="JOURNEY_EVENTS"/>
     </logger>
 
+    <!--
+        이슈 #326: 거부된 이벤트 원본을 journey-events와 물리적으로 분리된 파일에 남긴다 —
+        같은 appender/파일을 쓰면 정상 지표 집계 파이프라인(강민석 Lambda 투영)에
+        거부 이벤트가 섞여 들어간다.
+    -->
+    <springProperty scope="context" name="journeyEventsRejectedLogFile"
+                     source="events.rejected-log-file-path" defaultValue="./logs/journey-events-rejected.jsonl"/>
+
+    <appender name="JOURNEY_EVENTS_REJECTED" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${journeyEventsRejectedLogFile}</file>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${journeyEventsRejectedLogFile}.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="journey-events-rejected" level="INFO" additivity="false">
+        <appender-ref ref="JOURNEY_EVENTS_REJECTED"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/src/test/java/com/mio/events/config/EventWhitelistTest.java
+++ b/src/test/java/com/mio/events/config/EventWhitelistTest.java
@@ -113,4 +113,22 @@ class EventWhitelistTest {
     void isValidPropertyValue_enumField_rejectsNonStringCoercion() {
         assertThat(whitelist.isValidPropertyValue("profile_submitted", "gender", true)).isFalse();
     }
+
+    @Test
+    @DisplayName("#326 — 카탈로그에 있는 키는 known으로 판정한다")
+    void isKnownProperty_catalogued_returnsTrue() {
+        assertThat(whitelist.isKnownProperty("chat_message_sent", "message_index")).isTrue();
+    }
+
+    @Test
+    @DisplayName("#326 — 카탈로그에 없는 키는 unknown으로 판정한다 (값 도메인과 무관)")
+    void isKnownProperty_uncatalogued_returnsFalse() {
+        assertThat(whitelist.isKnownProperty("profile_submitted", "totally_made_up_key")).isFalse();
+    }
+
+    @Test
+    @DisplayName("#326 — 모르는 이벤트의 프로퍼티는 항상 unknown이다")
+    void isKnownProperty_unknownEvent_returnsFalse() {
+        assertThat(whitelist.isKnownProperty("totally_made_up_event", "message_index")).isFalse();
+    }
 }

--- a/src/test/java/com/mio/events/service/EventIngestServiceTest.java
+++ b/src/test/java/com/mio/events/service/EventIngestServiceTest.java
@@ -60,7 +60,18 @@ class EventIngestServiceTest {
         assertThat(response.acceptedCount()).isZero();
         assertThat(response.rejected()).hasSize(1);
         assertThat(response.rejected().get(0).reason()).isEqualTo("UNKNOWN_EVENT_NAME");
-        verifyNoInteractions(eventLogWriter);
+        verify(eventLogWriter, never()).write(any(), any());
+    }
+
+    @Test
+    @DisplayName("#326 — 거부된 이벤트는 원본 payload가 index·reason과 함께 rejected 전용 로거로 넘어간다")
+    void ingest_rejectedEvent_writesToRejectedLogger() {
+        when(eventWhitelist.isKnownEvent("chat_message_sent")).thenReturn(false);
+        EventEnvelope event = validEvent("e1");
+
+        eventIngestService.ingest(List.of(event), "req-1");
+
+        verify(eventLogWriter).writeRejected(event, 0, "UNKNOWN_EVENT_NAME", "req-1");
     }
 
     @Test

--- a/src/test/java/com/mio/events/service/EventLogWriterTest.java
+++ b/src/test/java/com/mio/events/service/EventLogWriterTest.java
@@ -1,0 +1,123 @@
+package com.mio.events.service;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventWhitelist;
+import com.mio.events.dto.EventEnvelope;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #326 — journey-events-rejected 로거와 property drop/invalid 로그 라인 검증. */
+@ExtendWith(MockitoExtension.class)
+class EventLogWriterTest {
+
+    @Mock private EventWhitelist eventWhitelist;
+
+    private EventLogWriter eventLogWriter;
+    private ListAppender<ILoggingEvent> journeyAppender;
+    private ListAppender<ILoggingEvent> rejectedAppender;
+    private ListAppender<ILoggingEvent> classAppender;
+
+    private static final String VALID_TS = "2026-08-06T21:13:02+09:00";
+
+    @BeforeEach
+    void setUp() {
+        eventLogWriter = new EventLogWriter(eventWhitelist, new ObjectMapper());
+        journeyAppender = attach("journey-events");
+        rejectedAppender = attach("journey-events-rejected");
+        classAppender = attach(EventLogWriter.class.getName());
+    }
+
+    @AfterEach
+    void tearDown() {
+        detach("journey-events", journeyAppender);
+        detach("journey-events-rejected", rejectedAppender);
+        detach(EventLogWriter.class.getName(), classAppender);
+    }
+
+    private ListAppender<ILoggingEvent> attach(String loggerName) {
+        Logger logger = (Logger) LoggerFactory.getLogger(loggerName);
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        return appender;
+    }
+
+    private void detach(String loggerName, ListAppender<ILoggingEvent> appender) {
+        ((Logger) LoggerFactory.getLogger(loggerName)).detachAppender(appender);
+    }
+
+    private EventEnvelope event(Map<String, Object> properties) {
+        return new EventEnvelope("e1", "chat_message_sent", 3, VALID_TS,
+                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", properties);
+    }
+
+    @Test
+    @DisplayName("카탈로그에 없는 키는 journey_property_dropped로 로그되고 결과에서 빠진다")
+    void write_unknownKey_logsDropped() {
+        when(eventWhitelist.isKnownProperty("chat_message_sent", "made_up_key")).thenReturn(false);
+
+        eventLogWriter.write(event(Map.of("made_up_key", "x")), "req-1");
+
+        assertThat(classAppender.list)
+                .anyMatch(e -> e.getFormattedMessage().contains("journey_property_dropped")
+                        && e.getFormattedMessage().contains("made_up_key"));
+        assertThat(journeyAppender.list).hasSize(1);
+        assertThat(journeyAppender.list.get(0).getFormattedMessage()).doesNotContain("made_up_key");
+    }
+
+    @Test
+    @DisplayName("아는 키인데 값이 도메인 밖이면 journey_property_invalid로 로그되고 결과에서 빠진다")
+    void write_invalidValue_logsInvalid() {
+        when(eventWhitelist.isKnownProperty("chat_message_sent", "message_index")).thenReturn(true);
+        when(eventWhitelist.isValidPropertyValue("chat_message_sent", "message_index", "not-a-number"))
+                .thenReturn(false);
+
+        eventLogWriter.write(event(Map.of("message_index", "not-a-number")), "req-1");
+
+        assertThat(classAppender.list)
+                .anyMatch(e -> e.getFormattedMessage().contains("journey_property_invalid")
+                        && e.getFormattedMessage().contains("message_index"));
+        assertThat(journeyAppender.list.get(0).getFormattedMessage()).doesNotContain("not-a-number");
+    }
+
+    @Test
+    @DisplayName("유효한 속성은 journey-events 로거에 그대로 남는다")
+    void write_validProperty_isKept() {
+        when(eventWhitelist.isKnownProperty("chat_message_sent", "message_index")).thenReturn(true);
+        when(eventWhitelist.isValidPropertyValue("chat_message_sent", "message_index", 3)).thenReturn(true);
+
+        eventLogWriter.write(event(Map.of("message_index", 3)), "req-1");
+
+        assertThat(journeyAppender.list).hasSize(1);
+        assertThat(journeyAppender.list.get(0).getFormattedMessage()).contains("\"message_index\":3");
+    }
+
+    @Test
+    @DisplayName("#326 — 거부된 이벤트는 원본 그대로 journey-events-rejected 로거에 남는다")
+    void writeRejected_logsOriginalPayload() {
+        EventEnvelope event = event(Map.of("message_index", 3));
+
+        eventLogWriter.writeRejected(event, 2, "UNKNOWN_EVENT_NAME", "req-1");
+
+        assertThat(rejectedAppender.list).hasSize(1);
+        String message = rejectedAppender.list.get(0).getFormattedMessage();
+        assertThat(message).contains("\"index\":2");
+        assertThat(message).contains("\"reject_reason\":\"UNKNOWN_EVENT_NAME\"");
+        assertThat(message).contains("\"event_id\":\"e1\"");
+        assertThat(journeyAppender.list).isEmpty();
+    }
+}


### PR DESCRIPTION
## 요약
거부된 이벤트의 원본 payload를 `journey-events-rejected.jsonl` 전용 로거에 남기고, 화이트리스트 검증 과정에서 속성이 drop/invalid 처리될 때 각각 별도 로그 라인을 남긴다.

## 관련 이슈
- Closes #326

## 변경 사항
- `EventLogWriter.writeRejected()` 신규 — 거부된 이벤트 원본(index, reject_reason 포함)을 `journey-events-rejected` 전용 로거로 기록
- `logback-spring.xml`에 `JOURNEY_EVENTS_REJECTED` appender/logger 추가 (`journey-events`와 물리적으로 분리, additivity=false)
- `EventWhitelist.isKnownProperty()` 신규 — "키가 카탈로그에 없음"과 "키는 있는데 값이 무효"를 구분하기 위한 메서드
- `EventLogWriter.write()`에서 property 필터링 시 원인별로 `journey_property_dropped`(unknown key) / `journey_property_invalid`(known key, invalid value) 로그 라인 추가
- `EventIngestService.ingest()`가 검증 실패 이벤트마다 `eventLogWriter.writeRejected()` 호출
- `application.yml`에 `events.rejected-log-file-path` (`EVENTS_REJECTED_LOG_FILE_PATH`) 추가, `docker-compose.prod.yml`에 prod 경로(`/var/log/mio/journey-events-rejected.jsonl`) 설정 추가

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (`EVENTS_REJECTED_LOG_FILE_PATH` — 기본값 있어 미설정 시에도 동작)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (신규 로그 파일 + 신규 로그 라인 2종)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava` / `./gradlew test --tests "com.mio.events.*"`
### 확인 내용
- `EventLogWriterTest`(신규): unknown key → journey_property_dropped 로그 + 결과에서 제외, known key/invalid value → journey_property_invalid 로그 + 결과에서 제외, 유효 속성은 그대로 유지, writeRejected()가 index/reject_reason/원본 payload를 journey-events-rejected 로거에 정확히 남기는지 검증 (4건)
- `EventWhitelistTest`: `isKnownProperty()` 신규 케이스 3건 추가
- `EventIngestServiceTest`: 거부 이벤트가 `writeRejected()`로 정확한 인자와 함께 전달되는지 검증 1건 추가, 기존 `verifyNoInteractions(eventLogWriter)` 단언을 `write()` 미호출 검증으로 수정 (writeRejected 호출과 충돌했음)
- 이벤트 패키지 전체 34개 테스트 통과

## 중점 리뷰 포인트
- `journey-events-rejected` 로거를 `journey-events`와 별도 appender/파일로 분리한 것이 맞는 접근인지 (정상 지표 집계 파이프라인 오염 방지 목적)
- 배치 내 중복(`DUPLICATE_IN_BATCH`)은 이번 로깅 대상에서 제외했음 — 원본이 이미 첫 건으로 정상 기록되므로 중복 로깅이 불필요하다고 판단, 이견 있으면 리뷰에서 알려달라

## 배포 / 롤백
- Rollout: 코드 배포만으로 적용됨. `EVENTS_REJECTED_LOG_FILE_PATH` 미설정 시 기본값(`./logs/journey-events-rejected.jsonl`)으로 동작하므로 즉시 배포 가능. 단, CloudWatch Agent가 새 파일을 실제로 수집하게 하려면 EC2 Agent 설정(`journey-events.json`)에 신규 로그 그룹/파일 경로를 추가하는 별도 인프라 작업이 필요함 (이 PR 범위 밖)
- Rollback: 코드 롤백만으로 원복 가능. 로그 파일 자체는 남지만 문제 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
