### PR TITLE
fix: generating 에 고착된 턴을 회수하는 스위퍼를 붙인다 (P0-7)

### DIFF
--- a/src/main/java/com/mio/session/job/MessageTurnSweepJob.java
+++ b/src/main/java/com/mio/session/job/MessageTurnSweepJob.java
@@ -1,0 +1,86 @@
+package com.mio.session.job;
+
+import com.mio.session.repository.MessageTurnRepository;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * {@code generating} 에 고착된 턴을 회수한다 (이슈 #365, 로드맵 §12 P0-7).
+ *
+ * <p>프로세스가 죽거나 컨테이너가 재배포되면 그 순간 진행 중이던 턴은 터미널 전이를 남기지
+ * 못한다. {@code V40} 이 회수용 부분 인덱스({@code idx_message_turns_generating})까지 만들어
+ * 두고 리포지터리에도 조회 메서드가 선언돼 있었지만, 호출하는 곳이 없어 그런 턴은 영원히
+ * {@code generating} 으로 남았다.
+ *
+ * <p>지금까지의 유일한 완화책은 {@code SessionService.IN_FLIGHT_TURN_WINDOW}(90초)였는데,
+ * 그것은 <b>사용자가 직접 재시도할 때만</b> 동작한다. 사용자가 그 세션에 다시 오지 않으면
+ * 고착된 턴은 그대로 남는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MessageTurnSweepJob {
+
+    /**
+     * 이 시간 이상 갱신이 없으면 버려진 턴으로 본다.
+     *
+     * <p>살아 있는 턴을 죽이지 않는 것이 우선이므로 넉넉하게 잡는다. 근거는 세 가지다.
+     * {@code TurnHeartbeat} 가 25초마다 {@code updated_at} 을 밀고, SSE emitter 와 Nginx
+     * {@code proxy_read_timeout} 이 각각 60초이며, 사용자 재시도 창이 90초다. 5분 동안
+     * 아무 갱신이 없는 턴은 어느 기준으로도 이미 끝난 것이다.
+     *
+     * <p>{@code TurnHeartbeat} 의 보장 범위가 "청크가 들어오는 동안" 이라 청크 자체가 오래
+     * 오지 않는 무응답 구간은 덮이지 않는다. 그 구간에서도 클라이언트는 60초 타임아웃으로
+     * 이미 떠난 뒤이므로 회수해도 잃을 응답이 없다.
+     */
+    private static final Duration STALE_AFTER = Duration.ofMinutes(5);
+
+    private static final Duration SWEEP_INTERVAL = Duration.ofMinutes(5);
+
+    /**
+     * SSE {@code done} 이벤트의 값 집합에 없는 값이다.
+     *
+     * <p>회수된 턴은 {@code FAILED} 이고, 재생은 {@code COMPLETED} 턴에만 일어나므로
+     * (`SessionService.acquireTurnLock`) 이 값이 클라이언트에 나가는 경로가 없다. 그래서
+     * {@code error} 로 뭉뚱그리지 않고 구별되는 값을 쓴다 — 인밴드 실패와 프로세스 사망을
+     * 같은 값으로 적으면 어느 쪽이 늘고 있는지 알 수 없다.
+     */
+    private static final String FINISHED_REASON_ABANDONED = "abandoned";
+
+    private static final String SWEEP_METRIC = "mio.turns.swept";
+
+    private final MessageTurnRepository messageTurnRepository;
+    private final MeterRegistry meterRegistry;
+
+    @Scheduled(fixedDelay = 5 * 60 * 1000, initialDelay = 60 * 1000)
+    public void run() {
+        OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+        OffsetDateTime staleBefore = now.minus(STALE_AFTER);
+        try {
+            // 커밋까지 이 호출 안에서 끝난다. 아래 catch 가 실제로 감싸는 것이 커밋이어야
+            // "잡은 정상 종료했는데 회수는 안 된" 조합이 생기지 않는다.
+            int swept = messageTurnRepository.abandonStaleGeneratingTurns(
+                    staleBefore, FINISHED_REASON_ABANDONED, now);
+            if (swept > 0) {
+                log.warn("MessageTurnSweepJob: reclaimed {} stuck turns older than {}",
+                        swept, staleBefore);
+                meterRegistry.counter(SWEEP_METRIC, "outcome", "reclaimed").increment(swept);
+            }
+        } catch (Exception e) {
+            log.error("MessageTurnSweepJob: sweep failed", e);
+            meterRegistry.counter(SWEEP_METRIC, "outcome", "failed").increment();
+        }
+    }
+
+    /** 테스트·운영 점검에서 주기를 확인할 때 쓴다. */
+    static Duration sweepInterval() {
+        return SWEEP_INTERVAL;
+    }
+}

--- a/src/main/java/com/mio/session/job/MessageTurnSweepJob.java
+++ b/src/main/java/com/mio/session/job/MessageTurnSweepJob.java
@@ -42,8 +42,6 @@ public class MessageTurnSweepJob {
      */
     private static final Duration STALE_AFTER = Duration.ofMinutes(5);
 
-    private static final Duration SWEEP_INTERVAL = Duration.ofMinutes(5);
-
     /**
      * SSE {@code done} 이벤트의 값 집합에 없는 값이다.
      *
@@ -59,7 +57,9 @@ public class MessageTurnSweepJob {
     private final MessageTurnRepository messageTurnRepository;
     private final MeterRegistry meterRegistry;
 
-    @Scheduled(fixedDelay = 5 * 60 * 1000, initialDelay = 60 * 1000)
+    // 주기를 상수로 따로 두지 않는다. 상수와 애노테이션 리터럴이 둘 다 있으면 한쪽만 바뀌어
+    // 조용히 어긋난다. ISO-8601 문자열이 그 자체로 읽히므로 여기 한 곳에만 적는다.
+    @Scheduled(fixedDelayString = "PT5M", initialDelayString = "PT1M")
     public void run() {
         OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
         OffsetDateTime staleBefore = now.minus(STALE_AFTER);
@@ -77,10 +77,5 @@ public class MessageTurnSweepJob {
             log.error("MessageTurnSweepJob: sweep failed", e);
             meterRegistry.counter(SWEEP_METRIC, "outcome", "failed").increment();
         }
-    }
-
-    /** 테스트·운영 점검에서 주기를 확인할 때 쓴다. */
-    static Duration sweepInterval() {
-        return SWEEP_INTERVAL;
     }
 }

--- a/src/main/java/com/mio/session/repository/MessageTurnRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageTurnRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -76,4 +77,38 @@ public interface MessageTurnRepository extends JpaRepository<MessageTurn, UUID> 
                      @Param("assistantMessageId") UUID assistantMessageId,
                      @Param("crisisSeverity") Integer crisisSeverity,
                      @Param("now") OffsetDateTime now);
