### PR TITLE
chore: develop → main 승격 — 프로덕션 장애 수정 2건 (#359, #361)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -14,6 +14,10 @@ services:
       # 이슈 #326 — 거부 이벤트 원본 로그. 같은 /var/log/mio 볼륨에 남기고, CloudWatch
       # Agent 설정에 별도 로그 그룹으로 추가하는 건 이 PR과 분리된 인프라 작업이다.
       EVENTS_REJECTED_LOG_FILE_PATH: /var/log/mio/journey-events-rejected.jsonl
+      # 이슈 #353 — 위와 동일한 이유. 이 오버라이드가 빠지면 컨테이너 안에서 상대경로
+      # (./logs/journey-events-internal.jsonl)로 열리는데 그 디렉터리가 없어 logback이
+      # 기동 자체를 실패시킨다(2026-08-06 프로덕션 장애 원인).
+      EVENTS_INTERNAL_LOG_FILE_PATH: /var/log/mio/journey-events-internal.jsonl
     volumes:
       # 호스트에 /var/log/mio 디렉터리·권한이 먼저 준비돼 있어야 한다
       # (강민석 인프라 명세 §4-B: mkdir + 앱 실행 유저 소유 + cwagent 그룹 추가).

--- a/src/main/java/com/mio/ai/domain/UserSelfModel.java
+++ b/src/main/java/com/mio/ai/domain/UserSelfModel.java
@@ -28,10 +28,14 @@ public class UserSelfModel {
     @Column(name = "narrative_summary_dek_id")
     private String narrativeSummaryDekId;
 
+    // 이슈 #361 — 다른 10개 배열 컬럼과 원소 타입을 text[]로 통일한다. uuid[]가 섞여 있으면
+    // Hibernate의 DdlTypeRegistry가 SqlTypes.ARRAY(2003) 디스크립터를 원소 타입별로 서로
+    // 덮어써, 엔티티 처리 순서(환경마다 달라질 수 있음)에 따라 스키마 검증이 비결정적으로
+    // 실패한다(2026-08-06 프로덕션 장애). 이 필드는 현재 미사용(항상 빈 배열)이라 안전하다.
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(name = "active_belief_ids", columnDefinition = "uuid[]")
+    @Column(name = "active_belief_ids", columnDefinition = "text[]")
     @Builder.Default
-    private List<UUID> activeBeliefIds = List.of();
+    private List<String> activeBeliefIds = List.of();
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "dominant_emotions", columnDefinition = "text[]")

--- a/src/main/resources/db/migration/V52__fix_user_self_model_active_belief_ids_array_type.sql
+++ b/src/main/resources/db/migration/V52__fix_user_self_model_active_belief_ids_array_type.sql
@@ -1,0 +1,7 @@
+-- 이슈 #361 — active_belief_ids를 uuid[]에서 text[]로 바꿔 다른 배열 컬럼들과 원소 타입을
+-- 통일한다. Hibernate의 DdlTypeRegistry가 SqlTypes.ARRAY 디스크립터를 원소 타입별로 서로
+-- 덮어써(2003 하나만 유지), 서로 다른 원소 타입(uuid[] vs text[])이 섞이면 엔티티 처리
+-- 순서에 따라 스키마 검증이 비결정적으로 실패한다(2026-08-06 프로덕션 장애).
+-- 이 컬럼은 현재 애플리케이션 코드 어디서도 읽거나 쓰지 않아 항상 빈 배열이다.
+ALTER TABLE user_self_model
+    ALTER COLUMN active_belief_ids TYPE text[] USING active_belief_ids::text[];


### PR DESCRIPTION
## 요약
develop → main 승격 — 2026-08-06 밤 프로덕션 장애 수정 2건 (#359, #361)

## 관련 이슈
- Closes #359
- Closes #361

## 변경 사항
- #359: `docker-compose.prod.yml`에 `EVENTS_INTERNAL_LOG_FILE_PATH` 오버라이드 추가 — #353 배포 시 크래시 루프의 원인이었던 로그백 설정 누락 수정
- #361: `UserSelfModel.activeBeliefIds` 배열 원소 타입을 `text[]`로 통일 — Hibernate DdlTypeRegistry 충돌로 인한 비결정적 스키마 검증 실패의 원인 수정 (`V52` 마이그레이션 포함)

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (`V52` — `user_self_model.active_belief_ids` 컬럼 타입 변경, 대상은 항상 빈 배열이라 실질 데이터 영향 없음)
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. (`EVENTS_INTERNAL_LOG_FILE_PATH`, 이미 긴급 반영했던 걸 레포에 동기화)
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test`
### 확인 내용
각 PR(#360, #362)에서 개별 검증 완료. #361은 fresh DB로 3회 연속 재기동 검증까지 마침. 상세: [프로덕션 장애 대응 기록](https://app.notion.com/p/3b4226b7125d81128be1fa7ddb124039)

## 중점 리뷰 포인트
이 두 수정이 반영된 뒤에도 배포가 실패하면(가능성 낮지만) 즉시 `sha-db18182`로 pin 롤백 — 오늘 밤 여러 번 검증된 안전한 복구 경로.

## 배포 / 롤백
- Rollout: 병합 후 `main` push로 CD 파이프라인 자동 트리거(EC2 배포). 마이그레이션은 Flyway가 기동 시 자동 적용
- Rollback: 이전 이미지(`sha-db18182`)로 즉시 pin 가능 — 오늘 밤 여러 차례 검증된 절차

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
