### PR TITLE
fix: 배열 컬럼을 String[]로 저장해 순서 의존 스키마 검증 실패를 없앤다 (#374)

### DIFF
--- a/src/main/java/com/mio/ai/domain/UserSelfModel.java
+++ b/src/main/java/com/mio/ai/domain/UserSelfModel.java
@@ -7,6 +7,7 @@ import org.hibernate.type.SqlTypes;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 
@@ -28,24 +29,29 @@ public class UserSelfModel {
     @Column(name = "narrative_summary_dek_id")
     private String narrativeSummaryDekId;
 
-    // 이슈 #361 — 다른 10개 배열 컬럼과 원소 타입을 text[]로 통일한다. uuid[]가 섞여 있으면
-    // Hibernate의 DdlTypeRegistry가 SqlTypes.ARRAY(2003) 디스크립터를 원소 타입별로 서로
-    // 덮어써, 엔티티 처리 순서(환경마다 달라질 수 있음)에 따라 스키마 검증이 비결정적으로
-    // 실패한다(2026-08-06 프로덕션 장애). 이 필드는 현재 미사용(항상 빈 배열)이라 안전하다.
+    // 이슈 #374 — 저장 타입이 String[]인 이유: List<String>으로 두면 안 된다.
+    // 같은 페르시스턴스 유닛의 UserOnboardingAnswer.concernTypes가 List<String>을
+    // SqlTypes.JSON으로 매핑하는데, Hibernate는 한 Java 타입의 BasicType을 전역 단일
+    // 슬롯에 등록한다. 그래서 두 매핑이 경합해 먼저 처리된 쪽이 이기고, 엔티티 처리
+    // 순서(= jar 엔트리 스캔 순서, 빌드마다 달라짐)에 따라 이 컬럼들이 jsonb로 해석돼
+    // 기동 시 스키마 검증이 비결정적으로 실패했다(2026-08-06/08-07 프로덕션 장애).
+    // String[]은 List<String>과 다른 Java 타입이라 그 경합 자체가 사라진다.
+    // (#361에서 uuid[] → text[]로 통일한 것은 이 장애의 원인이 아니었으나,
+    //  원소 타입이 text[]로 통일된 상태 자체는 유지한다.)
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "active_belief_ids", columnDefinition = "text[]")
     @Builder.Default
-    private List<String> activeBeliefIds = List.of();
+    private String[] activeBeliefIds = new String[0];
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "dominant_emotions", columnDefinition = "text[]")
     @Builder.Default
-    private List<String> dominantEmotions = List.of();
+    private String[] dominantEmotions = new String[0];
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "recurring_trigger_tags", columnDefinition = "text[]")
     @Builder.Default
-    private List<String> recurringTriggerTags = List.of();
+    private String[] recurringTriggerTags = new String[0];
 
     /** avoidance / rumination / problem_solving / social_support */
     @Column(name = "coping_style")
