### PR TITLE
chore: JVM 힙 상한과 컨테이너 메모리 상한을 명시한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,11 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder /app/build/libs/*.jar app.jar
 USER app
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# MaxRAMPercentage 를 명시하지 않으면 기본값 25% 가 적용되고, 컨테이너에 mem_limit 이
+# 없으면 그 25% 마저 호스트 전체 RAM 기준으로 산정된다(2026-08-07 장애 기여 요인).
+# compose 의 mem_limit(800m) 기준 힙 440MB. 비힙 167MB + 스레드 35MB + 다이렉트/GC 40MB
+# 를 더해도 약 685MB 로 상한 안에 115MB 여유가 남는다.
+#
+# ExitOnOutOfMemoryError: 힙이 고갈된 JVM 이 절뚝이며 버티면 헬스체크는 통과하면서
+# 요청만 실패한다. 즉시 종료시켜 restart 정책이 되살리게 한다.
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=55", "-XX:+ExitOnOutOfMemoryError", "-jar", "app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,12 @@ services:
   app:
     image: ghcr.io/yarr-mio/mio_server:latest
     restart: unless-stopped
+    # 상한은 예약이 아니라 보호 장치다. 상한이 없으면 메모리를 폭주시킨 컨테이너를
+    # cgroup 이 막지 못해 호스트 전체가 페이지 캐시 스래싱에 빠진다(2026-08-07 장애).
+    # 당시 커널은 회수 가능한 캐시가 남아 있다고 보아 OOM Killer 를 발동하지 않았고,
+    # 컨테이너가 죽지 않아 restart 정책도 작동하지 못했다.
+    # t4g.small(1841MB) 실사용 381MB 기준. JVM MaxRAMPercentage=55 와 짝을 이룬다.
+    mem_limit: 800m
     ports:
       - "127.0.0.1:8080:8080"
     env_file:
@@ -42,6 +48,9 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
+    # 실사용 57MB. shared_buffers 128MB + HikariCP 풀(20) x work_mem 4MB 를
+    # 고려해 320m. maxmemory 정책이 아니라 폭주 차단용 상한이다.
+    mem_limit: 320m
     environment:
       POSTGRES_DB: ${DB_NAME:-mio}
       POSTGRES_USER: ${DB_USERNAME}
@@ -57,6 +66,9 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    # 실사용 11MB. 세션 버퍼가 예상 밖으로 커지는 경우를 막는 상한이다.
+    # redis 자체의 maxmemory/eviction 정책 도입은 별건으로 둔다.
+    mem_limit: 128m
     command: >
       redis-server
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}


### PR DESCRIPTION
## 요약

2026-08-07 프로덕션 정지 장애의 **기여 요인 3·4번**을 해소합니다.

t4g.small 이관(#380)으로 물리 메모리는 916 MB → 1,841 MB로 늘었지만, **경계가 없는 구조는 그대로**입니다. JVM 힙 상한도, 컨테이너 메모리 상한도 지정돼 있지 않습니다.

- `docs/히스토리/2026-08-07_프로덕션_정지_장애보고서.md`
- `docs/백엔드 문서/16_t4g_전환_인프라_설계.md` §8

## 관련 이슈

- Closes #383

## 변경 사항

- `Dockerfile` — `-XX:MaxRAMPercentage=55`, `-XX:+ExitOnOutOfMemoryError` 추가
- `docker-compose.prod.yml` — `app: 800m` / `postgres: 320m` / `redis: 128m` `mem_limit` 추가

## 중점 리뷰 포인트

### 같은 이미지가 호스트에 따라 힙을 다르게 잡습니다

옵션 없이 띄운 JVM의 실측입니다.

```bash
# 상한 없음 (현행) — 로컬 머신에서
$ docker run --rm eclipse-temurin:21-jre-alpine java -XX:+PrintFlagsFinal -version | grep MaxHeapSize
  size_t MaxHeapSize = 1027604480      # 980 MB

# 프로덕션(1841 MB)에서는
  size_t MaxHeapSize =  484442112      # 462 MB
```

JVM은 **자신이 보는 RAM의 25%**를 힙으로 잡습니다. 컨테이너에 `mem_limit`이 없으면 그 "보는 RAM"이 호스트 전체가 됩니다. 이미지는 동일한데 배포 대상에 따라 동작이 달라집니다.

### 적용 후 검증

```bash
$ docker run --rm -m 800m eclipse-temurin:21-jre-alpine \
    java -XX:MaxRAMPercentage=55 -XX:+ExitOnOutOfMemoryError -XX:+PrintFlagsFinal -version

  bool   ExitOnOutOfMemoryError = true        {command line}
  size_t MaxHeapSize            = 461373440   # 440 MB — 계산과 정확히 일치
  double MaxRAMPercentage       = 55.000000   {command line}
```

### `mem_limit`은 예약이 아니라 보호 장치입니다

이번 장애의 핵심 메커니즘입니다. 상한이 없으면 메모리를 폭주시킨 컨테이너를 cgroup이 막지 못하고, 호스트 전체가 페이지 캐시 스래싱에 빠집니다.

당시 커널은 **회수 가능한 페이지 캐시가 남아 있다고 판단해 OOM Killer를 발동하지 않았습니다.** 컨테이너가 죽지 않으니 `restart: unless-stopped`도 작동하지 않았고, 죽지도 살지도 못한 채 9시간 44분이 지났습니다.

`mem_limit`이 있으면 해당 컨테이너만 cgroup OOM으로 죽고 재시작됩니다. **호스트 전체 마비가 컨테이너 하나의 재시작으로 바뀝니다.**

### OOM kill 이 DB 를 날리지 않습니다

`mem_limit` 도입 시 가장 먼저 나올 우려라 미리 정리합니다.

`postgres_data` 는 named volume 이라 컨테이너 수명과 분리돼 있습니다. 컨테이너가 죽든 지워지든 재생성되든 볼륨은 남습니다. 볼륨이 삭제되는 경로는 `down -v` 뿐이고, 이는 과거 배포마다 DB 가 초기화되던 문제(현행 `cd.yml` 주석에 기록됨) 때문에 이미 제거됐습니다.

다만 cgroup OOM kill 은 SIGKILL 이라 **비정상 종료**입니다. PostgreSQL 은 이를 위해 WAL 을 쓰고 재시작 시 crash recovery 로 커밋된 데이터를 복원합니다(`fsync=on` 기본값). **데이터 손실은 없지만 재시작 중 수십 초 불가용**은 발생합니다.

그래서 postgres 상한을 실사용(57 MB) 대비 **5.6배인 320m** 으로 가장 넉넉하게 잡았습니다. 셋 중 OOM 의 대가가 가장 큰 컴포넌트입니다.

### 왜 더 여유롭게 잡지 않았는가

1,841 MB 에서는 이 배분이 사실상 상한입니다.

| 배분 | 상한 합계 | 최악의 경우 페이지 캐시 |
|---|---|---|
| **이 PR (800/320/128)** | 1,248 MB | **275 MB** |
| app 900m 으로 | 1,348 MB | 175 MB |
| app 1000m 으로 | 1,448 MB | 75 MB |

**장애는 페이지 캐시가 148 MB 일 때 발생했습니다.** 175 MB 는 안전 마진이라 보기 어렵습니다.

상한을 더 키우는 것과 페이지 캐시 하한을 지키는 것은 정면으로 충돌하며, 이 장애의 원인이 후자였습니다. 실질적인 여유가 필요하다면 상한이 아니라 **인스턴스 상향(t4g.medium, 4 GiB)** 이 답입니다. 이 PR 의 범위 밖으로 둡니다.

### 값 산정 근거 — 프로덕션 실측

| 구분 | 실사용 | 상한 |
|---|---|---|
| app (JVM) | 381.7 MB | **800m** |
| postgres | 56.9 MB | **320m** |
| redis | 10.8 MB | **128m** |
| 호스트 오버헤드 | 318 MB | — |

**최악의 경우(전 컨테이너가 상한까지 사용)에도** `1,248 + 318 = 1,566 MB`로, 페이지 캐시가 **275 MB 이상** 남습니다. 장애 당시가 148 MB였습니다.

app 컨테이너 내부 배분 (상한 800m 기준):

```
힙 (55%)                440 MB
비힙 (ARM64 실측)       167 MB
스레드 스택 (33개)       35 MB
다이렉트 버퍼 · GC       40 MB
────────────────────────────
합계                    682 MB   → 상한까지 118 MB 여유
```

힙 440 MB는 **현재 실효값(462 MB)과 거의 같습니다.** 용량을 줄이는 변경이 아니라 경계를 명확히 하는 변경입니다.

### `ExitOnOutOfMemoryError`를 함께 두는 이유

힙이 고갈된 JVM은 GC에 시간을 다 쓰면서도 프로세스는 살아 있습니다. 헬스체크는 통과하는데 실제 요청만 실패하는 상태가 됩니다. 즉시 종료시켜 재시작 경로를 타게 합니다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

애플리케이션 코드 변경은 없습니다. 컨테이너·JVM 실행 설정만 바뀝니다.

## 테스트

### 실행 커맨드

```bash
# compose 문법 검증
docker compose -f docker-compose.prod.yml config --quiet

# JVM 힙 산정 검증
docker run --rm -m 800m eclipse-temurin:21-jre-alpine \
  java -XX:MaxRAMPercentage=55 -XX:+ExitOnOutOfMemoryError -XX:+PrintFlagsFinal -version \
  | grep -E "MaxHeapSize|MaxRAMPercentage|ExitOnOutOfMemoryError"
```

### 확인 내용

- `docker compose config` 문법 검증 통과
- `mem_limit 800m` + `MaxRAMPercentage=55` → `MaxHeapSize = 461373440` (440 MB) 확인
- `ExitOnOutOfMemoryError = true` 반영 확인
- 상한 없는 현행 방식이 호스트 RAM에 따라 힙을 다르게 잡는 것을 실측으로 대조

### 배포 후 확인 예정

```bash
docker stats --no-stream          # LIMIT 이 호스트 전체가 아닌 mem_limit 값으로 표시
docker exec mio-app-1 java -XX:+PrintFlagsFinal -version | grep MaxHeapSize
free -m                           # available 및 buff/cache 추이
```

## 배포 / 롤백

- **Rollout**: `develop` 병합 후 `main` 승격 시 CD가 새 이미지를 빌드하고 `docker compose up -d`로 컨테이너를 재생성합니다. `mem_limit` 변경은 컨테이너 재생성이 필요하므로 `up -d`가 자동 처리합니다.
- **Rollback**: 이 PR을 되돌리면 상한 없는 이전 동작으로 복귀합니다. 데이터·스키마 영향이 없어 롤백 비용이 없습니다.

## 남겨둔 것 (별건)

이 PR의 목적을 하나로 유지하기 위해 아래는 포함하지 않았습니다.

- redis `maxmemory` + eviction 정책
- postgres `effective_cache_size` 조정 (현재 1,841 MB 호스트에 4 GB로 설정돼 있어 플래너가 왜곡됨)
- `pg_dump` → S3 자동 백업 (현재 자동 백업 없음)
- `@Async` 6곳의 `SimpleAsyncTaskExecutor` 무제한 스레드 폴백

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

> 테스트 코드는 추가하지 않았습니다. 컨테이너 런타임 설정이라 단위 테스트로 검증할 대상이 없고, 실제 검증은 위 `docker run` 실측과 배포 후 `docker stats` 확인으로 수행합니다.