+
+    /**
+     * 오래 {@code generating} 에 머문 턴을 터미널 상태로 회수한다 (이슈 #365).
+     *
+     * <p>프로세스가 죽으면 그 순간 진행 중이던 턴은 터미널 전이를 남기지 못한다. 회수하는
+     * 코드가 없으면 영원히 {@code generating} 으로 남는다 — 스키마는
+     * {@code idx_message_turns_generating} 부분 인덱스까지 두고 회수를 전제했지만 스위퍼가
+     * 없었다.
+     *
+     * <p><b>리스 토큰을 보지 않는다.</b> 회수 대상은 정의상 소유자가 사라진 턴이고, 살아 있는
+     * 시도는 {@code touchIfHeld} 로 {@code updated_at} 을 밀고 있으므로 시간 조건만으로
+     * 충분하다. 토큰까지 맞추려 하면 죽은 프로세스의 토큰을 알 방법이 없어 아무것도 회수하지
+     * 못한다.
+     *
+     * <p><b>트랜잭션 경계가 이 메서드 안에 있다.</b> 스케줄러 메서드에 {@code @Transactional}
+     * 을 걸면 커밋이 메서드 반환 뒤 프록시에서 일어나, 스케줄러를 지키려고 감싼
+     * {@code try/catch} 가 쿼리 실패만 잡고 커밋 실패는 놓친다 — 잡이 정상 종료한 것처럼
+     * 보이면서 회수는 일어나지 않는 조합이다.
+     *
+     * @return 회수한 턴 수
+     */
+    @Transactional
+    @Modifying(clearAutomatically = true)
+    @Query("""
+            update MessageTurn t
+               set t.status = com.mio.session.domain.TurnStatus.FAILED,
+                   t.finishedReason = :finishedReason,
+                   t.updatedAt = :now
+             where t.status = com.mio.session.domain.TurnStatus.GENERATING
+               and t.updatedAt < :staleBefore
+            """)
+    int abandonStaleGeneratingTurns(@Param("staleBefore") OffsetDateTime staleBefore,
+                                    @Param("finishedReason") String finishedReason,
+                                    @Param("now") OffsetDateTime now);
 }

