### PR TITLE
fix: 조기 중단된 턴의 계약 위반도 Judge 에 전달한다 (P0-3)

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -373,8 +373,21 @@ public class ConversationOrchestrator {
                                 capturedSnapshotRef.set(candidate);
                                 log.warn("OutputGuard held back unit: session={} reasons={}",
                                         sessionId, unitCheck.failReasons());
+                                // 계약 위반도 판정 사유에 합류시킨다 (로드맵 §5.7, 이슈 #369).
+                                // 이전에는 유닛 검사 사유만 넘겨서, 조기 중단된 턴은 계약을
+                                // 위반해도 그 사실이 Judge 에 전달되지 않았다 — 승격이 경로에
+                                // 따라 달라졌다는 뜻이다.
+                                //
+                                // 검사 대상은 전체 응답이 아니라 이 스냅샷이다. 조기 중단 시
+                                // 실제로 나가는 것은 승인된 스냅샷이므로(아래 stopSendingDeltas
+                                // 분기), 판정 대상과 검사 대상이 같아야 한다. trace 의
+                                // contract_result 는 전체 응답 기준을 유지한다 — 그쪽은 턴 간
+                                // 비교 가능한 값이어야 한다.
+                                OutputPreFilterResult unitGuardInput = mergeContractViolations(
+                                        unitCheck,
+                                        responseContractValidator.validate(responsePlan, candidate));
                                 earlyJudgeFutureRef.set(CompletableFuture.supplyAsync(
-                                        () -> outputJudge.judge(candidate, unitCheck), outputJudgeExecutor));
+                                        () -> outputJudge.judge(candidate, unitGuardInput), outputJudgeExecutor));
                                 return false;
                             },
                             unit -> sendEvent(emitter, new SseEventDto.DeltaEvent(unit, outboundMsgId)));

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -1,0 +1,236 @@
+package com.mio.ai.orchestrator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.judge.OutputJudge;
+import com.mio.ai.judge.OutputJudgeResult;
+import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.llm.OpenAiLlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.LlmUsage;
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.moderation.OpenAiModerationClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+/**
+ * 응답 계약이 실제 요청 경로에서 배선돼 있는지 (이슈 #369, 로드맵 §12 P0-3).
+ *
+ * <p>{@code #303}·{@code #306} 은 단위 테스트만 남기고 오케스트레이터 레벨 테스트를 하나도
+ * 만들지 않았다. 그래서 계획 → 계약 검사 → 판정 승격 → trace 기록이 <b>실제로 연결돼
+ * 있는지</b>는 검증된 적이 없다. trace 필드는 이슈 {@code #305}(계약 준수율 실측)의
+ * 입력이므로, 여기가 틀리면 그쪽 결과 전체가 무의미해진다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class ConversationOrchestratorContractIntegrationTest {
+
+    @Autowired
+    private ConversationOrchestrator orchestrator;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    /**
+     * 인터페이스가 아니라 구현 타입을 목으로 둔다. {@code EmbeddingWorker} 가 구체 타입
+     * {@code OpenAiLlmClient} 를 주입받으므로 인터페이스만 대체하면 컨텍스트가 뜨지 않는다.
+     *
+     * <p>이 클래스 하나가 {@code LlmClient} 와 {@code EmbeddingClient} 를 함께 구현한다.
+     * 그래서 {@code EmbeddingClient} 를 따로 목으로 두면 같은 빈을 임베딩 전용 목으로
+     * 바꿔 버려 {@code LlmClient} 주입이 깨진다 — 하나만 둔다.
+     */
+    @MockBean
+    private OpenAiLlmClient llmClient;
+
+    @MockBean
+    private OutputJudge outputJudge;
+
+    @MockBean
+    private OpenAiModerationClient moderationClient;
+
+    /** 계약이 붙는 턴을 만들기 위한 고정 판정. */
+    private static final String MEDIUM_RISK_VERDICT = """
+            {
+              "security": {"level": "CLEAN", "attack_types": [], "require_output_security_guard": false},
+              "risk": {
+                "risk_level": "MEDIUM",
+                "risk_types": ["ambiguous_distress"],
+                "crisis_attribution": "NONE",
+                "recommended_generation_mode": "SUPPORTIVE",
+                "recommended_delivery": "CAUTIOUS_SPECULATIVE",
+                "require_output_safety_guard": false
+              },
+              "confidence": 0.8
+            }
+            """;
+
+    /**
+     * SafetyL1 의 위험 키워드를 건드려 룰이 Judge 를 부르게 하는 발화.
+     *
+     * <p><b>{@code SafetyL1.RISK_KEYWORDS} 의 "사라지고싶다" 에 의존한다.</b> 그 목록은 튜닝
+     * 대상이라 바뀔 수 있다. 바뀌면 이 턴은 계약이 붙지 않는 평범한 턴이 되는데, 그때
+     * 조용히 통과하지 않도록 각 테스트가 계약의 <b>구체적인 값</b>을 단언한다.
+     */
+    private static final String RISK_CANDIDATE_MESSAGE = "그냥 사라지고 싶다";
+
+    private UUID userId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "contract-it-" + userId);
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id) VALUES (?, ?, 'mio')",
+                sessionId, userId);
+
+        when(moderationClient.moderate(anyString())).thenReturn(ModerationResult.clear());
+        when(llmClient.embed(anyString())).thenReturn(new float[]{0.1f});
+        when(outputJudge.judge(anyString(), any())).thenReturn(OutputJudgeResult.send());
+        // InputJudge 는 실제 빈이다. MEDIUM 판정을 주면 EMOTION_CHECK 계약(질문 1개,
+        // 4문장)이 붙고 전달은 CAUTIOUS_SPECULATIVE 가 된다 — 계약이 실제로 걸리는 턴.
+        when(llmClient.completeJson(any())).thenReturn(MEDIUM_RISK_VERDICT);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
+    }
+
+    @Test
+    @DisplayName("계약 지시가 실제 생성 프롬프트에 실려 나간다")
+    void contractInstructionReachesTheGenerationPrompt() {
+        streamReplies("무슨 일이 있었는지 조금 더 들려주실 수 있을까요?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        ArgumentCaptor<LlmRequest> request = ArgumentCaptor.forClass(LlmRequest.class);
+        org.mockito.Mockito.verify(llmClient).stream(request.capture(), any());
+
+        // 계약을 검사만 하고 지시하지 않으면 위반이 정상 경로가 된다.
+        String systemPrompt = request.getValue().messages().stream()
+                .filter(message -> "system".equals(message.role()))
+                .map(LlmRequest.Message::content)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("시스템 프롬프트가 없다"));
+
+        assertThat(systemPrompt)
+                .as("계획이 붙은 턴은 상한이 프롬프트에도 실려야 한다")
+                .contains("[응답 계약]");
+    }
+
+    @Test
+    @DisplayName("계약 결과와 응답 행위가 trace 에 기록된다")
+    void contractResultAndActAreRecordedInTrace() {
+        streamReplies("그런 일이 있었군요. 어떤 점이 가장 힘드셨나요?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        JsonNode trace = awaitTrace();
+
+        // 키가 있는지만 보면 안 된다. 계획이 붙지 않은 턴도 response_act=UNPLANNED,
+        // contract_result=NOT_APPLICABLE 로 같은 키를 남기기 때문에, 위 트리거가 조용히
+        // 깨져도 테스트는 계속 통과한다. 구체적인 값을 고정해 그런 퇴화를 소리나게 만든다.
+        assertThat(trace.path("response_act").asText())
+                .as("MEDIUM 판정 턴은 EMOTION_CHECK 계약이 붙어야 한다")
+                .isEqualTo("EMOTION_CHECK");
+        assertThat(trace.path("generation_freedom").asText()).isEqualTo("CONSTRAINED");
+        // PASS 또는 VIOLATED — 둘 다 "검사했다" 는 뜻이다. NOT_APPLICABLE/UNCHECKED 면
+        // 계약이 안 걸렸거나 검사 지점이 없었다는 뜻이라 이 테스트의 전제가 무너진다.
+        assertThat(trace.path("contract_result").asText())
+                .as("계약이 걸린 턴은 실제로 검사돼야 한다")
+                .isIn("PASS", "VIOLATED");
+    }
+
+    /**
+     * 조기 중단 경로에서도 계약 위반이 판정 사유로 전달된다 (이 이슈의 본체).
+     *
+     * <p>승인 단위 게이트가 스트림을 멈추면, 이전 구현은 유닛 검사 사유만으로 Judge future 를
+     * 만들었다. 그래서 그 턴의 계약 위반은 trace 에만 남고 Judge 는 보지 못했다.
+     */
+    @Test
+    @DisplayName("조기 중단된 턴의 계약 위반도 Judge 입력에 합류한다")
+    void contractViolationsReachTheJudgeEvenWhenTheStreamStopsEarly() {
+        // 첫 문장이 출력 사전 필터를 위반하도록 만들어 승인 게이트가 스트림을 멈추게 한다.
+        // 동시에 질문을 여러 개 넣어 응답 계약(질문 1개)도 위반시킨다.
+        streamReplies("당신은 우울증 초기 증상 같아요. 어떠세요? 언제부터였나요? 힘드셨죠?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        ArgumentCaptor<OutputPreFilterResult> judgeInput =
+                ArgumentCaptor.forClass(OutputPreFilterResult.class);
+        org.mockito.Mockito.verify(outputJudge).judge(anyString(), judgeInput.capture());
+
+        assertThat(judgeInput.getValue().failReasons())
+                .as("계약 위반은 Judge 승격 사유다 — 조기 중단 여부가 그것을 바꾸면 안 된다")
+                .anyMatch(reason -> reason.startsWith("contract:"));
+    }
+
+    /** LLM 이 주어진 텍스트를 한 청크로 흘리도록 한다. */
+    private void streamReplies(String reply) {
+        when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
+            Consumer<String> chunkHandler = invocation.getArgument(1);
+            chunkHandler.accept(reply);
+            return new LlmStreamResult(10L, LlmUsage.unresolved("gpt-4o"), false);
+        });
+    }
+
+    /**
+     * 결정 로그는 비동기로 쓰인다.
+     *
+     * <p>문자열 부분일치로 보지 않고 파싱해서 돌려준다. {@code trace} 는 {@code jsonb}
+     * 컬럼이라 PostgreSQL 이 콜론 뒤에 공백을 넣어 다시 직렬화한다 — {@code "key":"value"}
+     * 로 찾으면 값이 맞아도 걸리지 않고, {@code doesNotContain} 은 반대로 항상 통과한다.
+     */
+    private JsonNode awaitTrace() {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            List<String> traces = jdbcTemplate.queryForList(
+                    "SELECT trace FROM ai_policy_decisions WHERE session_id = ?",
+                    String.class, sessionId);
+            if (!traces.isEmpty()) {
+                try {
+                    return objectMapper.readTree(traces.get(0));
+                } catch (Exception e) {
+                    throw new AssertionError("trace 를 파싱할 수 없다: " + traces.get(0), e);
+                }
+            }
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        throw new AssertionError("결정 로그가 기록되지 않았다 — trace 배선이 끊겼다는 뜻이다");
+    }
+}

