### PR TITLE
chore: JVM 힙 상한과 컨테이너 메모리 상한을 명시한다

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,11 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder /app/build/libs/*.jar app.jar
 USER app
 EXPOSE 8080
-ENTRYPOINT ["java", "-jar", "app.jar"]
+# MaxRAMPercentage 를 명시하지 않으면 기본값 25% 가 적용되고, 컨테이너에 mem_limit 이
+# 없으면 그 25% 마저 호스트 전체 RAM 기준으로 산정된다(2026-08-07 장애 기여 요인).
+# compose 의 mem_limit(800m) 기준 힙 440MB. 비힙 167MB + 스레드 35MB + 다이렉트/GC 40MB
+# 를 더해도 약 685MB 로 상한 안에 115MB 여유가 남는다.
+#
+# ExitOnOutOfMemoryError: 힙이 고갈된 JVM 이 절뚝이며 버티면 헬스체크는 통과하면서
+# 요청만 실패한다. 즉시 종료시켜 restart 정책이 되살리게 한다.
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=55", "-XX:+ExitOnOutOfMemoryError", "-jar", "app.jar"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,6 +2,12 @@ services:
   app:
     image: ghcr.io/yarr-mio/mio_server:latest
     restart: unless-stopped
+    # 상한은 예약이 아니라 보호 장치다. 상한이 없으면 메모리를 폭주시킨 컨테이너를
+    # cgroup 이 막지 못해 호스트 전체가 페이지 캐시 스래싱에 빠진다(2026-08-07 장애).
+    # 당시 커널은 회수 가능한 캐시가 남아 있다고 보아 OOM Killer 를 발동하지 않았고,
+    # 컨테이너가 죽지 않아 restart 정책도 작동하지 못했다.
+    # t4g.small(1841MB) 실사용 381MB 기준. JVM MaxRAMPercentage=55 와 짝을 이룬다.
+    mem_limit: 800m
     ports:
       - "127.0.0.1:8080:8080"
     env_file:
@@ -42,6 +48,9 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
+    # 실사용 57MB. shared_buffers 128MB + HikariCP 풀(20) x work_mem 4MB 를
+    # 고려해 320m. maxmemory 정책이 아니라 폭주 차단용 상한이다.
+    mem_limit: 320m
     environment:
       POSTGRES_DB: ${DB_NAME:-mio}
       POSTGRES_USER: ${DB_USERNAME}
@@ -57,6 +66,9 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
+    # 실사용 11MB. 세션 버퍼가 예상 밖으로 커지는 경우를 막는 상한이다.
+    # redis 자체의 maxmemory/eviction 정책 도입은 별건으로 둔다.
+    mem_limit: 128m
     command: >
       redis-server
       ${REDIS_PASSWORD:+--requirepass ${REDIS_PASSWORD}}


### PR DESCRIPTION
## 요약

`develop` 의 메모리 상한 설정을 프로덕션에 반영하기 위한 승격 PR입니다.

**CD 는 `main` 푸시에만 반응**하므로, #384 가 `develop` 에 머지된 것만으로는 배포되지 않았습니다. 현재 프로덕션에는 `mem_limit` 과 JVM 옵션이 적용되지 않은 상태입니다.

```
main    e5f9402   Dockerfile: java -jar app.jar
develop d3f0ed9   Dockerfile: java -XX:MaxRAMPercentage=55 -XX:+ExitOnOutOfMemoryError -jar app.jar
```

## 관련 이슈

- #383 (PR #384 로 develop 반영 완료)

## 포함되는 변경

- **#384** — JVM 힙 상한과 컨테이너 메모리 상한 명시 (`chore/#383-memory-limits`)
  - `Dockerfile` — `-XX:MaxRAMPercentage=55`, `-XX:+ExitOnOutOfMemoryError`
  - `docker-compose.prod.yml` — `app: 800m` / `postgres: 320m` / `redis: 128m`

`main` 에 없는 커밋은 위 2건(`d3f0ed9`, `ec94760`)뿐입니다. #381(멀티아치 빌드)은 #382 로 이미 승격돼 배포됐습니다.

## 배경

2026-08-07 프로덕션이 메모리 고갈로 9시간 44분 정지했습니다. t4g.small 이관으로 물리 메모리는 확보했으나, **경계가 없는 구조**(JVM 이 호스트 전체 RAM 기준으로 힙 산정, 컨테이너 상한 부재)는 그대로 남아 있습니다.

- `docs/히스토리/2026-08-07_프로덕션_정지_장애보고서.md`
- `docs/백엔드 문서/16_t4g_전환_인프라_설계.md`

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

애플리케이션 코드 변경은 없습니다. 컨테이너·JVM 실행 설정만 바뀝니다.

`mem_limit` 변경은 컨테이너 재생성이 필요하며, CD 의 `docker compose up -d` 가 자동 처리합니다.

## 테스트

### 실행 커맨드

```bash
# #384 에서 수행한 검증
docker compose -f docker-compose.prod.yml config --quiet
docker run --rm -m 800m eclipse-temurin:21-jre-alpine \
  java -XX:MaxRAMPercentage=55 -XX:+ExitOnOutOfMemoryError -XX:+PrintFlagsFinal -version \
  | grep -E "MaxHeapSize|MaxRAMPercentage|ExitOnOutOfMemoryError"
```

### 확인 내용

`mem_limit 800m` + `MaxRAMPercentage=55` → `MaxHeapSize = 461373440` (440 MB) 확인 완료.

### 배포 후 확인 (필수)

현재 프로덕션은 상한이 호스트 전체(`1.798GiB`)로 잡혀 있습니다. 배포 후 아래로 반영을 확인합니다.

```bash
docker stats --no-stream
#  현재: mio-app-1  437.7MiB / 1.798GiB   ← 상한 미적용
#  기대: mio-app-1  ~440MiB  / 800MiB

docker exec mio-app-1 java -XX:+PrintFlagsFinal -version | grep -E "MaxHeapSize|ExitOnOut"
#  현재: MaxHeapSize = 484442112 / ExitOnOutOfMemoryError = false {default}
#  기대: MaxHeapSize = 461373440 / ExitOnOutOfMemoryError = true  {command line}
```

## 중점 리뷰 포인트

`develop` 의 검증된 변경을 그대로 옮기는 승격 PR이라 새로운 코드는 없습니다. **배포 후 위 검증을 반드시 수행**해 상한이 실제로 적용됐는지 확인해야 합니다.

## 배포 / 롤백

- **Rollout**: 머지 시 CD 가 이미지를 빌드하고 `docker compose up -d` 로 컨테이너를 재생성합니다.
- **Rollback**: 이 PR 을 되돌리면 상한 없는 이전 동작으로 복귀합니다. 데이터·스키마 영향이 없어 롤백 비용이 없습니다.

## 참고 — 알려진 플래키 테스트

CI 가 `StaleSummarySweepIntegrationTest` 에서 간헐 실패할 수 있습니다. 같은 커밋에서도 결과가 갈리는 기존 문제이며 이 PR 과 무관합니다. 재실행하면 통과합니다.

- #386 에 재현 이력과 원인 가설을 정리해 두었습니다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
