### PR TITLE
fix: employment_status 3종 불일치로 인한 이벤트 드롭 및 가입 400 회귀 수정 (#347)

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -34,7 +34,9 @@ public class AuthService {
 
     // #320 — 이벤트 화이트리스트(event-whitelist.yml)에만 enum 검증을 걸면 DB엔 오염값이
     // 남아 나중에 백필이 불가능하다. 코호트 축이라 여기서도 막는다. 선택 필드라 null/blank는 통과.
-    private static final Set<String> VALID_EMPLOYMENT_STATUSES = Set.of("job_seeker", "employed");
+    // package-private — #347 EmploymentStatusConsistencyTest가 event-whitelist.yml과 대조한다.
+    static final Set<String> VALID_EMPLOYMENT_STATUSES =
+            Set.of("student_or_unemployed", "job_seeker", "employed");
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;

--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -32,7 +32,7 @@ events:
   profile_submitted:
     age_range: {enum: ["10대", "20대", "30대", "40대+"]}
     gender: {enum: [male, female, other]}
-    employment_status: {enum: [job_seeker, employed]}
+    employment_status: {enum: [student_or_unemployed, job_seeker, employed]}
   signup_completed: {}
   onboarding_step_completed:
     step: {type: int}

--- a/src/test/java/com/mio/auth/service/EmploymentStatusConsistencyTest.java
+++ b/src/test/java/com/mio/auth/service/EmploymentStatusConsistencyTest.java
@@ -1,0 +1,44 @@
+package com.mio.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 이슈 #347 — event-whitelist.yml의 employment_status enum과
+ * AuthService.VALID_EMPLOYMENT_STATUSES는 물리적으로 다른 곳에 있어 값 집합이 조용히
+ * 갈라질 수 있다(#330 CI는 property 키만 비교하고 enum 값은 비교하지 않는다). 두 값 집합이
+ * 항상 일치하는지 여기서 강제한다.
+ */
+class EmploymentStatusConsistencyTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void whitelistAndAuthService_haveSameEmploymentStatusValues() throws Exception {
+        Yaml yaml = new Yaml();
+        Map<String, Object> events;
+        try (InputStream in = new ClassPathResource("event-whitelist.yml").getInputStream()) {
+            Map<String, Object> root = yaml.load(in);
+            events = (Map<String, Object>) root.get("events");
+        }
+
+        Map<String, Object> profileSubmitted = (Map<String, Object>) events.get("profile_submitted");
+        Map<String, Object> employmentStatusSpec = (Map<String, Object>) profileSubmitted.get("employment_status");
+        Set<String> whitelistValues = new TreeSet<>((List<String>) employmentStatusSpec.get("enum"));
+
+        assertThat(new TreeSet<>(AuthService.VALID_EMPLOYMENT_STATUSES))
+                .as("event-whitelist.yml의 employment_status enum(%s)과 "
+                        + "AuthService.VALID_EMPLOYMENT_STATUSES(%s)가 다르다 — 한쪽만 고치면 "
+                        + "이벤트 property 드롭 또는 가입 API 400 회귀가 생긴다",
+                        whitelistValues, AuthService.VALID_EMPLOYMENT_STATUSES)
+                .isEqualTo(whitelistValues);
+    }
+}


### PR DESCRIPTION
## 요약
`employment_status`의 서버 측 허용 값 집합을 앱과 동일한 3종으로 맞추고, 두 값 집합이 다시 갈라지는 것을 CI에서 감지하는 테스트를 추가한다.

## 관련 이슈
- Closes #347

## 변경 사항
- `event-whitelist.yml`의 `employment_status` enum에 `student_or_unemployed` 추가
- `AuthService.VALID_EMPLOYMENT_STATUSES`에 `student_or_unemployed` 추가 (package-private로 완화해 테스트에서 참조)
- `EmploymentStatusConsistencyTest` 신설 — `event-whitelist.yml`과 `AuthService`의 값 집합이 항상 일치하는지 검증. 기존 `#330` CI(`EventCatalogConsistencyTest`)는 property 키만 비교하고 enum 값은 비교하지 않아 이 드리프트를 못 잡았음

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test --tests "com.mio.auth.service.*" --tests "com.mio.events.config.EventCatalogConsistencyTest"`
### 확인 내용
`employment_status=student_or_unemployed`로 프로필 제출 시 400이 더 이상 발생하지 않는지, 이벤트 로그에서 `journey_property_invalid` 경고가 사라지는지, 두 값 집합 drift 감지 테스트가 통과하는지

## 중점 리뷰 포인트
`AuthService.VALID_EMPLOYMENT_STATUSES` 접근 제한자를 `private`에서 package-private으로 완화한 것이 괜찮은지 (테스트 전용 목적)

## 배포 / 롤백
- Rollout: 일반 배포. 배포 순서상 BE가 앱 빌드보다 먼저 나가야 함(반대 순서면 가입 400이 실사용자에게 계속 노출됨)
- Rollback: 이전 이미지로 롤백하면 `student_or_unemployed` 선택 시 다시 400/드롭 발생 — 기존 데이터에는 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
