### PR TITLE
fix: 탈퇴한 유저를 알림 발송 대상에서 제외한다 (#388)

### DIFF
--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -5,6 +5,8 @@ import com.mio.auth.provider.SocialAuthProvider;
 import com.mio.common.audit.AuditLogService;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.notification.domain.DeviceToken;
+import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.domain.UserConsent;
@@ -42,6 +44,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final UserConsentRepository userConsentRepository;
     private final UserDeviceRepository userDeviceRepository;
+    private final DeviceTokenRepository deviceTokenRepository;
     private final JwtTokenService jwtTokenService;
     private final RefreshTokenService refreshTokenService;
     private final AuditLogService auditLogService;
@@ -226,6 +229,7 @@ public class AuthService {
 
         refreshTokenService.invalidateAll(userId.toString());
         userDeviceRepository.deleteAllByUser_Id(userId);
+        invalidateDeviceTokens(userId);
 
         // PII 비식별화 정책 — social_id를 해시로 대체해 재가입 방지 키만 유지
         String anonymizedSocialId = sha256(user.getSocialId());
@@ -237,6 +241,22 @@ public class AuthService {
         ));
 
         return new WithdrawResponse(user.getDeletedAt());
+    }
+
+    /**
+     * 탈퇴 시 푸시 토큰을 전부 무효화한다 (이슈 #388).
+     *
+     * <p>{@code user_devices} 삭제만으로는 {@code device_tokens}가 남아 탈퇴자 기기로 실제
+     * 배달이 가능한 상태가 유지된다. 행 자체는 {@code DataRetentionJob}의 30일 하드 삭제에
+     * 맡기고, 여기서는 즉시 발송 불가 상태로 만든다.
+     */
+    private void invalidateDeviceTokens(UUID userId) {
+        List<DeviceToken> tokens = deviceTokenRepository.findByUser_IdAndIsValidTrue(userId);
+        if (tokens.isEmpty()) {
+            return;
+        }
+        tokens.forEach(DeviceToken::invalidate);
+        deviceTokenRepository.saveAll(tokens);
     }
 
     private SocialAuthProvider getProvider(String providerName) {

--- a/src/main/java/com/mio/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/mio/notification/repository/NotificationSettingRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
@@ -13,6 +14,28 @@ public interface NotificationSettingRepository extends JpaRepository<Notificatio
 
     Optional<NotificationSetting> findByUser_Id(UUID userId);
 
+    /**
+     * 스케줄 발송 대상 조회 (이슈 #388).
+     *
+     * <p>탈퇴(soft delete)한 유저의 {@code notification_settings} 행은 그대로 남기 때문에,
+     * 동의 플래그만 보면 탈퇴자에게 계속 푸시가 나간다. 개인정보 처리 정지 요구에 반하므로
+     * {@code users}를 조인해 상태로 거른다.
+     *
+     * <ul>
+     *   <li>{@code deleted_at IS NULL} — soft delete 유저 제외</li>
+     *   <li>{@code status NOT IN ('DELETED', 'SUSPENDED')} — 탈퇴/정지 유저 제외</li>
+     * </ul>
+     *
+     * <p>설정 행을 비활성화하지 않고 조인 조건으로만 거르는 이유는, 계정 복구·재가입 시
+     * 유저가 지정했던 알림 시각을 되살릴 수 있어야 하기 때문이다.
+     */
     @EntityGraph(attributePaths = "user")
-    Slice<NotificationSetting> findByNotificationAgreeTrue(Pageable pageable);
+    @Query("""
+            select ns from NotificationSetting ns
+            join ns.user u
+            where ns.notificationAgree = true
+              and u.deletedAt is null
+              and u.status not in ('DELETED', 'SUSPENDED')
+            """)
+    Slice<NotificationSetting> findSendableTargets(Pageable pageable);
 }

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -141,7 +141,8 @@ public class NotificationService {
         Pageable pageable = PageRequest.of(0, SCHEDULER_BATCH_SIZE, SCHEDULER_SORT);
         Slice<NotificationSetting> batch;
         do {
-            batch = notificationSettingRepository.findByNotificationAgreeTrue(pageable);
+            // 탈퇴(DELETED)·정지(SUSPENDED) 유저는 조회 단계에서 제외된다 (이슈 #388)
+            batch = notificationSettingRepository.findSendableTargets(pageable);
             for (NotificationSetting setting : batch.getContent()) {
                 evaluateAndSend(setting, now);
             }

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -5,6 +5,8 @@ import com.mio.auth.provider.SocialAuthProvider;
 import com.mio.common.audit.AuditLogService;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.notification.domain.DeviceToken;
+import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.user.domain.SignupStep;
 import com.mio.user.domain.User;
 import com.mio.user.domain.UserDevice;
@@ -34,6 +36,7 @@ class AuthServiceTest {
     @Mock private UserRepository userRepository;
     @Mock private UserConsentRepository userConsentRepository;
     @Mock private UserDeviceRepository userDeviceRepository;
+    @Mock private DeviceTokenRepository deviceTokenRepository;
     @Mock private JwtTokenService jwtTokenService;
     @Mock private RefreshTokenService refreshTokenService;
     @Mock private AuditLogService auditLogService;
@@ -51,7 +54,7 @@ class AuthServiceTest {
                 .thenReturn(Optional.empty());
         authService = new AuthService(
                 List.of(kakaoProvider), userRepository, userConsentRepository,
-                userDeviceRepository, jwtTokenService, refreshTokenService, auditLogService
+                userDeviceRepository, deviceTokenRepository, jwtTokenService, refreshTokenService, auditLogService
         );
     }
 
@@ -349,7 +352,47 @@ class AuthServiceTest {
         assertThat(user.getEmail()).isNull();
     }
 
+    @Test
+    @DisplayName("회원탈퇴 시 유효한 디바이스 토큰을 모두 무효화한다")
+    void withdraw_invalidatesAllDeviceTokens() {
+        User user = buildUser(USER_ID, "kakao", "original-social-id", SignupStep.COMPLETED, "ACTIVE");
+        DeviceToken iosToken = buildDeviceToken(user, "device-ios", "ios", "apns-token");
+        DeviceToken androidToken = buildDeviceToken(user, "device-android", "android", "fcm-token");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(USER_ID))
+                .thenReturn(List.of(iosToken, androidToken));
+
+        authService.withdraw(USER_ID);
+
+        assertThat(iosToken.isValid()).isFalse();
+        assertThat(androidToken.isValid()).isFalse();
+        verify(deviceTokenRepository).saveAll(List.of(iosToken, androidToken));
+    }
+
+    @Test
+    @DisplayName("유효한 디바이스 토큰이 없으면 탈퇴 시 저장을 시도하지 않는다")
+    void withdraw_withoutDeviceTokens_skipsSave() {
+        User user = buildUser(USER_ID, "kakao", "original-social-id", SignupStep.COMPLETED, "ACTIVE");
+
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(USER_ID)).thenReturn(List.of());
+
+        authService.withdraw(USER_ID);
+
+        verify(deviceTokenRepository, never()).saveAll(any());
+    }
+
     // ──────────────── helpers ────────────────
+
+    private DeviceToken buildDeviceToken(User user, String deviceId, String platform, String token) {
+        return DeviceToken.builder()
+                .user(user)
+                .deviceId(deviceId)
+                .platform(platform)
+                .token(token)
+                .build();
+    }
 
     private User buildUser(UUID id, String provider, String socialId, SignupStep signupStep, String status) {
         return User.builder()

--- a/src/test/java/com/mio/notification/repository/NotificationSettingRepositoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/repository/NotificationSettingRepositoryIntegrationTest.java
@@ -1,0 +1,116 @@
+package com.mio.notification.repository;
+
+import com.mio.notification.domain.NotificationSetting;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.Sort;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 스케줄 발송 대상 조회가 탈퇴·정지 유저를 실제 DB에서 걸러내는지 검증한다 (이슈 #388).
+ *
+ * <p>목으로는 확인할 수 없다. 필터는 전적으로 JPQL 조인 조건에 들어 있어서, 조건이 빠지거나
+ * 컬럼 매핑이 어긋나도 서비스 단위 테스트는 그대로 통과한다. 탈퇴자에게 푸시가 나가는 것은
+ * 개인정보 처리 정지 위반이므로 쿼리 자체를 실행해서 확인한다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class NotificationSettingRepositoryIntegrationTest {
+
+    @Autowired private NotificationSettingRepository notificationSettingRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> createdUserIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        for (UUID userId : createdUserIds) {
+            jdbcTemplate.update("DELETE FROM notification_settings WHERE user_id = ?", userId);
+            jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
+        }
+        createdUserIds.clear();
+    }
+
+    @Test
+    @DisplayName("탈퇴한 유저의 알림 설정은 발송 대상에서 제외된다")
+    void findSendableTargets_excludesWithdrawnUser() {
+        UUID activeUserId = createUserWithSetting(user -> user.activate());
+        UUID withdrawnUserId = createUserWithSetting(user -> user.softDelete("anonymized-" + UUID.randomUUID()));
+
+        List<UUID> targetUserIds = sendableTargetUserIds();
+
+        assertThat(targetUserIds).contains(activeUserId);
+        assertThat(targetUserIds).doesNotContain(withdrawnUserId);
+    }
+
+    @Test
+    @DisplayName("정지된 유저의 알림 설정은 발송 대상에서 제외된다")
+    void findSendableTargets_excludesSuspendedUser() {
+        UUID suspendedUserId = createUserWithSetting(user -> user.activate());
+        jdbcTemplate.update("UPDATE users SET status = 'SUSPENDED' WHERE id = ?", suspendedUserId);
+
+        assertThat(sendableTargetUserIds()).doesNotContain(suspendedUserId);
+    }
+
+    @Test
+    @DisplayName("status가 남아 있어도 deleted_at이 찍힌 유저는 발송 대상에서 제외된다")
+    void findSendableTargets_excludesUserWithDeletedAt() {
+        UUID userId = createUserWithSetting(user -> user.activate());
+        jdbcTemplate.update("UPDATE users SET deleted_at = now() WHERE id = ?", userId);
+
+        assertThat(sendableTargetUserIds()).doesNotContain(userId);
+    }
+
+    @Test
+    @DisplayName("알림에 동의하지 않은 유저는 발송 대상에서 제외된다")
+    void findSendableTargets_excludesUserWithoutAgreement() {
+        UUID userId = createUserWithSetting(user -> user.activate());
+        jdbcTemplate.update("UPDATE notification_settings SET notification_agree = false WHERE user_id = ?", userId);
+
+        assertThat(sendableTargetUserIds()).doesNotContain(userId);
+    }
+
+    /** 로컬 DB에는 다른 테스트가 남긴 유저도 있으므로 전체 페이지를 훑어 모은다. */
+    private List<UUID> sendableTargetUserIds() {
+        List<UUID> userIds = new ArrayList<>();
+        Pageable pageable = PageRequest.of(0, 200, Sort.by(Sort.Direction.ASC, "id"));
+        Slice<NotificationSetting> slice;
+        do {
+            slice = notificationSettingRepository.findSendableTargets(pageable);
+            // user 가 즉시 로딩되지 않으면(EntityGraph 누락) 여기서 LazyInitializationException 이 난다.
+            slice.getContent().forEach(setting -> userIds.add(setting.getUser().getId()));
+            pageable = slice.hasNext() ? slice.nextPageable() : Pageable.unpaged();
+        } while (slice.hasNext());
+        return userIds;
+    }
+
+    private UUID createUserWithSetting(java.util.function.Consumer<User> mutation) {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("notification-target-it-" + UUID.randomUUID())
+                .privacyConsent(true)
+                .build();
+        mutation.accept(user);
+        User saved = userRepository.saveAndFlush(user);
+        createdUserIds.add(saved.getId());
+
+        notificationSettingRepository.saveAndFlush(NotificationSetting.builder().user(saved).build());
+        return saved.getId();
+    }
+}

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -253,7 +253,7 @@ class NotificationServiceTest {
                 .token("fcm-token")
                 .build();
 
-        when(notificationSettingRepository.findByNotificationAgreeTrue(any())).thenReturn(
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
                 new org.springframework.data.domain.SliceImpl<>(List.of(setting))
         );
         when(valueOperations.get(anyString())).thenReturn(null);
@@ -320,14 +320,14 @@ class NotificationServiceTest {
     @Test
     @DisplayName("스케줄러 페이지 조회는 안정적인 id 정렬을 사용한다")
     void processScheduledNotifications_usesStableSort() {
-        when(notificationSettingRepository.findByNotificationAgreeTrue(any())).thenReturn(
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
                 new org.springframework.data.domain.SliceImpl<>(List.of())
         );
 
         notificationService.processScheduledNotifications();
 
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        verify(notificationSettingRepository).findByNotificationAgreeTrue(pageableCaptor.capture());
+        verify(notificationSettingRepository).findSendableTargets(pageableCaptor.capture());
         assertThat(pageableCaptor.getValue().getSort().getOrderFor("id")).isNotNull();
     }
 


### PR DESCRIPTION
## 요약
탈퇴한 유저에게 서비스 알림이 계속 발송되던 문제를 고친다. **개인정보 이슈다** — 탈퇴는 처리 정지 요구이므로 그 시점부터 알림 발송이 멈춰야 하는데, 프로덕션에서 2026-08-03 탈퇴한 유저(`ea85a102`)가 08-07까지 체크인 리마인더를 6건 받았다. 추가로 탈퇴 시 `device_tokens`가 정리되지 않아 탈퇴자 기기로 **실제 배달이 가능한 유효 토큰**이 남아 있었다(프로덕션 APNs 프로브 HTTP 200 확인, `223a0c6f`).

## 관련 이슈
- Closes #388

## 변경 사항
- `NotificationSettingRepository.findSendableTargets(Pageable)` 추가 — `notification_settings`에 `users`를 조인해 `deleted_at IS NULL` 이고 `status NOT IN ('DELETED','SUSPENDED')` 인 유저만 발송 대상으로 고른다. 필터 없는 `findByNotificationAgreeTrue`는 같은 실수를 다시 유발하므로 제거했다.
- `NotificationService.processScheduledNotifications`의 대상 조회를 새 메서드로 교체.
- `AuthService.withdraw`에서 해당 유저의 유효 `device_tokens`를 전부 `is_valid=false`로 무효화. 행 삭제는 기존 PII 정책대로 `DataRetentionJob`의 30일 하드 삭제에 맡긴다.
- 탈퇴 유저 제외 / 토큰 무효화 테스트 추가.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

스키마 변경은 없다. 기존 컬럼(`users.status`, `users.deleted_at`)만 쿼리 조건으로 쓰므로 마이그레이션이 필요 없다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- `NotificationSettingRepositoryIntegrationTest` (신규, 실 PostgreSQL) — 필터가 전적으로 JPQL 조인 조건 안에 있어 목으로는 검증되지 않는다. 그래서 쿼리를 실제로 실행해서 확인한다.
  - 탈퇴(soft delete) 유저 제외 / ACTIVE 유저는 그대로 포함
  - `SUSPENDED` 유저 제외
  - `status`가 남아 있어도 `deleted_at`이 찍힌 유저 제외
  - `notification_agree = false` 유저 제외 (기존 동작 회귀 방지)
  - 조인 조건을 제거한 상태로 돌려 3건이 실패하는 것(RED)을 먼저 확인한 뒤 필터를 되돌렸다.
- `AuthServiceTest` — 탈퇴 시 유효 토큰이 전부 `is_valid=false`가 되고 `saveAll`이 호출되는 것, 토큰이 없으면 저장을 시도하지 않는 것.
- `NotificationServiceTest` — 스케줄러가 필터 적용 조회만 사용하는 것.
- 전체 빌드: **956 tests, BUILD SUCCESSFUL**.
  - 다만 로컬 `mio` DB는 V42/V45 재번호 이력이 어긋나 있어 `local` 프로파일의 `MioApplicationTests.contextLoads`가 Flyway validate에서 깨진다. 이 브랜치와 무관한 기존 로컬 환경 문제라, 깨끗한 임시 DB를 만들어 전체 빌드를 통과시켜 확인했다. CI는 매번 새 Postgres 서비스 컨테이너를 쓰므로 영향 없다.

## 중점 리뷰 포인트
**1) 탈퇴 경로 조사 결과 — 두 경로는 대립이 아니라 한 수명주기다.**
- soft delete: `AuthService.withdraw` → `User.softDelete()` (`status='DELETED'`, `deleted_at` 세팅, `social_id`는 SHA-256으로 익명화). 유저가 탈퇴 버튼을 누르면 실제로 타는 유일한 경로다.
- hard delete: `DataRetentionJob.hardDeleteExpiredUsers` — 매일 00:00 UTC에 `status='DELETED' AND deleted_at < now()-30d` 인 유저를 `deleteAll` 한다. 이슈에서 "완전 삭제"로 보인 `1e9a6289`는 별도 경로가 아니라 이 30일 보존 만료분이다(`proactive_care_logs`가 함께 사라진 것도 V13 CASCADE로 설명된다).
- 즉 **soft → 30일 후 hard** 이며, 알림이 새는 구간은 그 30일이다. hard delete 이후에는 `notification_settings` 행도 CASCADE로 사라져 조회 자체가 안 되므로, `deleted_at`/`status` 필터만으로 두 경로 모두 커버된다.

**2) `notification_settings` 행 유지 + 조인 필터를 택한 근거.**
설정 행을 `notification_agree=false`로 꺼버리는 방식도 가능하지만 택하지 않았다. (a) 유저가 지정한 체크인 시각 같은 설정을 파괴해 계정 복구·재가입 시 되살릴 수 없다. (b) 필터가 "탈퇴 시점에 한 번 쓰기"에 의존하게 되어, 이미 탈퇴한 존량 유저나 쓰기가 누락된 케이스가 그대로 새어 나간다. 조인 필터는 상태를 단일 진실 소스(`users`)에서 매 조회마다 읽으므로 존량까지 즉시 고쳐진다.

**3) `SUSPENDED`도 함께 제외했다.** 로그인이 막힌 계정에 리마인더를 보내는 것은 무의미하고, `checkUserStatus`가 이미 `SUSPENDED`/`DELETED`를 같은 급으로 다룬다. `PENDING`은 가입 진행 중일 뿐이라 기존 동작을 그대로 뒀다.

**4) `AuthService`가 `DeviceTokenRepository`를 직접 주입한다.** 도메인 간 리포지터리 참조인데, `NotificationService`가 `CheckinRepository`/`BehaviorTaskRepository`를 쓰는 기존 관행과 같은 결이라 판단했다. `DeviceTokenService` 경유가 낫다는 의견이면 후속으로 바꾸겠다.

**5) 토큰은 무효화만 하고 행은 남긴다.** 원문 토큰이 30일간 테이블에 남는 점은 기존 soft delete + 30일 보존 정책과 동일한 수준이다. 즉시 파기가 필요하다는 판단이면 별도 이슈로 분리하는 게 맞다고 본다.

## 배포 / 롤백
- Rollout: 스키마 변경이 없어 코드 배포만으로 끝난다. 배포 즉시 다음 `ProactiveCareJob` 실행(5분 주기)부터 탈퇴 유저가 대상에서 빠진다. 이미 탈퇴한 존량 유저의 살아있는 토큰은 이 PR로 자동 정리되지 않으므로, 배포 후 `UPDATE device_tokens SET is_valid = false WHERE user_id IN (SELECT id FROM users WHERE status = 'DELETED')` 를 1회 수행하는 것을 권한다.
- Rollback: 코드 리버트만 하면 된다. 데이터 되돌림은 불필요하다(무효화된 토큰은 재로그인 시 `refreshToken()`으로 다시 유효해진다).

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (스키마 변경 없음)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
