### PR TITLE
fix: 새벽(KST 00:00~08:59) 생성 Todo가 즉시 expired로 잘못 표시되는 버그 수정 (#334)

### DIFF
--- a/src/main/java/com/mio/todo/service/TodoService.java
+++ b/src/main/java/com/mio/todo/service/TodoService.java
@@ -86,8 +86,11 @@ public class TodoService {
     }
 
     private boolean isExpired(BehaviorTask task, LocalDate today) {
+        // Postgres 세션 타임존이 UTC라 DB에서 다시 읽은 OffsetDateTime은 +00:00으로 오는데,
+        // KST 00:00~08:59에 생성된 값은 그대로 toLocalDate()하면 UTC 기준 "전날"이 나온다.
+        // atZoneSameInstant로 KST 인스턴트를 다시 계산해야 오프셋과 무관하게 날짜가 맞는다.
         return TaskStatus.SUGGESTED == task.getStatus()
-                && task.getCreatedAt().toLocalDate().isBefore(today);
+                && task.getCreatedAt().atZoneSameInstant(AppConstants.ZONE).toLocalDate().isBefore(today);
     }
 
     private TaskStatus effectiveStatus(BehaviorTask task, LocalDate today) {

--- a/src/test/java/com/mio/todo/service/TodoTimezoneIntegrationTest.java
+++ b/src/test/java/com/mio/todo/service/TodoTimezoneIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.mio.todo.service;
+
+import com.mio.common.AppConstants;
+import com.mio.todo.domain.BehaviorTask;
+import com.mio.todo.dto.TodoResponse;
+import com.mio.todo.repository.BehaviorTaskRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 고하늘 QA 리포트(2026-08-06) — 채팅 종료 직후 생성된 당일 Todo가 GET /v1/todos에서
+ * status: expired로 내려옴. 재현 결과, Postgres 세션 타임존이 UTC라 TIMESTAMPTZ로 저장된
+ * KST 값을 다시 읽으면 +00:00으로 정규화된다. KST 00:00~08:59에 생성된 값은 UTC로는
+ * "전날"이라 {@code TodoService.isExpired()}의 {@code toLocalDate()}가 하루 전 날짜를
+ * 반환해 오늘 생성된 SUGGESTED Todo가 EXPIRED로 잘못 계산됐다.
+ *
+ * <p>Mockito 기반 {@link TodoServiceTest}는 createdAt을 리플렉션으로 직접 주입해 DB
+ * 왕복 자체가 없으므로 이 문제를 못 잡는다 — 실제 Postgres에 저장 후 재조회해야 재현된다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class TodoTimezoneIntegrationTest {
+
+    @Autowired private TodoService todoService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private BehaviorTaskRepository behaviorTaskRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private EntityManager entityManager;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("todo-tz-it-" + UUID.randomUUID())
+                .privacyConsent(true)
+                .build();
+        user.completeOnboarding("mio");
+        user = userRepository.save(user);
+        userId = user.getId();
+
+        BehaviorTask task = behaviorTaskRepository.save(BehaviorTask.builder()
+                .user(user)
+                .generatedFrom("chat")
+                .actionText("아침 심호흡")
+                .category("심리_안정")
+                .difficulty(1)
+                .estimatedMinutes(5)
+                .build());
+
+        // @PrePersist가 저장 시점 now()로 덮어쓰므로, KST 새벽 생성 상황은 저장 후 직접
+        // created_at을 갱신해서 재현한다 — 오늘 KST 00:30.
+        OffsetDateTime earlyMorningKst = LocalDate.now(AppConstants.ZONE)
+                .atTime(0, 30)
+                .atZone(AppConstants.ZONE)
+                .toOffsetDateTime();
+        jdbcTemplate.update("UPDATE behavior_tasks SET created_at = ? WHERE id = ?",
+                earlyMorningKst, task.getId());
+        entityManager.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("DELETE FROM behavior_tasks WHERE user_id = ?", userId);
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
+    }
+
+    @Test
+    @DisplayName("KST 00:00~08:59에 생성된 당일 Todo가 DB 재조회 후에도 expired로 잘못 표시되지 않는다")
+    void getTodos_earlyMorningKstTask_notMisreportedAsExpired() {
+        List<TodoResponse> result = todoService.getTodos(userId, LocalDate.now(AppConstants.ZONE), null);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).status()).isEqualTo("suggested");
+    }
+}