--- a/src/test/java/com/mio/session/job/MessageTurnSweepIntegrationTest.java
+++ b/src/test/java/com/mio/session/job/MessageTurnSweepIntegrationTest.java
@@ -1,0 +1,131 @@
+package com.mio.session.job;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 고착된 턴 회수의 실 DB 검증 (이슈 #365, 로드맵 §12 P0-7).
+ *
+ * <p><b>이 테스트에는 의도적으로 {@code @Transactional} 이 없다.</b> 테스트에 앰비언트
+ * 트랜잭션이 걸려 있으면 회수 쿼리가 자기 경계를 갖지 못해도 테스트 트랜잭션에 얹혀
+ * 통과한다 — 그러면 검증하려던 대상(커밋이 실제로 일어나는가)을 그대로 통과시킨다.
+ * {@code #356} 후속 작업에서 확인된 형태다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class MessageTurnSweepIntegrationTest {
+
+    @Autowired
+    private MessageTurnSweepJob sweepJob;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private UUID userId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "turn-sweep-it-" + userId);
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id) VALUES (?, ?, 'mio')",
+                sessionId, userId);
+    }
+
+    @AfterEach
+    void tearDown() {
+        // message_turns 는 sessions FK 의 ON DELETE CASCADE 로 함께 제거된다.
+        jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
+    }
+
+    @Test
+    @DisplayName("오래 generating 에 머문 턴을 failed 로 회수하고 커밋한다")
+    void reclaimsStuckGeneratingTurn() {
+        UUID turnId = insertTurn("generating", minutesAgo(30), null);
+
+        sweepJob.run();
+
+        // 앰비언트 트랜잭션이 없으므로 이 조회는 커밋된 상태만 본다.
+        assertThat(statusOf(turnId)).isEqualTo("failed");
+        assertThat(finishedReasonOf(turnId)).isEqualTo("abandoned");
+    }
+
+    @Test
+    @DisplayName("하트비트가 살아 있는 턴은 회수하지 않는다")
+    void leavesLiveTurnAlone() {
+        // TurnHeartbeat 이 25초마다 updated_at 을 민다. 방금 갱신된 턴은 살아 있는 턴이다.
+        UUID turnId = insertTurn("generating", minutesAgo(1), null);
+
+        sweepJob.run();
+
+        assertThat(statusOf(turnId)).isEqualTo("generating");
+        assertThat(finishedReasonOf(turnId)).isNull();
+    }
+
+    @Test
+    @DisplayName("이미 끝난 턴의 종료 사유를 덮어쓰지 않는다")
+    void doesNotTouchTerminalTurns() {
+        UUID turnId = insertTurn("completed", minutesAgo(30), "stop");
+
+        sweepJob.run();
+
+        assertThat(statusOf(turnId)).isEqualTo("completed");
+        assertThat(finishedReasonOf(turnId)).isEqualTo("stop");
+    }
+
+    @Test
+    @DisplayName("회수 대상이 없으면 아무것도 바꾸지 않는다")
+    void isNoOpWhenNothingIsStuck() {
+        UUID fresh = insertTurn("generating", minutesAgo(1), null);
+        UUID done = insertTurn("completed", minutesAgo(120), "stop");
+
+        sweepJob.run();
+
+        assertThat(statusOf(fresh)).isEqualTo("generating");
+        assertThat(statusOf(done)).isEqualTo("completed");
+    }
+
+    private UUID insertTurn(String status, OffsetDateTime updatedAt, String finishedReason) {
+        UUID turnId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO message_turns
+                    (id, session_id, user_id, status, lease_token, finished_reason, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                turnId, sessionId, userId, status, UUID.randomUUID(), finishedReason, updatedAt, updatedAt);
+        return turnId;
+    }
+
+    private OffsetDateTime minutesAgo(int minutes) {
+        return OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(minutes);
+    }
+
+    private String statusOf(UUID turnId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT status FROM message_turns WHERE id = ?", String.class, turnId);
+    }
+
+    private String finishedReasonOf(UUID turnId) {
+        return jdbcTemplate.queryForObject(
+                "SELECT finished_reason FROM message_turns WHERE id = ?", String.class, turnId);
+    }
+}

