### PR TITLE
chore: develop → main 승격 — 이벤트 파이프라인 P0/P1 3건 (#347, #348, #353)

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -34,7 +34,9 @@ public class AuthService {
 
     // #320 — 이벤트 화이트리스트(event-whitelist.yml)에만 enum 검증을 걸면 DB엔 오염값이
     // 남아 나중에 백필이 불가능하다. 코호트 축이라 여기서도 막는다. 선택 필드라 null/blank는 통과.
-    private static final Set<String> VALID_EMPLOYMENT_STATUSES = Set.of("job_seeker", "employed");
+    // package-private — #347 EmploymentStatusConsistencyTest가 event-whitelist.yml과 대조한다.
+    static final Set<String> VALID_EMPLOYMENT_STATUSES =
+            Set.of("student_or_unemployed", "job_seeker", "employed");
 
     private final List<SocialAuthProvider> socialAuthProviders;
     private final UserRepository userRepository;

--- a/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/mio/common/error/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -49,6 +50,19 @@ public class GlobalExceptionHandler {
                 .collect(Collectors.joining(", "));
         log.warn("ValidationException: {}", message);
         return ResponseEntity.badRequest().body(ErrorResponse.of(ErrorCode.INVALID_INPUT, message, getTraceId(request)));
+    }
+
+    /**
+     * 이슈 #348 — MissingRequestHeaderException(예: X-Device-Id 누락)은 이 타입의 하위
+     * 클래스다. 핸들러가 없으면 아래 Exception.class 폴백으로 떨어져 클라이언트 오류가
+     * 500으로 보고되고 5xx 알람이 오염된다.
+     */
+    @ExceptionHandler(ServletRequestBindingException.class)
+    public ResponseEntity<ErrorResponse> handleServletRequestBindingException(
+            ServletRequestBindingException e, HttpServletRequest request) {
+        log.warn("ServletRequestBindingException: {}", e.getMessage());
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.of(ErrorCode.INVALID_INPUT, e.getMessage(), getTraceId(request)));
     }
 
     @ExceptionHandler(AuthenticationException.class)

--- a/src/main/java/com/mio/events/config/EventSchemaProperties.java
+++ b/src/main/java/com/mio/events/config/EventSchemaProperties.java
@@ -18,4 +18,7 @@ import java.util.List;
 public class EventSchemaProperties {
 
     private List<Integer> acceptedSchemaVersions = List.of(3);
+
+    // 이슈 #353 — 검증 기기 격리. 비어 있으면(기본값) 전부 journey-events로 간다.
+    private List<String> internalAnonymousIds = List.of();
 }

--- a/src/main/java/com/mio/events/service/EventLogWriter.java
+++ b/src/main/java/com/mio/events/service/EventLogWriter.java
@@ -2,6 +2,7 @@ package com.mio.events.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventSchemaProperties;
 import com.mio.events.config.EventWhitelist;
 import com.mio.events.dto.EventEnvelope;
 import lombok.RequiredArgsConstructor;
@@ -25,8 +26,10 @@ public class EventLogWriter {
 
     private static final Logger JOURNEY_LOG = LoggerFactory.getLogger("journey-events");
     private static final Logger JOURNEY_REJECTED_LOG = LoggerFactory.getLogger("journey-events-rejected");
+    private static final Logger JOURNEY_INTERNAL_LOG = LoggerFactory.getLogger("journey-events-internal");
 
     private final EventWhitelist eventWhitelist;
+    private final EventSchemaProperties eventSchemaProperties;
     private final ObjectMapper objectMapper;
 
     public void write(EventEnvelope event, String requestId) {
@@ -64,8 +67,13 @@ public class EventLogWriter {
         line.put("os_version", event.osVersion());
         line.put("properties", filteredProperties);
 
+        // 이슈 #353 — 검증 기기 트래픽은 버리지 않되 실사용자 지표 집계와 물리적으로 분리한다.
+        Logger destination = eventSchemaProperties.getInternalAnonymousIds().contains(event.anonymousId())
+                ? JOURNEY_INTERNAL_LOG
+                : JOURNEY_LOG;
+
         try {
-            JOURNEY_LOG.info(objectMapper.writeValueAsString(line));
+            destination.info(objectMapper.writeValueAsString(line));
         } catch (JsonProcessingException e) {
             // 이벤트 로그 기록 실패는 통계적 손실일 뿐 — 요청 자체를 막지 않는다 (감사로그와 다른 성격)
             log.error("Failed to serialize journey event: event_id={}", event.eventId(), e);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -148,3 +148,9 @@ events:
   # 이슈 #322 — 앱 버전 혼재 시 구버전이 영구 소실되는 걸 막기 위해 거부가 아니라
   # 통과+태깅으로 처리한다. 명세 개정 시 [3, 4]로 잠시 병행한다.
   accepted-schema-versions: [3]
+  # 이슈 #353 — 검증 기기 anonymous_id 목록. 여기 등록된 값은 journey-events가 아니라
+  # journey-events-internal로 격리된다(실사용자 지표 오염 방지). 빈 목록이면 기존과 동일하게
+  # 전부 journey-events로 간다 — 실제 검증 기기 값은 필요할 때 채운다.
+  internal-anonymous-ids: []
+  # journey-events-internal 전용 로그 파일 경로. journey-events/-rejected와 물리적으로 분리한다.
+  internal-log-file-path: ${EVENTS_INTERNAL_LOG_FILE_PATH:./logs/journey-events-internal.jsonl}

--- a/src/main/resources/event-whitelist.yml
+++ b/src/main/resources/event-whitelist.yml
@@ -32,7 +32,7 @@ events:
   profile_submitted:
     age_range: {enum: ["10대", "20대", "30대", "40대+"]}
     gender: {enum: [male, female, other]}
-    employment_status: {enum: [job_seeker, employed]}
+    employment_status: {enum: [student_or_unemployed, job_seeker, employed]}
   signup_completed: {}
   onboarding_step_completed:
     step: {type: int}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -54,6 +54,30 @@
         <appender-ref ref="JOURNEY_EVENTS_REJECTED"/>
     </logger>
 
+    <!--
+        이슈 #353: 검증 기기(events.internal-anonymous-ids) 이벤트를 journey-events와
+        물리적으로 분리한다 — 실사용자 지표 집계 파이프라인에 검증 트래픽이 섞여 들어가지
+        않게 한다. journey-events-rejected와 같은 패턴.
+    -->
+    <springProperty scope="context" name="journeyEventsInternalLogFile"
+                     source="events.internal-log-file-path" defaultValue="./logs/journey-events-internal.jsonl"/>
+
+    <appender name="JOURNEY_EVENTS_INTERNAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${journeyEventsInternalLogFile}</file>
+        <encoder>
+            <pattern>%msg%n</pattern>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${journeyEventsInternalLogFile}.%d{yyyy-MM-dd}</fileNamePattern>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>100MB</totalSizeCap>
+        </rollingPolicy>
+    </appender>
+
+    <logger name="journey-events-internal" level="INFO" additivity="false">
+        <appender-ref ref="JOURNEY_EVENTS_INTERNAL"/>
+    </logger>
+
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>
     </root>

--- a/src/test/java/com/mio/auth/service/EmploymentStatusConsistencyTest.java
+++ b/src/test/java/com/mio/auth/service/EmploymentStatusConsistencyTest.java
@@ -1,0 +1,44 @@
+package com.mio.auth.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 이슈 #347 — event-whitelist.yml의 employment_status enum과
+ * AuthService.VALID_EMPLOYMENT_STATUSES는 물리적으로 다른 곳에 있어 값 집합이 조용히
+ * 갈라질 수 있다(#330 CI는 property 키만 비교하고 enum 값은 비교하지 않는다). 두 값 집합이
+ * 항상 일치하는지 여기서 강제한다.
+ */
+class EmploymentStatusConsistencyTest {
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void whitelistAndAuthService_haveSameEmploymentStatusValues() throws Exception {
+        Yaml yaml = new Yaml();
+        Map<String, Object> events;
+        try (InputStream in = new ClassPathResource("event-whitelist.yml").getInputStream()) {
+            Map<String, Object> root = yaml.load(in);
+            events = (Map<String, Object>) root.get("events");
+        }
+
+        Map<String, Object> profileSubmitted = (Map<String, Object>) events.get("profile_submitted");
+        Map<String, Object> employmentStatusSpec = (Map<String, Object>) profileSubmitted.get("employment_status");
+        Set<String> whitelistValues = new TreeSet<>((List<String>) employmentStatusSpec.get("enum"));
+
+        assertThat(new TreeSet<>(AuthService.VALID_EMPLOYMENT_STATUSES))
+                .as("event-whitelist.yml의 employment_status enum(%s)과 "
+                        + "AuthService.VALID_EMPLOYMENT_STATUSES(%s)가 다르다 — 한쪽만 고치면 "
+                        + "이벤트 property 드롭 또는 가입 API 400 회귀가 생긴다",
+                        whitelistValues, AuthService.VALID_EMPLOYMENT_STATUSES)
+                .isEqualTo(whitelistValues);
+    }
+}

--- a/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/mio/common/error/GlobalExceptionHandlerTest.java
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MissingRequestHeaderException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -45,5 +47,25 @@ class GlobalExceptionHandlerTest {
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS);
         assertThat(response.getHeaders().getFirst(HttpHeaders.RETRY_AFTER)).isNull();
+    }
+
+    @Test
+    @DisplayName("이슈 #348 — X-Device-Id 같은 필수 헤더 누락은 500이 아니라 400을 반환한다")
+    void handleServletRequestBindingException_missingHeader_returns400() throws NoSuchMethodException {
+        when(request.getAttribute("traceId")).thenReturn("trace-3");
+        MethodParameter parameter = new MethodParameter(
+                GlobalExceptionHandlerTest.class.getDeclaredMethod("dummyEndpoint", String.class), 0);
+        MissingRequestHeaderException exception = new MissingRequestHeaderException("X-Device-Id", parameter);
+
+        ResponseEntity<ErrorResponse> response =
+                handler.handleServletRequestBindingException(exception, request);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+        assertThat(response.getBody().error().code()).isEqualTo(ErrorCode.INVALID_INPUT.getCode());
+        assertThat(response.getBody().error().traceId()).isEqualTo("trace-3");
+    }
+
+    @SuppressWarnings("unused")
+    private void dummyEndpoint(String deviceId) {
     }
 }

--- a/src/test/java/com/mio/events/service/EventLogWriterTest.java
+++ b/src/test/java/com/mio/events/service/EventLogWriterTest.java
@@ -4,6 +4,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.events.config.EventSchemaProperties;
 import com.mio.events.config.EventWhitelist;
 import com.mio.events.dto.EventEnvelope;
 import org.junit.jupiter.api.AfterEach;
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -26,18 +28,22 @@ class EventLogWriterTest {
 
     @Mock private EventWhitelist eventWhitelist;
 
+    private EventSchemaProperties eventSchemaProperties;
     private EventLogWriter eventLogWriter;
     private ListAppender<ILoggingEvent> journeyAppender;
     private ListAppender<ILoggingEvent> rejectedAppender;
+    private ListAppender<ILoggingEvent> internalAppender;
     private ListAppender<ILoggingEvent> classAppender;
 
     private static final String VALID_TS = "2026-08-06T21:13:02+09:00";
 
     @BeforeEach
     void setUp() {
-        eventLogWriter = new EventLogWriter(eventWhitelist, new ObjectMapper());
+        eventSchemaProperties = new EventSchemaProperties();
+        eventLogWriter = new EventLogWriter(eventWhitelist, eventSchemaProperties, new ObjectMapper());
         journeyAppender = attach("journey-events");
         rejectedAppender = attach("journey-events-rejected");
+        internalAppender = attach("journey-events-internal");
         classAppender = attach(EventLogWriter.class.getName());
     }
 
@@ -45,6 +51,7 @@ class EventLogWriterTest {
     void tearDown() {
         detach("journey-events", journeyAppender);
         detach("journey-events-rejected", rejectedAppender);
+        detach("journey-events-internal", internalAppender);
         detach(EventLogWriter.class.getName(), classAppender);
     }
 
@@ -61,8 +68,12 @@ class EventLogWriterTest {
     }
 
     private EventEnvelope event(Map<String, Object> properties) {
+        return event(properties, "anon-1");
+    }
+
+    private EventEnvelope event(Map<String, Object> properties, String anonymousId) {
         return new EventEnvelope("e1", "chat_message_sent", 3, VALID_TS,
-                "anon-1", "user-1", "session-1", "1.0.0", "ios", "17.0", properties);
+                anonymousId, "user-1", "session-1", "1.0.0", "ios", "17.0", properties);
     }
 
     @Test
@@ -119,5 +130,26 @@ class EventLogWriterTest {
         assertThat(message).contains("\"reject_reason\":\"UNKNOWN_EVENT_NAME\"");
         assertThat(message).contains("\"event_id\":\"e1\"");
         assertThat(journeyAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("#353 — internal-anonymous-ids에 등록된 anonymous_id는 journey-events-internal로 간다")
+    void write_internalAnonymousId_routesToInternalLogger() {
+        eventSchemaProperties.setInternalAnonymousIds(List.of("dev-device-1"));
+
+        eventLogWriter.write(event(Map.of(), "dev-device-1"), "req-1");
+
+        assertThat(internalAppender.list).hasSize(1);
+        assertThat(internalAppender.list.get(0).getFormattedMessage()).contains("\"anonymous_id\":\"dev-device-1\"");
+        assertThat(journeyAppender.list).isEmpty();
+    }
+
+    @Test
+    @DisplayName("#353 — 목록이 비어 있으면(기본값) 기존과 동일하게 journey-events로 간다")
+    void write_emptyInternalList_routesToJourneyLogger() {
+        eventLogWriter.write(event(Map.of(), "anon-1"), "req-1");
+
+        assertThat(journeyAppender.list).hasSize(1);
+        assertThat(internalAppender.list).isEmpty();
     }
 }


### PR DESCRIPTION
## 요약
develop → main 승격 — 이벤트 파이프라인 P0/P1 3건 반영 (#347, #348, #353)

## 관련 이슈
- Closes #347
- Closes #348
- Closes #353

## 변경 사항
- #347: `employment_status` 3종 불일치로 인한 이벤트 드롭 및 가입 400 회귀 수정
- #348: `X-Device-Id` 헤더 누락 시 500 대신 400 반환
- #353: 검증 기기 이벤트를 `anonymous_id` 기반으로 격리 (기본값 빈 목록, no-op)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (#347 400 회귀 해소, #348 500→400)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (#353 `events.internal-anonymous-ids` 추가, 기본값 빈 목록이라 미설정 시 영향 없음)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (#353 journey-events-internal 로거 신설)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test`
### 확인 내용
각 PR(#349, #350, #354)에서 개별 검증 완료 — 이번 승격은 develop에 머지된 상태 그대로 올리는 것

## 중점 리뷰 포인트
**배포 순서 주의**: #347이 반영된 서버가 먼저 뜬 뒤에 앱 빌드가 나가야 합니다(반대 순서면 `student_or_unemployed` 선택 시 가입 400이 실사용자에게 노출됨). 이 PR 병합 시점이 이벤트 파이프라인 T0(적재 개시 기준일, 이슈 #352) 기준이 됩니다.

## 배포 / 롤백
- Rollout: 병합 후 `main` push로 CD 파이프라인 자동 트리거(EC2 배포)
- Rollback: 이전 이미지로 롤백 시 세 이슈 모두 원래 동작(드롭/400/미격리)으로 복귀 — 데이터 손실 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