@@ -64,16 +70,33 @@ public class UserSelfModel {
     @Builder.Default
     private int version = 1;
 
+    /** 저장은 String[]이지만(#374) 도메인 인터페이스는 List<String>을 유지한다. */
+    public List<String> getActiveBeliefIds() {
+        return activeBeliefIds == null ? null : Arrays.stream(activeBeliefIds).toList();
+    }
+
+    public List<String> getDominantEmotions() {
+        return dominantEmotions == null ? null : Arrays.stream(dominantEmotions).toList();
+    }
+
+    public List<String> getRecurringTriggerTags() {
+        return recurringTriggerTags == null ? null : Arrays.stream(recurringTriggerTags).toList();
+    }
+
     public void updateFromReflection(List<String> dominantEmotions,
                                      List<String> recurringTriggerTags,
                                      String copingStyle,
                                      String effectiveInterventions) {
-        this.dominantEmotions = dominantEmotions;
-        this.recurringTriggerTags = recurringTriggerTags;
+        this.dominantEmotions = toArray(dominantEmotions);
+        this.recurringTriggerTags = toArray(recurringTriggerTags);
         if (copingStyle != null) this.copingStyle = copingStyle;
         this.effectiveInterventions = effectiveInterventions;
         this.updatedAt = OffsetDateTime.now(ZoneOffset.UTC);
         this.version++;
+    }
+
+    private static String[] toArray(List<String> values) {
+        return values == null ? null : values.toArray(new String[0]);
     }
 
     @PrePersist

--- a/src/main/java/com/mio/ai/memory/ontology/BehaviorTemplate.java
+++ b/src/main/java/com/mio/ai/memory/ontology/BehaviorTemplate.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -27,13 +28,21 @@ public class BehaviorTemplate {
     @Column(name = "intervention_kind", nullable = false)
     private String interventionKind;
 
+    // 이슈 #374 — 저장 타입이 String[]인 이유: List<String>으로 두면 안 된다.
+    // 같은 페르시스턴스 유닛의 UserOnboardingAnswer.concernTypes가 List<String>을
+    // SqlTypes.JSON으로 매핑하는데, Hibernate는 한 Java 타입의 BasicType을 전역 단일
+    // 슬롯에 등록한다. 그래서 두 매핑이 경합해 먼저 처리된 쪽이 이기고, 엔티티 처리
+    // 순서(= jar 엔트리 스캔 순서, 빌드마다 달라짐)에 따라 이 컬럼이 jsonb로 해석돼
+    // 기동 시 스키마 검증이 비결정적으로 실패했다(2026-08-06/08-07 프로덕션 장애).
+    // String[]은 List<String>과 다른 Java 타입이라 그 경합 자체가 사라진다.
+    // 게터는 List<String>을 유지해 호출부를 그대로 둔다.
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "fits_distortions", columnDefinition = "text[]")
-    private List<String> fitsDistortions;
+    private String[] fitsDistortions;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "fits_emotions", columnDefinition = "text[]")
-    private List<String> fitsEmotions;
+    private String[] fitsEmotions;
 
     @Column(nullable = false)
     private Integer difficulty;
@@ -44,4 +53,13 @@ public class BehaviorTemplate {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(columnDefinition = "jsonb")
     private String prerequisites;
+
+    /** 컬럼이 NULL이면 null을 그대로 반환한다(호출부가 null을 분기하고 있다). */
+    public List<String> getFitsDistortions() {
+        return fitsDistortions == null ? null : Arrays.stream(fitsDistortions).toList();
+    }
+
+    public List<String> getFitsEmotions() {
+        return fitsEmotions == null ? null : Arrays.stream(fitsEmotions).toList();
+    }
 }

--- a/src/main/java/com/mio/ai/memory/ontology/CbtDistortionDef.java
+++ b/src/main/java/com/mio/ai/memory/ontology/CbtDistortionDef.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -26,13 +27,16 @@ public class CbtDistortionDef {
 
     private String description;
 
+    // 이슈 #374 — String[]로 저장하는 이유는 BehaviorTemplate 의 같은 주석 참고.
+    // List<String>은 UserOnboardingAnswer.concernTypes(JSON 매핑)와 Java 타입이 같아
+    // 엔티티 처리 순서에 따라 jsonb로 오염된다.
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "typical_triggers", columnDefinition = "text[]")
-    private List<String> typicalTriggers;
+    private String[] typicalTriggers;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "cooccur_codes", columnDefinition = "text[]")
-    private List<String> cooccurCodes;
+    private String[] cooccurCodes;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "counter_questions", columnDefinition = "jsonb")
@@ -44,5 +48,18 @@ public class CbtDistortionDef {
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "recommended_actions", columnDefinition = "text[]")
-    private List<String> recommendedActions;
+    private String[] recommendedActions;
+
+    /** 컬럼이 NULL이면 null을 그대로 반환한다(호출부가 null을 분기하고 있다). */
+    public List<String> getTypicalTriggers() {
+        return typicalTriggers == null ? null : Arrays.stream(typicalTriggers).toList();
+    }
+
+    public List<String> getCooccurCodes() {
+        return cooccurCodes == null ? null : Arrays.stream(cooccurCodes).toList();
+    }
+
+    public List<String> getRecommendedActions() {
+        return recommendedActions == null ? null : Arrays.stream(recommendedActions).toList();
+    }
 }

--- a/src/main/java/com/mio/ai/memory/ontology/EmotionDef.java
+++ b/src/main/java/com/mio/ai/memory/ontology/EmotionDef.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -30,9 +31,10 @@ public class EmotionDef {
     @Column(nullable = false)
     private String family;
 
+    // 이슈 #374 — String[]로 저장하는 이유는 BehaviorTemplate 의 같은 주석 참고.
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "escalation_to", columnDefinition = "text[]")
-    private List<String> escalationTo;
+    private String[] escalationTo;
 
     @Column(name = "crisis_risk_weight", nullable = false)
     private Double crisisRiskWeight;