--- a/src/test/java/com/mio/ai/plan/ResponseContractInvariantTest.java
+++ b/src/test/java/com/mio/ai/plan/ResponseContractInvariantTest.java
@@ -1,0 +1,142 @@
+package com.mio.ai.plan;
+
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.judge.RiskVerdict;
+import com.mio.ai.judge.SecurityVerdict;
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.policy.PolicyEngine;
+import com.mio.ai.safety.CombinedSignal;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.safety.SafetySignalCombiner;
+import com.mio.ai.security.SecurityAssessment;
+import com.mio.ai.security.EffectiveSecurityResolver;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 계약이 걸린 턴에는 반드시 검사 지점이 있어야 한다 (이슈 #369, 로드맵 §5.7).
+ *
+ * <p>{@code ResponseContractResult.UNCHECKED} 는 "계약은 있는데 검사할 자리가 없었다" 는
+ * 뜻이다. 지금은 계약이 걸리는 모든 경로가 검사 분기({@code BUFFER} /
+ * {@code CAUTIOUS_SPECULATIVE})로 가기 때문에 실제로 발생하지 않는다. 문제는 <b>그 사실이
+ * 어디에도 고정돼 있지 않다는 것</b>이다. 정책을 한 줄 고쳐 계약 있는 턴이
+ * {@code SPECULATIVE} 로 새면, 그 턴은 조용히 미검사로 기록되고 계약 준수율은 실제보다
+ * 좋아 보인다. 준수율은 이슈 {@code #305} 의 입력이므로 그쪽 결과까지 함께 틀어진다.
+ *
+ * <p>그래서 정책이 만들 수 있는 결정을 훑어 이 불변식을 직접 건다.
+ */
+@DisplayName("응답 계약 불변식 — 계약이 있으면 검사 지점도 있다")
+class ResponseContractInvariantTest {
+
+    private final PolicyEngine policyEngine = new PolicyEngine(new EffectiveSecurityResolver());
+    private final ResponsePlanner planner = new ResponsePlanner();
+    private final SafetySignalCombiner signalCombiner = new SafetySignalCombiner();
+
+    @Test
+    @DisplayName("계약이 걸린 결정은 결코 SPECULATIVE 로 전달되지 않는다")
+    void contractEnforcedDecisionsAlwaysHaveACheckpoint() {
+        List<String> violations = new ArrayList<>();
+
+        for (PolicyDecision decision : decisionMatrix()) {
+            ResponsePlan plan = planner.plan(decision);
+            if (!plan.isContractEnforced()) {
+                continue;
+            }
+            // SPECULATIVE 경로에는 계약 검사 호출이 없다 — 그 턴은 UNCHECKED 로 남는다.
+            if (decision.deliveryMode() == DeliveryMode.SPECULATIVE) {
+                violations.add("%s → act=%s delivery=%s risk=%s mode=%s".formatted(
+                        decision.decisionId(), plan.responseAct(), decision.deliveryMode(),
+                        decision.riskLevel(), decision.generationMode()));
+            }
+        }
+
+        assertThat(violations)
+                .as("계약이 걸린 턴이 검사 지점 없는 경로로 나가면 UNCHECKED 가 조용히 늘어난다")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("계약이 걸리는 결정이 실제로 존재한다")
+    void theMatrixActuallyProducesContractEnforcedDecisions() {
+        long enforced = decisionMatrix().stream()
+                .map(planner::plan)
+                .filter(ResponsePlan::isContractEnforced)
+                .count();
+
+        // 이 단언이 없으면 위 테스트는 "계약이 하나도 안 걸려서" 통과할 수 있다.
+        assertThat(enforced)
+                .as("행렬이 계약 경로를 하나도 만들지 못하면 불변식 테스트는 공허하다")
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("계약 없는 턴은 상한이 열려 있어 검사 대상이 아니다")
+    void unplannedTurnsAreNotContractEnforced() {
+        ResponsePlan unplanned = ResponsePlan.unplanned();
+
+        assertThat(unplanned.isContractEnforced()).isFalse();
+        assertThat(unplanned.responseAct()).isEqualTo(ResponseAct.UNPLANNED);
+    }
+
+    /**
+     * 정책이 만들 수 있는 결정을 폭넓게 훑는다.
+     *
+     * <p>{@code CombinedSignal} 을 직접 조립하지 않고 <b>실제 {@link SafetySignalCombiner} 로
+     * 만든다.</b> 손으로 조립하면 {@code requiresJudge} 를 프로덕션과 다르게 넣기 쉽고,
+     * 그러면 실제로는 나올 수 없는 상태에서 불변식이 깨졌다고 보고하게 된다. 결합기가
+     * {@code requiresJudge} 를 정하는 규칙(약신호 단독도 Judge 를 부른다)이 이 불변식의
+     * 전제이므로, 그 규칙이 바뀌면 이 테스트도 함께 움직여야 한다.
+     */
+    private List<PolicyDecision> decisionMatrix() {
+        List<PolicyDecision> decisions = new ArrayList<>();
+        List<RiskLevel> judgeRisks = new ArrayList<>();
+        judgeRisks.add(null);
+        judgeRisks.addAll(List.of(RiskLevel.CLEAR_LOW, RiskLevel.LOW, RiskLevel.MEDIUM,
+                RiskLevel.HIGH, RiskLevel.HARD_CRISIS));
+
+        for (SecurityAssessment security : List.of(SecurityAssessment.clean(),
+                SecurityAssessment.suspicious(List.of("roleplay")))) {
+            for (boolean riskCandidate : List.of(false, true)) {
+                for (boolean emotionSpike : List.of(false, true)) {
+                    for (boolean repetitiveNegative : List.of(false, true)) {
+                        for (boolean dependencyHint : List.of(false, true)) {
+                            for (ModerationResult moderation : List.of(
+                                    ModerationResult.clear(), ModerationResult.failOpen())) {
+                                SafetyL1Result l1 = new SafetyL1Result(
+                                        false, riskCandidate, emotionSpike, repetitiveNegative,
+                                        dependencyHint, moderation.flagged(), List.of(), 0.0);
+                                CombinedSignal combined =
+                                        signalCombiner.combine(security, l1, moderation);
+                                for (RiskLevel judgeRisk : judgeRisks) {
+                                    decisions.add(policyEngine.decide(
+                                            combined, judge(judgeRisk), null, null));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        return decisions;
+    }
+
+    private InputJudgeResult judge(RiskLevel riskLevel) {
+        if (riskLevel == null) {
+            return null;
+        }
+        return new InputJudgeResult(
+                SecurityVerdict.clean(),
+                new RiskVerdict(riskLevel, List.of(), GenerationMode.NORMAL,
+                        DeliveryMode.SPECULATIVE, false),
+                0.8);
+    }
+}

--- a/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
+++ b/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
@@ -1,5 +1,8 @@
 package com.mio.ai.prompt;
 
+import com.mio.ai.plan.GenerationFreedom;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.ai.plan.ResponsePlan;
 import com.mio.ai.policy.GenerationMode;
 import com.mio.ai.policy.InterventionHints;
 import org.junit.jupiter.api.DisplayName;
@@ -50,5 +53,76 @@ class PromptBuilderTest {
     void empty_hints_no_hints_section() {
         String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty());
         assertThat(prompt).doesNotContain("개입 힌트");
+    }
+
+    // ── 응답 계약의 프롬프트 주입 (이슈 #303 / #369, 로드맵 §5.7) ──────────────
+    //
+    // 계약을 검사만 하고 지시하지 않으면 위반이 정상 경로가 된다 — 모델은 제약을 모른 채
+    // 쓰고 서버가 사후에 거른다. 그런데 #303 은 이 주입에 대한 테스트를 남기지 않았다.
+
+    @Test
+    @DisplayName("계약이 있는 계획은 질문 수·문장 수 상한을 프롬프트에 적는다")
+    void contract_limits_are_written_into_the_prompt() {
+        ResponsePlan plan = new ResponsePlan(ResponseAct.EMOTION_CHECK, GenerationFreedom.CONSTRAINED,
+                1, 4, ResponsePlan.BASE_FORBIDDEN);
+
+        String prompt = builder.buildSystemPrompt(GenerationMode.SUPPORTIVE, InterventionHints.empty(),
+                null, "mio", null, plan);
+
+        assertThat(prompt).contains("[응답 계약]");
+        assertThat(prompt).contains("질문은 최대 1개");
+        assertThat(prompt).contains("전체 4문장 이내");
+    }
+
+    @Test
+    @DisplayName("금지 요소는 지시문으로도 전달된다")
+    void forbidden_elements_become_instructions() {
+        List<String> forbidden = new java.util.ArrayList<>(ResponsePlan.BASE_FORBIDDEN);
+        forbidden.add("advice");
+        forbidden.add("cbt_intervention");
+        ResponsePlan plan = new ResponsePlan(ResponseAct.EMPATHIC_REFLECTION,
+                GenerationFreedom.CONSTRAINED, 1, 3, forbidden);
+
+        String prompt = builder.buildSystemPrompt(GenerationMode.GUARDED, InterventionHints.empty(),
+                null, "mio", null, plan);
+
+        assertThat(prompt).contains("조언·제안은 하지 마세요");
+        assertThat(prompt).contains("다르게 해석해보자는 제안은 하지 마세요");
+        assertThat(prompt).contains("진단·단정·결과 보장 표현을 쓰지 마세요");
+    }
+
+    @Test
+    @DisplayName("응답 행위마다 다른 지시를 준다")
+    void each_act_gets_its_own_instruction() {
+        assertThat(promptFor(ResponseAct.EMPATHIC_REFLECTION)).contains("감정을 인정하고 반영");
+        assertThat(promptFor(ResponseAct.EMOTION_CHECK)).contains("감정과 그 강도를 확인");
+        assertThat(promptFor(ResponseAct.CLARIFY_CONTEXT)).contains("맥락을 확인");
+    }
+
+    @Test
+    @DisplayName("UNPLANNED 턴에는 계약 지시를 넣지 않는다")
+    void unplanned_turn_has_no_contract_instruction() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty(),
+                null, "mio", null, ResponsePlan.unplanned());
+
+        // 계획하지 않은 턴에 상한을 적으면 계약이 없는데도 있는 것처럼 모델이 제약된다.
+        assertThat(prompt).doesNotContain("[응답 계약]");
+    }
+
+    @Test
+    @DisplayName("계획이 null 이어도 프롬프트 생성이 깨지지 않는다")
+    void null_plan_is_tolerated() {
+        String prompt = builder.buildSystemPrompt(GenerationMode.NORMAL, InterventionHints.empty(),
+                null, "mio", null, null);
+
+        assertThat(prompt).contains("미오");
+        assertThat(prompt).doesNotContain("[응답 계약]");
+    }
+
+    private String promptFor(ResponseAct act) {
+        ResponsePlan plan = new ResponsePlan(act, GenerationFreedom.CONSTRAINED,
+                1, 4, ResponsePlan.BASE_FORBIDDEN);
+        return builder.buildSystemPrompt(GenerationMode.SUPPORTIVE, InterventionHints.empty(),
+                null, "mio", null, plan);
     }
 }


### PR DESCRIPTION
> **스택 PR입니다.** base 가 `fix/#364-retrieval-judge-failure-state`(PR #366)입니다.
> #366 이 머지되면 base 를 `develop` 으로 바꿔 주세요. 같은 파일
> (`ConversationOrchestrator`)을 건드려 충돌을 피하려고 쌓았습니다.

## 요약

계약 위반은 **OutputJudge 승격 사유로만** 쓴다는 것이 로드맵 §5.7 의 계약이다. 그런데
승인 단위 게이트가 스트림을 멈춘 경로에서는 그 승격이 일어나지 않았다.

게이트가 유닛 검사 사유만 가지고 judge future 를 미리 만들었고, 계약 위반을 합류시키는
`mergeContractViolations` 는 `judgeFuture == null` 분기 안에서만 호출됐다. 그래서 조기
중단된 턴의 계약 위반은 **trace 에만 남고 Judge 는 보지 못했다.** 완화는 아니지만 승격이
경로에 따라 달라졌다.

## 관련 이슈
- Closes #369

## 변경 사항

### 1. 계약 위반 합류를 게이트 안으로 (본체)

검사 대상은 전체 응답이 아니라 **그 시점의 스냅샷**이다. 조기 중단 시 실제로 나가는 것이
승인된 스냅샷이므로(`capturedSnapshotRef` → `DeltaReplaceEvent`) 판정 대상과 검사 대상이
같아야 한다. 계약 검사는 결정론적 정규식이라 게이트 안에서 해도 비용이 없고, 판정 호출을
미리 시작하는 기존 지연 이점도 그대로 남는다.

trace 의 `contract_result` 는 전체 응답 기준을 유지한다 — 그쪽은 턴 간 비교 가능한 값이어야
한다.

### 2. `UNCHECKED` 불변식 고정

`UNCHECKED` 는 "계약은 있는데 검사할 자리가 없었다" 는 뜻이다. 지금은 발생하지 않지만
**그 사실이 어디에도 고정돼 있지 않았다.** 정책을 한 줄 고쳐 계약 있는 턴이 `SPECULATIVE`
로 새면 조용히 미검사로 기록되고 준수율은 실제보다 좋아 보인다.

정책이 만들 수 있는 결정 384개를 훑어 불변식을 건다. `CombinedSignal` 을 손으로 조립하지
않고 실제 `SafetySignalCombiner` 로 만든다 — 손으로 만들면 `requiresJudge` 를 프로덕션과
다르게 넣어 **나올 수 없는 상태에서 불변식이 깨졌다고 보고**하게 된다(실제로 첫 시도에서
그렇게 됐다).

### 3. 오케스트레이터 레벨 테스트 (저장소 최초)

`#303`·`#306` 이 기존 테스트 파일을 하나도 건드리지 않아, 계획 → 계약 검사 → 판정 승격 →
trace 기록이 **실제 요청 경로에서 연결돼 있는지**는 검증된 적이 없었다. trace 필드는
`#305`(계약 준수율 실측)의 입력이므로 여기가 틀리면 그쪽 결과가 통째로 무의미해진다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

동작 변화는 조기 중단 + 계약 위반이 겹친 턴에서 Judge 프롬프트에 `contract:` 사유가
추가되는 것뿐이다. 승격 방향으로만 작동하며 위험도·전달 방식은 바뀌지 않는다.

## 테스트

### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- 신규 11건: 오케스트레이터 통합 3, 불변식 3, 프롬프트 주입 5
- **본체 수정을 되돌려 조기 중단 테스트 1건만 실패하는 것을 확인**했다
- 불변식 테스트도 `ResponsePlanner` 를 일부러 망가뜨려 실패하는 것을 확인했다
- trace 단언은 부분일치가 아니라 파싱해서 본다. `trace` 는 `jsonb` 컬럼이라 PostgreSQL 이
  콜론 뒤에 공백을 넣어 다시 직렬화하므로, `"key":"value"` 로 찾으면 값이 맞아도 걸리지
  않고 `doesNotContain` 은 반대로 **항상 통과**한다

## 중점 리뷰 포인트

- 스냅샷 기준 계약 검사(Judge 입력)와 전체 응답 기준 계약 결과(trace)를 나눈 것이 맞는지
- 통합 테스트가 `SafetyL1.RISK_KEYWORDS` 의 `"사라지고싶다"` 에 의존한다. 그 목록이 바뀌면
  계약이 안 붙는 턴이 되는데, 조용히 통과하지 않도록 각 테스트가 구체적인 값을 단언한다

## 배포 / 롤백
- Rollout: 스키마·설정 변경 없음.
- Rollback: 코드 되돌리기만 하면 된다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.