### PR TITLE
fix: UserSelfModel.activeBeliefIds 배열 타입을 text[]로 통일 (#361)

### DIFF
--- a/src/main/java/com/mio/ai/domain/UserSelfModel.java
+++ b/src/main/java/com/mio/ai/domain/UserSelfModel.java
@@ -28,10 +28,14 @@ public class UserSelfModel {
     @Column(name = "narrative_summary_dek_id")
     private String narrativeSummaryDekId;
 
+    // 이슈 #361 — 다른 10개 배열 컬럼과 원소 타입을 text[]로 통일한다. uuid[]가 섞여 있으면
+    // Hibernate의 DdlTypeRegistry가 SqlTypes.ARRAY(2003) 디스크립터를 원소 타입별로 서로
+    // 덮어써, 엔티티 처리 순서(환경마다 달라질 수 있음)에 따라 스키마 검증이 비결정적으로
+    // 실패한다(2026-08-06 프로덕션 장애). 이 필드는 현재 미사용(항상 빈 배열)이라 안전하다.
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "active_belief_ids", columnDefinition = "uuid[]")
+    @Column(name = "active_belief_ids", columnDefinition = "text[]")
     @Builder.Default
-    private List<UUID> activeBeliefIds = List.of();
+    private List<String> activeBeliefIds = List.of();
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "dominant_emotions", columnDefinition = "text[]")

--- a/src/main/resources/db/migration/V52__fix_user_self_model_active_belief_ids_array_type.sql
+++ b/src/main/resources/db/migration/V52__fix_user_self_model_active_belief_ids_array_type.sql
@@ -1,0 +1,7 @@
+-- 이슈 #361 — active_belief_ids를 uuid[]에서 text[]로 바꿔 다른 배열 컬럼들과 원소 타입을
+-- 통일한다. Hibernate의 DdlTypeRegistry가 SqlTypes.ARRAY 디스크립터를 원소 타입별로 서로
+-- 덮어써(2003 하나만 유지), 서로 다른 원소 타입(uuid[] vs text[])이 섞이면 엔티티 처리
+-- 순서에 따라 스키마 검증이 비결정적으로 실패한다(2026-08-06 프로덕션 장애).
+-- 이 컬럼은 현재 애플리케이션 코드 어디서도 읽거나 쓰지 않아 항상 빈 배열이다.
+ALTER TABLE user_self_model
+    ALTER COLUMN active_belief_ids TYPE text[] USING active_belief_ids::text[];


### PR DESCRIPTION
## 요약
`UserSelfModel.activeBeliefIds`의 배열 원소 타입을 `uuid[]` → `text[]`로 통일해, 2026-08-06 프로덕션 장애의 실제 원인(Hibernate DdlTypeRegistry 충돌)을 제거한다.

## 관련 이슈
- Closes #361

## 변경 사항
- `UserSelfModel.activeBeliefIds`: `List<UUID>` → `List<String>`, `columnDefinition`을 `uuid[]` → `text[]`로 변경 (다른 10개 배열 컬럼과 동일 패턴으로 통일)
- `V52` 마이그레이션: `user_self_model.active_belief_ids` 컬럼 타입을 `uuid[]` → `text[]`로 변경 (`USING` 캐스팅)

## 원인 요약
Hibernate의 `DdlTypeRegistry`는 SQL 타입코드별로 디스크립터를 전역 1개만 유지한다. `activeBeliefIds`(`uuid[]`)와 나머지 10개 배열 컬럼(`text[]`)이 같은 `@JdbcTypeCode(SqlTypes.ARRAY)`(코드 2003)를 쓰면서, 서로 다른 원소 타입의 디스크립터가 경합해 하나가 다른 하나를 덮어썼다. 어느 게 마지막에 남는지는 엔티티 처리 순서(환경마다 달라질 수 있음)에 달려 있어, 로컬에서는 통과하고 EC2에서는 실패하는 비결정적 스키마 검증 오류로 이어졌다. 상세 조사 기록: [Notion 장애 대응 기록](https://app.notion.com/p/3b4226b7125d81128be1fa7ddb124039) §4, §7.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (컬럼 타입 변경 — 대상은 항상 빈 배열이라 실질 데이터 영향 없음)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test`
### 확인 내용
- 전체 스위트 943건 중 실패 1건은 로컬 Flyway 체크섬 관련 기존 무관 실패(develop에서도 동일 재현) — 회귀 아님
- 수정 전: 컨트롤 테스트로 성공한 부팅 로그에 `DdlTypeRegistry ... replaced` 라인이 0건임을 먼저 확인해 원인 특정
- 수정 후: 로컬에서 fresh DB로 **3회 연속 재기동**, 매번 정상 기동 + `DdlTypeRegistry ... replaced` 로그 0건 확인 (엔티티 처리 순서 비결정성을 고려해 1회가 아닌 3회 검증)

## 중점 리뷰 포인트
`activeBeliefIds`가 정말 코드베이스 어디서도 안 쓰이는지 (grep으로 엔티티+마이그레이션 파일 2곳 외 참조 없음 확인함 — 리뷰어도 재확인 권장)

## 배포 / 롤백
- Rollout: 이 PR + #359(로그백 설정) 둘 다 반영된 뒤 `latest` 재배포. 마이그레이션이 컬럼 타입을 바꾸므로 배포 순서상 앱 재기동 전에 마이그레이션이 먼저 적용돼야 함(Flyway가 기동 시 자동 실행하므로 별도 조치 불필요)
- Rollback: 컬럼을 다시 `uuid[]`로 되돌리는 것도 가능하지만, 이 컬럼이 미사용이라 롤백 자체가 사실상 불필요함

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the storage format for active belief identifiers to ensure compatibility with PostgreSQL array data.
  * Added a database migration that preserves existing values while converting the column to the supported text array format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->