@@ -40,4 +42,9 @@ public class EmotionDef {
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "acknowledgment_phrases", columnDefinition = "jsonb")
     private String acknowledgmentPhrases;
+
+    /** 컬럼이 NULL이면 null을 그대로 반환한다. */
+    public List<String> getEscalationTo() {
+        return escalationTo == null ? null : Arrays.stream(escalationTo).toList();
+    }
 }

--- a/src/main/java/com/mio/ai/memory/ontology/InterventionDef.java
+++ b/src/main/java/com/mio/ai/memory/ontology/InterventionDef.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.type.SqlTypes;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Entity
@@ -24,13 +25,14 @@ public class InterventionDef {
     @Column(name = "ko_label", nullable = false)
     private String koLabel;
 
+    // 이슈 #374 — String[]로 저장하는 이유는 BehaviorTemplate 의 같은 주석 참고.
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "fits_distortions", columnDefinition = "text[]")
-    private List<String> fitsDistortions;
+    private String[] fitsDistortions;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
     @Column(name = "fits_emotions", columnDefinition = "text[]")
-    private List<String> fitsEmotions;
+    private String[] fitsEmotions;
 
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "contraindicated_when", columnDefinition = "jsonb")
@@ -41,4 +43,13 @@ public class InterventionDef {
 
     @Column(name = "expected_duration_min", nullable = false)
     private Integer expectedDurationMin;
+
+    /** 컬럼이 NULL이면 null을 그대로 반환한다. */
+    public List<String> getFitsDistortions() {
+        return fitsDistortions == null ? null : Arrays.stream(fitsDistortions).toList();
+    }
+
+    public List<String> getFitsEmotions() {
+        return fitsEmotions == null ? null : Arrays.stream(fitsEmotions).toList();
+    }
 }

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
@@ -388,11 +388,16 @@ class TodoRecommendationServiceTest {
         ReflectionTestUtils.setField(t, "category", category);
         ReflectionTestUtils.setField(t, "actionTextKo", actionText);
         ReflectionTestUtils.setField(t, "interventionKind", kind);
-        ReflectionTestUtils.setField(t, "fitsDistortions", fitsDistortions);
-        ReflectionTestUtils.setField(t, "fitsEmotions", fitsEmotions);
+        // #374 — 저장 필드는 String[]다(List<String>이면 JSON 매핑과 Java 타입이 겹쳐 오염된다).
+        ReflectionTestUtils.setField(t, "fitsDistortions", toArray(fitsDistortions));
+        ReflectionTestUtils.setField(t, "fitsEmotions", toArray(fitsEmotions));
         ReflectionTestUtils.setField(t, "difficulty", difficulty);
         ReflectionTestUtils.setField(t, "estimatedMinutes", 5);
         return t;
+    }
+
+    private static String[] toArray(List<String> values) {
+        return values == null ? null : values.toArray(new String[0]);
     }
 
     private BehaviorTemplate newTemplate() {

--- a/src/test/java/com/mio/config/ArrayColumnTypeResolutionTest.java
+++ b/src/test/java/com/mio/config/ArrayColumnTypeResolutionTest.java
@@ -1,0 +1,162 @@
+package com.mio.config;
+
+import jakarta.persistence.Entity;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.mapping.Column;
+import org.hibernate.mapping.PersistentClass;
+import org.hibernate.mapping.Property;
+import org.hibernate.mapping.Selectable;
+import org.hibernate.type.SqlTypes;
+import org.hibernate.type.descriptor.JdbcTypeNameMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AnnotationTypeFilter;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 이슈 #374 회귀 방지 — 배열 컬럼(`columnDefinition`이 `[]`로 끝나는 컬럼)이
+ * 엔티티 처리 순서와 무관하게 항상 {@code Types#ARRAY}로 해석되는지 검증한다.
+ *
+ * <p>배경: Hibernate는 한 Java 타입의 {@code BasicType}을 전역 단일 슬롯에 등록한다.
+ * 같은 Java 타입(예: {@code List<String>})을 한쪽에서 {@code SqlTypes.ARRAY}로,
+ * 다른 쪽에서 {@code SqlTypes.JSON}으로 매핑하면 두 해석이 경합해 먼저 처리된 쪽이
+ * 이긴다. 엔티티 처리 순서는 클래스패스 스캔 순서(= jar 엔트리 순서, 빌드마다 달라짐)에
+ * 달려 있어, 배열 컬럼이 jsonb로 해석되면 기동 시 스키마 검증이 실패한다
+ * (2026-08-06 / 08-07 프로덕션 장애).
+ *
+ * <p>이 테스트는 DB 연결 없이 Hibernate {@code Metadata}만 빌드하므로 CI에서 가볍게 돈다.
+ * 실제 장애 순서를 재현하기 위해 <b>JSON으로 매핑된 컬렉션 필드를 가진 엔티티를 맨 앞에</b>
+ * 두는 적대적 순서를 포함한다.
+ */
+class ArrayColumnTypeResolutionTest {
+
+    private static final String ENTITY_BASE_PACKAGE = "com.mio";
+
+    @Test
+    @DisplayName("배열 컬럼은 엔티티 처리 순서와 무관하게 Types#ARRAY로 해석된다 (#374)")
+    void arrayColumnsResolveToArray_regardlessOfEntityOrder() {
+        List<String> scanned = scanEntityClassNames();
+        assertThat(scanned)
+                .as("com.mio 하위 @Entity 스캔 결과가 비어 있으면 이 테스트는 아무것도 검증하지 못한다")
+                .isNotEmpty();
+
+        for (List<String> ordering : hostileOrderings(scanned)) {
+            List<String> mismatches = arrayColumnMismatches(ordering);
+            assertThat(mismatches)
+                    .as("배열 컬럼이 ARRAY 이외로 해석됐다 (선두 엔티티=%s)", ordering.get(0))
+                    .isEmpty();
+        }
+    }
+
+    /**
+     * 검증할 엔티티 순서 목록. 스캔 순서, 역순, 그리고 JSON 컬렉션 필드를 가진 엔티티를
+     * 각각 맨 앞에 세운 순서를 포함한다(실제 장애를 일으켰던 조건).
+     */
+    private static List<List<String>> hostileOrderings(List<String> scanned) {
+        List<List<String>> orderings = new ArrayList<>();
+        orderings.add(new ArrayList<>(scanned));
+
+        List<String> reversed = new ArrayList<>(scanned);
+        java.util.Collections.reverse(reversed);
+        orderings.add(reversed);
+
+        for (String jsonCollectionEntity : entitiesWithJsonCollectionField(scanned)) {
+            List<String> first = new ArrayList<>(scanned);
+            first.remove(jsonCollectionEntity);
+            first.add(0, jsonCollectionEntity);
+            orderings.add(first);
+        }
+        return orderings;
+    }
+
+    /**
+     * `columnDefinition`이 `[]`로 끝나는 컬럼 중 {@code Types#ARRAY}로 해석되지 않은 것들.
+     * 컬럼을 하드코딩하지 않으므로 앞으로 추가되는 배열 컬럼도 자동으로 검증 대상이 된다.
+     */
+    private static List<String> arrayColumnMismatches(List<String> entityOrder) {
+        StandardServiceRegistry registry = new StandardServiceRegistryBuilder()
+                .applySetting("hibernate.dialect", "org.hibernate.dialect.PostgreSQLDialect")
+                // DB 연결 없이 Metadata만 빌드한다
+                .applySetting("hibernate.boot.allow_jdbc_metadata_access", "false")
+                .applySetting("hibernate.connection.provider_class",
+                        "org.hibernate.engine.jdbc.connections.internal.UserSuppliedConnectionProviderImpl")
+                .build();
+        try {
+            MetadataSources sources = new MetadataSources(registry);
+            entityOrder.forEach(sources::addAnnotatedClassName);
+            Metadata metadata = sources.buildMetadata();
+
+            List<String> mismatches = new ArrayList<>();
+            for (PersistentClass persistentClass : metadata.getEntityBindings()) {
+                for (Property property : persistentClass.getPropertyClosure()) {
+                    for (Selectable selectable : property.getValue().getSelectables()) {
+                        if (!(selectable instanceof Column column)) {
+                            continue;
+                        }
+                        if (!column.getSqlType(metadata).endsWith("[]")) {
+                            continue;
+                        }
+                        int typeCode = column.getSqlTypeCode(metadata);
+                        if (typeCode != SqlTypes.ARRAY) {
+                            mismatches.add("%s.%s: %s (Types#%s)".formatted(
+                                    persistentClass.getTable().getName(),
+                                    column.getName(),
+                                    column.getSqlType(metadata),
+                                    JdbcTypeNameMapper.getTypeName(typeCode)));
+                        }
+                    }
+                }
+            }
+            return mismatches;
+        } finally {
+            StandardServiceRegistryBuilder.destroy(registry);
+        }
+    }
+
+    private static List<String> scanEntityClassNames() {
+        ClassPathScanningCandidateComponentProvider scanner =
+                new ClassPathScanningCandidateComponentProvider(false);
+        scanner.addIncludeFilter(new AnnotationTypeFilter(Entity.class));
+
+        Set<String> names = new LinkedHashSet<>();
+        scanner.findCandidateComponents(ENTITY_BASE_PACKAGE)
+                .forEach(definition -> names.add(definition.getBeanClassName()));
+        return new ArrayList<>(names).stream().sorted().toList();
+    }
+
+    /** {@code @JdbcTypeCode(SqlTypes.JSON)}이 붙은 컬렉션 필드를 가진 엔티티. */
+    private static List<String> entitiesWithJsonCollectionField(List<String> entityClassNames) {
+        List<String> result = new ArrayList<>();
+        for (String className : entityClassNames) {
+            Class<?> type;
+            try {
+                type = Class.forName(className);
+            } catch (ClassNotFoundException e) {
+                continue;
+            }
+            for (Field field : type.getDeclaredFields()) {
+                JdbcTypeCode annotation = field.getAnnotation(JdbcTypeCode.class);
+                if (annotation != null
+                        && annotation.value() == SqlTypes.JSON
+                        && Collection.class.isAssignableFrom(field.getType())) {
+                    result.add(className);
+                    break;
+                }
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
## 요약
배열 컬럼 11개의 저장 타입을 `List<String>` → `String[]`로 바꿔, 기동 시 스키마 검증이 **비결정적으로 실패**하던 원인을 제거한다.

같은 Java 타입 `List<String>`을 한쪽에서 `SqlTypes.ARRAY`로, 다른 쪽(`UserOnboardingAnswer.concernTypes`)에서 `SqlTypes.JSON`으로 매핑하고 있었다. Hibernate는 한 Java 타입의 `BasicType`을 전역 단일 슬롯에 등록하므로 두 매핑이 경합해 **먼저 처리된 쪽이 이긴다.** 엔티티 처리 순서는 클래스패스 스캔 순서(= jar 엔트리 순서)에 달려 있고 빌드마다 달라질 수 있어, 나쁜 순서로 뽑힌 빌드에서는 배열 컬럼이 jsonb로 해석돼 기동 자체가 실패했다.

```
Schema-validation: wrong column type encountered in column [fits_distortions]
in table [behavior_template]; found [_text (Types#ARRAY)], but expecting [text[] (Types#JSON)]
```

`String[]`은 `List<String>`과 다른 Java 타입이라 경합 자체가 사라진다. **게터는 `List<String>`을 유지하므로 호출부 변경이 없다.**

## 관련 이슈
- Closes #374
- #361 의 후속 (#361 의 진단이 불완전했음을 정정 — 코멘트로 기록)

## 변경 사항
- `BehaviorTemplate`, `CbtDistortionDef`, `EmotionDef`, `InterventionDef`, `UserSelfModel` 의 배열 컬럼 11개 저장 타입을 `String[]`로 변경
- 각 엔티티에 `List<String>`을 반환하는 게터를 명시적으로 추가 — 호출부 시그니처 유지, 컬럼이 NULL일 때 `null`을 반환하는 기존 동작도 유지(호출부가 null을 분기하고 있다)
- `UserSelfModel.updateFromReflection(List<String>, ...)` 시그니처 유지, 내부에서만 배열로 변환
- 회귀 방지 테스트 `ArrayColumnTypeResolutionTest` 추가
- `TodoRecommendationServiceTest` 의 `ReflectionTestUtils.setField` 를 배열로 맞춤

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

DDL은 그대로 `text[]`이므로 **마이그레이션 없음.** 전수조사 결과 배열 컬럼을 참조하는 `@Query`/네이티브 SQL이 없고, 이 엔티티들이 API 응답 DTO로 노출되는 경로도 없다. `escalationTo` / `activeBeliefIds` 는 소비처가 0건이다.

### V52 마이그레이션 주석을 고치지 않은 이유
`V52__fix_user_self_model_active_belief_ids_array_type.sql` 의 진단 주석이 부정확하지만 **수정하지 않았다.** Flyway 체크섬은 주석까지 포함한 파일 내용 기준이고 prod는 `validate-on-migrate` 가 켜져 있어, 파일을 건드리면 다음 기동에서 `FlywayValidateException` 으로 또 다른 장애가 난다. 정정 내용은 엔티티 주석과 #374 / #361 코멘트에 남겼다.

## 테스트
### 실행 커맨드
```bash
./gradlew build          # 950 tests, 0 failures
./gradlew test --tests "com.mio.config.ArrayColumnTypeResolutionTest"
```

### 확인 내용
**1. 재현 → 수정 확인 (DB 없이 Metadata만 빌드해 엔티티 등록 순서를 강제로 바꿔 검증)**

| `UserOnboardingAnswer` 위치 | 수정 전 | 수정 후 |
| --- | --- | --- |
| 첫 번째 (적대적 순서) | **11/11 오염** (`PostgreSQLJsonPGObjectJsonbType`) | 0 오염 (`ArrayJdbcType`) |
| 역순 | **11/11 오염** | 0 오염 |
| 스캔 순서 / 마지막 / 제외 | 0 오염 | 0 오염 |

**2. 프로덕션 이미지 교차 확인** — 실패 중이던 `latest` 이미지의 `app.jar` 엔트리 순서가 실제로 적대적 순서였다.
```
   130  BOOT-INF/classes/com/mio/user/domain/UserOnboardingAnswer.class   ← 먼저
   250  .../ai/memory/ontology/InterventionDef.class
   259  .../ai/memory/ontology/BehaviorTemplate.class
   311  .../ai/domain/UserSelfModel.class
```

**3. 회귀 테스트 역검증** — 엔티티 수정만 되돌리면 `ArrayColumnTypeResolutionTest` 가 실패하고, 수정을 적용하면 통과한다. (빈 통과가 아님을 확인)

**4. 기존 테스트** — `TodoRecommendationServiceTest`, `ai.memory.ontology.*`, `WeeklyReflectionJob*` 통과. 전체 950건 통과.

## 중점 리뷰 포인트
- **게터의 null 반환 유지**: `TodoRecommendationService:172,181` 이 `!= null` 로 분기하고, `ReactiveOntologyActivator:47` / `OntologyRelationExpander:26,41` 은 `Optional.map` 이 null이면 empty가 되는 동작에 의존한다. 그래서 게터가 빈 리스트가 아니라 `null` 을 그대로 반환하도록 맞췄다.
- **`Arrays.stream(x).toList()` 선택 이유**: 불변 리스트를 새로 만들어 반환하므로 내부 배열이 노출되지 않고(방어적 복사), `List.of(...)` 와 달리 원소 null도 허용한다.
- **엔티티 주석**: 왜 `List<String>` 이 아니라 `String[]` 인지 각 엔티티에 남겼다. 이 배경을 모르면 "정리"하면서 되돌려놓기 쉬운 코드다.
- **회귀 테스트 설계**: 컬럼명을 하드코딩하지 않고 "`columnDefinition` 이 `[]` 로 끝나면 항상 `Types#ARRAY`" 라는 불변식으로 검증한다. 적대적 순서도 JSON 컬렉션 필드를 가진 엔티티를 리플렉션으로 찾아 자동 구성하므로, 앞으로 추가되는 배열 컬럼이나 JSON 컬렉션 매핑도 자동 대상이 된다.

## 배포 / 롤백
- **Rollout**: 일반 배포. 마이그레이션·환경변수 변경 없음. 기동 후 `/actuator/health` 와 온톨로지 조회(추천 Todo 생성) 정상 동작 확인 권장.
- **Rollback**: 이미지 롤백만으로 복구된다. 단 되돌리면 순서 의존이 되살아나므로, 롤백 대상 이미지가 "좋은 순서"로 빌드됐다는 보장은 없다.
- **참고**: 임시 완충책으로 `ddl-auto: none` 을 쓰는 것은 권장하지 않는다. 검증만 끄면 매핑은 여전히 JSON으로 남아 온톨로지 조회 시점에 깨질 수 있고, 부팅 검증은 "이번 빌드가 나쁜 순서로 뽑혔다"를 알려주는 유일한 신호다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (변경 없음 — V52 를 건드리지 않은 이유는 위에 명시)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when storing and retrieving multi-value settings and metadata.
  * Preserved consistent list-based access for application features while improving compatibility with array-based database fields.
  * Added safeguards for empty or missing values.

* **Tests**
  * Added regression coverage to verify consistent handling of array-valued fields across entity processing orders.
  * Updated existing tests for the revised multi-value data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->