### PR TITLE
chore: Docker 이미지를 멀티아치(amd64+arm64)로 빌드한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,6 +42,11 @@ jobs:
             type=sha,prefix=sha-
             type=raw,value=latest
 
+      # arm64 런타임 스테이지를 만들기 위해 필요. builder 는 $BUILDPLATFORM 으로
+      # 고정돼 있어 에뮬레이션 대상은 최종 스테이지의 adduser/addgroup 뿐이다.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -50,6 +55,9 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          # amd64 를 함께 빌드하는 이유는 롤백이다. 같은 태그로 기존 x86 인스턴스와
+          # 신규 ARM 인스턴스 모두 기동할 수 있어 이관 실패 시 즉시 되돌릴 수 있다.
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
-FROM eclipse-temurin:21-jdk-alpine AS builder
+# builder 를 빌드 플랫폼(러너 아키텍처)에 고정한다.
+# JVM 바이트코드는 아키텍처 중립이라 Gradle 빌드는 네이티브로 돌리고 런타임 스테이지만
+# 타깃 아키텍처로 만들면 된다. 이 고정이 없으면 arm64 빌드 시 Gradle 전체가 QEMU
+# 에뮬레이션으로 실행되어 빌드가 10배 가까이 느려진다.
+FROM --platform=$BUILDPLATFORM eclipse-temurin:21-jdk-alpine AS builder
 WORKDIR /app
 COPY gradlew .
 COPY gradle gradle


### PR DESCRIPTION
## 요약

프로덕션 EC2를 **t3.micro(x86_64) → t4g.small(ARM64, Graviton2)** 로 이관하기 위해 Docker 이미지를 멀티아치로 빌드한다.

현재 CD는 러너 아키텍처인 amd64로만 이미지를 만들기 때문에, ARM64 인스턴스에서 컨테이너가 `exec format error` 로 기동하지 않는다.

이관 배경은 2026-08-07 메모리 고갈 장애다. t3.micro(916 MiB)에 JVM·PostgreSQL·Redis를 스왑 없이 올린 구성에서 페이지 캐시가 고갈되어 9시간 44분간 서비스가 정지했다.

- `docs/히스토리/2026-08-07_프로덕션_정지_장애보고서.md`
- `docs/백엔드 문서/16_t4g_전환_인프라_설계.md`

## 관련 이슈

- Closes #380

## 변경 사항

- `Dockerfile` — builder 스테이지를 `--platform=$BUILDPLATFORM` 으로 고정
- `.github/workflows/cd.yml` — `docker/setup-qemu-action@v3` 추가
- `.github/workflows/cd.yml` — `platforms: linux/amd64,linux/arm64` 지정

## 중점 리뷰 포인트

### `$BUILDPLATFORM` 고정이 이 PR의 핵심입니다

단순히 `platforms: linux/arm64` 만 추가하면 **Gradle 빌드 전체가 QEMU 에뮬레이션으로 실행됩니다.** Spring Boot 빌드가 3분에서 20~40분으로 늘어납니다.

JVM 바이트코드는 아키텍처 중립이므로, builder 스테이지를 빌드 플랫폼(러너의 amd64)에 고정하면 Gradle은 네이티브 속도로 돌고 런타임 스테이지만 타깃 아키텍처가 됩니다. 에뮬레이션 대상은 최종 스테이지의 `addgroup`/`adduser` 뿐입니다.

| | 현행 | `platforms` 만 추가 | **이 PR** |
|---|---|---|---|
| Gradle 빌드 | 네이티브 | QEMU (10배 느림) | 네이티브 |
| 총 빌드 시간 | 기준 | 20~40분 | **기준 +1~2분** |

### amd64를 함께 빌드하는 이유는 롤백입니다

`linux/arm64` 단독이 아니라 `linux/amd64,linux/arm64` 로 둡니다. 같은 태그로 기존 x86 인스턴스와 신규 ARM 인스턴스 모두 기동할 수 있어, 이관 실패 시 이미지 재빌드 없이 즉시 되돌릴 수 있습니다.

