### PR TITLE
fix: 알림 조용시간 폐기를 없애고 판정 창을 넓힌다

### DIFF
--- a/src/main/java/com/mio/notification/scheduler/ProactiveCareJob.java
+++ b/src/main/java/com/mio/notification/scheduler/ProactiveCareJob.java
@@ -11,6 +11,17 @@ public class ProactiveCareJob {
 
     private final NotificationService notificationService;
 
+    /**
+     * 5분 주기로 예약 알림 대상을 평가한다. (:00 :05 :10 … KST)
+     *
+     * <p>알림은 사용자가 설정한 시각 <b>이후 최초 실행</b>에 발송되므로,
+     * 5분 배수가 아닌 시각(예: 20:01)을 설정하면 최대 5분까지 지연될 수 있다.
+     * 이는 의도된 동작이며, 지연 자체를 없애려면 클라이언트에서 알림 시각 선택을
+     * 5분 단위로 제한해야 한다.
+     *
+     * <p>실행 주기(5분)보다 {@code NotificationService#isDue} 의 판정 창(10분)이 넓기 때문에
+     * 배포·재기동으로 한 틱을 건너뛰어도 다음 틱에서 보정 발송된다.
+     */
     @Scheduled(cron = "0 */5 * * * *", zone = "Asia/Seoul")
     public void run() {
         notificationService.processScheduledNotifications();

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
@@ -45,10 +46,11 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class NotificationService {
 
-    private static final LocalTime QUIET_HOURS_END = LocalTime.of(8, 0);
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
     private static final int DAILY_SEND_LIMIT = 3;
+    private static final int DUE_WINDOW_MINUTES = 10;
+    private static final int MINUTES_PER_DAY = 1440;
     private static final int DEFAULT_HISTORY_LIMIT = 20;
     private static final int MAX_HISTORY_LIMIT = 50;
     private static final int SCHEDULER_BATCH_SIZE = 200;
@@ -134,9 +136,6 @@ public class NotificationService {
 
     public void processScheduledNotifications() {
         OffsetDateTime now = OffsetDateTime.now(clock).truncatedTo(ChronoUnit.MINUTES);
-        if (now.toLocalTime().isBefore(QUIET_HOURS_END)) {
-            return;
-        }
 
         Pageable pageable = PageRequest.of(0, SCHEDULER_BATCH_SIZE, SCHEDULER_SORT);
         Slice<NotificationSetting> batch;
@@ -253,9 +252,24 @@ public class NotificationService {
         return tasks.stream().noneMatch(task -> task.getStatus() == TaskStatus.COMPLETED);
     }
 
+    /**
+     * 설정 시각 {@code target} 이 도래했는지 판정한다.
+     *
+     * <p>판정 창은 {@code [target, target + 10분)} 이다. 스케줄러가 5분 주기로 실행되므로
+     * 하나의 설정 시각에 대해 최소 2회의 실행 기회가 생기고, 배포·재기동으로 한 틱을
+     * 건너뛰어도 다음 틱에서 보정 발송된다. 창을 넓혀 생기는 중복 발송은
+     * {@code shouldSuppressTrigger} 의 24시간 억제가 막는다.
+     *
+     * <p>스케줄러 주기 특성상 알림은 <b>설정 시각 이후 최초 스케줄러 틱</b>에 발송되며,
+     * 5분 배수가 아닌 시각을 설정한 경우 최대 5분까지 지연될 수 있다.
+     *
+     * <p>{@code 23:55} 처럼 판정 창이 자정을 넘어가는 경우를 위해 단순 비교 대신
+     * 하루(1440분)를 주기로 하는 순환 경과 시간으로 계산한다.
+     */
     private boolean isDue(LocalTime target, OffsetDateTime now) {
         LocalTime current = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES);
-        return !current.isBefore(target) && current.isBefore(target.plusMinutes(5));
+        long elapsedMinutes = Math.floorMod(Duration.between(target, current).toMinutes(), MINUTES_PER_DAY);
+        return elapsedMinutes < DUE_WINDOW_MINUTES;
     }
 
     private boolean shouldSuppressTrigger(UUID userId, String triggerCode, OffsetDateTime now) {

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -38,6 +38,7 @@ import java.time.temporal.ChronoUnit;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -202,33 +203,49 @@ public class NotificationService {
 
     private String determineTrigger(NotificationSetting setting, OffsetDateTime now) {
         UUID userId = setting.getUser().getId();
-        LocalDate today = now.toLocalDate();
         boolean serverInitiatedAllowed = isWithinServerInitiatedWindow(now);
 
         if (setting.isCheckinEnabled() && serverInitiatedAllowed && hasNegativeEmotionStreak(userId)) {
             return "negative_emotion_streak";
         }
-        // 아래 체크인 리마인더는 유저가 직접 고른 시각이므로 시간대 제한을 두지 않는다.
         if (setting.isCheckinEnabled()) {
-            if (isDue(setting.getCheckinMorningTime(), now) && !hasCompletedCheckin(userId, today, "morning")) {
-                return "checkin_reminder_morning";
-            }
-            if (isDue(setting.getCheckinAfternoonTime(), now) && !hasCompletedCheckin(userId, today, "afternoon")) {
-                return "checkin_reminder_afternoon";
-            }
-            if (isDue(setting.getCheckinEveningTime(), now) && !hasCompletedCheckin(userId, today, "evening")) {
-                return "checkin_reminder_evening";
+            String checkinTrigger = determineCheckinReminder(setting, userId, now);
+            if (checkinTrigger != null) {
+                return checkinTrigger;
             }
         }
         if (setting.isReportEnabled() && serverInitiatedAllowed && isWeeklyReportDue(now)) {
             return "report_weekly";
         }
-        if (setting.isCharacterEnabled()
-                && setting.isTodoReminderOn()
-                && serverInitiatedAllowed
-                && isDue(TODO_REMINDER_TIME, now)
-                && hasIncompleteTodoToday(userId, now)) {
-            return "todo_incomplete";
+        if (setting.isCharacterEnabled() && setting.isTodoReminderOn() && serverInitiatedAllowed) {
+            Optional<LocalDate> todoDue = dueOccurrenceDate(TODO_REMINDER_TIME, now);
+            if (todoDue.isPresent() && hasIncompleteTodo(userId, todoDue.get())) {
+                return "todo_incomplete";
+            }
+        }
+        return null;
+    }
+
+    /**
+     * 체크인 리마인더는 유저가 직접 고른 시각이므로 발송 시간대 제한을 두지 않는다.
+     *
+     * <p>완료 여부는 반드시 <b>판정 시점의 날짜가 아니라 목표 시각의 발생일</b>로 조회한다.
+     * 예를 들어 저녁 체크인을 {@code 23:58} 로 설정한 유저가 그날 23:56 에 체크인을 마쳤다면,
+     * 다음 날 {@code 00:00} 틱에서도 판정 창(10분)은 아직 열려 있다. 이때 판정 시점 날짜로
+     * 조회하면 전날 남긴 완료 기록을 놓쳐 이미 체크인한 유저에게 리마인더를 보내게 된다.
+     */
+    private String determineCheckinReminder(NotificationSetting setting, UUID userId, OffsetDateTime now) {
+        Optional<LocalDate> morning = dueOccurrenceDate(setting.getCheckinMorningTime(), now);
+        if (morning.isPresent() && !hasCompletedCheckin(userId, morning.get(), "morning")) {
+            return "checkin_reminder_morning";
+        }
+        Optional<LocalDate> afternoon = dueOccurrenceDate(setting.getCheckinAfternoonTime(), now);
+        if (afternoon.isPresent() && !hasCompletedCheckin(userId, afternoon.get(), "afternoon")) {
+            return "checkin_reminder_afternoon";
+        }
+        Optional<LocalDate> evening = dueOccurrenceDate(setting.getCheckinEveningTime(), now);
+        if (evening.isPresent() && !hasCompletedCheckin(userId, evening.get(), "evening")) {
+            return "checkin_reminder_evening";
         }
         return null;
     }
@@ -255,8 +272,8 @@ public class NotificationService {
                 && !current.isAfter(SERVER_INITIATED_WINDOW_END);
     }
 
-    private boolean hasCompletedCheckin(UUID userId, LocalDate today, String slot) {
-        return checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(userId, today, slot);
+    private boolean hasCompletedCheckin(UUID userId, LocalDate occurrenceDate, String slot) {
+        return checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(userId, occurrenceDate, slot);
     }
 
     private boolean hasNegativeEmotionStreak(UUID userId) {
@@ -265,12 +282,23 @@ public class NotificationService {
                 && recentCheckins.stream().allMatch(checkin -> NEGATIVE_EMOTIONS.contains(checkin.getEmotionType()));
     }
 
+    /**
+     * 월요일 발생분인지는 판정 시점이 아니라 발생일 기준으로 본다.
+     * 현재 {@code WEEKLY_REPORT_TIME} 은 08:00 이라 창이 자정을 넘지 않지만,
+     * 시각이 바뀌어도 요일 판정이 어긋나지 않도록 발생일에 맞춰 둔다.
+     */
     private boolean isWeeklyReportDue(OffsetDateTime now) {
-        return now.getDayOfWeek().getValue() == 1 && isDue(WEEKLY_REPORT_TIME, now);
+        return dueOccurrenceDate(WEEKLY_REPORT_TIME, now)
+                .filter(occurrenceDate -> occurrenceDate.getDayOfWeek().getValue() == 1)
+                .isPresent();
     }
 
-    private boolean hasIncompleteTodoToday(UUID userId, OffsetDateTime now) {
-        OffsetDateTime from = now.toLocalDate().atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+    /**
+     * To-do 완료 여부도 발생일 하루치를 본다. 현재 {@code TODO_REMINDER_TIME} 은 21:00 이라
+     * 창이 자정을 넘지 않지만, 체크인과 같은 이유로 판정 시점이 아닌 발생일을 기준으로 삼는다.
+     */
+    private boolean hasIncompleteTodo(UUID userId, LocalDate occurrenceDate) {
+        OffsetDateTime from = occurrenceDate.atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
         OffsetDateTime to = from.plusDays(1);
         List<BehaviorTask> tasks = behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(userId, from, to);
         if (tasks.isEmpty()) {
@@ -292,11 +320,18 @@ public class NotificationService {
      *
      * <p>{@code 23:55} 처럼 판정 창이 자정을 넘어가는 경우를 위해 단순 비교 대신
      * 하루(1440분)를 주기로 하는 순환 경과 시간으로 계산한다.
+     *
+     * @return 도래했으면 그 목표 시각이 <b>실제로 발생한 날짜</b>, 아니면 {@code Optional.empty()}.
+     *         판정 창이 자정을 넘으면 발생일은 판정 시점의 전날이 된다. 완료 여부 조회처럼
+     *         날짜가 필요한 곳은 반드시 이 발생일을 써야 판정과 조회 기준이 어긋나지 않는다.
      */
-    private boolean isDue(LocalTime target, OffsetDateTime now) {
+    private Optional<LocalDate> dueOccurrenceDate(LocalTime target, OffsetDateTime now) {
         LocalTime current = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES);
         long elapsedMinutes = Math.floorMod(Duration.between(target, current).toMinutes(), MINUTES_PER_DAY);
-        return elapsedMinutes < DUE_WINDOW_MINUTES;
+        if (elapsedMinutes >= DUE_WINDOW_MINUTES) {
+            return Optional.empty();
+        }
+        return Optional.of(now.minusMinutes(elapsedMinutes).toLocalDate());
     }
 
     private boolean shouldSuppressTrigger(UUID userId, String triggerCode, OffsetDateTime now) {

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -48,6 +48,8 @@ public class NotificationService {
 
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
+    private static final LocalTime SERVER_INITIATED_WINDOW_START = LocalTime.of(8, 0);
+    private static final LocalTime SERVER_INITIATED_WINDOW_END = LocalTime.of(22, 0);
     private static final int DAILY_SEND_LIMIT = 3;
     private static final int DUE_WINDOW_MINUTES = 10;
     private static final int MINUTES_PER_DAY = 1440;
@@ -201,10 +203,12 @@ public class NotificationService {
     private String determineTrigger(NotificationSetting setting, OffsetDateTime now) {
         UUID userId = setting.getUser().getId();
         LocalDate today = now.toLocalDate();
+        boolean serverInitiatedAllowed = isWithinServerInitiatedWindow(now);
 
-        if (setting.isCheckinEnabled() && hasNegativeEmotionStreak(userId)) {
+        if (setting.isCheckinEnabled() && serverInitiatedAllowed && hasNegativeEmotionStreak(userId)) {
             return "negative_emotion_streak";
         }
+        // 아래 체크인 리마인더는 유저가 직접 고른 시각이므로 시간대 제한을 두지 않는다.
         if (setting.isCheckinEnabled()) {
             if (isDue(setting.getCheckinMorningTime(), now) && !hasCompletedCheckin(userId, today, "morning")) {
                 return "checkin_reminder_morning";
@@ -216,16 +220,39 @@ public class NotificationService {
                 return "checkin_reminder_evening";
             }
         }
-        if (setting.isReportEnabled() && isWeeklyReportDue(now)) {
+        if (setting.isReportEnabled() && serverInitiatedAllowed && isWeeklyReportDue(now)) {
             return "report_weekly";
         }
         if (setting.isCharacterEnabled()
                 && setting.isTodoReminderOn()
+                && serverInitiatedAllowed
                 && isDue(TODO_REMINDER_TIME, now)
                 && hasIncompleteTodoToday(userId, now)) {
             return "todo_incomplete";
         }
         return null;
+    }
+
+    /**
+     * 서버가 시점을 정하는 알림을 지금 보내도 되는지 판정한다. (KST 08:00~22:00, 양끝 포함)
+     *
+     * <p>알림 트리거는 두 종류로 나뉜다.
+     * <ul>
+     *   <li><b>유저가 시각을 직접 설정하는 트리거</b> — 체크인 리마인더(아침·오후·저녁).
+     *       유저가 새벽 01:08 을 골랐다면 그건 본인의 선택이므로 그대로 존중하고
+     *       이 창을 적용하지 않는다.</li>
+     *   <li><b>서버가 시점을 정하는 개입성 트리거</b> — {@code negative_emotion_streak}(시각 조건이
+     *       아예 없어 아무 틱에서나 발생), {@code report_weekly}, {@code todo_incomplete}.
+     *       유저가 동의한 적 없는 시점에 서버가 임의로 깨우는 셈이므로 심야를 피한다.</li>
+     * </ul>
+     *
+     * <p>창 밖이면 해당 트리거를 <b>건너뛰기만</b> 한다. 이월하거나 큐에 쌓지 않으며,
+     * 다음 날에도 조건이 여전히 충족되면 자연히 다시 잡힌다.
+     */
+    private boolean isWithinServerInitiatedWindow(OffsetDateTime now) {
+        LocalTime current = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES);
+        return !current.isBefore(SERVER_INITIATED_WINDOW_START)
+                && !current.isAfter(SERVER_INITIATED_WINDOW_END);
     }
 
     private boolean hasCompletedCheckin(UUID userId, LocalDate today, String slot) {

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -41,6 +41,7 @@ import com.mio.common.error.ErrorCode;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -329,6 +330,134 @@ class NotificationServiceTest {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(notificationSettingRepository).findSendableTargets(pageableCaptor.capture());
         assertThat(pageableCaptor.getValue().getSort().getOrderFor("id")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("판정 창 시작 경계(설정 시각 정각)에는 발송한다")
+    void isDue_windowStart_sends() {
+        runEveningScenario(LocalTime.of(22, 0), "2026-05-26T13:00:00Z");
+
+        assertEveningReminderSent();
+    }
+
+    @Test
+    @DisplayName("판정 창 끝 직전(설정 시각 +9분)에는 발송한다")
+    void isDue_justBeforeWindowEnd_sends() {
+        runEveningScenario(LocalTime.of(22, 0), "2026-05-26T13:09:00Z");
+
+        assertEveningReminderSent();
+    }
+
+    @Test
+    @DisplayName("판정 창을 벗어나면(설정 시각 +10분) 발송하지 않는다")
+    void isDue_windowEnd_doesNotSend() {
+        runEveningScenario(LocalTime.of(22, 0), "2026-05-26T13:10:00Z");
+
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("설정 시각 이전(-1분)에는 발송하지 않는다")
+    void isDue_beforeTarget_doesNotSend() {
+        runEveningScenario(LocalTime.of(22, 0), "2026-05-26T12:59:00Z");
+
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("자정을 넘기는 설정 시각(23:55)도 다음 날 00:04까지 발송한다")
+    void isDue_windowCrossingMidnight_sends() {
+        runEveningScenario(LocalTime.of(23, 55), "2026-05-26T15:04:00Z");
+
+        assertEveningReminderSent();
+    }
+
+    @Test
+    @DisplayName("자정을 넘긴 뒤 판정 창을 벗어나면(00:05) 발송하지 않는다")
+    void isDue_afterWindowCrossingMidnight_doesNotSend() {
+        runEveningScenario(LocalTime.of(23, 55), "2026-05-26T15:05:00Z");
+
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("새벽 시각(01:08)으로 설정한 알림도 조용시간 없이 발송한다")
+    void quietHoursRemoved_dawnScheduleSends() {
+        runEveningScenario(LocalTime.of(1, 8), "2026-05-26T16:08:00Z");
+
+        assertEveningReminderSent();
+    }
+
+    @Test
+    @DisplayName("00:00 설정도 조용시간에 폐기되지 않고 발송한다")
+    void quietHoursRemoved_midnightScheduleSends() {
+        runEveningScenario(LocalTime.of(0, 0), "2026-05-26T15:00:00Z");
+
+        assertEveningReminderSent();
+    }
+
+    /**
+     * 저녁 체크인 슬롯만 대상으로 스케줄러를 한 번 실행한다.
+     * 아침(09:00)·오후(12:00) 기본값과 주간 리포트(08:00)·To-do(21:00) 시각은
+     * 테스트에서 쓰는 시각들과 겹치지 않으므로 저녁 트리거만 격리된다.
+     */
+    private void runEveningScenario(LocalTime eveningTime, String utcInstant) {
+        Clock clock = Clock.fixed(Instant.parse(utcInstant), ZoneOffset.of("+09:00"));
+        NotificationService service = new NotificationService(
+                clock,
+                userRepository,
+                deviceTokenRepository,
+                notificationSettingRepository,
+                proactiveCareLogRepository,
+                checkinRepository,
+                behaviorTaskRepository,
+                stringRedisTemplate,
+                new NotificationMessageMapper(),
+                pushSender,
+                notificationPersistenceService
+        );
+
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        setField(setting, "checkinEveningTime", eveningTime);
+        DeviceToken token = DeviceToken.builder()
+                .user(user)
+                .deviceId("device-1")
+                .platform("android")
+                .token("fcm-token")
+                .build();
+
+        lenient().when(notificationSettingRepository.findByNotificationAgreeTrue(any())).thenReturn(
+                new org.springframework.data.domain.SliceImpl<>(List.of(setting))
+        );
+        lenient().when(valueOperations.get(anyString())).thenReturn(null);
+        lenient().when(proactiveCareLogRepository.countByUser_IdAndSentAtBetween(eq(userId), any(), any())).thenReturn(0L);
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndSentAtAfter(eq(userId), anyString(), any()))
+                .thenReturn(false);
+        lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(false);
+        lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any())).thenReturn(List.of());
+        lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(PushSendResult.SENT);
+
+        service.processScheduledNotifications();
+    }
+
+    private void assertEveningReminderSent() {
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId),
+                eq("checkin_reminder_evening"),
+                eq(true),
+                eq(List.of()),
+                eq(true)
+        );
+    }
+
+    private void assertNoReminderSent() {
+        verify(notificationPersistenceService, never()).persistNotificationResult(
+                any(), anyString(), anyBoolean(), any(), anyBoolean()
+        );
     }
 
     private void setUserId(User u, UUID id) {

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -399,6 +399,37 @@ class NotificationServiceTest {
     }
 
     @Test
+    @DisplayName("자정을 넘는 창에서는 체크인 완료 여부를 발생일(전날) 기준으로 조회한다")
+    void midnightCrossingWindow_checksCompletionOnOccurrenceDate() {
+        // 저녁 체크인 23:58 설정. 유저는 05-26 23:56 에 스스로 체크인을 마쳤다.
+        // 05-27 00:00 틱에서도 isDue 는 여전히 true(경과 2분)이므로,
+        // 완료 여부는 판정 시점(05-27)이 아니라 발생일(05-26)로 조회해야 한다.
+        runEveningScenario(LocalTime.of(23, 58), "2026-05-26T15:00:00Z", LocalDate.of(2026, 5, 26));
+
+        verify(checkinRepository).existsByUser_IdAndCheckinDateAndTimeOfDay(
+                userId, LocalDate.of(2026, 5, 26), "evening");
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("자정을 넘는 창이어도 전날 체크인이 없으면 정상 발송한다")
+    void midnightCrossingWindow_notCompleted_sends() {
+        runEveningScenario(LocalTime.of(23, 58), "2026-05-26T15:00:00Z", null);
+
+        assertEveningReminderSent();
+    }
+
+    @Test
+    @DisplayName("자정을 넘지 않는 창에서는 발생일이 판정 당일과 같다")
+    void sameDayWindow_checksCompletionOnSameDate() {
+        runEveningScenario(LocalTime.of(22, 0), "2026-05-26T13:05:00Z", null);
+
+        verify(checkinRepository).existsByUser_IdAndCheckinDateAndTimeOfDay(
+                userId, LocalDate.of(2026, 5, 26), "evening");
+        assertEveningReminderSent();
+    }
+
+    @Test
     @DisplayName("새벽에는 서버가 시점을 정하는 negative_emotion_streak 를 발송하지 않는다")
     void serverInitiatedTrigger_atDawn_isSkipped() {
         runStreakScenario(LocalTime.of(23, 30), "2026-05-25T18:00:00Z");
@@ -486,7 +517,21 @@ class NotificationServiceTest {
         runScenario(eveningTime, utcInstant, List.of());
     }
 
+    private void runEveningScenario(LocalTime eveningTime, String utcInstant, LocalDate completedEveningDate) {
+        runScenario(eveningTime, utcInstant, List.of(), completedEveningDate);
+    }
+
     private void runScenario(LocalTime eveningTime, String utcInstant, List<Checkin> recentCheckins) {
+        runScenario(eveningTime, utcInstant, recentCheckins, null);
+    }
+
+    /**
+     * @param completedEveningDate 유저가 저녁 체크인을 완료한 날짜. {@code null} 이면 미완료.
+     *                             날짜를 {@code any()} 로 뭉개지 않고 실제 전달된 값과 대조해,
+     *                             잘못된 날짜로 조회하면 완료 기록을 못 찾도록 한다.
+     */
+    private void runScenario(LocalTime eveningTime, String utcInstant, List<Checkin> recentCheckins,
+                             LocalDate completedEveningDate) {
         Clock clock = Clock.fixed(Instant.parse(utcInstant), ZoneOffset.of("+09:00"));
         NotificationService service = new NotificationService(
                 clock,
@@ -520,7 +565,9 @@ class NotificationServiceTest {
                 .thenReturn(false);
         lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(recentCheckins);
         lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
-                .thenReturn(false);
+                .thenAnswer(invocation -> completedEveningDate != null
+                        && completedEveningDate.equals(invocation.getArgument(1))
+                        && "evening".equals(invocation.getArgument(2)));
         lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any())).thenReturn(List.of());
         lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
         lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString()))

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -511,7 +511,7 @@ class NotificationServiceTest {
                 .token("fcm-token")
                 .build();
 
-        lenient().when(notificationSettingRepository.findByNotificationAgreeTrue(any())).thenReturn(
+        lenient().when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
                 new org.springframework.data.domain.SliceImpl<>(List.of(setting))
         );
         lenient().when(valueOperations.get(anyString())).thenReturn(null);

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -1,5 +1,6 @@
 package com.mio.notification.service;
 
+import com.mio.checkin.domain.Checkin;
 import com.mio.checkin.repository.CheckinRepository;
 import com.mio.notification.domain.DeviceToken;
 import com.mio.notification.domain.NotificationSetting;
@@ -25,6 +26,7 @@ import org.springframework.data.redis.core.ValueOperations;
 
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.time.OffsetDateTime;
@@ -396,12 +398,95 @@ class NotificationServiceTest {
         assertEveningReminderSent();
     }
 
+    @Test
+    @DisplayName("새벽에는 서버가 시점을 정하는 negative_emotion_streak 를 발송하지 않는다")
+    void serverInitiatedTrigger_atDawn_isSkipped() {
+        runStreakScenario(LocalTime.of(23, 30), "2026-05-25T18:00:00Z");
+
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("새벽이어도 유저가 직접 설정한 체크인 알림은 발송한다 (두 정책이 간섭하지 않는다)")
+    void userScheduledTrigger_atDawn_stillSends_whileServerTriggerSkipped() {
+        runStreakScenario(LocalTime.of(3, 0), "2026-05-25T18:00:00Z");
+
+        assertEveningReminderSent();
+        verify(notificationPersistenceService, never()).persistNotificationResult(
+                any(), eq("negative_emotion_streak"), anyBoolean(), any(), anyBoolean()
+        );
+    }
+
+    @Test
+    @DisplayName("서버 발생 트리거 허용 창 시작(08:00)에는 발송한다")
+    void serverInitiatedTrigger_atWindowStart_sends() {
+        runStreakScenario(LocalTime.of(23, 30), "2026-05-25T23:00:00Z");
+
+        assertStreakNotificationSent();
+    }
+
+    @Test
+    @DisplayName("서버 발생 트리거 허용 창 시작 직전(07:59)에는 발송하지 않는다")
+    void serverInitiatedTrigger_justBeforeWindowStart_isSkipped() {
+        runStreakScenario(LocalTime.of(23, 30), "2026-05-25T22:59:00Z");
+
+        assertNoReminderSent();
+    }
+
+    @Test
+    @DisplayName("서버 발생 트리거 허용 창 끝(22:00)에는 발송한다")
+    void serverInitiatedTrigger_atWindowEnd_sends() {
+        runStreakScenario(LocalTime.of(23, 30), "2026-05-26T13:00:00Z");
+
+        assertStreakNotificationSent();
+    }
+
+    @Test
+    @DisplayName("서버 발생 트리거 허용 창을 넘기면(22:01) 발송하지 않는다")
+    void serverInitiatedTrigger_afterWindowEnd_isSkipped() {
+        runStreakScenario(LocalTime.of(23, 30), "2026-05-26T13:01:00Z");
+
+        assertNoReminderSent();
+    }
+
+    /**
+     * 최근 체크인 3건이 모두 부정 감정인 상태(negative_emotion_streak 조건 충족)로
+     * 스케줄러를 한 번 실행한다.
+     */
+    private void runStreakScenario(LocalTime eveningTime, String utcInstant) {
+        runScenario(eveningTime, utcInstant, List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+    }
+
+    private Checkin negativeCheckin() {
+        return Checkin.builder()
+                .user(user)
+                .timeOfDay("evening")
+                .emotionType("sad")
+                .conditionScore(1)
+                .checkinDate(LocalDate.of(2026, 5, 25))
+                .build();
+    }
+
+    private void assertStreakNotificationSent() {
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId),
+                eq("negative_emotion_streak"),
+                eq(true),
+                eq(List.of()),
+                eq(true)
+        );
+    }
+
     /**
      * 저녁 체크인 슬롯만 대상으로 스케줄러를 한 번 실행한다.
      * 아침(09:00)·오후(12:00) 기본값과 주간 리포트(08:00)·To-do(21:00) 시각은
      * 테스트에서 쓰는 시각들과 겹치지 않으므로 저녁 트리거만 격리된다.
      */
     private void runEveningScenario(LocalTime eveningTime, String utcInstant) {
+        runScenario(eveningTime, utcInstant, List.of());
+    }
+
+    private void runScenario(LocalTime eveningTime, String utcInstant, List<Checkin> recentCheckins) {
         Clock clock = Clock.fixed(Instant.parse(utcInstant), ZoneOffset.of("+09:00"));
         NotificationService service = new NotificationService(
                 clock,
@@ -433,7 +518,7 @@ class NotificationServiceTest {
         lenient().when(proactiveCareLogRepository.countByUser_IdAndSentAtBetween(eq(userId), any(), any())).thenReturn(0L);
         lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndSentAtAfter(eq(userId), anyString(), any()))
                 .thenReturn(false);
-        lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(recentCheckins);
         lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
                 .thenReturn(false);
         lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any())).thenReturn(List.of());


### PR DESCRIPTION
## 요약
알림 스케줄 판정과 관련된 버그 3건을 함께 고칩니다.

핵심은 **조용시간(00:00~08:00) 정책을 제거하는 동작 변경**입니다. 기존에는 `processScheduledNotifications` 가 KST 08:00 이전이면 어떤 알림도 보내지 않고 즉시 return 했습니다. 프론트는 새벽 시각 설정을 허용하는데 서버가 그 설정을 아무 피드백 없이 폐기하고 있었고, 그 결과 새벽 시각으로 설정한 유저는 알림을 **영구히** 받지 못했습니다(2026-08-08 실측 기준 7명 중 2명 — `01:08`, `01:16`). 이제 유저가 설정한 시각을 그대로 존중합니다.

다만 조용시간을 일괄 제거하면 **유저가 시각을 지정하지 않는 트리거**(`negative_emotion_streak` 등)까지 새벽에 발송될 수 있어, 이들에 한해서만 **08:00~22:00 (KST)** 발송 창을 별도로 두었습니다. 즉 **"유저가 지정한 시각은 존중하되, 서버가 임의 시점에 발생시키는 개입성 알림은 심야를 피한다"** 는 정책입니다.

함께, `isDue` 판정 창이 스케줄러 주기와 같아 배포 중 알림이 유실되던 문제를 고치고, 5분 주기에서 비롯되는 지연이 예측 가능하고 문서화된 동작이 되도록 주석으로 명시했습니다.

## 관련 이슈
- Closes #393
- Closes #394
- Closes #395

## 변경 사항
- **조용시간 가드 제거 (#394)** — `QUIET_HOURS_END` 상수와 `processScheduledNotifications` 의 `08:00` 이전 early return 을 삭제. 00:00~08:00 으로 설정한 체크인 알림이 실제로 발송됩니다.
- **트리거 종류별 발송 시간대 분리 (#394 후속)** — `determineTrigger` 를 두 갈래로 정리했습니다.
  - *유저가 시각을 직접 설정하는 트리거* — `checkin_reminder_morning/afternoon/evening` 은 **시간 제한 없음**. 새벽 01:08 설정도 그대로 발송됩니다.
  - *서버가 시점을 정하는 개입성 트리거* — `negative_emotion_streak`(시각 조건이 아예 없어 아무 틱에서나 발생), `report_weekly`(월 08:00 고정), `todo_incomplete`(21:00 고정) 는 `SERVER_INITIATED_WINDOW_START/END` (08:00~22:00, 양끝 포함) 안에서만 발송합니다. 뒤의 둘은 이미 창 안이라 실질 변화는 없지만 같은 상수로 일관되게 처리했습니다.
  - 창 밖이면 해당 트리거를 **건너뛰기만** 합니다. 이월하거나 큐에 쌓지 않으며, 다음 날에도 조건이 충족되면 자연히 다시 잡힙니다.
- **`isDue` 판정 창 5분 → 10분 (#395)** — 창(5분)이 스케줄러 주기(5분)와 정확히 같아 창 안에 들어오는 실행이 단 한 번뿐이었습니다. 그 한 틱을 배포·재기동으로 놓치면 해당 트리거는 그날 영영 발송되지 않습니다. 창을 10분으로 넓혀 **최소 2회의 실행 기회**를 보장합니다.
- **자정 넘김 경계 처리 (#395)** — `target.plusMinutes(10)` 이 다음 날로 넘어가는 경우(예: `23:55` → `00:05`) 기존의 단순 `LocalTime` 비교가 깨집니다. `Math.floorMod(Duration.between(target, current).toMinutes(), 1440)` 으로 **하루를 주기로 하는 순환 경과 시간** 계산으로 바꿔 해결했습니다. 조용시간 가드를 제거하면 심야·새벽 설정이 실제로 동작하게 되므로 이 경계 처리가 반드시 필요합니다.
- **5분 지연 문서화 (#393)** — 스케줄러 주기는 5분으로 **유지**합니다. 알림이 "설정 시각 이후 최초 스케줄러 틱"에 발송되어 최대 5분 지연될 수 있다는 점을 `ProactiveCareJob#run` 과 `NotificationService#isDue` 의 Javadoc 에 명시했습니다.
- 위 경계를 고정 `Clock` 으로 검증하는 단위 테스트 14건 추가.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [x] Breaking change 가 있습니다.

> **동작 변경 (1)**: 조용시간 정책이 제거되어 이제 **유저가 직접 설정한 체크인 알림은 00:00~08:00 에도 발송됩니다.** 기존에는 이 시간대 전체가 차단되어 있었습니다. 새벽 알림을 원하는 유저가 실제로 존재한다는 것이 실측으로 확인되어 내린 결정입니다.
>
> **동작 변경 (2)**: 반대로 **서버가 시점을 정하는 트리거는 08:00~22:00 으로 제한됩니다.** 특히 `negative_emotion_streak` 는 기존에 08:00 이후 아무 시각에나(밤 23시 포함) 발송될 수 있었으나, 이제 22:00 이후에는 발송되지 않습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
./gradlew test --tests "com.mio.notification.*"
```

### 확인 내용
고정 `Clock`(`Clock.fixed(..., +09:00)`)으로 경계를 검증합니다. `LocalTime.now()` 직접 호출 없이 모든 시간 판정이 주입된 `Clock` 을 거칩니다.

**`isDue` 판정 창 (#393 / #395)**

| 시나리오 | 설정 시각 | 현재 시각(KST) | 기대 |
|---|---|---|---|
| 창 시작 경계 | 22:00 | 22:00 | 발송 |
| 창 끝 직전 | 22:00 | 22:09 | 발송 |
| 창 끝(경계 밖) | 22:00 | 22:10 | 미발송 |
| 설정 시각 이전 | 22:00 | 21:59 | 미발송 |
| **자정 넘김** | 23:55 | 익일 00:04 | 발송 |
| **자정 넘김 창 밖** | 23:55 | 익일 00:05 | 미발송 |
| **새벽(#394 실측 케이스)** | 01:08 | 01:08 | 발송 |
| **자정 정각** | 00:00 | 00:00 | 발송 |

**서버 발생 트리거 시간대 제한**

| 시나리오 | 현재 시각(KST) | 기대 |
|---|---|---|
| 새벽에 `negative_emotion_streak` 조건 충족 | 03:00 | **미발송** |
| 같은 새벽에 유저가 `03:00` 으로 직접 설정한 체크인 | 03:00 | **정상 발송** (두 정책이 간섭하지 않음) |
| 창 시작 직전 | 07:59 | 미발송 |
| 창 시작 경계 | 08:00 | 발송 |
| 창 끝 경계 | 22:00 | 발송 |
| 창 끝 직후 | 22:01 | 미발송 |

두 번째 행이 이번 정책의 핵심입니다 — **같은 새벽 시각에** 서버 발생 트리거는 막히고 유저 설정 트리거는 통과하는 것을 한 테스트에서 고정해, 두 정책이 서로 간섭하지 않음을 회귀 방지합니다.

수정 전 코드에서 각 단계별로 정확히 RED 를 확인한 뒤(판정 창 4건, 시간대 제한 4건) 구현했고, 나머지는 기존 동작 회귀 가드로 통과했습니다. 최종 전체 GREEN 입니다.

`./gradlew build` 결과: **964건 중 963건 통과**. 유일한 실패인 `MioApplicationTests.contextLoads()` 는 로컬 DB 의 Flyway 이력 어긋남에 의한 것으로, **이 브랜치의 변경 없이 develop 원본에서도 동일하게 실패**함을 확인했습니다(이 PR 과 무관). CI 환경에서는 정상 통과가 예상됩니다.

## 중점 리뷰 포인트
1. **`negative_emotion_streak` 발송 시간대 — 이렇게 처리했습니다.** 이 트리거는 유저가 설정한 시각이 아니라 조건 충족 시 아무 틱에서나 발생합니다. 기존에는 조용시간 가드가 *부수적으로* 이를 08:00 이후로 밀어주고 있었는데, 가드를 제거하면 새벽 3시에도 발송될 수 있게 됩니다. 그래서 **유저가 시각을 지정하지 않는 트리거에만** `08:00~22:00` 창(`isWithinServerInitiatedWindow`)을 적용했습니다. 체크인 리마인더는 이 창의 영향을 받지 않으므로 #394 의 수정(새벽 설정 존중)은 그대로 유지됩니다. **창 경계값(08:00 시작 포함 / 22:00 끝 포함)이 적절한지 확인 부탁드립니다.**
2. **판정 창 확대와 중복 발송** — 창이 10분이 되어 한 트리거가 2개 틱에 걸립니다. 중복은 `shouldSuppressTrigger` 의 24시간 억제에 의존합니다. 해당 로직이 상태를 구분하도록 고치는 작업이 별도 PR 로 진행 중이므로, 이 PR 에서는 읽기만 하고 수정하지 않았습니다. **두 PR 의 머지 순서에 따라 중복 발송 가능성이 달라질 수 있으니 순서 확인이 필요합니다.**
3. **후속 필요 — FE 5분 단위 제한** — #393 의 지연 자체를 없애려면 클라이언트에서 알림 시각 선택을 5분 단위로 제한해야 합니다. 이 PR 은 지연을 예측 가능하고 문서화된 동작으로 만드는 데까지가 범위이며, FE 작업은 **별도 과제**로 남습니다.
4. `Math.floorMod` 를 쓴 순환 경과 시간 계산이 자정 경계에서 의도대로 동작하는지 확인 부탁드립니다.

## 배포 / 롤백
- Rollout: 코드 배포만으로 즉시 적용됩니다. 마이그레이션·설정 변경 없음. 배포 직후 첫 새벽 구간(00:00~08:00)에 기존에 없던 체크인 푸시가 발생하므로, 발송량과 `proactive_care_logs` 추이를 모니터링하는 것이 좋습니다.
- Rollback: 코드 revert 만으로 즉시 원복됩니다. 상태나 스키마 변경이 없어 데이터 정합성 이슈는 없습니다. 원복 시 새벽 설정 유저는 다시 알림을 받지 못하게 됩니다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (해당 없음 — 판정 규칙은 코드 Javadoc 에 명시)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
