### PR TITLE
fix: docker-compose.prod.yml에 EVENTS_INTERNAL_LOG_FILE_PATH 오버라이드 추가 (#359)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,10 @@ services:
       # 이슈 #326 — 거부 이벤트 원본 로그. 같은 /var/log/mio 볼륨에 남기고, CloudWatch
       # Agent 설정에 별도 로그 그룹으로 추가하는 건 이 PR과 분리된 인프라 작업이다.
       EVENTS_REJECTED_LOG_FILE_PATH: /var/log/mio/journey-events-rejected.jsonl
+      # 이슈 #353 — 위와 동일한 이유. 이 오버라이드가 빠지면 컨테이너 안에서 상대경로
+      # (./logs/journey-events-internal.jsonl)로 열리는데 그 디렉터리가 없어 logback이
+      # 기동 자체를 실패시킨다(2026-08-06 프로덕션 장애 원인).
+      EVENTS_INTERNAL_LOG_FILE_PATH: /var/log/mio/journey-events-internal.jsonl
     volumes:
       # 호스트에 /var/log/mio 디렉터리·권한이 먼저 준비돼 있어야 한다
       # (강민석 인프라 명세 §4-B: mkdir + 앱 실행 유저 소유 + cwagent 그룹 추가).


### PR DESCRIPTION
## 요약
`docker-compose.prod.yml`에 `EVENTS_INTERNAL_LOG_FILE_PATH` 절대경로 오버라이드를 추가한다 — #353 배포 중 발생한 프로덕션 장애의 긴급 수정을 레포에 반영.

## 관련 이슈
- Closes #359

## 변경 사항
- `app.environment`에 `EVENTS_INTERNAL_LOG_FILE_PATH: /var/log/mio/journey-events-internal.jsonl` 추가 — 기존 `EVENTS_LOG_FILE_PATH`·`EVENTS_REJECTED_LOG_FILE_PATH`와 동일 패턴

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (프로덕션에는 이미 수동 적용됨 — 레포 동기화만)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
N/A — 설정 파일 변경, 프로덕션에서 이미 검증됨
### 확인 내용
2026-08-06 밤 프로덕션에 수동 적용해 크래시 루프가 해소되는 것을 직접 확인함

## 중점 리뷰 포인트
누락 없이 세 로그 경로 모두 절대경로로 맞춰졌는지

## 배포 / 롤백
- Rollout: 다음 배포부터 이 설정이 함께 나감 — 프로덕션은 이미 수동 적용 상태라 즉시 영향 없음
- Rollback: 이전 상태로 돌리면 오버라이드가 다시 빠지지만, 지금은 이미지가 `sha-db18182`(이 오버라이드가 필요없는 #353 이전 버전)로 고정돼 있어 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [ ] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured production deployments to store internal event logs in a dedicated log file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->