### 배포 측은 수정하지 않았습니다

`docker compose pull` 이 매니페스트 리스트에서 호스트 아키텍처를 자동 선택하므로 `docker-compose.prod.yml` 변경이 필요 없습니다.

`env.SG_ID` 와 `secrets.EC2_HOST` 도 그대로 둡니다. 신규 인스턴스가 **동일 보안그룹(`sg-0927ddc743bbbcf82`)과 동일 EIP** 를 사용하도록 구성했습니다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

애플리케이션 코드 변경은 없습니다. 빌드·배포 파이프라인만 수정합니다.

## 테스트

### 실행 커맨드

```bash
# 로컬 멀티아치 빌드 검증 (푸시 없이 빌드 그래프 전체 실행)
docker buildx build --platform linux/amd64,linux/arm64 --output type=cacheonly .
```

### 확인 내용

로컬에서 멀티아치 빌드를 실행했고 **exit code 0** 으로 성공했습니다. 빌드 로그에서 확인한 내용입니다.

```
종료 코드                  EXIT=0
builder 스테이지 RUN       [linux/arm64 builder 6/8] RUN   ← 1회
                           [linux/arm64 builder 8/8] RUN   ← 1회
gradlew bootJar 실행       1회
런타임 스테이지(stage-1)    [linux/amd64 stage-1 1~4/4]
                           [linux/arm64 stage-1 1~4/4]
COPY --from=builder        양쪽 모두 성공
```

**`linux/amd64 builder` 는 한 번도 실행되지 않았습니다.** 두 타깃이 builder 스테이지의 산출물(jar)을 공유했고, 비싼 Gradle 빌드는 정확히 1회만 돌았습니다. `$BUILDPLATFORM` 고정이 의도대로 동작함을 확인했습니다.

> 검증 환경이 Apple Silicon(arm64)이라 `BUILDPLATFORM=linux/arm64` 로 잡혔습니다. GitHub 러너에서는 `linux/amd64` 가 되며, builder 가 러너 네이티브 아키텍처에서 1회만 실행된다는 성질은 동일합니다.

병합 후 `main` 배포 시 아래로 매니페스트를 최종 확인합니다.

```bash
docker manifest inspect ghcr.io/yarr-mio/mio_server:latest | grep architecture
# amd64, arm64 두 항목이 모두 출력되어야 합니다
```

### 사전 호환성 검증

전환을 막는 요소가 없음을 실측으로 확인했습니다.

| 항목 | 결과 |
|---|---|
| `eclipse-temurin:21-jdk-alpine` / `21-jre-alpine` | amd64, arm64 지원 |
| `pgvector/pgvector:pg16` | amd64, arm64 지원 |
| `redis:7-alpine` | arm64 포함 다중 아키텍처 |
| `build.gradle.kts` 아키텍처 고정 의존성 | 없음 |
| APNs 구현 | `java.net.http.HttpClient` (JDK 내장, 순수 Java) |
| Firebase Admin SDK 9.4.1 | 순수 Java + gRPC (aarch64 네이티브 포함) |
| `synchronized` 블록 | 0건 |

## 배포 / 롤백

- **Rollout**: `develop` 병합 후 `main` 승격 시 CD가 멀티아치 이미지를 푸시합니다. 신규 t4g 인스턴스에서 `docker compose pull` 로 arm64 이미지를 받습니다.
- **Rollback**: 멀티아치 이미지이므로 기존 x86 인스턴스에서도 동일 태그가 그대로 기동합니다. 이 PR 자체를 되돌리면 amd64 단일 빌드로 복귀합니다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

> 테스트 코드는 추가하지 않았습니다. 빌드 파이프라인 변경이라 단위 테스트로 검증할 대상이 없고, 실제 검증은 위 `docker buildx build` 와 배포 후 매니페스트 확인으로 수행합니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and publishing container images for both AMD64 and ARM64 platforms.
* **Bug Fixes**
  * Improved cross-platform container builds by ensuring build tools run on the appropriate platform while preserving the runtime environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->