--- a/src/test/java/com/mio/session/job/MessageTurnSweepJobTest.java
+++ b/src/test/java/com/mio/session/job/MessageTurnSweepJobTest.java
@@ -1,0 +1,82 @@
+package com.mio.session.job;
+
+import com.mio.session.repository.MessageTurnRepository;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 스위퍼의 계약 (이슈 #365).
+ *
+ * <p>실제 회수 동작은 {@code MessageTurnSweepIntegrationTest} 가 실 DB 로 본다. 여기서는
+ * 임계값 계산과 실패 처리만 확인한다.
+ */
+class MessageTurnSweepJobTest {
+
+    private final MessageTurnRepository repository = mock(MessageTurnRepository.class);
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private final MessageTurnSweepJob job = new MessageTurnSweepJob(repository, meterRegistry);
+
+    @Test
+    @DisplayName("하트비트·타임아웃·재시도 창보다 넉넉한 임계값으로 회수한다")
+    void usesThresholdSafelyAboveHeartbeatAndRetryWindow() {
+        when(repository.abandonStaleGeneratingTurns(any(), anyString(), any())).thenReturn(0);
+        OffsetDateTime before = OffsetDateTime.now();
+
+        job.run();
+
+        ArgumentCaptor<OffsetDateTime> staleBefore = ArgumentCaptor.forClass(OffsetDateTime.class);
+        verify(repository).abandonStaleGeneratingTurns(staleBefore.capture(), anyString(), any());
+
+        Duration age = Duration.between(staleBefore.getValue(), before);
+        // 하트비트 25초, SSE/Nginx 타임아웃 60초, 사용자 재시도 창 90초보다 커야
+        // 살아 있는 턴을 죽이지 않는다.
+        assertThat(age).isGreaterThanOrEqualTo(Duration.ofMinutes(4));
+    }
+
+    @Test
+    @DisplayName("회수 건수를 메트릭으로 남긴다")
+    void recordsReclaimedCount() {
+        when(repository.abandonStaleGeneratingTurns(any(), anyString(), any())).thenReturn(3);
+
+        job.run();
+
+        assertThat(meterRegistry.counter("mio.turns.swept", "outcome", "reclaimed").count())
+                .isEqualTo(3.0);
+    }
+
+    @Test
+    @DisplayName("회수할 것이 없으면 카운터를 올리지 않는다")
+    void doesNotCountWhenNothingReclaimed() {
+        when(repository.abandonStaleGeneratingTurns(any(), anyString(), any())).thenReturn(0);
+
+        job.run();
+
+        assertThat(meterRegistry.counter("mio.turns.swept", "outcome", "reclaimed").count())
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("회수가 실패해도 스케줄러를 죽이지 않고 실패를 기록한다")
+    void survivesRepositoryFailureAndRecordsIt() {
+        when(repository.abandonStaleGeneratingTurns(any(), anyString(), any()))
+                .thenThrow(new RuntimeException("db down"));
+
+        job.run();
+
+        // 조용히 삼키면 회수가 멈춘 것을 알 방법이 없다.
+        assertThat(meterRegistry.counter("mio.turns.swept", "outcome", "failed").count())
+                .isEqualTo(1.0);
+    }
+}


### PR DESCRIPTION
## 요약

프로세스가 죽거나 컨테이너가 재배포되면 그 순간 진행 중이던 턴은 터미널 전이를 남기지
못하고 `generating` 에 영원히 남았다.

`V40` 이 회수용 부분 인덱스 `idx_message_turns_generating` 까지 만들어 두고 리포지터리에도
조회 메서드가 선언돼 있었지만, **`src/main` 에 호출자가 0건이었다.** 스키마는 회수를
전제했는데 스위퍼만 없었던 상태다.

지금까지의 유일한 완화책인 `IN_FLIGHT_TURN_WINDOW`(90초)는 **사용자가 직접 재시도할 때만**
동작한다. 사용자가 그 세션에 다시 오지 않으면 고착된 턴은 그대로 남는다.

## 관련 이슈
- Closes #365

## 변경 사항

- `MessageTurnRepository.abandonStaleGeneratingTurns` — 원자적 bulk UPDATE
- `MessageTurnSweepJob` — 5분 주기, 임계값 5분
- 메트릭 `mio.turns.swept{outcome=reclaimed|failed}`

### 설계 근거

**임계값 5분.** 하트비트 25초, SSE emitter·Nginx 타임아웃 60초, 사용자 재시도 창 90초보다
넉넉히 잡았다. 살아 있는 턴을 죽이지 않는 쪽을 우선한다. `TurnHeartbeat` 의 보장 범위가
"청크가 들어오는 동안" 이라 무응답 구간은 덮이지 않지만, 그 구간에서도 클라이언트는 60초
타임아웃으로 이미 떠난 뒤라 회수해도 잃을 응답이 없다.

**리스 토큰을 보지 않는다.** 회수 대상은 정의상 소유자가 사라진 턴이다. 죽은 프로세스의
토큰을 알 방법이 없어 토큰까지 맞추려 하면 아무것도 회수하지 못한다. 살아 있는 시도는
`touchIfHeld` 로 `updated_at` 을 밀고 있으므로 시간 조건만으로 충분하다.

**트랜잭션 경계가 리포지터리 메서드 안에 있다.** 스케줄러 메서드에 `@Transactional` 을 걸면
커밋이 반환 뒤 프록시에서 일어나, 스케줄러를 지키려는 `try/catch` 가 쿼리 실패만 잡고 커밋
실패는 놓친다 — 잡이 정상 종료한 것처럼 보이면서 회수는 일어나지 않는 조합이다
(`#356` 후속에서 확인된 형태).

**`finished_reason = 'abandoned'`.** 재생은 `COMPLETED` 턴에만 일어나므로
(`ConversationOrchestrator.replayCompletedTurn`) 이 값이 클라이언트에 나가는 경로가 없다.
`error` 로 뭉뚱그리면 인밴드 실패와 프로세스 사망 중 어느 쪽이 늘고 있는지 알 수 없다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

스케줄 잡 1개 추가(5분 주기). 기존 `@Scheduled` 잡들과 스레드 풀을 공유한다(#313 관련).

## 테스트

### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- `MessageTurnSweepIntegrationTest` 4건 — 실 DB, **`@Transactional` 없이** 작성
  - 30분 된 `generating` → `failed` + `abandoned` 로 회수되고 커밋된다
  - 1분 전 갱신된 턴은 회수하지 않는다
  - 이미 끝난 턴의 `finished_reason` 을 덮어쓰지 않는다
- `MessageTurnSweepJobTest` 4건 — 임계값 계산, 메트릭, 실패 시 스케줄러 생존
- 앰비언트 트랜잭션을 두지 않은 이유: 테스트에 `@Transactional` 이 걸려 있으면 경계 없는
  구현도 테스트 트랜잭션에 얹혀 통과한다. 검증 과정에서 `@Transactional` 을 떼고 돌려
  `TransactionRequiredException` 으로 실패하는 것을 확인했다.

## 중점 리뷰 포인트

- 임계값 5분이 실제 운영 LLM 응답 시간 상한을 넘는지
- 늦게 도착한 원래 시도가 `finishIfHeld` 로 깨끗하게 물러나는지
  (검증: `status != GENERATING` 이라 0을 반환하고 `completeTurn` 이 롤백한다)
- 멀티 인스턴스에서 동시에 돌 때 (검증: 조건부 bulk UPDATE 라 중복 회수는 무해)

## 배포 / 롤백
- Rollout: 스키마 변경 없음. 배포 후 첫 실행에서 누적된 고착 턴이 한 번에 회수될 수 있으므로
  `mio.turns.swept{outcome=reclaimed}` 초기 스파이크는 정상이다.
- Rollback: 코드 되돌리기만 하면 된다. 회수된 턴을 되돌릴 필요는 없다 — 어차피 응답이 없는
  턴이다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.