### PR TITLE
feat: 이벤트 배치 rate limit 20/분/device로 조정 및 Retry-After 헤더 추가 (#328)

### DIFF
--- a/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.mio.common.error;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
@@ -16,6 +17,20 @@ import java.util.stream.Collectors;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    /**
+     * 이슈 #328 — 이벤트 배치 rate limit만 Retry-After 헤더를 붙인다. 아래 공용
+     * BusinessException 핸들러보다 서브타입이라 우선 매칭된다 — 체크인/세션 메시지의
+     * 429 응답 형태는 그대로 유지된다.
+     */
+    @ExceptionHandler(RateLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleRateLimitExceeded(
+            RateLimitExceededException e, HttpServletRequest request) {
+        return ResponseEntity
+                .status(ErrorCode.RATE_LIMIT_EXCEEDED.getHttpStatus())
+                .header(HttpHeaders.RETRY_AFTER, String.valueOf(e.getRetryAfterSeconds()))
+                .body(ErrorResponse.of(ErrorCode.RATE_LIMIT_EXCEEDED, getTraceId(request)));
+    }
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<ErrorResponse> handleBusinessException(

--- a/src/main/java/com/mio/common/error/RateLimitExceededException.java
+++ b/src/main/java/com/mio/common/error/RateLimitExceededException.java
@@ -1,0 +1,20 @@
+package com.mio.common.error;
+
+import lombok.Getter;
+
+/**
+ * 이슈 #328 — 공용 {@code BusinessException(RATE_LIMIT_EXCEEDED)}를 던지는 도메인
+ * (체크인/세션 메시지)은 여럿인데, 이벤트 배치만 Retry-After 헤더가 필요해서 서브클래스로
+ * 분리했다. {@link GlobalExceptionHandler}가 이 타입을 BusinessException보다 더
+ * 구체적인 핸들러로 잡아 헤더를 붙인다 — 다른 도메인의 429 응답 형태는 그대로 유지된다.
+ */
+@Getter
+public class RateLimitExceededException extends BusinessException {
+
+    private final long retryAfterSeconds;
+
+    public RateLimitExceededException(long retryAfterSeconds) {
+        super(ErrorCode.RATE_LIMIT_EXCEEDED);
+        this.retryAfterSeconds = retryAfterSeconds;
+    }
+}

--- a/src/main/java/com/mio/events/service/EventRateLimiter.java
+++ b/src/main/java/com/mio/events/service/EventRateLimiter.java
@@ -1,7 +1,6 @@
 package com.mio.events.service;
 
-import com.mio.common.error.BusinessException;
-import com.mio.common.error.ErrorCode;
+import com.mio.common.error.RateLimitExceededException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -11,14 +10,15 @@ import java.util.concurrent.TimeUnit;
 /**
  * X-Device-Id 기준 속도 제한 — 익명 허용의 대가 (강민석 명세 §5 ③).
  *
- * <p>임계치는 명세에 구체적 수치가 없어 SessionService의 메시지 rate limit(60/분)과
- * 같은 자릿수로 잠정 설정했다. 실사용량 보고 조정 필요.
+ * <p>이슈 #328 — 배치당 최대 100개 이벤트를 실을 수 있어 요청 수 자체는 자주 낼 필요가
+ * 없다. 감사 문서가 제안한 20 batches/분/device로 조정했다 (기존 60은 명세에 구체적
+ * 수치가 없어 SessionService 메시지 rate limit과 같은 자릿수로 잠정 설정했던 값).
  */
 @Component
 @RequiredArgsConstructor
 public class EventRateLimiter {
 
-    private static final int MAX_REQUESTS_PER_MINUTE = 60;
+    private static final int MAX_BATCHES_PER_MINUTE = 20;
     private static final long TTL_SECONDS = 60L;
 
     private final StringRedisTemplate redisTemplate;
@@ -32,8 +32,14 @@ public class EventRateLimiter {
         if (count == 1) {
             redisTemplate.expire(key, TTL_SECONDS, TimeUnit.SECONDS);
         }
-        if (count > MAX_REQUESTS_PER_MINUTE) {
-            throw new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED);
+        if (count > MAX_BATCHES_PER_MINUTE) {
+            throw new RateLimitExceededException(retryAfterSeconds(key));
         }
+    }
+
+    /** TTL이 아직 안 걸렸거나(이론상 거의 없음) 이미 만료된 경우를 대비해 창 길이로 보정한다. */
+    private long retryAfterSeconds(String key) {
+        Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
+        return (ttl == null || ttl < 0) ? TTL_SECONDS : ttl;
     }
 }

--- a/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
@@ -1,0 +1,49 @@
+package com.mio.common.error;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #328 — RateLimitExceededException 전용 핸들러가 Retry-After 헤더를 정확히 얹는지 검증. */
+@ExtendWith(MockitoExtension.class)
+class GlobalExceptionHandlerTest {
+
+    @Mock private HttpServletRequest request;
+
+    private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+    @Test
+    @DisplayName("RateLimitExceededException은 429와 Retry-After 헤더(초 단위)를 함께 반환한다")
+    void handleRateLimitExceeded_returns429WithRetryAfterHeader() {
+        when(request.getAttribute("traceId")).thenReturn("trace-1");
+
+        ResponseEntity<ErrorResponse> response =
+                handler.handleRateLimitExceeded(new RateLimitExceededException(37L), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isEqualTo("37");
+        assertThat(response.getBody().error().code()).isEqualTo(ErrorCode.RATE_LIMIT_EXCEEDED.getCode());
+        assertThat(response.getBody().error().traceId()).isEqualTo("trace-1");
+    }
+
+    @Test
+    @DisplayName("일반 BusinessException(RATE_LIMIT_EXCEEDED)에는 Retry-After 헤더가 붙지 않는다 — 체크인/세션은 영향 없음")
+    void handleBusinessException_plainRateLimitExceeded_noRetryAfterHeader() {
+        when(request.getAttribute("traceId")).thenReturn("trace-2");
+
+        ResponseEntity<ErrorResponse> response =
+                handler.handleBusinessException(new BusinessException(ErrorCode.RATE_LIMIT_EXCEEDED), request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
+        assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isNull();
+    }
+}

--- a/src/test/java/com/mio/events/service/EventRateLimiterTest.java
+++ b/src/test/java/com/mio/events/service/EventRateLimiterTest.java
@@ -1,0 +1,82 @@
+package com.mio.events.service;
+
+import com.mio.common.error.RateLimitExceededException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #328 — 20/분/device 임계치와 Retry-After용 잔여 TTL 계산 검증. */
+@ExtendWith(MockitoExtension.class)
+class EventRateLimiterTest {
+
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    private EventRateLimiter eventRateLimiter;
+
+    private static final String KEY = "events:ratelimit:device-1";
+
+    @BeforeEach
+    void setUp() {
+        eventRateLimiter = new EventRateLimiter(redisTemplate);
+    }
+
+    @Test
+    @DisplayName("20회 이하이면 통과하고 첫 요청에서만 TTL을 건다")
+    void check_withinLimit_passes() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(KEY)).thenReturn(1L);
+
+        assertThatCode(() -> eventRateLimiter.check("device-1")).doesNotThrowAnyException();
+
+        verify(redisTemplate).expire(KEY, 60L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @DisplayName("두 번째 요청부터는 TTL을 다시 걸지 않는다")
+    void check_secondRequest_doesNotResetTtl() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(KEY)).thenReturn(2L);
+
+        eventRateLimiter.check("device-1");
+
+        verify(redisTemplate, org.mockito.Mockito.never()).expire(KEY, 60L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @DisplayName("21번째 요청은 RateLimitExceededException으로 거부되고 Redis TTL을 Retry-After로 그대로 쓴다")
+    void check_exceedsLimit_throwsWithRedisTtl() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(KEY)).thenReturn(21L);
+        when(redisTemplate.getExpire(KEY, TimeUnit.SECONDS)).thenReturn(37L);
+
+        assertThatThrownBy(() -> eventRateLimiter.check("device-1"))
+                .isInstanceOf(RateLimitExceededException.class)
+                .satisfies(e -> assertThat(((RateLimitExceededException) e).getRetryAfterSeconds()).isEqualTo(37L));
+    }
+
+    @Test
+    @DisplayName("Redis TTL이 없거나 이미 만료됐으면(-1/-2) 60초 창 길이로 보정한다")
+    void check_exceedsLimit_missingTtl_fallsBackToWindowLength() {
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.increment(KEY)).thenReturn(21L);
+        when(redisTemplate.getExpire(KEY, TimeUnit.SECONDS)).thenReturn(-2L);
+
+        assertThatThrownBy(() -> eventRateLimiter.check("device-1"))
+                .isInstanceOf(RateLimitExceededException.class)
+                .satisfies(e -> assertThat(((RateLimitExceededException) e).getRetryAfterSeconds()).isEqualTo(60L));
+    }
+}


### PR DESCRIPTION
## 요약
`/v1/events` rate limit을 60/분에서 20/분/device로 낮추고, 한도 초과 시 429 응답에 `Retry-After` 헤더(Redis TTL 기반)를 추가한다.

## 관련 이슈
- Closes #328

## 변경 사항
- `EventRateLimiter`의 임계치를 `MAX_REQUESTS_PER_MINUTE=60` → `MAX_BATCHES_PER_MINUTE=20`으로 변경
- 한도 초과 시 Redis rate-limit key의 실제 TTL(`getExpire`)을 계산해 `RateLimitExceededException`에 실어 던짐 (TTL이 없거나 이미 만료된 예외 케이스는 60초 창 길이로 보정)
- `RateLimitExceededException` 신규 (`common.error`, `BusinessException`의 서브타입) — 이벤트 rate limit만 `Retry-After` 헤더가 필요해서 공용 `BusinessException(RATE_LIMIT_EXCEEDED)`와 분리
- `GlobalExceptionHandler`에 `RateLimitExceededException` 전용 핸들러 추가 — `BusinessException` 핸들러보다 서브타입이라 우선 매칭되고, `Retry-After` 헤더를 얹어 429 반환. 체크인/세션 메시지의 기존 `BusinessException(RATE_LIMIT_EXCEEDED)` 흐름은 그대로 유지됨

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (429 응답에 `Retry-After` 헤더 추가, non-breaking)
- [ ] Breaking change 가 있습니다. (rate limit 수치 하향 — 배치당 최대 100 이벤트이므로 정상 클라이언트가 분당 20 batch를 넘길 일은 없다고 판단)

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava` / `./gradlew test --tests "com.mio.events.*" --tests "com.mio.common.error.*"` / 전체 회귀 확인차 `./gradlew test`
### 확인 내용
- `EventRateLimiterTest`(신규): 20 이하 통과, 첫 요청에서만 TTL 설정, 21번째 요청에서 `RateLimitExceededException` + Redis TTL 값 그대로 사용, TTL 없음/만료(-1/-2) 시 60초로 보정 (4건)
- `GlobalExceptionHandlerTest`(신규): `RateLimitExceededException`은 429 + `Retry-After` 헤더 반환, 일반 `BusinessException(RATE_LIMIT_EXCEEDED)`(체크인/세션 경로)는 헤더 없이 기존 그대로 반환 (2건)
- 이벤트 패키지 전체 통과, 전체 스위트 856개 중 855개 통과 — 나머지 1개(`MioApplicationTests.contextLoads`)는 로컬 Flyway V18 체크섬 불일치로 인한 기존 환경 이슈이며 이 PR과 무관 (#320 때부터 동일하게 확인된 사항)

## 중점 리뷰 포인트
- `RateLimitExceededException`을 `BusinessException` 서브타입으로 둬서 Spring이 더 구체적인 `@ExceptionHandler`를 우선 매칭하는 방식이 맞는 접근인지 (체크인/세션 rate limit의 기존 429 응답 형태를 건드리지 않는 게 목적)
- 20/분 수치가 실사용 패턴(배치당 최대 100 이벤트) 기준으로 충분히 여유로운지

## 배포 / 롤백
- Rollout: 코드 배포만으로 적용. 스키마/설정 변경 없음
- Rollback: 코드 롤백만으로 원복 가능, 데이터 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added rate-limit error responses with HTTP 429 status, retry timing, and trace ID details.
  - Rate limits are now set to 20 requests per device per minute.
  - Retry periods reflect the remaining limit window, with a 60-second fallback.

- **Tests**
  - Added coverage for rate-limit responses, headers, thresholds, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->