### PR TITLE
fix: 추천 행동 Todo의 최고점 고정을 감점·가중추출로 푼다

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/ScoreWeightedSelector.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ScoreWeightedSelector.java
@@ -1,0 +1,74 @@
+package com.mio.ai.memory.consolidation;
+
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.DoubleSupplier;
+
+/**
+ * 점수 기반 가중 확률 추출 (이슈 #337).
+ *
+ * <p>최고점 후보만 뽑으면 입력 신호가 같을 때 결과가 완전히 결정적이다. 세션 신호는
+ * 재발하는 것이 정상이므로({@code cbt_patterns.recurrence_count} 가 재발을 추적한다),
+ * 같은 신호가 돌아올 때마다 같은 결과가 나오면 사용자에게는 "돌려막기"로 보인다.
+ * 점수차를 확률차로 바꿔 적합도는 유지하면서 다양성을 확보한다.
+ *
+ * <p>가중치는 softmax {@code exp((score - top) / temperature)} 다. 최고점을 빼는 것은
+ * 결과에 영향을 주지 않고(정규화 상수) 지수 오버플로만 막는다. temperature 가 작을수록
+ * 최고점에 몰리고, 클수록 평평해진다.
+ */
+@Component
+public class ScoreWeightedSelector {
+
+    private final DoubleSupplier randomSource;
+
+    public ScoreWeightedSelector() {
+        // ThreadLocalRandom.current() 를 호출 시점마다 평가해야 한다. 메서드 참조로 고정하면
+        // 빈 생성 스레드의 인스턴스가 @Async 워커 스레드에서 공유된다.
+        this(() -> ThreadLocalRandom.current().nextDouble());
+    }
+
+    ScoreWeightedSelector(DoubleSupplier randomSource) {
+        this.randomSource = randomSource;
+    }
+
+    /** 점수가 매겨진 후보. */
+    public record Scored<T>(T value, int score) {}
+
+    /**
+     * 점수를 가중치로 환산해 후보 1건을 추출한다. 후보가 비어 있으면 null 을 반환한다.
+     *
+     * <p>후보를 점수 내림차순으로 정렬한 뒤 누적 추출하므로, 난수원이 0을 반환하면 항상
+     * 최고점 후보가 선택된다 — 테스트에서 결정적으로 만들 수 있다.
+     */
+    public <T> T select(List<Scored<T>> candidates, double temperature) {
+        if (candidates == null || candidates.isEmpty()) {
+            return null;
+        }
+        // 안정 정렬이라 동점 후보의 원래 순서는 보존된다.
+        List<Scored<T>> ordered = new ArrayList<>(candidates);
+        ordered.sort(Comparator.comparingInt(Scored<T>::score).reversed());
+
+        int top = ordered.getFirst().score();
+        double[] weights = new double[ordered.size()];
+        double total = 0.0;
+        for (int i = 0; i < ordered.size(); i++) {
+            weights[i] = Math.exp((ordered.get(i).score() - top) / temperature);
+            total += weights[i];
+        }
+
+        double threshold = randomSource.getAsDouble() * total;
+        double cumulative = 0.0;
+        for (int i = 0; i < ordered.size(); i++) {
+            cumulative += weights[i];
+            if (threshold < cumulative) {
+                return ordered.get(i).value();
+            }
+        }
+        // 난수가 1.0 에 극히 근접해 부동소수 누적이 total 에 못 미치는 경우.
+        return ordered.getLast().value();
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
@@ -16,6 +16,7 @@ import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -24,16 +25,19 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 
 /**
  * CBT 개입 완료 세션 종료 시 behavior_template 기반으로 Todo 3건 자동 생성 (MIO-CBT-015).
  * 3가지 카테고리(심리_안정 / 인지_재구성 / 행동_활성화) 각 1건씩 균형 배정.
  *
- * <p>선택은 세션 신호(전체 왜곡코드·지배 감정)로 템플릿을 스코어링하고, 최고점 동점 후보 중
- * 무작위로 뽑아 다양성을 확보한다. 이후 {@link TodoActionPersonalizer}가 선택된 템플릿의
- * action_text를 세션 맥락으로 개인화한다(실패 시 원본 문구 폴백). — 이슈 #228
+ * <p>선택은 세션 신호(전체 왜곡코드·지배 감정)로 템플릿을 스코어링한 뒤
+ * {@link ScoreWeightedSelector}로 가중 확률 추출한다. 이후 {@link TodoActionPersonalizer}가
+ * 선택된 템플릿의 action_text를 세션 맥락으로 개인화한다(실패 시 원본 문구 폴백). — 이슈 #228
+ *
+ * <p>최근 발급한 템플릿은 <b>후보에서 빼지 않고 감점</b>한다(이슈 #337). 배제하면 그 사용자에게
+ * 가장 잘 맞는 과제를 일정 기간 아예 못 주게 되고, 남은 후보가 적은 카테고리에서는 임상 적합도가
+ * 크게 떨어진다. 감점은 직전 세션 발급분의 선택 가중치를 약 0.37배로 낮출 뿐 여전히 뽑힐 수 있다.
  */
 @Slf4j
 @Service
@@ -44,9 +48,25 @@ public class TodoRecommendationService {
     private static final int TODOS_PER_SESSION = 3;
     private static final int DISTORTION_MATCH_WEIGHT = 2;
     private static final int EMOTION_MATCH_WEIGHT = 1;
-    // 과거 성과(intervention_outcomes) 반영 상한. 왜곡 매칭 1건(+2)과 동일 크기로 제한해
+    // 과거 성과(intervention_outcomes) 반영 상한. 왜곡 매칭 1건(+2)보다 작게 두어
     // 임상 적합도가 이력보다 우선하도록 한다.
-    private static final int HISTORY_AFFINITY_CAP = 2;
+    //
+    // 상한이 +2 였을 때는 긍정 반응이 쌓인 intervention_kind 가 왜곡 매칭 1건과 같은 무게를
+    // 얻어 상위에 고정됐다 — 좋아했던 과제일수록 계속 같은 것만 나오는 자기강화 루프다(이슈 #337).
+    private static final int HISTORY_AFFINITY_CAP = 1;
+
+    // 최근 발급 감점 — 배열 index 가 세션 거리(0 = 직전 세션)다.
+    // temperature 2.0 기준 감점 -2 는 선택 가중치 약 0.37배, -1 은 약 0.61배에 해당한다.
+    // 배제가 아니라 "덜 뽑히게" 하는 크기다.
+    private static final int[] RECENCY_PENALTY_BY_SESSION_DISTANCE = {2, 1};
+
+    // 감점 창(2세션)을 덮기에 충분한 조회 상한. 세션당 3건이므로 12건이면 4세션 분량이다.
+    private static final int RECENT_TEMPLATE_LOOKBACK = 12;
+
+    // softmax 온도. 낮을수록 최고점에 몰리고 높을수록 평평해진다. 2.0 은 시드 데이터 기준
+    // 임상 최적 후보를 여전히 최다 선택으로 유지하면서(예: self_blame+ashamed → 35% vs 차순위 13%)
+    // 연속 세션 동일 과제 확률을 65% → 7% 로 낮추는 지점이다.
+    private static final double SELECTION_TEMPERATURE = 2.0;
 
     private final BehaviorTemplateRepository templateRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
@@ -55,6 +75,7 @@ public class TodoRecommendationService {
     private final UserRepository userRepository;
     private final SessionRepository sessionRepository;
     private final TodoActionPersonalizer actionPersonalizer;
+    private final ScoreWeightedSelector selector;
     private final ObjectMapper objectMapper;
 
     /**
@@ -80,7 +101,9 @@ public class TodoRecommendationService {
         }
 
         Map<String, Integer> historyAffinity = loadHistoryAffinity(userId);
-        List<BehaviorTemplate> selected = selectBalanced(pool, distortions, emotion, historyAffinity);
+        Map<String, Integer> recencyPenalty = loadRecencyPenalty(userId);
+        List<BehaviorTemplate> selected =
+                selectBalanced(pool, distortions, emotion, historyAffinity, recencyPenalty);
         if (selected.isEmpty()) {
             return 0;
         }
@@ -116,10 +139,11 @@ public class TodoRecommendationService {
         return tasks.size();
     }
 
-    /** 카테고리별로 세션 신호 스코어 최고점 후보 중 무작위 1건 선택. */
+    /** 카테고리별로 세션 신호 스코어를 가중치로 환산해 1건씩 추출. */
     private List<BehaviorTemplate> selectBalanced(List<BehaviorTemplate> pool,
                                                   Set<String> distortions, String emotion,
-                                                  Map<String, Integer> historyAffinity) {
+                                                  Map<String, Integer> historyAffinity,
+                                                  Map<String, Integer> recencyPenalty) {
         Map<String, List<BehaviorTemplate>> byCategory = pool.stream()
                 .collect(Collectors.groupingBy(BehaviorTemplate::getCategory));
 
@@ -128,22 +152,22 @@ public class TodoRecommendationService {
             List<BehaviorTemplate> group = byCategory.getOrDefault(category, List.of());
             if (group.isEmpty()) continue;
 
-            int topScore = group.stream()
-                    .mapToInt(t -> score(t, distortions, emotion, historyAffinity))
-                    .max()
-                    .orElse(0);
-            List<BehaviorTemplate> best = group.stream()
-                    .filter(t -> score(t, distortions, emotion, historyAffinity) == topScore)
+            List<ScoreWeightedSelector.Scored<BehaviorTemplate>> scored = group.stream()
+                    .map(t -> new ScoreWeightedSelector.Scored<>(
+                            t, score(t, distortions, emotion, historyAffinity, recencyPenalty)))
                     .toList();
 
-            result.add(best.get(ThreadLocalRandom.current().nextInt(best.size())));
+            BehaviorTemplate picked = selector.select(scored, SELECTION_TEMPERATURE);
+            if (picked != null) {
+                result.add(picked);
+            }
             if (result.size() >= TODOS_PER_SESSION) break;
         }
         return result;
     }
 
     private int score(BehaviorTemplate template, Set<String> distortions, String emotion,
-                      Map<String, Integer> historyAffinity) {
+                      Map<String, Integer> historyAffinity, Map<String, Integer> recencyPenalty) {
         int score = 0;
         List<String> fitsDistortions = template.getFitsDistortions();
         if (fitsDistortions != null) {
@@ -160,7 +184,37 @@ public class TodoRecommendationService {
         }
         // 과거 성과: 감정이 개선됐던 개입은 가점, 악화됐던 개입은 감점 (상한/하한 클램프).
         score += historyAffinity.getOrDefault(template.getInterventionKind(), 0);
+        // 최근 발급: 가까운 세션에서 준 과제일수록 크게 감점한다. 배제가 아니라 확률 하향이다.
+        score -= recencyPenalty.getOrDefault(template.getCode(), 0);
         return score;
+    }
+
+    /**
+     * 최근 세션에서 발급한 템플릿의 감점을 세션 거리별로 집계한다 (이슈 #337).
+     *
+     * <p>조회는 최신순이므로 같은 코드가 여러 번 나오면 <b>먼저 만난 것이 더 가까운 세션</b>이다.
+     * {@code Math::max} 로 병합해 가장 최근 발급 기준 감점을 남긴다.
+     */
+    private Map<String, Integer> loadRecencyPenalty(UUID userId) {
+        List<BehaviorTaskRepository.RecentTemplateRow> rows =
+                behaviorTaskRepository.findRecentSessionTemplates(
+                        userId, PageRequest.of(0, RECENT_TEMPLATE_LOOKBACK));
+
+        List<UUID> sessionsNewestFirst = new ArrayList<>();
+        Map<String, Integer> penalty = new HashMap<>();
+        for (BehaviorTaskRepository.RecentTemplateRow row : rows) {
+            int distance = sessionsNewestFirst.indexOf(row.getSessionId());
+            if (distance < 0) {
+                sessionsNewestFirst.add(row.getSessionId());
+                distance = sessionsNewestFirst.size() - 1;
+            }
+            if (distance >= RECENCY_PENALTY_BY_SESSION_DISTANCE.length) {
+                continue;
+            }
+            penalty.merge(row.getTemplateCode(),
+                    RECENCY_PENALTY_BY_SESSION_DISTANCE[distance], Math::max);
+        }
+        return penalty;
     }
 
     /**
@@ -197,6 +251,7 @@ public class TodoRecommendationService {
                 .difficulty(template.getDifficulty())
                 .estimatedMinutes(template.getEstimatedMinutes())
                 .interventionKind(template.getInterventionKind())
+                .templateCode(template.getCode())
                 .build();
     }
 

--- a/src/main/java/com/mio/todo/domain/BehaviorTask.java
+++ b/src/main/java/com/mio/todo/domain/BehaviorTask.java
@@ -55,6 +55,16 @@ public class BehaviorTask {
     @Column(name = "intervention_kind")
     private String interventionKind;
 
+    /**
+     * 생성 출처 behavior_template.code (이슈 #337).
+     *
+     * <p>intervention_kind 는 여러 템플릿이 공유하므로 "직전에 준 과제를 또 줬는지"를
+     * 판정할 수 없다. 최근 발급 감점을 템플릿 단위로 매기기 위해 출처를 보존한다.
+     * 템플릿을 거치지 않는 생성 경로(체크인 등)에서는 null 이다.
+     */
+    @Column(name = "template_code")
+    private String templateCode;
+
     @Column(name = "status", nullable = false)
     @Builder.Default
     private TaskStatus status = TaskStatus.SUGGESTED;

--- a/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
+++ b/src/main/java/com/mio/todo/repository/BehaviorTaskRepository.java
@@ -2,6 +2,7 @@ package com.mio.todo.repository;
 
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -30,6 +31,29 @@ public interface BehaviorTaskRepository extends JpaRepository<BehaviorTask, UUID
             OffsetDateTime from,
             OffsetDateTime to
     );
+
+    /**
+     * 최근 발급 감점(이슈 #337)용 — 세션에서 생성된 Todo 의 출처 템플릿을 최신순으로 조회한다.
+     *
+     * <p>세션 거리로 감점을 매기므로 {@code sourceSession} 이 없는 생성 경로(체크인 등)와
+     * 템플릿을 거치지 않은 과거 row 는 제외한다. 조회 건수는 호출측이 {@link Pageable} 로 제한한다.
+     */
+    @Query("""
+            SELECT t.templateCode AS templateCode, t.sourceSession.id AS sessionId
+            FROM BehaviorTask t
+            WHERE t.user.id = :userId
+              AND t.templateCode IS NOT NULL
+              AND t.sourceSession IS NOT NULL
+            ORDER BY t.createdAt DESC
+            """)
+    List<RecentTemplateRow> findRecentSessionTemplates(@Param("userId") UUID userId, Pageable pageable);
+
+    /** {@link #findRecentSessionTemplates} 투영. */
+    interface RecentTemplateRow {
+        String getTemplateCode();
+
+        UUID getSessionId();
+    }
 
     // 리포트용: status·category별 집계
     @Query("SELECT t.status, t.category, COUNT(t) FROM BehaviorTask t WHERE t.user.id = :userId AND t.createdAt >= :start AND t.createdAt < :end GROUP BY t.status, t.category")

--- a/src/main/resources/db/migration/V50__add_template_code_to_behavior_tasks.sql
+++ b/src/main/resources/db/migration/V50__add_template_code_to_behavior_tasks.sql
@@ -10,9 +10,9 @@
 ALTER TABLE behavior_tasks
     ADD COLUMN template_code TEXT REFERENCES behavior_template(code);
 
--- 최근 발급 이력 조회는 (user_id, created_at DESC) 로 스캔한다.
-CREATE INDEX idx_behavior_tasks_user_created_at
-    ON behavior_tasks (user_id, created_at DESC);
+-- 인덱스는 새로 만들지 않는다. 최근 발급 이력 조회
+-- (WHERE user_id = ? ORDER BY created_at DESC)는 V5 에서 만든
+-- idx_behavior_tasks_user (user_id, created_at DESC) 가 그대로 커버한다.
 
 COMMENT ON COLUMN behavior_tasks.template_code IS
     '생성 출처 behavior_template.code. 최근 발급 감점 판정에 사용한다. 템플릿을 거치지 않은 생성 경로는 NULL.';

--- a/src/main/resources/db/migration/V50__add_template_code_to_behavior_tasks.sql
+++ b/src/main/resources/db/migration/V50__add_template_code_to_behavior_tasks.sql
@@ -1,0 +1,18 @@
+-- 추천 행동 Todo 중복 해소 (이슈 #337)
+--
+-- behavior_tasks 는 지금까지 category / intervention_kind 만 남기고 어떤 템플릿에서
+-- 나왔는지는 버렸다. intervention_kind 는 여러 템플릿이 공유하므로(예: cognitive_restructuring
+-- 4종) 그 단위로는 "직전에 준 과제를 또 줬는지"를 판정할 수 없다.
+-- 최근 발급 감점을 템플릿 단위로 매기기 위해 출처 코드를 보존한다.
+--
+-- nullable: 기존 row 와 체크인 등 템플릿을 거치지 않는 생성 경로는 NULL 로 남고,
+-- 감점 대상에서 자연스럽게 제외된다. 백필하지 않는다.
+ALTER TABLE behavior_tasks
+    ADD COLUMN template_code TEXT REFERENCES behavior_template(code);
+
+-- 최근 발급 이력 조회는 (user_id, created_at DESC) 로 스캔한다.
+CREATE INDEX idx_behavior_tasks_user_created_at
+    ON behavior_tasks (user_id, created_at DESC);
+
+COMMENT ON COLUMN behavior_tasks.template_code IS
+    '생성 출처 behavior_template.code. 최근 발급 감점 판정에 사용한다. 템플릿을 거치지 않은 생성 경로는 NULL.';

--- a/src/test/java/com/mio/ai/memory/consolidation/ScoreWeightedSelectorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/ScoreWeightedSelectorTest.java
@@ -1,0 +1,111 @@
+package com.mio.ai.memory.consolidation;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScoreWeightedSelectorTest {
+
+    private static final double T = 2.0;
+
+    @Test
+    @DisplayName("난수원이 0이면 항상 최고점 후보가 선택된다")
+    void picksTopScoreWhenRandomIsZero() {
+        var selector = new ScoreWeightedSelector(() -> 0.0);
+
+        String picked = selector.select(List.of(
+                new ScoreWeightedSelector.Scored<>("low", 0),
+                new ScoreWeightedSelector.Scored<>("high", 4),
+                new ScoreWeightedSelector.Scored<>("mid", 2)), T);
+
+        assertThat(picked).isEqualTo("high");
+    }
+
+    @Test
+    @DisplayName("동점이면 입력 순서가 앞선 후보가 선택된다")
+    void keepsInputOrderAmongTies() {
+        var selector = new ScoreWeightedSelector(() -> 0.0);
+
+        String picked = selector.select(List.of(
+                new ScoreWeightedSelector.Scored<>("first", 3),
+                new ScoreWeightedSelector.Scored<>("second", 3)), T);
+
+        assertThat(picked).isEqualTo("first");
+    }
+
+    @Test
+    @DisplayName("후보가 비면 null을 반환한다")
+    void returnsNullWhenEmpty() {
+        var selector = new ScoreWeightedSelector(() -> 0.0);
+
+        assertThat(selector.<String>select(List.of(), T)).isNull();
+        assertThat(selector.<String>select(null, T)).isNull();
+    }
+
+    @Test
+    @DisplayName("점수가 낮은 후보도 배제되지 않고 확률적으로 선택된다")
+    void lowScoreCandidateIsStillSelectable() {
+        var selector = new ScoreWeightedSelector(new Random(1234)::nextDouble);
+        var candidates = List.of(
+                new ScoreWeightedSelector.Scored<>("high", 4),
+                new ScoreWeightedSelector.Scored<>("low", 0));
+
+        Map<String, Integer> counts = draw(selector, candidates, 5000);
+
+        assertThat(counts.get("low")).isPositive();
+        // exp(-4/2) = 0.135 → 약 12%. 배제(0%)도 균등(50%)도 아님을 확인한다.
+        assertThat(counts.get("low") / 5000.0).isBetween(0.07, 0.19);
+        assertThat(counts.get("high")).isGreaterThan(counts.get("low"));
+    }
+
+    @Test
+    @DisplayName("점수 순서가 선택 빈도 순서로 유지된다")
+    void higherScoreIsChosenMoreOften() {
+        var selector = new ScoreWeightedSelector(new Random(99)::nextDouble);
+        var candidates = List.of(
+                new ScoreWeightedSelector.Scored<>("a", 0),
+                new ScoreWeightedSelector.Scored<>("b", 2),
+                new ScoreWeightedSelector.Scored<>("c", 4));
+
+        Map<String, Integer> counts = draw(selector, candidates, 5000);
+
+        assertThat(counts.get("c")).isGreaterThan(counts.get("b"));
+        assertThat(counts.get("b")).isGreaterThan(counts.get("a"));
+    }
+
+    @Test
+    @DisplayName("온도가 낮을수록 최고점에 더 몰린다")
+    void lowerTemperatureConcentratesOnTopScore() {
+        var candidates = List.of(
+                new ScoreWeightedSelector.Scored<>("high", 4),
+                new ScoreWeightedSelector.Scored<>("low", 0));
+
+        int sharp = draw(new ScoreWeightedSelector(new Random(7)::nextDouble), candidates, 5000)
+                .getOrDefault("high", 0);
+        int flat = draw(new ScoreWeightedSelector(new Random(7)::nextDouble), candidates, 5000, 8.0)
+                .getOrDefault("high", 0);
+
+        assertThat(sharp).isGreaterThan(flat);
+    }
+
+    private Map<String, Integer> draw(ScoreWeightedSelector selector,
+                                      List<ScoreWeightedSelector.Scored<String>> candidates, int times) {
+        return draw(selector, candidates, times, T);
+    }
+
+    private Map<String, Integer> draw(ScoreWeightedSelector selector,
+                                      List<ScoreWeightedSelector.Scored<String>> candidates,
+                                      int times, double temperature) {
+        Map<String, Integer> counts = new HashMap<>();
+        for (int i = 0; i < times; i++) {
+            counts.merge(selector.select(candidates, temperature), 1, Integer::sum);
+        }
+        return counts;
+    }
+}

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
@@ -19,8 +19,11 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +31,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,14 +59,14 @@ class TodoRecommendationServiceTest {
         sessionRepository = mock(SessionRepository.class);
         actionPersonalizer = mock(TodoActionPersonalizer.class);
 
-        service = new TodoRecommendationService(
-                templateRepository, behaviorTaskRepository, memoryPreferenceRepository,
-                outcomeRepository, userRepository, sessionRepository, actionPersonalizer, new ObjectMapper());
+        // 난수원이 0을 반환하면 항상 최고점 후보가 뽑힌다 — 점수 계산을 결정적으로 검증하기 위함.
+        service = newService(new ScoreWeightedSelector(() -> 0.0));
 
         User mockUser = user();
         Session mockSession = session();
         when(memoryPreferenceRepository.findByUserId(any())).thenReturn(Optional.empty());
         when(outcomeRepository.findRecentByUserId(any())).thenReturn(List.of());
+        when(behaviorTaskRepository.findRecentSessionTemplates(any(), any())).thenReturn(List.of());
         when(userRepository.findById(any())).thenReturn(Optional.of(mockUser));
         when(sessionRepository.findById(any())).thenReturn(Optional.of(mockSession));
         // 개인화기는 기본적으로 입력 템플릿 문구를 그대로 반환하도록(폴백 경로) 스텁.
@@ -202,7 +206,161 @@ class TodoRecommendationServiceTest {
         verify(behaviorTaskRepository, never()).saveAll(any());
     }
 
+    // ── 최근 발급 감점 (이슈 #337) ────────────────────────────
+
+    @Test
+    @DisplayName("직전 세션에 발급한 템플릿은 감점되어 동점 후보에 밀린다")
+    void penalizesTemplateIssuedInPreviousSession() {
+        // 두 후보 모두 왜곡 1건 매칭(+2). 감점이 없으면 목록 선두인 recent가 뽑힌다.
+        var recent = template("bt_recent", "심리_안정", "호흡", "breathing",
+                List.of("catastrophizing"), List.of(), 1);
+        var fresh = template("bt_fresh", "심리_안정", "그라운딩", "grounding",
+                List.of("catastrophizing"), List.of(), 1);
+        when(templateRepository.findAll()).thenReturn(List.of(recent, fresh));
+        when(behaviorTaskRepository.findRecentSessionTemplates(any(), any()))
+                .thenReturn(List.of(recentRow("bt_recent", UUID.randomUUID())));
+
+        service.generateForSession(userId, sessionId,
+                new TodoRecommendationService.TodoGenerationInput(
+                        List.of("catastrophizing"), null, List.of(), "요약"));
+
+        List<BehaviorTask> saved = captureSaved();
+        assertThat(saved).hasSize(1);
+        assertThat(saved.get(0).getTemplateCode()).isEqualTo("bt_fresh");
+    }
+
+    @Test
+    @DisplayName("감점된 템플릿도 후보에서 배제되지 않아 여전히 선택될 수 있다")
+    void penalizedTemplateIsStillSelectable() {
+        var recent = template("bt_recent", "심리_안정", "호흡", "breathing",
+                List.of("catastrophizing"), List.of(), 1);
+        var fresh = template("bt_fresh", "심리_안정", "그라운딩", "grounding",
+                List.of("catastrophizing"), List.of(), 1);
+        when(templateRepository.findAll()).thenReturn(List.of(recent, fresh));
+        when(behaviorTaskRepository.findRecentSessionTemplates(any(), any()))
+                .thenReturn(List.of(recentRow("bt_recent", UUID.randomUUID())));
+
+        // 실제 난수원(고정 시드)으로 반복 추출 — 감점이 배제로 동작하면 recent가 한 번도 나오지 않는다.
+        var randomized = newService(new ScoreWeightedSelector(new Random(42)::nextDouble));
+        Set<String> picked = new HashSet<>();
+        for (int i = 0; i < 200; i++) {
+            reset(behaviorTaskRepository);
+            when(behaviorTaskRepository.findRecentSessionTemplates(any(), any()))
+                    .thenReturn(List.of(recentRow("bt_recent", UUID.randomUUID())));
+            randomized.generateForSession(userId, sessionId,
+                    new TodoRecommendationService.TodoGenerationInput(
+                            List.of("catastrophizing"), null, List.of(), "요약"));
+            picked.add(captureSaved().get(0).getTemplateCode());
+        }
+        assertThat(picked).containsExactlyInAnyOrder("bt_recent", "bt_fresh");
+    }
+
+    @Test
+    @DisplayName("두 세션 전에 발급한 템플릿은 직전 세션보다 적게 감점된다")
+    void olderSessionIsPenalizedLess() {
+        // twoAgo: 왜곡 매칭 +2, 2세션 전 감점 -1 → 1
+        // prev:   왜곡 매칭 +2, 직전 세션 감점 -2 → 0
+        var prev = template("bt_prev", "심리_안정", "호흡", "breathing",
+                List.of("catastrophizing"), List.of(), 1);
+        var twoAgo = template("bt_two_ago", "심리_안정", "그라운딩", "grounding",
+                List.of("catastrophizing"), List.of(), 1);
+        when(templateRepository.findAll()).thenReturn(List.of(prev, twoAgo));
+
+        UUID prevSession = UUID.randomUUID();
+        UUID twoAgoSession = UUID.randomUUID();
+        when(behaviorTaskRepository.findRecentSessionTemplates(any(), any()))
+                .thenReturn(List.of(
+                        recentRow("bt_prev", prevSession),
+                        recentRow("bt_two_ago", twoAgoSession)));
+
+        service.generateForSession(userId, sessionId,
+                new TodoRecommendationService.TodoGenerationInput(
+                        List.of("catastrophizing"), null, List.of(), "요약"));
+
+        assertThat(captureSaved().get(0).getTemplateCode()).isEqualTo("bt_two_ago");
+    }
+
+    @Test
+    @DisplayName("감점 창 밖(3세션 전)의 발급 이력은 점수에 영향을 주지 않는다")
+    void outsideRecencyWindowIsNotPenalized() {
+        var old = template("bt_old", "심리_안정", "호흡", "breathing",
+                List.of("catastrophizing"), List.of(), 1);
+        var other = template("bt_other", "심리_안정", "그라운딩", "grounding",
+                List.of("catastrophizing"), List.of(), 1);
+        when(templateRepository.findAll()).thenReturn(List.of(old, other));
+
+        // bt_old는 3번째로 오래된 세션 → 감점 창(2세션) 밖.
+        when(behaviorTaskRepository.findRecentSessionTemplates(any(), any()))
+                .thenReturn(List.of(
+                        recentRow("bt_unrelated_a", UUID.randomUUID()),
+                        recentRow("bt_unrelated_b", UUID.randomUUID()),
+                        recentRow("bt_old", UUID.randomUUID())));
+
+        service.generateForSession(userId, sessionId,
+                new TodoRecommendationService.TodoGenerationInput(
+                        List.of("catastrophizing"), null, List.of(), "요약"));
+
+        // 감점이 없으므로 동점이고, 결정적 선택기는 목록 선두(bt_old)를 고른다.
+        assertThat(captureSaved().get(0).getTemplateCode()).isEqualTo("bt_old");
+    }
+
+    @Test
+    @DisplayName("생성된 Todo에 출처 template_code가 저장된다")
+    void persistsSourceTemplateCode() {
+        var t = template("bt_a", "심리_안정", "호흡", "breathing", List.of(), List.of(), 1);
+        when(templateRepository.findAll()).thenReturn(List.of(t));
+
+        service.generateForSession(userId, sessionId,
+                new TodoRecommendationService.TodoGenerationInput(List.of(), null, List.of(), "요약"));
+
+        assertThat(captureSaved().get(0).getTemplateCode()).isEqualTo("bt_a");
+    }
+
+    @Test
+    @DisplayName("과거 성과 가점(+1)은 왜곡 매칭 1건(+2)을 넘지 못한다")
+    void historyAffinityCannotOutweighSingleDistortionMatch() {
+        // manyPositive: 성과 3건(클램프 없으면 +3) / 매칭 0
+        var manyPositive = template("bt_a", "인지_재구성", "일기", "journaling",
+                List.of(), List.of(), 2);
+        // match: 왜곡 1건 매칭(+2) / 성과 0
+        var match = template("bt_b", "인지_재구성", "증거 점검", "evidence_check",
+                List.of("catastrophizing"), List.of(), 2);
+        when(templateRepository.findAll()).thenReturn(List.of(manyPositive, match));
+        // outcome() 은 내부에서 스터빙하므로 when(...) 인자 안에서 호출하면 스터빙이 깨진다.
+        var outcomes = List.of(
+                outcome("journaling", "positive"), outcome("journaling", "positive"),
+                outcome("journaling", "positive"));
+        when(outcomeRepository.findRecentByUserId(any())).thenReturn(outcomes);
+
+        service.generateForSession(userId, sessionId,
+                new TodoRecommendationService.TodoGenerationInput(
+                        List.of("catastrophizing"), null, List.of(), "요약"));
+
+        assertThat(captureSaved().get(0).getInterventionKind()).isEqualTo("evidence_check");
+    }
+
     // ── helpers ──────────────────────────────────────────────
+
+    private TodoRecommendationService newService(ScoreWeightedSelector selector) {
+        return new TodoRecommendationService(
+                templateRepository, behaviorTaskRepository, memoryPreferenceRepository,
+                outcomeRepository, userRepository, sessionRepository, actionPersonalizer,
+                selector, new ObjectMapper());
+    }
+
+    private BehaviorTaskRepository.RecentTemplateRow recentRow(String templateCode, UUID sessionId) {
+        return new BehaviorTaskRepository.RecentTemplateRow() {
+            @Override
+            public String getTemplateCode() {
+                return templateCode;
+            }
+
+            @Override
+            public UUID getSessionId() {
+                return sessionId;
+            }
+        };
+    }
 
     @SuppressWarnings("unchecked")
     private List<BehaviorTask> captureSaved() {


### PR DESCRIPTION
## 요약
세션 신호(왜곡·감정)가 같으면 Todo 선택이 완전히 결정적이라 같은 과제가 세션마다 반복됐다. QA 문의("추천 행동 템플릿이 너무 겹친다")의 원인이다. 최고점 단독 선택을 **최근 발급 감점 + 가중 확률 추출**로 바꾼다.

템플릿 개수를 늘리는 접근은 택하지 않았다. 문제는 자원 수가 아니라 선택 알고리즘이라, 시드를 늘려도 최고점 고정은 그대로 남는다.

## 관련 이슈
- Closes #337

## 변경 사항
- `behavior_tasks.template_code` 컬럼 추가 (V50, nullable) — `intervention_kind` 는 여러 템플릿이 공유해 템플릿 단위 중복 판정이 불가능했다
- 최근 발급 감점 — 세션 거리별 `직전 -2 / 2세션 전 -1`. **후보 배제가 아니라 감점**이다
- `ScoreWeightedSelector` 신규 — 최고점 동점군 균등 추첨 → 전체 후보 softmax(T=2.0) 추출. 난수원 주입으로 테스트에서 결정적 검증 가능
- `HISTORY_AFFINITY_CAP` 2 → 1 — 자기강화 루프 완화

## 설계 의도

**왜 배제가 아니라 감점인가.** 최근 발급 템플릿을 후보에서 빼면 그 사용자에게 가장 잘 맞는 과제를 일정 기간 아예 못 주게 된다. 후보가 적은 카테고리(행동_활성화는 기법 3종)에서는 임상 적합도가 크게 떨어진다. 감점은 직전 발급분의 선택 가중치를 **0.37배로 낮출 뿐** 여전히 뽑힌다 — 테스트 `penalizedTemplateIsStillSelectable` 로 고정했다.

**왜 `HISTORY_AFFINITY_CAP` 을 내리는가.** +2 는 왜곡 매칭 1건과 같은 무게다. 긍정 반응이 쌓인 `intervention_kind` 가 상위에 영구 고정되어, 좋아했던 과제일수록 계속 같은 것만 나오는 자기강화 루프였다.

## 효과 (시드 데이터 기준 시뮬레이션, 왜곡 0~2개 × 감정 7종 = 154개 신호 조합)

| 지표 | 변경 전 | 변경 후 |
|---|---|---|
| 연속 세션 동일 과제 | 56~65% | **7%** |
| 8세션 내 서로 다른 과제 (8종 중) | 2.1~2.4개 | **5.3개** |
| 임상 적합도 손실 (왜곡매칭=2점 척도) | 0 | 0.94 |
| 최적 후보가 여전히 최다 선택인가 | — | ✅ `self_blame+ashamed` → `bt_self_kind_words` 35%, 차순위 13% |

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. — `behavior_tasks.template_code` 추가 (nullable, **백필 없음**), `(user_id, created_at DESC)` 인덱스 추가
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — 세션 종료 후 컨솔리데이션의 Todo 생성 경로. 쿼리 1회 추가(최근 발급 12건 조회), LLM 호출 증가 없음
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

기존 row 는 `template_code` 가 NULL 이라 감점 대상에서 자연히 제외된다. 배포 직후에는 이력이 없어 감점이 작동하지 않고, 세션이 쌓이면서 점진적으로 적용된다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- 전체 871건 통과, 실패 0건
- 신규 `ScoreWeightedSelectorTest` 6건 — 난수원 0일 때 최고점 선택, 동점 시 입력 순서 유지, 빈 후보 null, 저점 후보도 선택 가능(12% 내외), 점수 순서 = 빈도 순서, 온도 낮을수록 최고점 집중
- 신규 `TodoRecommendationServiceTest` 6건 — 직전 세션 발급분 감점, **감점된 템플릿도 선택 가능**(고정 시드 200회 추출로 확인), 2세션 전은 감점 완화, 감점 창 밖은 영향 없음, `template_code` 저장, 성과 가점 상한(+1) < 왜곡 매칭(+2)
- 기존 테스트는 난수원 0을 주입해 결정적 최고점 선택으로 검증하므로 점수 계산 회귀를 그대로 잡는다

## 중점 리뷰 포인트
- **감점 크기와 온도의 조합** — `RECENCY_PENALTY_BY_SESSION_DISTANCE = {2, 1}` 와 `SELECTION_TEMPERATURE = 2.0` 은 함께 읽어야 한다. 감점이 가중치 배율로 환산되는 값(0.37x / 0.61x)이 "배제가 아닌 하향"의 실제 크기다. 더 강한 회피를 원하면 감점을, 더 넓은 다양성을 원하면 온도를 올리는 축이다
- `ScoreWeightedSelector` 기본 생성자가 `ThreadLocalRandom.current()` 를 **호출 시점마다** 평가한다. 메서드 참조로 고정하면 빈 생성 스레드의 인스턴스가 `@Async` 워커에서 공유된다
- `loadRecencyPenalty` 의 세션 거리 계산 — 조회가 최신순이므로 같은 코드의 첫 등장이 가장 가까운 세션이고, `Math::max` 로 병합한다

## 배포 / 롤백
- Rollout: V50 마이그레이션 적용 후 배포. 백필이 없어 다운타임 없음
- Rollback: 이전 버전 배포로 즉시 복구. `template_code` 컬럼은 nullable 이라 남아 있어도 무해하므로 마이그레이션 되돌림 불필요

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added smarter todo template recommendations using score- and temperature-based selection.
  * Recommendations now balance relevance with variety, allowing lower-scored options to appear occasionally.
  * Recent templates receive gradually reduced preference rather than being completely excluded.
  * Todo tasks retain their originating template information for improved history and traceability.

* **Bug Fixes**
  * Limited history-based influence to prevent it from overwhelming other recommendation signals.

* **Tests**
  * Added coverage for recommendation variety, recency handling, and template attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->