### PR TITLE
fix: 추천 행동 문구를 상황 선행에서 행동 선두로 바꾼다

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * 선택된 behavior_template의 action_text를 세션 맥락(요약·트리거)으로 리라이팅한다 (MIO-CBT-015 개인화).
@@ -18,6 +19,10 @@ import java.util.List;
  * <p>CBT 기법의 본질(category/difficulty/intervention_kind)은 검증된 템플릿이 담보하고,
  * 여기서는 <b>표면 문구만</b> 개인화한다. LLM 실패·형식 오류 시 항목별로 원본 템플릿 문구로 폴백하므로
  * category 등 DB CHECK 제약 대상 필드에는 LLM 값이 절대 들어가지 않는다.
+ *
+ * <p>문구는 <b>행동이 앞에 오도록</b> 쓴다(이슈 #338). 과제는 실행을 위한 것이라 무엇을 할지가
+ * 먼저 읽혀야 하는데, 상황·감정 묘사를 앞에 두면 행동이 뒤로 밀린다. 프롬프트 지시만으로는
+ * 모델이 습관적으로 상황을 앞세우므로 {@link #SITUATION_PREAMBLE} 로 결정론적으로 검사한다.
  */
 @Slf4j
 @Component
@@ -33,18 +38,44 @@ public class TodoActionPersonalizer {
             당신은 CBT(인지행동치료) 코칭의 실천 과제 문구를 다듬는 전문가입니다.
             아래에 세션 요약과 '기본 과제 문구' 목록이 주어집니다.
             각 기본 과제의 CBT 기법과 핵심 행동은 그대로 유지하되,
-            세션에서 드러난 사용자의 구체적 상황·트리거를 반영해 문구를 자연스럽게 개인화하세요.
+            세션에서 드러난 사용자의 구체적 상황을 반영해 문구를 자연스럽게 개인화하세요.
 
             규칙:
             - 과제의 핵심 행동(호흡, 사고 기록, 산책, 안부 연락 등)을 절대 다른 행동으로 바꾸지 않습니다.
-            - 세션에 등장한 상황을 한 조각만 자연스럽게 얹습니다. 억지로 끼워넣지 않습니다.
-            - 반영할 만한 구체 상황이 없으면 기본 문구를 거의 그대로 둡니다.
+            - 행동을 문장 맨 앞에 둡니다. 상황이나 감정 묘사를 행동 앞에 붙이지 않습니다.
+              나쁨: "발표 준비로 불안할 때, 4-7-8 호흡을 3회 해보기"
+              좋음: "4-7-8 호흡을 3회 하고, 발표 걱정이 떠오르면 다시 해보기"
+            - 세션 맥락은 행동 뒤에 한 조각만 덧붙입니다. 덧붙일 것이 없으면 행동만 씁니다.
             - 개인 식별 정보(실명, 연락처 등)는 포함하지 않습니다.
             - 각 문구는 한국어 한 문장, %d자 이내.
             - 반드시 아래 JSON만 출력합니다. 배열 길이와 순서는 입력과 동일해야 합니다.
 
             {"actions": ["개인화된 문구1", "개인화된 문구2", "개인화된 문구3"]}
             """.formatted(MAX_ACTION_LENGTH);
+
+    /**
+     * 상황 선행 문구 검출 (이슈 #338).
+     *
+     * <p>문장 앞머리의 짧은 절이 시간·이유·상태를 나타내는 연결어미로 끝나면 상황 서술이 행동보다
+     * 앞선 것으로 본다("발표 준비로 불안할 때, ~"). 지시만으로는 모델이 습관적으로 상황을 앞에
+     * 붙이므로 결정론적으로 걸러낸다.
+     *
+     * <p>어미 목록에서 뺀 것들에는 이유가 있다. {@code 하면}·{@code 해서}·{@code 동안} 은 행동
+     * 절에도 흔히 쓰인다. {@code 기 전에}·{@code 자마자} 는 "자기 전에 5분 스트레칭하기" 처럼
+     * 습관 과제에서 정상적으로 쓰이는 시점 표현이라, 걸러내면 멀쩡한 문구를 잃는다.
+     *
+     * <p>{@code [가-힣]데} 는 {@code -는데/-은데/-ㄴ데}("복잡한데", "어려운데") 를 한 번에
+     * 잡는다. 받침 ㄴ 이 앞 음절에 합성되는 활용형은 음절 단위 정규식으로 열거할 수 없다.
+     * 다만 이 대안만 <b>쉼표를 요구</b>한다 — 공백까지 허용하면 "천천히 3회 호흡하는데
+     * 집중해보기" 처럼 행동이 이미 앞에 온 문장의 {@code -는 데(에)} 까지 걸린다.
+     *
+     * <p>오탐이 나도 방향은 안전하다 — 거부되면 검증된 템플릿 원문이 나간다. 반대로 미탐은
+     * 상황 선행 문구가 그대로 나가므로, 확실한 상황 어미는 넓게 잡는 쪽을 택했다.
+     */
+    private static final Pattern SITUATION_PREAMBLE = Pattern.compile(
+            "^.{0,30}?(?:[가-힣]데,"
+                    + "|(?:때마다|때면|때는|때|느라고|느라|다면|니까|더니"
+                    + "|순간에|상황에|도중에|중에|탓에|때문에|이라서|라서)(?:,|\\s))");
 
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
@@ -129,6 +160,19 @@ public class TodoActionPersonalizer {
     }
 
     private boolean isValid(String text) {
-        return text != null && !text.isBlank() && text.trim().length() <= MAX_ACTION_LENGTH;
+        if (text == null || text.isBlank() || text.trim().length() > MAX_ACTION_LENGTH) {
+            return false;
+        }
+        if (startsWithSituation(text.trim())) {
+            // 문구 본문은 세션 파생 민감 정보를 포함할 수 있어 로깅하지 않는다.
+            log.warn("[TodoPersonalizer] rejected situation-leading action text; using template default");
+            return false;
+        }
+        return true;
+    }
+
+    /** 행동보다 상황 서술이 앞선 문구인지 판정한다 (이슈 #338). */
+    private boolean startsWithSituation(String text) {
+        return SITUATION_PREAMBLE.matcher(text).find();
     }
 }

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
@@ -1,0 +1,148 @@
+package com.mio.ai.memory.consolidation;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.memory.ontology.BehaviorTemplate;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class TodoActionPersonalizerTest {
+
+    private static final String TEMPLATE_TEXT = "4-7-8 호흡법 3회 연습하기";
+    private static final String SUMMARY = "발표를 앞두고 불안이 커졌고, 최악의 상황부터 떠올리는 패턴이 보였다.";
+
+    private LlmClient llmClient;
+    private TodoActionPersonalizer personalizer;
+
+    @BeforeEach
+    void setUp() {
+        llmClient = mock(LlmClient.class);
+        personalizer = new TodoActionPersonalizer(llmClient, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("행동으로 시작하는 개인화 문구는 그대로 채택된다")
+    void acceptsBehaviorLeadingText() {
+        String behaviorFirst = "4-7-8 호흡을 3회 하고, 발표 걱정이 떠오르면 다시 해보기";
+        stubLlm("{\"actions\": [\"%s\"]}".formatted(behaviorFirst));
+
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+
+        assertThat(result).containsExactly(behaviorFirst);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "발표 준비로 불안할 때, 4-7-8 호흡을 3회 해보기",
+            "발표 걱정이 떠오를 때 4-7-8 호흡을 3회 해보기",
+            "불안이 커지는 순간에 4-7-8 호흡하기",
+            "발표 준비를 하느라 지쳤다면, 4-7-8 호흡을 3회 하기",
+            "마음이 복잡한데, 4-7-8 호흡을 3회 해보기",
+            "발표 때문에 긴장되면 4-7-8 호흡을 3회 하기",
+            "주말이라서, 4-7-8 호흡을 3회 해보기",
+            "발표 준비에 지쳤다면, 4-7-8 호흡을 3회 하기",
+            "마음이 불안하니까 4-7-8 호흡을 3회 하기",
+            "어제는 괜찮더니, 4-7-8 호흡을 3회 해보기"
+    })
+    @DisplayName("상황 서술이 행동보다 앞선 문구는 거부되고 템플릿 원문으로 폴백된다")
+    void rejectsSituationLeadingText(String situationFirst) {
+        stubLlm("{\"actions\": [\"%s\"]}".formatted(situationFirst));
+
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+
+        assertThat(result).containsExactly(TEMPLATE_TEXT);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "4-7-8 호흡을 3회 하고, 발표 걱정이 떠오르면 다시 해보기",
+            "5분 동안 박스 호흡을 하며 어깨 힘 빼기",
+            "15분 산책하며 발표 준비 말고 다른 생각 해보기",
+            "자동적 사고 기록지에 발표 상황을 적고 대안 사고 찾아보기",
+            "최악의 시나리오가 일어날 확률을 0~100%로 적어보기",
+            "친한 사람 한 명에게 안부 문자 보내기",
+            "천천히 3회 호흡하는데 집중해보기",
+            "자기 전에 5분 스트레칭하기",
+            "일어나자마자 물 한 컵 마시기"
+    })
+    @DisplayName("행동으로 시작하는 문구는 상황 어휘가 섞여 있어도 거부되지 않는다")
+    void doesNotRejectBehaviorLeadingTextWithSituationWords(String behaviorFirst) {
+        stubLlm("{\"actions\": [\"%s\"]}".formatted(behaviorFirst));
+
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+
+        assertThat(result).containsExactly(behaviorFirst);
+    }
+
+    @Test
+    @DisplayName("여러 항목 중 상황 선행 문구만 폴백되고 나머지는 유지된다")
+    void fallsBackPerItem() {
+        var breathing = template("4-7-8 호흡법 3회 연습하기");
+        var walk = template("15분 짧은 산책하기");
+        stubLlm("""
+                {"actions": [
+                  "마음이 불안할 때, 4-7-8 호흡을 3회 해보기",
+                  "15분 산책하며 오늘 있었던 일을 떠올려보기"
+                ]}
+                """);
+
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(breathing, walk));
+
+        assertThat(result).containsExactly(
+                "4-7-8 호흡법 3회 연습하기",
+                "15분 산책하며 오늘 있었던 일을 떠올려보기");
+    }
+
+    @Test
+    @DisplayName("길이 상한을 넘는 문구는 기존대로 폴백된다")
+    void rejectsTooLongText() {
+        stubLlm("{\"actions\": [\"%s\"]}".formatted("호흡하기 ".repeat(40)));
+
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+
+        assertThat(result).containsExactly(TEMPLATE_TEXT);
+    }
+
+    @Test
+    @DisplayName("세션 요약이 없으면 LLM을 호출하지 않고 템플릿 문구를 반환한다")
+    void skipsWhenSummaryBlank() {
+        List<String> result = personalizer.personalize("  ", List.of("발표"), List.of(template()));
+
+        assertThat(result).containsExactly(TEMPLATE_TEXT);
+    }
+
+    // ── helpers ──────────────────────────────────────────────
+
+    private void stubLlm(String responseJson) {
+        doAnswer(invocation -> {
+            Consumer<String> sink = invocation.getArgument(1);
+            sink.accept(responseJson);
+            return mock(LlmStreamResult.class);
+        }).when(llmClient).stream(any(LlmRequest.class), any());
+    }
+
+    private BehaviorTemplate template() {
+        return template(TEMPLATE_TEXT);
+    }
+
+    /** 개인화기는 템플릿에서 action_text_ko 만 읽는다. */
+    private BehaviorTemplate template(String actionText) {
+        BehaviorTemplate t = mock(BehaviorTemplate.class);
+        when(t.getActionTextKo()).thenReturn(actionText);
+        return t;
+    }
+}


### PR DESCRIPTION
## 요약
과제 문구가 상황·감정 묘사로 시작해 정작 무엇을 할지가 뒤로 밀렸다. 과제는 실행을 위한 것이므로 행동이 먼저 읽혀야 한다.

```
변경 전: "발표 준비로 불안할 때, 4-7-8 호흡을 3회 해보기"
변경 후: "4-7-8 호흡을 3회 하고, 발표 걱정이 떠오르면 다시 해보기"
```

## 관련 이슈
- Closes #338

## 변경 사항
- `TodoActionPersonalizer.SYSTEM_PROMPT` — 상황을 앞에 얹으라는 지시를 걷어내고, 행동을 문장 맨 앞에 두도록 좋음/나쁨 예시와 함께 지시
- 함께 있던 `"반영할 만한 구체 상황이 없으면 기본 문구를 거의 그대로 둡니다"` 지시 제거 — 템플릿 원문을 그대로 노출시켜 과제가 매번 똑같아 보이게 만드는 요인이었다 (#337 과 같은 증상의 다른 원인)
- 상황 선행 문구를 걸러내는 결정론적 계약 검사 추가. 위반 시 **해당 항목만** 템플릿 원문으로 폴백

## 설계 의도

**왜 검사까지 붙이는가.** 프롬프트 지시만으로는 모델이 습관적으로 상황을 앞세운다. `ResponseContractValidator` 와 같은 방식으로 — 세지 않아도 되는 것만 정규식으로 세고 의미 판단은 하지 않는다 — LLM Judge 추가 호출 없이 막는다.

**오탐 방향이 안전하다.** 문장 앞머리의 짧은 절(30자 이내)이 시간·이유·상태 연결어미로 끝나면 거부한다. 오탐이 나도 개인화 문구 대신 **검증된 템플릿 원문**이 나가므로 사용자에게 나쁜 문구가 도달하지 않는다. 그래서 어미 목록은 넓게 잡되, `하면`·`해서`·`동안`처럼 행동 절에도 흔히 쓰이는 것은 뺐다.

**`[가-힣]데` 를 쓰는 이유.** `-는데/-은데/-ㄴ데`("복잡한데", "어려운데")는 받침 ㄴ 이 앞 음절에 합성되어 음절 단위 정규식으로 열거할 수 없다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — 세션 종료 후 Todo 개인화 경로. LLM 호출 횟수·모델 변경 없음
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

`GET /v1/sessions/{id}/summary` 의 `todos[].action_text` **문구 스타일**이 바뀐다. 필드·타입은 그대로다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- 전체 842건 통과, 실패 0건
- 신규 `TodoActionPersonalizerTest` 17건
  - 행동 선두 문구는 그대로 채택
  - **상황 선행 7종 거부 + 폴백** — `~할 때,` / `~떠오를 때` / `~순간에` / `~하느라` / `~한데,` / `~때문에` / `~이라서,`
  - **오탐 방지 6종** — `"5분 동안 박스 호흡을..."`, `"15분 산책하며..."`, `"최악의 시나리오가 일어날 확률을..."` 등 상황 어휘가 섞인 행동 선두 문구는 통과
  - 항목별 폴백 — 2건 중 상황 선행 1건만 템플릿으로 되돌아가고 나머지는 유지
  - 기존 경로 회귀 — 길이 초과 폴백, 요약 없을 때 LLM 미호출

## 중점 리뷰 포인트
- **어미 목록의 경계** — 넣을지 말지 갈리는 것은 `동안`(뺌: "5분 동안 호흡하기"가 정상 문구), `해서/하면`(뺌: 행동 절에도 흔함), `순간에/상황에`(넣음). 실제 문구를 보면서 조정할 여지가 있는 부분이다
- 30자 앞머리 제한 — 긴 행동 문장 중간에 우연히 어미가 걸리는 것을 막는 장치다

## 배포 / 롤백
- Rollout: 배포만 하면 신규 세션부터 적용. 기존 Todo 문구는 그대로 남는다
- Rollback: 이전 버전 배포로 즉시 복구. 스키마·데이터 변경이 없어 부수효과 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.