### PR TITLE
feat: 검증 기기 이벤트를 anonymous_id 기반으로 격리 (#353)

### DIFF
--- a/src/main/java/com/mio/events/config/EventSchemaProperties.java
+++ b/src/main/java/com/mio/events/config/EventSchemaProperties.java
@@ -18,4 +18,7 @@ import java.util.List;
 public class EventSchemaProperties {
 
     private List<Integer> acceptedSchemaVersions = List.of(3);
+
+    // 이슈 #353 — 검증 기기 격리. 비어 있으면(기본값) 전부 journey-events로 간다.
+    private List<String> internalAnonymousIds = List.of();
 }

--- a/src/main/java/com/mio/events/service/EventLogWriter.java
+++ b/src/main/java/com/mio/events/service/EventLogWriter.java
@@ -2,6 +2,7 @@ package com.mio.events.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventSchemaProperties;
 import com.mio.events.config.EventWhitelist;
 import com.mio.events.dto.EventEnvelope;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,10 @@ public class EventLogWriter {
 
     private static final Logger JOURNEY_LOG = LoggerFactory.getLogger("journey-events");
     private static final Logger JOURNEY_REJECTED_LOG = LoggerFactory.getLogger("journey-events-rejected");
+    private static final Logger JOURNEY_INTERNAL_LOG = LoggerFactory.getLogger("journey-events-internal");
 
     private final EventWhitelist eventWhitelist;
+    private final EventSchemaProperties eventSchemaProperties;
     private final ObjectMapper objectMapper;
 
     public void write(EventEnvelope event, String requestId) {
@@ -64,8 +67,13 @@ public class EventLogWriter {
         line.put("os_version", event.osVersion());
         line.put("properties", filteredProperties);
 
+        // 이슈 #353 — 검증 기기 트래픽은 버리지 않되 실사용자 지표 집계와 물리적으로 분리한다.
+        Logger destination = eventSchemaProperties.getInternalAnonymousIds().contains(event.anonymousId())
+                ? JOURNEY_INTERNAL_LOG
+                : JOURNEY_LOG;
+
         try {
-            JOURNEY_LOG.info(objectMapper.writeValueAsString(line));
+            destination.info(objectMapper.writeValueAsString(line));
         } catch (JsonProcessingException e) {
             // 이벤트 로그 기록 실패는 통계적 손실일 뿐 — 요청 자체를 막지 않는다 (감사로그와 다른 성격)
             log.error("Failed to serialize journey event: event_id={}", event.eventId(), e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,3 +148,9 @@ events:
   # 이슈 #322 — 앱 버전 혼재 시 구버전이 영구 소실되는 걸 막기 위해 거부가 아니라
   # 통과+태깅으로 처리한다. 명세 개정 시 [3, 4]로 잠시 병행한다.
   accepted-schema-versions: [3]
+  # 이슈 #353 — 검증 기기 anonymous_id 목록. 여기 등록된 값은 journey-events가 아니라
+  # journey-events-internal로 격리된다(실사용자 지표 오염 방지). 빈 목록이면 기존과 동일하게
+  # 전부 journey-events로 간다 — 실제 검증 기기 값은 필요할 때 채운다.
+  internal-anonymous-ids: []
+  # journey-events-internal 전용 로그 파일 경로. journey-events/-rejected와 물리적으로 분리한다.
+  internal-log-file-path: ${EVENTS_INTERNAL_LOG_FILE_PATH:./logs/journey-events-internal.jsonl}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -54,6 +54,30 @@
         <appender-ref ref="JOURNEY_EVENTS_REJECTED"/>
     </logger>
 
+    <!--
+        이슈 #353: 검증 기기(events.internal-anonymous-ids) 이벤트를 journey-events와
+        물리적으로 분리한다 — 실사용자 지표 집계 파이프라인에 검증 트래픽이 섞여 들어가지
+        않게 한다. journey-events-rejected와 같은 패턴.
+    -->
+    <springProperty scope="context" name="journeyEventsInternalLogFile"
+                     source="events.internal-log-file-path" defaultValue="./logs/journey-events-internal.jsonl"/>
+
+    <appender name="JOURNEY_EVENTS_INTERNAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${journeyEventsInternalLogFile}</file>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${journeyEventsInternalLogFile}.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="journey-events-internal" level="INFO" additivity="false">
+        <appender-ref ref="JOURNEY_EVENTS_INTERNAL"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/src/test/java/com/mio/events/service/EventLogWriterTest.java
+++ b/src/test/java/com/mio/events/service/EventLogWriterTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventSchemaProperties;
 import com.mio.events.config.EventWhitelist;
 import com.mio.events.dto.EventEnvelope;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,18 +28,22 @@ class EventLogWriterTest {
 
     @Mock private EventWhitelist eventWhitelist;
 
+    private EventSchemaProperties eventSchemaProperties;
     private EventLogWriter eventLogWriter;
     private ListAppender<ILoggingEvent> journeyAppender;
     private ListAppender<ILoggingEvent> rejectedAppender;
+    private ListAppender<ILoggingEvent> internalAppender;
     private ListAppender<ILoggingEvent> classAppender;
 
     private static final String VALID_TS = "2026-08-06T21:13:02+09:00";
 
     @BeforeEach
     void setUp() {
-        eventLogWriter = new EventLogWriter(eventWhitelist, new ObjectMapper());
+        eventSchemaProperties = new EventSchemaProperties();
+        eventLogWriter = new EventLogWriter(eventWhitelist, eventSchemaProperties, new ObjectMapper());
         journeyAppender = attach("journey-events");
         rejectedAppender = attach("journey-events-rejected");
+        internalAppender = attach("journey-events-internal");
         classAppender = attach(EventLogWriter.class.getName());
     }
 
@@ -45,6 +51,7 @@ class EventLogWriterTest {
     void tearDown() {
         detach("journey-events", journeyAppender);
         detach("journey-events-rejected", rejectedAppender);
+        detach("journey-events-internal", internalAppender);
         detach(EventLogWriter.class.getName(), classAppender);
     }
 
@@ -61,8 +68,12 @@ class EventLogWriterTest {
     }
 
     private EventEnvelope event(Map<String, Object> properties) {
+        return event(properties, "anon-1");
+    }
+
+    private EventEnvelope event(Map<String, Object> properties, String anonymousId) {
         return new EventEnvelope("e1", "chat_message_sent", 3, VALID_TS,
-                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", properties);
+                anonymousId, "user-1", "session-1", "1.0.0", "ios", "17.0", properties);
     }
 
     @Test
@@ -119,5 +130,26 @@ class EventLogWriterTest {
         assertThat(message).contains("\"reject_reason\":\"UNKNOWN_EVENT_NAME\"");
         assertThat(message).contains("\"event_id\":\"e1\"");
         assertThat(journeyAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("#353 — internal-anonymous-ids에 등록된 anonymous_id는 journey-events-internal로 간다")
+    void write_internalAnonymousId_routesToInternalLogger() {
+        eventSchemaProperties.setInternalAnonymousIds(List.of("dev-device-1"));
+
+        eventLogWriter.write(event(Map.of(), "dev-device-1"), "req-1");
+
+        assertThat(internalAppender.list).hasSize(1);
+        assertThat(internalAppender.list.get(0).getFormattedMessage()).contains("\"anonymous_id\":\"dev-device-1\"");
+        assertThat(journeyAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("#353 — 목록이 비어 있으면(기본값) 기존과 동일하게 journey-events로 간다")
+    void write_emptyInternalList_routesToJourneyLogger() {
+        eventLogWriter.write(event(Map.of(), "anon-1"), "req-1");
+
+        assertThat(journeyAppender.list).hasSize(1);
+        assertThat(internalAppender.list).isEmpty();
     }
 }


### PR DESCRIPTION
## 요약
검증 기기(개발자 테스트 트래픽) 이벤트를 `anonymous_id` 기반 설정 라우팅으로 실사용자 이벤트와 물리적으로 분리한다.

## 관련 이슈
- Closes #353

## 변경 사항
- `EventSchemaProperties.internalAnonymousIds` 설정 프로퍼티 추가 (`events.internal-anonymous-ids`, 기본값 빈 목록)
- `logback-spring.xml`에 `journey-events-internal` 전용 appender + logger(`additivity=false`) 추가 — `journey-events-rejected`와 동일 패턴
- `EventLogWriter.write`에서 `anonymous_id`가 목록에 있으면 `journey-events-internal`로, 없으면 기존 `journey-events`로 라우팅
- 테스트 추가: 목록에 있을 때/없을 때(기본값) 각각 올바른 로거로 가는지 검증

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (`events.internal-anonymous-ids` 추가 — 기본값 빈 목록이라 채우기 전까지 기존과 100% 동일하게 동작)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test --tests "com.mio.events.service.EventLogWriterTest"`
### 확인 내용
`internal-anonymous-ids`에 등록된 `anonymous_id`가 `journey-events-internal`로, 미등록/기본값이면 기존 `journey-events`로 가는지 확인. 기존 drop/invalid/rejected 테스트 회귀 없음

## 중점 리뷰 포인트
실제 검증 기기 `anonymous_id` 값은 이 PR 범위 밖 — 배포 후 필요할 때 설정값만 채우면 됨. 채워 넣는 방식(환경변수 vs 배포 설정)은 리뷰어 판단 필요

## 배포 / 롤백
- Rollout: 일반 배포. 기본값이 빈 목록이라 배포 자체로는 동작 변화 없음
- Rollback: 이전 이미지로 롤백해도 데이터 영향 없음(설정을 안 채웠으면 애초에 no-op)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