### PR DESCRIPTION
## 요약
KST 00:00~08:59에 생성된 당일 Todo가 `GET /v1/todos`에서 즉시 `status: expired`로 잘못 표시되는 버그를 수정한다 (고하늘 QA 리포트, 2026-08-06).

## 관련 이슈
- Closes #334

## 변경 사항
- `TodoService.isExpired()`를 `task.getCreatedAt().atZoneSameInstant(AppConstants.ZONE).toLocalDate()`로 수정. Postgres 세션 타임존이 `Etc/UTC`라 TIMESTAMPTZ로 저장된 KST(+09:00) 값을 JPA가 재조회하면 +00:00으로 정규화되는데, KST 00:00~08:59 값은 UTC 기준 "전날"이라 기존 `.toLocalDate()`가 하루 전 날짜를 반환해 `isBefore(today)`가 잘못 true가 됐음
- `TodoTimezoneIntegrationTest` 신규 — 실제 Postgres에 저장 후 재조회하는 회귀 테스트. `@PrePersist`가 저장 시점 now()로 덮어써서 새벽 생성 상황을 직접 만들 수 없어, 저장 후 JdbcTemplate으로 `created_at`을 KST 00:30으로 갱신 + `entityManager.clear()`로 1차 캐시를 비우고 재조회하는 방식으로 재현

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

응답 필드 구조는 그대로, `status` 값만 버그 수정으로 정상화됨(`suggested`가 나와야 할 게 `expired`로 나오던 게 고쳐짐). `TodoService.checkin()`의 만료 판정도 같은 `isExpired()`를 재사용하므로 함께 고쳐짐 — 새벽에 생성한 Todo를 체크인할 때 `TODO_EXPIRED`가 잘못 뜨던 문제도 같이 해결됨.

## 테스트
### 실행 커맨드
`./gradlew test --tests "com.mio.todo.*"`
### 확인 내용
- `TodoTimezoneIntegrationTest`(신규, 실제 Postgres 대상): 수정 전 코드로 실행 시 RED(재현 확인) → 수정 후 GREEN 확인
- 기존 `TodoServiceTest`(8건) / `TodoControllerTest`(7건) 회귀 없음 확인 — 다만 이 테스트들은 Mockito로 `createdAt`을 직접 주입해서 DB 왕복이 없어 이번 버그 자체는 못 잡았던 테스트들임 (그래서 별도 통합 테스트를 추가함)

## 중점 리뷰 포인트
- Postgres 세션 타임존이 `Etc/UTC`인 게 이 프로젝트의 의도된 설정인지, 아니면 애초에 `Asia/Seoul`로 맞추는 게 맞는지 — 이번엔 애플리케이션 코드에서 오프셋 무관하게 안전한 방식으로 고쳤지만, 다른 곳에서도 DB에서 읽은 `OffsetDateTime`에 `.toLocalDate()`를 직접 호출하는 패턴이 있으면 같은 문제가 잠재해 있을 수 있음 (grep으로 확인한 범위에서는 이번 건이 유일했음 — 나머지는 전부 메모리상에서 갓 생성한 `OffsetDateTime.now(zone)` 값이라 안전)

## 배포 / 롤백
- Rollout: 코드 배포만으로 적용, 마이그레이션 없음
- Rollback: 코드 롤백만으로 원복 가능 (단, 롤백 시 버그도 재발함)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Todo expiration checks for tasks created shortly after midnight in the application timezone.
  * Prevented timezone conversion issues from incorrectly marking active Todos as expired.

* **Tests**
  * Added integration coverage for early-morning Todo creation and timezone handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->