### PR TITLE
feat: event-catalog.yml 신설 및 event-whitelist.yml과의 CI 드리프트 검증 (#330)

### DIFF
--- a/src/main/resources/event-catalog.yml
+++ b/src/main/resources/event-catalog.yml
@@ -1,0 +1,92 @@
+# 강민석 "mio 이벤트 로그 명세" 카탈로그 — 사람이 읽는 참조용 소스 (이슈 #326-7).
+#
+# event-whitelist.yml은 런타임 검증(타입/enum 도메인)을 위한 설정이고, 이 파일은 이벤트
+# 카탈로그 자체(어떤 이벤트가 있고 어떤 속성을 갖는지)를 스펙 관점에서 따로 유지한다.
+# 파일이 둘로 나뉘어 있으면 한쪽만 고치고 다른 쪽을 깜빡하는 드리프트가 생기므로,
+# EventCatalogConsistencyTest가 이벤트 이름·property 키 집합이 두 파일에서 완전히
+# 일치하는지 CI에서 강제한다. 이벤트나 속성을 추가/삭제할 때는 반드시 두 파일을 함께 고친다.
+
+events:
+  # §4-A 세션 백본
+  app_session_started:
+    properties: [entry_point, is_first_session, days_since_last_session]
+  app_session_ended:
+    properties: [last_screen, duration_ms, screen_count]
+  screen_viewed:
+    properties: [screen_name, referrer_screen]
+  app_installed:
+    properties: []
+
+  # §4-B 가입·온보딩 퍼널
+  consent_agreed:
+    properties: [consent_version, marketing_agree, sensitive_info_agreed]
+  profile_submitted:
+    properties: [age_range, gender, employment_status]
+  signup_completed:
+    properties: []
+  onboarding_step_completed:
+    properties: [step, selected_emotion, concern_types, preferred_style]
+  onboarding_step_skipped:
+    properties: [step]
+  character_selected:
+    properties: [character_id, is_auto_assigned]
+  onboarding_completed:
+    properties: []
+  push_permission_prompted:
+    properties: [trigger]
+  push_permission_result:
+    properties: [granted, trigger]
+  identify:
+    properties: [previous_anonymous_id, user_id]
+  login_succeeded:
+    properties: [provider, is_new_user, is_new_device]
+
+  # §4-C Core Action 5종 (최우선)
+  checkin_completed:
+    properties: [condition_score, has_memo, emotion_type, time_of_day]
+  chat_message_sent:
+    properties: [chat_session_id, message_index, char_count, ai_emotion_score, is_socratic, cbt_intervention_state, is_crisis_flagged]
+  session_summary_viewed:
+    properties: [chat_session_id]
+  todo_checked_in:
+    properties: [todo_id, task_status, chat_session_id, emotion_before, emotion_after, emotion_delta, has_feedback, days_since_suggested]
+  report_viewed:
+    properties: [period]
+
+  # §4-D 대화 세션 부속 (session_summarized·todo_suggested는 서버 발행)
+  session_summarized:
+    properties: [chat_session_id, duration_seconds, message_count, bias_types_detected, socratic_count, problem_type, classifier_version, dominant_emotion, cbt_intervened, avg_emotion_score, todo_suggested_count]
+  todo_suggested:
+    properties: [chat_session_id, count, categories, difficulty_avg]
+  chat_session_created:
+    properties: [chat_session_id]
+  chat_session_ended:
+    properties: [duration_ms, message_count, chat_session_id, completion_reason, socratic_count]
+  emotion_score_recorded:
+    properties: [score, chat_session_id, reconstruction_id, score_before, score_delta]
+
+  # §4-E 알림·보조 기능
+  notification_opened:
+    properties: [notification_type]
+  account_withdrawn:
+    properties: []
+  logout:
+    properties: []
+  checkin_started:
+    properties: []
+  checkin_updated:
+    properties: []
+  todo_list_viewed:
+    properties: [todo_count]
+  emotion_trend_viewed:
+    properties: [period, days]
+  daily_test_viewed:
+    properties: []
+  daily_test_answered:
+    properties: [test_id]
+  notification_settings_changed:
+    properties: [setting_key, enabled]
+  character_changed:
+    properties: [from_id, to_id]
+  crisis_flow_triggered:
+    properties: []

--- a/src/test/java/com/mio/events/config/EventCatalogConsistencyTest.java
+++ b/src/test/java/com/mio/events/config/EventCatalogConsistencyTest.java
@@ -1,0 +1,80 @@
+package com.mio.events.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 이슈 #330 — event-catalog.yml(사람이 읽는 참조용 카탈로그)과 event-whitelist.yml(런타임
+ * 검증 설정)은 물리적으로 다른 파일이라, 이벤트나 property를 추가/삭제할 때 한쪽만 고치고
+ * 다른 쪽을 깜빡하면 조용히 어긋난다. 이벤트 이름과 property 키 집합이 두 파일에서 완전히
+ * 일치하는지 CI에서 강제한다.
+ */
+class EventCatalogConsistencyTest {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadEvents(String resourcePath) throws Exception {
+        Yaml yaml = new Yaml();
+        try (InputStream in = new ClassPathResource(resourcePath).getInputStream()) {
+            Map<String, Object> root = yaml.load(in);
+            return (Map<String, Object>) root.get("events");
+        }
+    }
+
+    /** whitelist는 {key: {spec}} 맵, catalog는 {properties: [key, ...]} — 형식은 다르지만 키 집합만 비교한다. */
+    @SuppressWarnings("unchecked")
+    private Set<String> whitelistPropertyKeys(Object rawProperties) {
+        if (!(rawProperties instanceof Map<?, ?> propertiesMap)) {
+            return Set.of();
+        }
+        return new TreeSet<>((Set<String>) propertiesMap.keySet());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Set<String> catalogPropertyKeys(Map<String, Object> catalogEvent) {
+        List<String> properties = (List<String>) catalogEvent.get("properties");
+        return properties == null ? Set.of() : new TreeSet<>(properties);
+    }
+
+    @Test
+    void catalogAndWhitelist_haveSameEventNames() throws Exception {
+        Map<String, Object> catalog = loadEvents("event-catalog.yml");
+        Map<String, Object> whitelist = loadEvents("event-whitelist.yml");
+
+        assertThat(catalog.keySet())
+                .as("event-catalog.yml과 event-whitelist.yml의 이벤트 이름 집합이 달라졌다 — 둘 다 함께 고쳐야 한다")
+                .containsExactlyInAnyOrderElementsOf(whitelist.keySet());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void catalogAndWhitelist_havePropertyKeysPerEvent() throws Exception {
+        Map<String, Object> catalog = loadEvents("event-catalog.yml");
+        Map<String, Object> whitelist = loadEvents("event-whitelist.yml");
+
+        for (Map.Entry<String, Object> entry : whitelist.entrySet()) {
+            String eventName = entry.getKey();
+            Object catalogEntry = catalog.get(eventName);
+
+            assertThat(catalogEntry)
+                    .as("event-catalog.yml에 '%s' 이벤트가 없다 — event-whitelist.yml과 동기화 필요", eventName)
+                    .isNotNull();
+
+            Set<String> whitelistKeys = whitelistPropertyKeys(entry.getValue());
+            Set<String> catalogKeys = catalogPropertyKeys((Map<String, Object>) catalogEntry);
+
+            assertThat(catalogKeys)
+                    .as("이벤트 '%s'의 property 키가 event-catalog.yml(%s)과 event-whitelist.yml(%s)에서 다르다",
+                            eventName, catalogKeys, whitelistKeys)
+                    .containsExactlyInAnyOrderElementsOf(whitelistKeys);
+        }
+    }
+}


### PR DESCRIPTION
## 요약
사람이 읽는 참조용 카탈로그 파일 `event-catalog.yml`을 신설하고, `event-whitelist.yml`(런타임 검증 설정)과 이벤트/property 이름이 어긋나지 않도록 CI 테스트로 강제한다.

## 관련 이슈
- Closes #330

## 변경 사항
- `src/main/resources/event-catalog.yml` 신설 — `event-whitelist.yml`의 37개 이벤트를 이벤트별 property 이름 목록으로 미러링 (타입/enum 도메인은 담지 않음, 런타임에 로드되지 않는 순수 참조용 파일)
- `EventCatalogConsistencyTest` 신규 — 두 YAML을 SnakeYAML로 파싱해 (1) 이벤트 이름 집합 일치, (2) 이벤트별 property 키 집합 일치를 검증. 어긋나면 어떤 이벤트/키가 다른지 실패 메시지에 명시

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

신규 리소스 파일 + 신규 테스트만 추가되며, 런타임 동작(`EventWhitelist`, 검증 로직)은 전혀 변경되지 않는다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava` / `./gradlew test --tests "com.mio.events.*"`
### 확인 내용
- `EventCatalogConsistencyTest`(신규): 이벤트 이름 집합 일치, 37개 이벤트 전체의 property 키 집합 일치 검증 (2건) — 둘 다 통과해 `event-catalog.yml`이 현재 `event-whitelist.yml`과 정확히 동기화됐음을 확인
- 이벤트 패키지 전체(6개 클래스, 40건) 통과

## 중점 리뷰 포인트
- `event-catalog.yml`의 스키마(`properties: [key, ...]`만 담고 타입/enum은 생략)가 참조용으로 적절한지 — 나중에 이벤트 설명(description) 등을 추가할 여지는 열어뒀지만 이번 PR에서는 이름 동기화 목적에만 집중했다
- 앞으로 이벤트/property를 추가·삭제할 때 두 파일을 함께 고쳐야 한다는 걸 리뷰어들도 인지해야 함 (CI가 잡아주긴 하지만)

## 배포 / 롤백
- Rollout: 코드 배포만으로 적용, 런타임 영향 없음
- Rollback: 파일 삭제만으로 원복 가능, 데이터/설정 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
