### PR TITLE
feat: 세션 요약을 2트랙으로 나누고 사용자 요약에 캐릭터 톤을 입힌다

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -97,6 +97,8 @@ public class SessionConsolidator {
     private final ObjectMapper objectMapper;
     private final OntologyValidator ontologyValidator;
     private final TodoRecommendationService todoRecommendationService;
+    private final SessionSummaryRenderer sessionSummaryRenderer;
+    private final UserSummaryWriter userSummaryWriter;
     private final SummaryStatusWriter summaryStatusWriter;
     private final CrisisEpisodePromoter crisisEpisodePromoter;
     // 메모리 보강을 별도 트랜잭션(REQUIRES_NEW)으로 호출하기 위한 self 프록시.
@@ -152,6 +154,21 @@ public class SessionConsolidator {
                 self.getObject().enrichMemory(enrichInput);
             } catch (Exception e) {
                 log.error("SessionConsolidator: memory enrichment failed but summary preserved sessionId={}",
+                        event.sessionId(), e);
+            }
+
+            // 사용자 노출용 요약 렌더링 (이슈 #339). 블로킹 LLM 호출이므로 요약 트랜잭션 밖에서
+            // 실행하고, 쓰기만 별도 트랜잭션으로 분리한다.
+            // 실패해도 진행한다 — user_summary_text 가 비면 조회 시 summary_text 로 폴백되므로
+            // 사용자는 (분석 톤이긴 해도) 요약을 받는다. 렌더링 실패로 요약을 잃게 두지 않는다.
+            try {
+                String userSummary = sessionSummaryRenderer.render(
+                        enrichInput.summaryText(), event.characterId());
+                if (userSummary != null) {
+                    userSummaryWriter.write(enrichInput.sessionId(), userSummary);
+                }
+            } catch (Exception e) {
+                log.error("SessionConsolidator: user summary rendering failed but summary preserved sessionId={}",
                         event.sessionId(), e);
             }
 

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
@@ -2,11 +2,13 @@ package com.mio.ai.memory.consolidation;
 
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
 import com.mio.character.domain.CharacterPersona;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -63,9 +65,13 @@ public class SessionSummaryRenderer {
      */
     private static final Map<String, Pattern> FORBIDDEN_PATTERNS = Map.of(
             // 요약은 3인칭 케이스 노트처럼 읽히는 것이 문제의 출발점이었다.
-            "third_person", Pattern.compile("사용자(는|가|의|에게)|내담자|이용자(는|가)"),
+            // 조사를 열거하지 않는다. 사용자에게 직접 말하는 요약에 "사용자"·"내담자"·"이용자"가
+            // 어떤 조사와 함께든 등장하면 그 자체로 3인칭 케이스 노트 톤이다.
+            "third_person", Pattern.compile("사용자|내담자|이용자"),
+            // ADHD 처럼 대문자로 나올 수 있어 대소문자를 무시한다.
             "diagnosis", Pattern.compile(
-                    "(우울증|불안장애|공황장애|조현병|adhd|양극성|경계선 ?성격)\\s*(초기|증상|인 ?것|인 ?듯|같아요|같습니다|이에요|입니다|진단)"),
+                    "(우울증|불안장애|공황장애|조현병|adhd|양극성|경계선 ?성격)\\s*(초기|증상|인 ?것|인 ?듯|같아요|같습니다|이에요|입니다|진단)",
+                    Pattern.CASE_INSENSITIVE),
             "guaranteed_outcome", Pattern.compile(
                     "반드시 (좋아|나아|괜찮)|무조건 (좋아|나아|괜찮)|꼭 좋아질 (거예요|겁니다)|보장(해요|합니다|할게요)"),
             "certainty_about_user", Pattern.compile(
@@ -86,10 +92,18 @@ public class SessionSummaryRenderer {
 
         try {
             StringBuilder response = new StringBuilder();
-            llmClient.stream(
+            LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(MODEL, buildSystemPrompt(persona), "세션 기록:\n" + internalSummary)
                             .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
                     response::append);
+
+            // 잘린 텍스트를 그대로 저장하면 사용자는 문장 중간에서 끊긴 요약을 받고, 잘렸다는
+            // 사실은 어디에도 남지 않는다 (LlmStreamResult.truncated 계약).
+            if (result.truncated()) {
+                log.warn("[SummaryRenderer] output truncated character={}; falling back to internal summary",
+                        persona.characterId());
+                return null;
+            }
 
             String rendered = response.toString().trim();
             List<String> violations = findViolations(rendered);
@@ -116,7 +130,7 @@ public class SessionSummaryRenderer {
         if (rendered.isBlank()) {
             return List.of("empty");
         }
-        List<String> violations = new java.util.ArrayList<>();
+        List<String> violations = new ArrayList<>();
 
         if (rendered.length() > MAX_LENGTH) {
             violations.add("max_length(%d>%d)".formatted(rendered.length(), MAX_LENGTH));

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
@@ -1,0 +1,145 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.character.domain.CharacterPersona;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * 내부 세션 요약을 사용자 노출용 요약으로 다시 쓴다 (이슈 #339).
+ *
+ * <p>{@code summary_text} 는 ExtractorLLM 과 Retriever 3종이 읽는 <b>내부 기억</b>이라
+ * 분석가 시점("감지된 인지 왜곡 패턴", "CBT 개입 여부")으로 쓰여 있다. 그대로 사용자에게
+ * 보여주면 임상 케이스 노트처럼 읽히므로, 여기서 표현만 다시 쓴다.
+ *
+ * <p><b>사실은 바꾸지 않는다.</b> 캐릭터가 바꾸는 것은 말투이지 안전 기준이나 사실이 아니다
+ * (docs/피치덱_QA/03_AI_파이프라인.md). 어휘·강조점만 캐릭터를 타고, 어미는 해요체로 통일해
+ * API 명세의 요약 예시와 일치시킨다.
+ *
+ * <p>실패하면 null 을 반환한다. 호출측은 저장을 건너뛰고, 조회 시 기존 {@code summary_text} 로
+ * 폴백된다. 렌더링 실패가 이미 성공한 요약을 죽이지 않게 하는 것이 이 경로의 원칙이다(이슈 #219).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SessionSummaryRenderer {
+
+    private static final String MODEL = "gpt-4o-mini";
+    // 2~3문장 200자를 요구한다. 한국어 1자 ≈ 0.71 토큰이라 ~142 토큰, 2배 이상 여유를 둔다.
+    private static final int MAX_COMPLETION_TOKENS = 400;
+    private static final int MAX_LENGTH = 200;
+    private static final int MAX_SENTENCES = 3;
+
+    private static final String SYSTEM_PROMPT_FORMAT = """
+            당신은 %s입니다. %s
+
+            아래 '세션 기록'은 분석용으로 작성된 내부 메모입니다.
+            이것을 사용자에게 직접 보여줄 요약으로 다시 쓰세요.
+
+            규칙:
+            - 사용자에게 말하듯 '-어요/-았어요' 해요체로 씁니다.
+            - 2~3문장, %d자 이내.
+            - '사용자는', '내담자' 같은 3인칭 표현을 쓰지 않습니다.
+            - 진단명을 붙이거나 결과를 보장하지 않습니다. 단정하지 않습니다.
+            - 세션 기록에 없는 사실을 만들지 않습니다.
+            - 요약 문장만 출력합니다. 머리말·꼬리말·따옴표를 붙이지 않습니다.
+            """;
+
+    private static final Pattern SENTENCE_END = Pattern.compile("[.!?。！？\\n]+");
+
+    /** 해요체 종결 여부. 요약 전체가 대화체로 읽히도록 마지막 문장 어미를 본다. */
+    private static final Pattern POLITE_ENDING = Pattern.compile("(요|죠|네요|어요|아요|예요|에요)[.!?]?$");
+
+    /**
+     * 금지 표현. {@code ai.plan.ResponseContractValidator} 와 목적이 같지만 검사 대상이 다르다 —
+     * 그쪽은 대화 턴(질문 수·문장 수 계약)을, 여기는 요약 한 덩어리를 본다. 계약 대상이 달라
+     * 한 클래스로 합치면 어느 쪽 규칙인지 읽히지 않으므로 분리해 둔다.
+     */
+    private static final Map<String, Pattern> FORBIDDEN_PATTERNS = Map.of(
+            // 요약은 3인칭 케이스 노트처럼 읽히는 것이 문제의 출발점이었다.
+            "third_person", Pattern.compile("사용자(는|가|의|에게)|내담자|이용자(는|가)"),
+            "diagnosis", Pattern.compile(
+                    "(우울증|불안장애|공황장애|조현병|adhd|양극성|경계선 ?성격)\\s*(초기|증상|인 ?것|인 ?듯|같아요|같습니다|이에요|입니다|진단)"),
+            "guaranteed_outcome", Pattern.compile(
+                    "반드시 (좋아|나아|괜찮)|무조건 (좋아|나아|괜찮)|꼭 좋아질 (거예요|겁니다)|보장(해요|합니다|할게요)"),
+            "certainty_about_user", Pattern.compile(
+                    "분명(히|해요|합니다)|틀림없(이|어요)|당신은 .{0,12}(사람이|성격이)"));
+
+    private final LlmClient llmClient;
+
+    /**
+     * @param internalSummary 내부용 요약({@code summary_text})
+     * @param characterId     세션에서 사용한 캐릭터. 알 수 없으면 기본 캐릭터 어조로 렌더링한다
+     * @return 사용자 노출용 요약. 렌더링·계약 검사 실패 시 null
+     */
+    public String render(String internalSummary, String characterId) {
+        if (internalSummary == null || internalSummary.isBlank()) {
+            return null;
+        }
+        CharacterPersona persona = CharacterPersona.findOrDefault(characterId);
+
+        try {
+            StringBuilder response = new StringBuilder();
+            llmClient.stream(
+                    LlmRequest.of(MODEL, buildSystemPrompt(persona), "세션 기록:\n" + internalSummary)
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
+                    response::append);
+
+            String rendered = response.toString().trim();
+            List<String> violations = findViolations(rendered);
+            if (!violations.isEmpty()) {
+                log.warn("[SummaryRenderer] contract violated {} character={}; falling back to internal summary",
+                        violations, persona.characterId());
+                return null;
+            }
+            return rendered;
+        } catch (Exception e) {
+            // 요약 본문은 세션 파생 민감 정보라 로깅하지 않는다.
+            log.warn("[SummaryRenderer] rendering failed character={}; falling back to internal summary",
+                    persona.characterId(), e);
+            return null;
+        }
+    }
+
+    private String buildSystemPrompt(CharacterPersona persona) {
+        return SYSTEM_PROMPT_FORMAT.formatted(persona.displayName(), persona.summaryVoice(), MAX_LENGTH);
+    }
+
+    /** 결정론적 계약 검사. LLM Judge 를 부르지 않는다. */
+    private List<String> findViolations(String rendered) {
+        if (rendered.isBlank()) {
+            return List.of("empty");
+        }
+        List<String> violations = new java.util.ArrayList<>();
+
+        if (rendered.length() > MAX_LENGTH) {
+            violations.add("max_length(%d>%d)".formatted(rendered.length(), MAX_LENGTH));
+        }
+        int sentences = countSentences(rendered);
+        if (sentences > MAX_SENTENCES) {
+            violations.add("max_sentences(%d>%d)".formatted(sentences, MAX_SENTENCES));
+        }
+        if (!POLITE_ENDING.matcher(rendered).find()) {
+            violations.add("not_polite_ending");
+        }
+        FORBIDDEN_PATTERNS.forEach((name, pattern) -> {
+            if (pattern.matcher(rendered).find()) {
+                violations.add(name);
+            }
+        });
+        return violations;
+    }
+
+    private int countSentences(String text) {
+        return (int) SENTENCE_END.splitAsStream(text)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .count();
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/UserSummaryWriter.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/UserSummaryWriter.java
@@ -1,0 +1,39 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.session.repository.SessionSummaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 사용자 노출용 요약을 독립 트랜잭션으로 기록한다 (이슈 #339).
+ *
+ * <p>렌더링은 블로킹 LLM 호출이라 요약 트랜잭션 밖에서 수행한다(이슈 #228 에서 Todo 개인화를
+ * 트랜잭션 밖으로 뺀 것과 같은 이유). 그래서 쓰기만 짧은 REQUIRES_NEW 로 분리한다.
+ *
+ * <p>실패해도 예외를 밖으로 던지지 않는다 — 이 컬럼이 비면 조회 시 기존 요약으로 폴백되므로
+ * 사용자에게 보이는 산출물은 유지된다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UserSummaryWriter {
+
+    private final SessionSummaryRepository sessionSummaryRepository;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void write(UUID sessionId, String userSummaryText) {
+        try {
+            int updated = sessionSummaryRepository.updateUserSummaryText(sessionId, userSummaryText);
+            if (updated == 0) {
+                log.warn("[SummaryRenderer] no summary row to update sessionId={}", sessionId);
+            }
+        } catch (Exception e) {
+            log.error("[SummaryRenderer] failed to persist user summary sessionId={}", sessionId, e);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/prompt/PromptBuilder.java
+++ b/src/main/java/com/mio/ai/prompt/PromptBuilder.java
@@ -4,51 +4,13 @@ import com.mio.ai.plan.ResponseAct;
 import com.mio.ai.plan.ResponsePlan;
 import com.mio.ai.policy.GenerationMode;
 import com.mio.ai.policy.InterventionHints;
+import com.mio.character.domain.CharacterPersona;
 import org.springframework.stereotype.Component;
 
-import java.util.Map;
 
 @Component
 public class PromptBuilder {
 
-    private static final Map<String, String> CHARACTER_BASE_PROMPTS = Map.of(
-            "mio",
-            "당신은 미오입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, " +
-            "사용자의 감정을 진심으로 이해하고 곁에서 지지합니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 사용자가 스스로 감정을 탐색할 수 있도록 돕습니다. " +
-            "진단이나 처방을 내리지 않으며, 의존성을 강화하는 표현은 하지 않습니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.",
-
-            "bau",
-            "당신은 바우입니다. 활기차고 응원해주는 AI 코칭 캐릭터로, " +
-            "사용자가 작은 변화와 행동에서 자신감을 찾도록 돕습니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 구체적인 다음 단계를 함께 탐색합니다. " +
-            "진단이나 처방을 내리지 않으며, 긍정적인 모멘텀을 유지합니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.",
-
-            "rumi",
-            "당신은 루미입니다. 명확하고 논리적인 AI 코칭 캐릭터로, " +
-            "사용자의 생각 패턴을 체계적으로 탐색하고 정리할 수 있도록 돕습니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 인지 왜곡을 함께 살펴봅니다. " +
-            "진단이나 처방을 내리지 않으며, 단정적 표현을 피합니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.",
-
-            "momo",
-            "당신은 모모입니다. 온화하고 수용적인 AI 코칭 캐릭터로, " +
-            "지치고 힘든 사용자의 마음을 따뜻하게 감싸드립니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 사용자가 자기 자신을 있는 그대로 받아들이도록 돕습니다. " +
-            "진단이나 처방을 내리지 않으며, 압박감을 주는 표현은 하지 않습니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다.",
-
-            "chichi",
-            "당신은 치치입니다. 현실적이고 직접적인 AI 코칭 캐릭터로, " +
-            "사용자가 실질적인 해결책을 찾고 변화를 이끌 수 있도록 돕습니다. " +
-            "CBT(인지행동치료) 원칙에 기반해 구체적이고 실천 가능한 접근을 제안합니다. " +
-            "진단이나 처방을 내리지 않으며, 불필요한 감정적 표현은 최소화합니다. " +
-            "응답은 2-4문장으로 간결하게 유지합니다."
-    );
-
-    private static final String DEFAULT_CHARACTER = "mio";
 
     private static final String SUPPORTIVE_INSTRUCTION =
             "\n\n[현재 세션 지시] 감정을 먼저 충분히 인정하고 공감하세요. " +
@@ -59,11 +21,11 @@ public class PromptBuilder {
             "단정적 표현을 사용하지 마세요. 사용자의 말을 조심스럽게 반영하세요.";
 
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints) {
-        return buildSystemPrompt(mode, hints, null, DEFAULT_CHARACTER, null);
+        return buildSystemPrompt(mode, hints, null, CharacterPersona.DEFAULT.characterId(), null);
     }
 
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints, String memoryContext) {
-        return buildSystemPrompt(mode, hints, memoryContext, DEFAULT_CHARACTER, null);
+        return buildSystemPrompt(mode, hints, memoryContext, CharacterPersona.DEFAULT.characterId(), null);
     }
 
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints,
@@ -95,9 +57,7 @@ public class PromptBuilder {
     }
 
     private String resolveBasePrompt(String characterId) {
-        if (characterId == null) return CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER);
-        String normalized = characterId.trim().toLowerCase();
-        return CHARACTER_BASE_PROMPTS.getOrDefault(normalized, CHARACTER_BASE_PROMPTS.get(DEFAULT_CHARACTER));
+        return CharacterPersona.findOrDefault(characterId).chatSystemPrompt();
     }
 
     private String buildModeInstruction(GenerationMode mode) {

--- a/src/main/java/com/mio/character/domain/CharacterPersona.java
+++ b/src/main/java/com/mio/character/domain/CharacterPersona.java
@@ -1,0 +1,119 @@
+package com.mio.character.domain;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 캐릭터별 어조 정의 — LLM 프롬프트에 들어가는 표현 층의 단일 출처 (이슈 #339).
+ *
+ * <p>캐릭터가 바꾸는 것은 <b>말투와 접근 방식</b>이지 안전 기준이나 사실이 아니다
+ * (docs/피치덱_QA/03_AI_파이프라인.md). 그래서 여기에는 어조만 담고, 위험도 판정·사실
+ * 추출은 캐릭터를 참조하지 않는다.
+ *
+ * <p>대화 응답과 세션 요약이 같은 캐릭터를 서로 다르게 해석하면 사용자에겐 다른 인격으로
+ * 보인다. 두 소비처가 이 enum 하나를 참조하게 해서 어조가 갈라지지 않도록 한다.
+ */
+public enum CharacterPersona {
+
+    MIO("mio", "미오",
+            "당신은 미오입니다. 따뜻하고 공감적인 AI 코칭 캐릭터로, "
+                    + "사용자의 감정을 진심으로 이해하고 곁에서 지지합니다. "
+                    + "CBT(인지행동치료) 원칙에 기반해 사용자가 스스로 감정을 탐색할 수 있도록 돕습니다. "
+                    + "진단이나 처방을 내리지 않으며, 의존성을 강화하는 표현은 하지 않습니다. "
+                    + "응답은 2-4문장으로 간결하게 유지합니다.",
+            "따뜻하고 공감적인 어조. 무엇을 느꼈는지를 먼저 알아주는 표현을 고른다."),
+
+    BAU("bau", "바우",
+            "당신은 바우입니다. 활기차고 응원해주는 AI 코칭 캐릭터로, "
+                    + "사용자가 작은 변화와 행동에서 자신감을 찾도록 돕습니다. "
+                    + "CBT(인지행동치료) 원칙에 기반해 구체적인 다음 단계를 함께 탐색합니다. "
+                    + "진단이나 처방을 내리지 않으며, 긍정적인 모멘텀을 유지합니다. "
+                    + "응답은 2-4문장으로 간결하게 유지합니다.",
+            "활기차고 응원하는 어조. 시도한 것과 움직인 부분에 초점을 둔다."),
+
+    RUMI("rumi", "루미",
+            "당신은 루미입니다. 명확하고 논리적인 AI 코칭 캐릭터로, "
+                    + "사용자의 생각 패턴을 체계적으로 탐색하고 정리할 수 있도록 돕습니다. "
+                    + "CBT(인지행동치료) 원칙에 기반해 인지 왜곡을 함께 살펴봅니다. "
+                    + "진단이나 처방을 내리지 않으며, 단정적 표현을 피합니다. "
+                    + "응답은 2-4문장으로 간결하게 유지합니다.",
+            "명확하고 차분한 어조. 생각이 어떻게 이어졌는지를 정리해 보여준다."),
+
+    MOMO("momo", "모모",
+            "당신은 모모입니다. 온화하고 수용적인 AI 코칭 캐릭터로, "
+                    + "지치고 힘든 사용자의 마음을 따뜻하게 감싸드립니다. "
+                    + "CBT(인지행동치료) 원칙에 기반해 사용자가 자기 자신을 있는 그대로 받아들이도록 돕습니다. "
+                    + "진단이나 처방을 내리지 않으며, 압박감을 주는 표현은 하지 않습니다. "
+                    + "응답은 2-4문장으로 간결하게 유지합니다.",
+            "온화하고 수용적인 어조. 애쓴 마음을 있는 그대로 인정한다."),
+
+    CHICHI("chichi", "치치",
+            "당신은 치치입니다. 현실적이고 직접적인 AI 코칭 캐릭터로, "
+                    + "사용자가 실질적인 해결책을 찾고 변화를 이끌 수 있도록 돕습니다. "
+                    + "CBT(인지행동치료) 원칙에 기반해 구체적이고 실천 가능한 접근을 제안합니다. "
+                    + "진단이나 처방을 내리지 않으며, 불필요한 감정적 표현은 최소화합니다. "
+                    + "응답은 2-4문장으로 간결하게 유지합니다.",
+            "담백하고 직접적인 어조. 군더더기 없이 무슨 일이 있었는지 짚는다.");
+
+    public static final CharacterPersona DEFAULT = MIO;
+
+    private final String characterId;
+    private final String displayName;
+    private final String chatSystemPrompt;
+    private final String summaryVoice;
+
+    CharacterPersona(String characterId, String displayName,
+                     String chatSystemPrompt, String summaryVoice) {
+        this.characterId = characterId;
+        this.displayName = displayName;
+        this.chatSystemPrompt = chatSystemPrompt;
+        this.summaryVoice = summaryVoice;
+    }
+
+    public String characterId() {
+        return characterId;
+    }
+
+    public String displayName() {
+        return displayName;
+    }
+
+    /** 대화 응답 생성용 시스템 프롬프트. */
+    public String chatSystemPrompt() {
+        return chatSystemPrompt;
+    }
+
+    /**
+     * 세션 요약 렌더링용 어조 지시.
+     *
+     * <p>대화 프롬프트를 그대로 쓰지 않는 이유는 그쪽이 "응답은 2-4문장" 같은 대화 턴 규칙을
+     * 포함하기 때문이다. 요약은 대화 턴이 아니므로 어조만 가져온다.
+     */
+    public String summaryVoice() {
+        return summaryVoice;
+    }
+
+    /** 알 수 없는 id 는 비어 있는 Optional. 호출측이 {@link #DEFAULT} 로 폴백할지 결정한다. */
+    public static Optional<CharacterPersona> find(String characterId) {
+        if (characterId == null || characterId.isBlank()) {
+            return Optional.empty();
+        }
+        String normalized = characterId.trim().toLowerCase();
+        return Arrays.stream(values())
+                .filter(persona -> persona.characterId.equals(normalized))
+                .findFirst();
+    }
+
+    /** 알 수 없는 id 면 {@link #DEFAULT}. */
+    public static CharacterPersona findOrDefault(String characterId) {
+        return find(characterId).orElse(DEFAULT);
+    }
+
+    public static Set<String> validIds() {
+        return Arrays.stream(values())
+                .map(CharacterPersona::characterId)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+}

--- a/src/main/java/com/mio/character/service/CharacterService.java
+++ b/src/main/java/com/mio/character/service/CharacterService.java
@@ -1,5 +1,6 @@
 package com.mio.character.service;
 
+import com.mio.character.domain.CharacterPersona;
 import com.mio.character.dto.*;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -16,7 +17,10 @@ import java.util.*;
 @RequiredArgsConstructor
 public class CharacterService {
 
-    private static final Set<String> VALID_IDS = Set.of("mio", "bau", "rumi", "momo", "chichi");
+    // 유효 id 는 CharacterPersona 를 단일 출처로 삼는다 (이슈 #339). 캐릭터를 추가할 때
+    // 어조 정의와 허용 목록이 따로 놀지 않게 한다. 아래 카탈로그의 사용자 노출 문구
+    // (설명·태그·인사말)는 표현 층이 아니라 제품 카피라 여기 남겨 둔다.
+    private static final Set<String> VALID_IDS = CharacterPersona.validIds();
 
     // 내부 카탈로그 (character_id → CharacterDto)
     private static final Map<String, CharacterDto> CATALOG_MAP;

--- a/src/main/java/com/mio/session/domain/SessionSummary.java
+++ b/src/main/java/com/mio/session/domain/SessionSummary.java
@@ -33,8 +33,19 @@ public class SessionSummary {
     @Column(name = "character_id", nullable = false)
     private String characterId;
 
+    /**
+     * 내부용 요약. ExtractorLLM 과 Retriever 3종이 읽는 기억 원문이라 분석 시점으로 쓰여 있다.
+     * 사용자에게 그대로 노출하지 않는다 — {@link #userSummaryText} 참조.
+     */
     @Column(name = "summary_text", nullable = false)
     private String summaryText;
+
+    /**
+     * 사용자 노출용 요약 (이슈 #339). 캐릭터 톤의 해요체로 렌더링한 결과.
+     * 렌더링 실패·기존 세션은 null 이며, 조회 시 {@link #summaryText} 로 폴백한다.
+     */
+    @Column(name = "user_summary_text")
+    private String userSummaryText;
 
     /** AES-256 암호화된 요약 원문 */
     @Column(name = "summary_ciphertext")

--- a/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionSummaryResponse.java
@@ -61,7 +61,7 @@ public record SessionSummaryResponse(
                 session.getEndedAt(),
                 session.durationSeconds(),
                 session.getMessageCount(),
-                summary.getSummaryText(),
+                userFacingSummary(summary),
                 summary.getDominantEmotion(),
                 session.getAvgEmotionScore(),
                 summary.getBiasTypesDetected(),
@@ -70,5 +70,16 @@ public record SessionSummaryResponse(
                 summary.getSocraticCount(),
                 todos.stream().map(TodoItem::from).toList()
         );
+    }
+
+    /**
+     * 사용자 노출용 요약을 고른다 (이슈 #339).
+     *
+     * <p>렌더링이 끝난 세션은 캐릭터 톤 요약을, 아직 없는 세션(기존 데이터·렌더링 실패)은
+     * 내부용 요약을 그대로 내보낸다. 톤은 아쉬워도 요약이 사라지는 것보다 낫다.
+     */
+    private static String userFacingSummary(SessionSummary summary) {
+        String rendered = summary.getUserSummaryText();
+        return rendered != null && !rendered.isBlank() ? rendered : summary.getSummaryText();
     }
 }

--- a/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
@@ -2,10 +2,24 @@ package com.mio.session.repository;
 
 import com.mio.session.domain.SessionSummary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface SessionSummaryRepository extends JpaRepository<SessionSummary, UUID> {
     Optional<SessionSummary> findBySession_Id(UUID sessionId);
+
+    /**
+     * 사용자 노출용 요약을 채운다 (이슈 #339).
+     *
+     * <p>요약 본문이 이미 커밋된 뒤 별도 트랜잭션에서 호출되므로 엔티티를 다시 로드하지 않고
+     * 컬럼만 갱신한다.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("UPDATE SessionSummary s SET s.userSummaryText = :userSummaryText WHERE s.session.id = :sessionId")
+    int updateUserSummaryText(@Param("sessionId") UUID sessionId,
+                              @Param("userSummaryText") String userSummaryText);
 }

--- a/src/main/resources/db/migration/V51__add_user_summary_text_to_session_summaries.sql
+++ b/src/main/resources/db/migration/V51__add_user_summary_text_to_session_summaries.sql
@@ -1,0 +1,17 @@
+-- 세션 요약 2트랙 분리 (이슈 #339)
+--
+-- summary_text 는 지금까지 두 역할을 겸했다: ExtractorLLM·Retriever 가 읽는 내부 기억이면서,
+-- 동시에 GET /v1/sessions/{id}/summary 로 사용자에게 그대로 나가는 텍스트였다.
+-- 그래서 프롬프트가 분석가 시점("감지된 인지 왜곡 패턴", "CBT 개입 여부")으로 고정될 수밖에
+-- 없었고, 사용자에게는 임상 케이스 노트처럼 읽혔다.
+--
+-- 사용자 노출용 렌더링 결과를 별도 컬럼으로 분리한다. summary_text 는 그대로 두어
+-- 추출·검색 품질에 회귀가 생기지 않게 한다.
+--
+-- nullable: 기존 row 와 렌더링 실패 세션은 NULL 로 남고, 조회 시 summary_text 로 폴백된다.
+-- 백필하지 않는다 — 과거 세션을 다시 렌더링하려면 세션 수만큼 LLM 비용이 든다.
+ALTER TABLE session_summaries
+    ADD COLUMN user_summary_text TEXT;
+
+COMMENT ON COLUMN session_summaries.user_summary_text IS
+    '사용자 노출용 요약. 캐릭터 톤의 해요체로 렌더링한 결과. NULL 이면 summary_text 로 폴백한다.';

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -50,6 +50,8 @@ class SessionConsolidatorTest {
     private SessionRepository sessionRepository;
     private TodoRecommendationService todoRecommendationService;
     private SummaryStatusWriter summaryStatusWriter;
+    private SessionSummaryRenderer sessionSummaryRenderer;
+    private UserSummaryWriter userSummaryWriter;
     private CrisisEpisodePromoter crisisEpisodePromoter;
     private ObjectProvider<SessionConsolidator> self;
 
@@ -63,6 +65,8 @@ class SessionConsolidatorTest {
         sessionRepository = mock(SessionRepository.class);
         todoRecommendationService = mock(TodoRecommendationService.class);
         summaryStatusWriter = mock(SummaryStatusWriter.class);
+        sessionSummaryRenderer = mock(SessionSummaryRenderer.class);
+        userSummaryWriter = mock(UserSummaryWriter.class);
         crisisEpisodePromoter = mock(CrisisEpisodePromoter.class);
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
@@ -88,6 +92,8 @@ class SessionConsolidatorTest {
                 new ObjectMapper(),
                 mock(OntologyValidator.class),
                 todoRecommendationService,
+                sessionSummaryRenderer,
+                userSummaryWriter,
                 summaryStatusWriter,
                 crisisEpisodePromoter,
                 selfProvider
@@ -130,6 +136,69 @@ class SessionConsolidatorTest {
 
         // 승격 호출이 통째로 빠져도 나머지 단언은 통과한다 — 배선 자체를 고정한다 (이슈 #256).
         verify(crisisEpisodePromoter).promoteIfCrisis(userId, sessionId, "regular");
+    }
+
+    @Test
+    @DisplayName("사용자 노출용 요약은 내부 요약과 세션 캐릭터로 렌더링해 저장한다")
+    void onSessionEnded_persistsRenderedUserSummary() {
+        SessionConsolidator consolidator = newConsolidator();
+        SessionConsolidator proxy = mock(SessionConsolidator.class);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
+                userId, sessionId, List.of(), null, List.of(), List.of(), "내부 요약", "regular");
+        when(self.getObject()).thenReturn(proxy);
+        when(proxy.consolidate(sessionId, userId, "chichi", 2)).thenReturn(input);
+        when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
+        when(sessionSummaryRenderer.render("내부 요약", "chichi")).thenReturn("오늘 이야기 정리해봤어요.");
+
+        consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "chichi", 2));
+
+        verify(sessionSummaryRenderer).render("내부 요약", "chichi");
+        verify(userSummaryWriter).write(sessionId, "오늘 이야기 정리해봤어요.");
+        verify(summaryStatusWriter).markDone(sessionId);
+    }
+
+    @Test
+    @DisplayName("렌더링이 계약 위반으로 비면 저장을 건너뛰고 요약은 그대로 노출한다")
+    void onSessionEnded_whenRenderReturnsNull_skipsWriteButKeepsSummary() {
+        SessionConsolidator consolidator = newConsolidator();
+        SessionConsolidator proxy = mock(SessionConsolidator.class);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
+                userId, sessionId, List.of(), null, List.of(), List.of(), "내부 요약", "regular");
+        when(self.getObject()).thenReturn(proxy);
+        when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
+        when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
+        when(sessionSummaryRenderer.render(any(), any())).thenReturn(null);
+
+        consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2));
+
+        verifyNoInteractions(userSummaryWriter);
+        verify(summaryStatusWriter).markDone(sessionId);
+        verify(summaryStatusWriter, never()).markFailed(sessionId);
+    }
+
+    @Test
+    @DisplayName("렌더링이 예외로 죽어도 요약과 Todo 흐름은 그대로 완료된다")
+    void onSessionEnded_whenRenderThrows_summaryStillCompletes() {
+        SessionConsolidator consolidator = newConsolidator();
+        SessionConsolidator proxy = mock(SessionConsolidator.class);
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        SessionConsolidator.EnrichmentInput input = new SessionConsolidator.EnrichmentInput(
+                userId, sessionId, List.of(), null, List.of(), List.of(), "내부 요약", "regular");
+        when(self.getObject()).thenReturn(proxy);
+        when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
+        when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
+        when(sessionSummaryRenderer.render(any(), any())).thenThrow(new RuntimeException("LLM down"));
+
+        assertThatCode(() -> consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2)))
+                .doesNotThrowAnyException();
+
+        verify(summaryStatusWriter).markDone(sessionId);
+        verify(summaryStatusWriter, never()).markFailed(sessionId);
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
@@ -3,6 +3,7 @@ package com.mio.ai.memory.consolidation;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.LlmUsage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -81,7 +82,12 @@ class SessionSummaryRendererTest {
             // 사용자 단정
             "발표 걱정을 나눴어요. 당신은 완벽주의 성격이에요.",
             // 해요체 아님 — 분석 보고 문체
-            "사용자가 발표 불안을 이야기했으며 파국화 패턴이 관찰되었다."
+            "사용자가 발표 불안을 이야기했으며 파국화 패턴이 관찰되었다.",
+            // 3인칭 — 조사가 달라도 걸려야 한다
+            "오늘 세션에서 사용자를 격려했어요.",
+            "이용자와 함께 확률을 따져봤어요.",
+            // 진단명 — 대문자 표기도 걸려야 한다
+            "요즘 집중이 어려워 보여요. ADHD 증상 같아요."
     })
     @DisplayName("계약을 위반한 렌더링 결과는 null을 반환해 내부 요약으로 폴백시킨다")
     void returnsNullOnContractViolation(String violating) {
@@ -115,6 +121,15 @@ class SessionSummaryRendererTest {
     }
 
     @Test
+    @DisplayName("출력이 토큰 상한에 걸려 잘리면 null을 반환한다")
+    void returnsNullWhenTruncated() {
+        // 계약 검사를 통과하는 문장이라도 잘렸으면 정본으로 저장하지 않는다.
+        stubLlm("오늘은 발표 걱정을 많이 이야기했어요. 확률을 같이 따져봤어요.", true);
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+    }
+
+    @Test
     @DisplayName("내부 요약이 비면 LLM을 호출하지 않는다")
     void skipsWhenInternalSummaryBlank() {
         assertThat(renderer.render("  ", "mio")).isNull();
@@ -126,10 +141,14 @@ class SessionSummaryRendererTest {
     // ── helpers ──────────────────────────────────────────────
 
     private void stubLlm(String response) {
+        stubLlm(response, false);
+    }
+
+    private void stubLlm(String response, boolean truncated) {
         doAnswer(invocation -> {
             Consumer<String> sink = invocation.getArgument(1);
             sink.accept(response);
-            return mock(LlmStreamResult.class);
+            return new LlmStreamResult(1L, LlmUsage.unresolved("test"), truncated);
         }).when(llmClient).stream(any(LlmRequest.class), any());
     }
 

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
@@ -1,0 +1,145 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+class SessionSummaryRendererTest {
+
+    private static final String INTERNAL_SUMMARY =
+            "사용자는 발표에 대한 불안을 이야기했다. 파국화 패턴이 감지되었으며, "
+                    + "확률 추정을 통한 인지 재구성 개입에 부분적으로 반응했다.";
+
+    private LlmClient llmClient;
+    private SessionSummaryRenderer renderer;
+
+    @BeforeEach
+    void setUp() {
+        llmClient = mock(LlmClient.class);
+        renderer = new SessionSummaryRenderer(llmClient);
+    }
+
+    @Test
+    @DisplayName("계약을 지킨 렌더링 결과는 그대로 반환된다")
+    void returnsRenderedSummary() {
+        String rendered = "오늘은 발표 걱정을 많이 이야기했어요. "
+                + "최악의 장면부터 떠올리는 마음이 보였는데, 실제 확률을 같이 따져보면서 조금 가벼워졌어요.";
+        stubLlm(rendered);
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isEqualTo(rendered);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "mio, 미오", "bau, 바우", "rumi, 루미", "momo, 모모", "chichi, 치치"
+    })
+    @DisplayName("캐릭터별 이름과 어조가 시스템 프롬프트에 반영된다")
+    void injectsCharacterVoiceIntoPrompt(String characterId, String displayName) {
+        stubLlm("오늘 이야기 나눈 걸 정리해봤어요. 마음이 조금 정리된 것 같아요.");
+
+        renderer.render(INTERNAL_SUMMARY, characterId);
+
+        assertThat(capturedSystemPrompt()).contains("당신은 " + displayName + "입니다");
+    }
+
+    @Test
+    @DisplayName("알 수 없는 캐릭터 id는 기본 캐릭터 어조로 렌더링된다")
+    void fallsBackToDefaultPersona() {
+        stubLlm("오늘 이야기 나눈 걸 정리해봤어요. 마음이 조금 정리된 것 같아요.");
+
+        renderer.render(INTERNAL_SUMMARY, "unknown-character");
+
+        assertThat(capturedSystemPrompt()).contains("당신은 미오입니다");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            // 3인칭 케이스 노트 — 이 이슈가 잡으려는 바로 그 톤
+            "사용자는 발표 불안을 호소했어요. 파국화 패턴이 관찰되었어요.",
+            "내담자의 인지 재구성 반응이 부분적이었어요.",
+            // 진단명 귀속
+            "요즘 마음이 많이 무거워 보여요. 불안장애 초기 증상 같아요.",
+            // 결과 보장
+            "오늘 이야기 잘 나눴어요. 앞으로 반드시 좋아질 거예요.",
+            // 사용자 단정
+            "발표 걱정을 나눴어요. 당신은 완벽주의 성격이에요.",
+            // 해요체 아님 — 분석 보고 문체
+            "사용자가 발표 불안을 이야기했으며 파국화 패턴이 관찰되었다."
+    })
+    @DisplayName("계약을 위반한 렌더링 결과는 null을 반환해 내부 요약으로 폴백시킨다")
+    void returnsNullOnContractViolation(String violating) {
+        stubLlm(violating);
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+    }
+
+    @Test
+    @DisplayName("문장 수 상한을 넘으면 null을 반환한다")
+    void returnsNullWhenTooManySentences() {
+        stubLlm("오늘 이야기했어요. 걱정이 많았어요. 확률을 따져봤어요. 조금 가벼워졌어요.");
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+    }
+
+    @Test
+    @DisplayName("길이 상한을 넘으면 null을 반환한다")
+    void returnsNullWhenTooLong() {
+        stubLlm("오늘은 발표 걱정을 아주 많이 이야기했어요 ".repeat(12) + "그래서 조금 가벼워졌어요.");
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+    }
+
+    @Test
+    @DisplayName("LLM 호출이 실패하면 null을 반환하고 예외를 전파하지 않는다")
+    void returnsNullOnLlmFailure() {
+        doThrow(new RuntimeException("LLM down")).when(llmClient).stream(any(LlmRequest.class), any());
+
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+    }
+
+    @Test
+    @DisplayName("내부 요약이 비면 LLM을 호출하지 않는다")
+    void skipsWhenInternalSummaryBlank() {
+        assertThat(renderer.render("  ", "mio")).isNull();
+        assertThat(renderer.render(null, "mio")).isNull();
+
+        verify(llmClient, never()).stream(any(LlmRequest.class), any());
+    }
+
+    // ── helpers ──────────────────────────────────────────────
+
+    private void stubLlm(String response) {
+        doAnswer(invocation -> {
+            Consumer<String> sink = invocation.getArgument(1);
+            sink.accept(response);
+            return mock(LlmStreamResult.class);
+        }).when(llmClient).stream(any(LlmRequest.class), any());
+    }
+
+    private String capturedSystemPrompt() {
+        ArgumentCaptor<LlmRequest> captor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmClient).stream(captor.capture(), any());
+        return captor.getValue().messages().stream()
+                .filter(m -> "system".equals(m.role()))
+                .map(LlmRequest.Message::content)
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/com/mio/character/domain/CharacterPersonaTest.java
+++ b/src/test/java/com/mio/character/domain/CharacterPersonaTest.java
@@ -1,0 +1,54 @@
+package com.mio.character.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CharacterPersonaTest {
+
+    @ParameterizedTest
+    @EnumSource(CharacterPersona.class)
+    @DisplayName("모든 캐릭터가 대화 프롬프트와 요약 어조를 모두 정의한다")
+    void everyPersonaDefinesBothVoices(CharacterPersona persona) {
+        assertThat(persona.characterId()).isNotBlank();
+        assertThat(persona.displayName()).isNotBlank();
+        assertThat(persona.chatSystemPrompt()).contains("당신은 " + persona.displayName() + "입니다");
+        assertThat(persona.summaryVoice()).isNotBlank();
+    }
+
+    @ParameterizedTest
+    @EnumSource(CharacterPersona.class)
+    @DisplayName("요약 어조에는 대화 턴 전용 규칙이 섞이지 않는다")
+    void summaryVoiceHasNoChatTurnRules(CharacterPersona persona) {
+        // "응답은 2-4문장" 같은 대화 턴 규칙이 요약 어조에 새면 요약 길이 계약과 충돌한다.
+        assertThat(persona.summaryVoice()).doesNotContain("응답은");
+    }
+
+    @Test
+    @DisplayName("id로 캐릭터를 찾고, 대소문자·공백은 정규화한다")
+    void findNormalizesInput() {
+        assertThat(CharacterPersona.find("chichi")).contains(CharacterPersona.CHICHI);
+        assertThat(CharacterPersona.find("  CHICHI  ")).contains(CharacterPersona.CHICHI);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "unknown", "MIO2"})
+    @DisplayName("알 수 없는 id는 비어 있는 Optional, findOrDefault는 기본 캐릭터")
+    void unknownIdFallsBackToDefault(String characterId) {
+        assertThat(CharacterPersona.find(characterId)).isEmpty();
+        assertThat(CharacterPersona.findOrDefault(characterId)).isEqualTo(CharacterPersona.DEFAULT);
+    }
+
+    @Test
+    @DisplayName("validIds는 정의된 캐릭터 전체를 반환한다")
+    void validIdsCoversAllPersonas() {
+        assertThat(CharacterPersona.validIds())
+                .containsExactlyInAnyOrder("mio", "bau", "rumi", "momo", "chichi");
+    }
+}

--- a/src/test/java/com/mio/session/dto/SessionSummaryResponseTest.java
+++ b/src/test/java/com/mio/session/dto/SessionSummaryResponseTest.java
@@ -1,0 +1,55 @@
+package com.mio.session.dto;
+
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SessionSummary;
+import com.mio.session.domain.SummaryStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SessionSummaryResponseTest {
+
+    private static final String INTERNAL = "사용자는 발표 불안을 이야기했다. 파국화 패턴이 감지되었다.";
+    private static final String RENDERED = "오늘은 발표 걱정을 많이 이야기했어요.";
+
+    @Test
+    @DisplayName("렌더링된 사용자 요약이 있으면 그것을 노출한다")
+    void prefersRenderedUserSummary() {
+        var response = SessionSummaryResponse.from(session(), summary(RENDERED), List.of());
+
+        assertThat(response.summary()).isEqualTo(RENDERED);
+    }
+
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    @DisplayName("렌더링된 요약이 없으면 내부 요약으로 폴백한다")
+    void fallsBackToInternalSummary(String userSummaryText) {
+        var response = SessionSummaryResponse.from(session(), summary(userSummaryText), List.of());
+
+        assertThat(response.summary()).isEqualTo(INTERNAL);
+    }
+
+    // ── helpers ──────────────────────────────────────────────
+
+    private Session session() {
+        Session session = mock(Session.class);
+        when(session.getSummaryStatus()).thenReturn(SummaryStatus.VIEWED);
+        return session;
+    }
+
+    private SessionSummary summary(String userSummaryText) {
+        SessionSummary summary = mock(SessionSummary.class);
+        when(summary.getSummaryText()).thenReturn(INTERNAL);
+        when(summary.getUserSummaryText()).thenReturn(userSummaryText);
+        return summary;
+    }
+}


### PR DESCRIPTION
## 요약
세션 요약이 "상담사가 상급자에게 보고하는" 임상 케이스 노트처럼 읽힌다는 QA 문의가 있었다. 원인은 **사용자에게 보여주는 요약과 AI 가 내부적으로 쓰는 요약이 같은 텍스트 한 벌**이라는 것이다.

```
현행 프롬프트: "당신은 CBT 코칭 세션 분석 전문가입니다"
              "- 감지된 인지 왜곡 패턴 / CBT 개입 여부 및 사용자 반응"
→ 3인칭 분석 문체가 나올 수밖에 없고, 그게 그대로 API 응답으로 나간다
```

**프롬프트만 바꿀 수는 없다.** 같은 `summary_text` 를 `ExtractorLlmClient` 가 읽어 사고·감정·`episodeType` 을 뽑고, `LexicalRetriever`/`VectorRetriever`/`StructuredRetriever` 가 다음 세션 프롬프트에 주입한다. 톤을 사용자향으로 바꾸면 추출 품질과 기억 검색 품질이 함께 떨어진다.

## 관련 이슈
- Closes #339

## 설계

```
대화 → [내부 요약]  summary_text        (프롬프트 변경 없음)
              ├──→ ExtractorLLM / Retriever 3종  ← 추출·검색 회귀 없음
              └──→ [렌더링] user_summary_text    ← 캐릭터 톤, 해요체, 2~3문장
                            └──→ API 응답: user_summary_text ?? summary_text
```

캐릭터 적용 범위는 문서상 원칙을 그대로 따른다 (`docs/피치덱_QA/03_AI_파이프라인.md`):
> 캐릭터가 바뀌는 건 "말투와 접근 방식"이지 "안전 기준"이 아니다 — 이 분리가 원칙적으로 중요하다.

즉 요약의 **사실은 캐릭터 무관 트랙**에 두고, **표현만** 캐릭터를 타게 한다. 어미는 해요체로 통일해 API 명세 예시와 일치시키고 요약 화면을 대화창과 구분한다.

```
■ 미오(펭귄, 따뜻·공감)
오늘은 발표 걱정을 많이 이야기했어요. 최악의 장면부터 떠올리는 마음이
보였는데, 실제로 그럴 확률을 같이 따져보면서 조금 가벼워졌어요.

■ 치치(고양이, 현실·직접)
발표 이야기에서 최악의 결과부터 떠올리고 있었어요. 그 확률을 실제로
따져보니 생각만큼 높지 않다는 게 나왔어요.
```

## 변경 사항
- `session_summaries.user_summary_text` 컬럼 추가 (V51, nullable, **백필 없음**)
- `CharacterPersona` enum 신규 — 캐릭터 어조의 단일 출처. `PromptBuilder.CHARACTER_BASE_PROMPTS` 를 이리로 옮기고, `CharacterService.VALID_IDS` 도 여기서 파생
- `SessionSummaryRenderer` 신규 — 내부 요약 + `characterId` → 사용자향 요약. 결정론적 계약 검사 포함
- `UserSummaryWriter` 신규 — REQUIRES_NEW 짧은 쓰기
- `SessionConsolidator` — 렌더링을 `consolidate()` 트랜잭션 **밖**에서 호출
- `SessionSummaryResponse.from` — `user_summary_text ?? summary_text` 폴백

## 설계 의도

**왜 렌더링이 트랜잭션 밖인가.** 블로킹 LLM 호출을 `consolidate()`(REQUIRES_NEW) 안에서 하면 HTTP 대기 동안 DB 커넥션을 점유한다. #228 에서 Todo 개인화를 트랜잭션 밖으로 뺀 것과 같은 이유다.

**왜 실패해도 진행하는가.** 렌더링 실패 시 `user_summary_text` 를 NULL 로 두고 그냥 진행한다. `summary_status` 는 건드리지 않는다. 톤이 아쉬운 요약이 **요약이 사라지는 것**보다 낫다 — 사용자 노출 산출물을 후속 단계 실패로 잃지 않게 하는 #219 의 원칙을 그대로 따른다.

**왜 어조 정의를 enum 하나로 모으는가.** 대화 응답과 세션 요약이 같은 캐릭터를 서로 다르게 해석하면 사용자에겐 다른 인격으로 보인다. `summaryVoice` 는 `chatSystemPrompt` 와 분리했는데, 대화 프롬프트에는 "응답은 2-4문장" 같은 **대화 턴 전용 규칙**이 섞여 있어 요약 길이 계약과 충돌하기 때문이다 (테스트로 고정).

**계약 검사는 왜 별도 클래스인가.** `ai.plan.ResponseContractValidator` 와 목적은 같지만 검사 대상이 다르다 — 그쪽은 대화 턴(질문 수·문장 수), 여기는 요약 한 덩어리(3인칭 표현·해요체 종결). 한 클래스로 합치면 어느 쪽 규칙인지 읽히지 않아 분리했다.

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. — `GET /v1/sessions/{id}/summary` 의 `summary` **문체 변경**. 필드·타입은 그대로
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. — `session_summaries.user_summary_text` 추가 (nullable, 백필 없음)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `SessionConsolidator` 에 gpt-4o-mini 호출 1회 추가 (세션당)
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

> ⚠️ **API 명세 문서 반영 필요** — 이 저장소는 `docs/` 를 `.gitignore` 하고 있어 `api 명세서/04_Session_Message_세션_메시지.md` 의 `summary` 필드 설명을 PR 에 담지 못했다. 로컬에는 반영해 두었으니 공유 문서를 쓰는 쪽에서 별도 반영이 필요하다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- 전체 900건 통과, 실패 0건
- `SessionSummaryRendererTest` 16건
  - 캐릭터 5종 각각의 이름·어조가 시스템 프롬프트에 주입되는지
  - 알 수 없는 캐릭터 id → 기본 캐릭터 폴백
  - **계약 위반 6종 → null 반환(내부 요약 폴백)** — 3인칭("사용자는"/"내담자"), 진단명 귀속, 결과 보장, 사용자 단정, 해요체 아닌 분석 문체
  - 문장 수·길이 상한 초과 → null
  - LLM 예외 → null, 예외 미전파
  - 내부 요약이 비면 LLM 미호출
- `SessionConsolidatorTest` +3건 — 렌더링 결과 저장, **렌더링이 null 이어도 `markDone` 진행**, **렌더링이 예외로 죽어도 요약·Todo 흐름 완료**
- `SessionSummaryResponseTest` 4건 — 렌더링 요약 우선, null/빈 문자열/공백일 때 내부 요약 폴백
- `CharacterPersonaTest` 13건 — 전 캐릭터가 두 어조를 모두 정의, **요약 어조에 대화 턴 규칙이 새지 않음**, id 정규화, 미지 id 폴백
- 기존 `SessionConsolidatorTest` 회귀 — Todo 0건 시 `markFailed` 전환은 그대로

## 중점 리뷰 포인트
- **`SessionSummaryRenderer.FORBIDDEN_PATTERNS` 의 `third_person` 규칙** — `"사용자(는|가|의|에게)"` 를 막는다. 요약이 3인칭 케이스 노트로 읽히는 것이 이 이슈의 출발점이라 넣었는데, 정상 문장에서 걸릴 여지가 있는지 봐 주면 좋겠다. 걸리면 내부 요약으로 폴백하므로 안전 방향이긴 하다
- **`POLITE_ENDING` 판정** — 마지막 문장 어미만 본다. 중간 문장이 다른 문체여도 통과한다. 실제 출력을 보고 조일지 판단할 부분
- **캐릭터 정의의 남은 중복** — `CharacterService.CATALOG_MAP`/`GREETINGS` 의 사용자 노출 문구(설명·태그·인사말)는 표현 층이 아니라 제품 카피라 이번에 옮기지 않았다. 합치는 게 맞다고 보면 별도 이슈로 뺄 수 있다
- `summary_text` 를 읽는 경로(ExtractorLLM, Retriever 3종)는 **한 줄도 건드리지 않았다** — 추출·검색 회귀가 없는지 이 관점에서 확인 부탁

## 배포 / 롤백
- Rollout: V51 마이그레이션 적용 후 배포. 백필이 없어 다운타임 없음. 신규 세션부터 캐릭터 톤 요약이 나가고, 기존 세션은 기존 요약을 그대로 노출
- Rollback: 이전 버전 배포로 즉시 복구. `user_summary_text` 컬럼은 nullable 이고 조회측 폴백이 있어 남아 있어도 무해하므로 마이그레이션 되돌림 불필요

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 마이그레이션 반영 완료. API 명세는 `docs/` 가 gitignore 대상이라 위에 별도 표기
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.