### PR TITLE
fix: X-Device-Id 헤더 누락 시 500 대신 400 반환 (#348)

### DIFF
--- a/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -49,6 +50,19 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
         log.warn("ValidationException: {}", message);
         return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message, getTraceId(request)));
+    }
+
+    /**
+     * 이슈 #348 — MissingRequestHeaderException(예: X-Device-Id 누락)은 이 타입의 하위
+     * 클래스다. 핸들러가 없으면 아래 Exception.class 폴백으로 떨어져 클라이언트 오류가
+     * 500으로 보고되고 5xx 알람이 오염된다.
+     */
+    @ExceptionHandler(ServletRequestBindingException.class)
+    public ResponseEntity<ErrorResponse> handleServletRequestBindingException(
+            ServletRequestBindingException e, HttpServletRequest request) {
+        log.warn("ServletRequestBindingException: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage(), getTraceId(request)));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -45,5 +47,25 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
         assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isNull();
+    }
+
+    @Test
+    @DisplayName("이슈 #348 — X-Device-Id 같은 필수 헤더 누락은 500이 아니라 400을 반환한다")
+    void handleServletRequestBindingException_missingHeader_returns400() throws NoSuchMethodException {
+        when(request.getAttribute("traceId")).thenReturn("trace-3");
+        MethodParameter parameter = new MethodParameter(
+                GlobalExceptionHandlerTest.class.getDeclaredMethod("dummyEndpoint", String.class), 0);
+        MissingRequestHeaderException exception = new MissingRequestHeaderException("X-Device-Id", parameter);
+
+        ResponseEntity<ErrorResponse> response =
+                handler.handleServletRequestBindingException(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().error().code()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(response.getBody().error().traceId()).isEqualTo("trace-3");
+    }
+
+    @SuppressWarnings("unused")
+    private void dummyEndpoint(String deviceId) {
     }
 }


### PR DESCRIPTION
## 요약
`X-Device-Id` 헤더 누락 시 500이 아닌 400을 반환하도록 전역 예외 핸들러를 보강한다.

## 관련 이슈
- Closes #348

## 변경 사항
- `GlobalExceptionHandler`에 `ServletRequestBindingException` 핸들러 추가 (`400 INVALID_INPUT`)
- `MissingRequestHeaderException`은 이 타입의 하위 클래스라 `X-Device-Id`뿐 아니라 향후 다른 필수 헤더 누락에도 동일하게 적용됨
- 테스트 추가: 헤더 누락 시 400 반환 검증

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test --tests "com.mio.common.error.GlobalExceptionHandlerTest"`
### 확인 내용
`X-Device-Id` 누락 요청이 500이 아닌 400을 반환하는지, 기존 RateLimitExceededException·BusinessException 핸들러 동작에 회귀가 없는지 확인

## 중점 리뷰 포인트
`ServletRequestBindingException`이 `MissingRequestHeaderException`의 상위 타입이 맞는지, 다른 곳에서 이 예외를 더 구체적으로 잡고 있는 핸들러가 없는지

## 배포 / 롤백
- Rollout: 일반 배포, 별도 절차 없음
- Rollback: 이전 이미지로 롤백하면 500 반환 동작으로 복귀 (기능 영향 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Missing required request headers and other request-binding errors now return a clear HTTP 400 response instead of an internal server error.
  * Error responses include an `INVALID_INPUT` status, the relevant message, and the request trace ID.
* **Tests**
  * Added coverage to verify the updated handling of missing request headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->