### PR TITLE
fix: 한 기기에 유효한 디바이스 토큰이 하나만 남게 한다 (#391, #392)

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminDeviceTokenController.java
+++ b/src/main/java/com/mio/admin/controller/AdminDeviceTokenController.java
@@ -1,0 +1,34 @@
+package com.mio.admin.controller;
+
+import com.mio.common.response.ApiResponse;
+import com.mio.notification.dto.StaleDeviceTokenUserResponse;
+import com.mio.notification.service.DeviceTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 운영자용 디바이스 토큰 상태 조회 (이슈 #392).
+ *
+ * <p>{@code ROLE_ADMIN} 필요 ({@code /v1/admin/**}).
+ *
+ * <p>APNs 400/410 응답에 따른 토큰 무효화는 정상 동작이지만, 앱이 재등록을 호출하지 않으면 그 유저는
+ * 영구히 알림을 받지 못한 채 발송만 유령 SENT 로 기록된다. 끊긴 유저를 집계해 재등록 유도가 가능하도록 한다.
+ */
+@RestController
+@RequestMapping("/v1/admin/notifications/device-tokens")
+@RequiredArgsConstructor
+public class AdminDeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    /** 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저 목록. */
+    @GetMapping("/stale-users")
+    public ResponseEntity<ApiResponse<List<StaleDeviceTokenUserResponse>>> staleUsers() {
+        return ResponseEntity.ok(ApiResponse.ok(deviceTokenService.findUsersWithoutValidToken()));
+    }
+}

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -67,6 +67,8 @@ public enum ErrorCode {
     // Notification
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_NOT_FOUND", "알림 설정을 찾을 수 없습니다."),
     DEVICE_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "DEVICE_TOKEN_NOT_FOUND", "디바이스 토큰을 찾을 수 없습니다."),
+    DEVICE_TOKEN_REGISTER_CONFLICT(HttpStatus.CONFLICT, "DEVICE_TOKEN_REGISTER_CONFLICT",
+            "다른 요청이 같은 기기의 토큰을 등록 중입니다. 잠시 후 다시 시도해 주세요."),
 
     // Report
     REPORT_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "SERVER_ERROR", "서버 오류로 리포트 조회에 실패했습니다."),

--- a/src/main/java/com/mio/notification/dto/StaleDeviceTokenUserResponse.java
+++ b/src/main/java/com/mio/notification/dto/StaleDeviceTokenUserResponse.java
@@ -1,0 +1,24 @@
+package com.mio.notification.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.notification.repository.DeviceTokenRepository;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 유효 디바이스 토큰이 0개라 알림이 끊긴 유저 (이슈 #392).
+ *
+ * <p>토큰 값 자체는 담지 않는다. 운영자가 재등록을 유도할 대상을 식별하는 데 필요한 정보만 노출한다.
+ */
+public record StaleDeviceTokenUserResponse(
+        @JsonProperty("user_id") UUID userId,
+        @JsonProperty("last_token_updated_at") OffsetDateTime lastTokenUpdatedAt,
+        @JsonProperty("invalid_token_count") long invalidTokenCount
+) {
+
+    public static StaleDeviceTokenUserResponse from(DeviceTokenRepository.UserWithoutValidToken row) {
+        return new StaleDeviceTokenUserResponse(
+                row.getUserId(), row.getLastTokenUpdatedAt(), row.getInvalidTokenCount());
+    }
+}

--- a/src/main/java/com/mio/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/mio/notification/repository/DeviceTokenRepository.java
@@ -36,17 +36,25 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, UUID> 
                                          @Param("token") String token);
 
     /**
-     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저를 집계한다 (이슈 #392).
+     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 <b>발송 대상 유저</b>를 집계한다 (이슈 #392).
      *
      * <p>APNs 400/410 응답으로 토큰이 무효화된 뒤 앱이 재등록을 호출하지 않으면 그 유저의 발송은
      * 전부 유령 SENT 가 된다. 무효화 자체는 정상 동작이므로 없애지 않고, 끊긴 유저를 관측 가능하게 만든다.
+     *
+     * <p>탈퇴·정지 유저는 애초에 발송 대상이 아니므로 목록에서 제외한다. 판정 기준은 스케줄 발송 대상
+     * 조회({@code NotificationSettingRepository#findSendableTargets}, 이슈 #388)와 동일하게
+     * {@code deleted_at IS NULL AND status NOT IN ('DELETED', 'SUSPENDED')} 를 쓴다. 두 곳이 다른
+     * 기준을 쓰면 "발송은 되는데 목록에는 없는" 유저가 생겨 관측 자체를 신뢰할 수 없게 된다.
      */
     @Query("""
-            select d.user.id as userId,
+            select u.id as userId,
                    max(d.updatedAt) as lastTokenUpdatedAt,
-                   count(d) as invalidTokenCount
+                   sum(case when d.isValid = false then 1 else 0 end) as invalidTokenCount
             from DeviceToken d
-            group by d.user.id
+            join d.user u
+            where u.deletedAt is null
+              and u.status not in ('DELETED', 'SUSPENDED')
+            group by u.id
             having sum(case when d.isValid = true then 1 else 0 end) = 0
             order by max(d.updatedAt) desc
             """)

--- a/src/main/java/com/mio/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/mio/notification/repository/DeviceTokenRepository.java
@@ -2,7 +2,10 @@ package com.mio.notification.repository;
 
 import com.mio.notification.domain.DeviceToken;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -14,4 +17,47 @@ public interface DeviceTokenRepository extends JpaRepository<DeviceToken, UUID> 
     Optional<DeviceToken> findByUser_IdAndDeviceId(UUID userId, String deviceId);
 
     Optional<DeviceToken> findByUser_IdAndToken(UUID userId, String token);
+
+    /**
+     * 등록하려는 (deviceId, token) 과 충돌하는 <b>타 행</b>의 유효 토큰을 찾는다 (이슈 #391).
+     *
+     * <p>같은 물리 기기를 여러 계정이 돌려 쓰면 device_id 나 token 이 겹친 채로 여러 행이
+     * 동시에 유효해져 알림이 다른 사람 기기로 배달된다. 등록 대상 본인 행
+     * ({@code userId} + {@code deviceId} 가 모두 일치)만 제외하고 나머지를 모두 회수 대상으로 본다.
+     */
+    @Query("""
+            select d from DeviceToken d
+            where d.isValid = true
+              and (d.deviceId = :deviceId or d.token = :token)
+              and (d.user.id <> :userId or d.deviceId <> :deviceId)
+            """)
+    List<DeviceToken> findValidConflicts(@Param("userId") UUID userId,
+                                         @Param("deviceId") String deviceId,
+                                         @Param("token") String token);
+
+    /**
+     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저를 집계한다 (이슈 #392).
+     *
+     * <p>APNs 400/410 응답으로 토큰이 무효화된 뒤 앱이 재등록을 호출하지 않으면 그 유저의 발송은
+     * 전부 유령 SENT 가 된다. 무효화 자체는 정상 동작이므로 없애지 않고, 끊긴 유저를 관측 가능하게 만든다.
+     */
+    @Query("""
+            select d.user.id as userId,
+                   max(d.updatedAt) as lastTokenUpdatedAt,
+                   count(d) as invalidTokenCount
+            from DeviceToken d
+            group by d.user.id
+            having sum(case when d.isValid = true then 1 else 0 end) = 0
+            order by max(d.updatedAt) desc
+            """)
+    List<UserWithoutValidToken> findUsersWithoutValidToken();
+
+    /** {@link #findUsersWithoutValidToken()} 결과 projection. */
+    interface UserWithoutValidToken {
+        UUID getUserId();
+
+        OffsetDateTime getLastTokenUpdatedAt();
+
+        long getInvalidTokenCount();
+    }
 }

--- a/src/main/java/com/mio/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/mio/notification/service/DeviceTokenService.java
@@ -18,15 +18,28 @@ import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeviceTokenService {
 
-    /** 경합 재시도 횟수. 충돌 상대가 커밋을 끝내면 다음 시도에서 그 행을 보고 회수한다. */
-    private static final int MAX_REGISTER_ATTEMPTS = 3;
+    /**
+     * 경합 재시도 횟수. 충돌 상대가 커밋을 끝내면 다음 시도에서 그 행을 보고 회수하므로, 회차가 늘수록
+     * 성공 확률이 올라간다. 409 로 떨어지는 경로를 최대한 좁히려고 넉넉히 잡았다.
+     */
+    private static final int MAX_REGISTER_ATTEMPTS = 5;
+
+    /**
+     * 재시도 지연: {@code 20ms * 회차 + 0~20ms 지터}.
+     *
+     * <p>고정 지연만 쓰면 배포 직후처럼 다수 기기가 한꺼번에 재등록할 때 밀려난 요청들이 같은 타이밍에
+     * 깨어나 다시 충돌한다. 지터로 깨어나는 시점을 흩어 재충돌 확률을 낮춘다. 4회 재시도 기준 총 지연은
+     * 최악이라도 (20+40+60+80) + 최대 80 = 280ms 로, 요청 응답으로 체감되지 않는 선이다.
+     */
     private static final long RETRY_BACKOFF_MILLIS = 20L;
+    private static final long RETRY_JITTER_MILLIS = 20L;
 
     private final DeviceTokenRepository deviceTokenRepository;
     private final UserRepository userRepository;
@@ -42,7 +55,8 @@ public class DeviceTokenService {
      * <p>두 계정이 거의 동시에 등록하면 서로의 미커밋 행을 볼 수 없어 나중에 커밋하는 쪽이 부분 유니크
      * 인덱스를 위반한다. 이때 500 으로 새어 등록이 유실되지 않도록, 트랜잭션 경계를 메서드 밖으로 꺼내
      * <b>짧은 backoff 후 새 트랜잭션에서 재시도</b>한다. 재시도는 이미 커밋된 상대 행을 보고 정상적으로
-     * 회수한다. 끝내 실패하면 재시도 가능한 409 로 응답한다.
+     * 회수한다. {@value #MAX_REGISTER_ATTEMPTS} 회를 모두 소진해야만 409 로 응답하며, 이 엔드포인트는
+     * 앱 시작 시마다 호출되므로 그마저도 다음 실행에서 자동 복구된다.
      *
      * <p>기존 행이 무효화된 상태였다면 {@link DeviceToken#refreshToken} 이 다시 유효로 되돌린다.
      * APNs 거절로 끊긴 유저의 유일한 복구 경로이므로 (이슈 #392) 이 동작을 유지한다.
@@ -131,8 +145,10 @@ public class DeviceTokenService {
     }
 
     private void backoff(int attempt) {
+        long delay = RETRY_BACKOFF_MILLIS * attempt
+                + ThreadLocalRandom.current().nextLong(RETRY_JITTER_MILLIS + 1);
         try {
-            Thread.sleep(RETRY_BACKOFF_MILLIS * attempt);
+            Thread.sleep(delay);
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new BusinessException(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);

--- a/src/main/java/com/mio/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/mio/notification/service/DeviceTokenService.java
@@ -11,8 +11,10 @@ import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.util.List;
 import java.util.UUID;
@@ -22,8 +24,13 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class DeviceTokenService {
 
+    /** 경합 재시도 횟수. 충돌 상대가 커밋을 끝내면 다음 시도에서 그 행을 보고 회수한다. */
+    private static final int MAX_REGISTER_ATTEMPTS = 3;
+    private static final long RETRY_BACKOFF_MILLIS = 20L;
+
     private final DeviceTokenRepository deviceTokenRepository;
     private final UserRepository userRepository;
+    private final TransactionTemplate transactionTemplate;
 
     /**
      * 디바이스 토큰을 등록하거나 갱신한다.
@@ -32,11 +39,55 @@ public class DeviceTokenService {
      * 돌려 쓰면 이전 계정 행이 유효한 채로 남아 그 계정의 알림이 지금 로그인한 사람 기기로 배달된다.
      * 그래서 본인 행을 갱신하기 전에 device_id 나 token 이 겹치는 타 행을 먼저 무효화한다.
      *
+     * <p>두 계정이 거의 동시에 등록하면 서로의 미커밋 행을 볼 수 없어 나중에 커밋하는 쪽이 부분 유니크
+     * 인덱스를 위반한다. 이때 500 으로 새어 등록이 유실되지 않도록, 트랜잭션 경계를 메서드 밖으로 꺼내
+     * <b>짧은 backoff 후 새 트랜잭션에서 재시도</b>한다. 재시도는 이미 커밋된 상대 행을 보고 정상적으로
+     * 회수한다. 끝내 실패하면 재시도 가능한 409 로 응답한다.
+     *
      * <p>기존 행이 무효화된 상태였다면 {@link DeviceToken#refreshToken} 이 다시 유효로 되돌린다.
      * APNs 거절로 끊긴 유저의 유일한 복구 경로이므로 (이슈 #392) 이 동작을 유지한다.
      */
-    @Transactional
     public DeviceTokenResponse register(UUID userId, DeviceTokenRegisterRequest request) {
+        for (int attempt = 1; attempt <= MAX_REGISTER_ATTEMPTS; attempt++) {
+            try {
+                return transactionTemplate.execute(status -> registerInTransaction(userId, request));
+            } catch (DataIntegrityViolationException e) {
+                log.warn("Device token registration raced (attempt {}/{}): deviceId={} token={}",
+                        attempt, MAX_REGISTER_ATTEMPTS, request.deviceId(), maskToken(request.pushToken()));
+                if (attempt < MAX_REGISTER_ATTEMPTS) {
+                    backoff(attempt);
+                }
+            }
+        }
+        throw new BusinessException(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);
+    }
+
+    /**
+     * 로그아웃 등으로 본인 토큰을 해제한다.
+     *
+     * <p>조회를 {@code userId} 로 한정하므로 같은 기기에 남아 있는 다른 계정 행에는 영향을 주지 않는다.
+     * 행을 지우지 않고 무효화만 하는 이유는 재로그인 시 같은 행을 다시 유효화해 이력을 유지하기 위해서다.
+     */
+    @Transactional
+    public void deleteByToken(UUID userId, String rawToken) {
+        DeviceToken token = deviceTokenRepository.findByUser_IdAndToken(userId, rawToken)
+                .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_TOKEN_NOT_FOUND));
+        token.invalidate();
+    }
+
+    /**
+     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 <b>발송 대상 유저</b>를 조회한다 (이슈 #392).
+     *
+     * <p>APNs 거절로 무효화된 뒤 재등록이 없어 알림이 끊긴 유저를 식별하는 용도다.
+     */
+    @Transactional(readOnly = true)
+    public List<StaleDeviceTokenUserResponse> findUsersWithoutValidToken() {
+        return deviceTokenRepository.findUsersWithoutValidToken().stream()
+                .map(StaleDeviceTokenUserResponse::from)
+                .toList();
+    }
+
+    private DeviceTokenResponse registerInTransaction(UUID userId, DeviceTokenRegisterRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -57,32 +108,10 @@ public class DeviceTokenService {
                                 .build()
                 ));
 
+        // 커밋 시점이 아니라 여기서 제약 위반이 드러나야 재시도 루프가 그 예외를 잡을 수 있다.
+        deviceTokenRepository.flush();
+
         return DeviceTokenResponse.from(token);
-    }
-
-    /**
-     * 로그아웃 등으로 본인 토큰을 해제한다.
-     *
-     * <p>조회를 {@code userId} 로 한정하므로 같은 기기에 남아 있는 다른 계정 행에는 영향을 주지 않는다.
-     * 행을 지우지 않고 무효화만 하는 이유는 재로그인 시 같은 행을 다시 유효화해 이력을 유지하기 위해서다.
-     */
-    @Transactional
-    public void deleteByToken(UUID userId, String rawToken) {
-        DeviceToken token = deviceTokenRepository.findByUser_IdAndToken(userId, rawToken)
-                .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_TOKEN_NOT_FOUND));
-        token.invalidate();
-    }
-
-    /**
-     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저를 조회한다 (이슈 #392).
-     *
-     * <p>APNs 거절로 무효화된 뒤 재등록이 없어 알림이 끊긴 유저를 식별하는 용도다.
-     */
-    @Transactional(readOnly = true)
-    public List<StaleDeviceTokenUserResponse> findUsersWithoutValidToken() {
-        return deviceTokenRepository.findUsersWithoutValidToken().stream()
-                .map(StaleDeviceTokenUserResponse::from)
-                .toList();
     }
 
     private void invalidateConflicts(UUID userId, DeviceTokenRegisterRequest request) {
@@ -99,6 +128,15 @@ public class DeviceTokenService {
 
         log.info("Reclaimed {} conflicting device token(s) for deviceId={} token={}",
                 conflicts.size(), request.deviceId(), maskToken(request.pushToken()));
+    }
+
+    private void backoff(int attempt) {
+        try {
+            Thread.sleep(RETRY_BACKOFF_MILLIS * attempt);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new BusinessException(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);
+        }
     }
 
     private String maskToken(String token) {

--- a/src/main/java/com/mio/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/mio/notification/service/DeviceTokenService.java
@@ -5,15 +5,19 @@ import com.mio.common.error.ErrorCode;
 import com.mio.notification.domain.DeviceToken;
 import com.mio.notification.dto.DeviceTokenRegisterRequest;
 import com.mio.notification.dto.DeviceTokenResponse;
+import com.mio.notification.dto.StaleDeviceTokenUserResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.UUID;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DeviceTokenService {
@@ -21,10 +25,22 @@ public class DeviceTokenService {
     private final DeviceTokenRepository deviceTokenRepository;
     private final UserRepository userRepository;
 
+    /**
+     * 디바이스 토큰을 등록하거나 갱신한다.
+     *
+     * <p>한 물리 기기에는 유효한 토큰 행이 하나만 존재해야 한다 (이슈 #391). 같은 기기를 여러 계정이
+     * 돌려 쓰면 이전 계정 행이 유효한 채로 남아 그 계정의 알림이 지금 로그인한 사람 기기로 배달된다.
+     * 그래서 본인 행을 갱신하기 전에 device_id 나 token 이 겹치는 타 행을 먼저 무효화한다.
+     *
+     * <p>기존 행이 무효화된 상태였다면 {@link DeviceToken#refreshToken} 이 다시 유효로 되돌린다.
+     * APNs 거절로 끊긴 유저의 유일한 복구 경로이므로 (이슈 #392) 이 동작을 유지한다.
+     */
     @Transactional
     public DeviceTokenResponse register(UUID userId, DeviceTokenRegisterRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        invalidateConflicts(userId, request);
 
         DeviceToken token = deviceTokenRepository.findByUser_IdAndDeviceId(userId, request.deviceId())
                 .map(existing -> {
@@ -44,10 +60,51 @@ public class DeviceTokenService {
         return DeviceTokenResponse.from(token);
     }
 
+    /**
+     * 로그아웃 등으로 본인 토큰을 해제한다.
+     *
+     * <p>조회를 {@code userId} 로 한정하므로 같은 기기에 남아 있는 다른 계정 행에는 영향을 주지 않는다.
+     * 행을 지우지 않고 무효화만 하는 이유는 재로그인 시 같은 행을 다시 유효화해 이력을 유지하기 위해서다.
+     */
     @Transactional
     public void deleteByToken(UUID userId, String rawToken) {
         DeviceToken token = deviceTokenRepository.findByUser_IdAndToken(userId, rawToken)
                 .orElseThrow(() -> new BusinessException(ErrorCode.DEVICE_TOKEN_NOT_FOUND));
         token.invalidate();
+    }
+
+    /**
+     * 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저를 조회한다 (이슈 #392).
+     *
+     * <p>APNs 거절로 무효화된 뒤 재등록이 없어 알림이 끊긴 유저를 식별하는 용도다.
+     */
+    @Transactional(readOnly = true)
+    public List<StaleDeviceTokenUserResponse> findUsersWithoutValidToken() {
+        return deviceTokenRepository.findUsersWithoutValidToken().stream()
+                .map(StaleDeviceTokenUserResponse::from)
+                .toList();
+    }
+
+    private void invalidateConflicts(UUID userId, DeviceTokenRegisterRequest request) {
+        List<DeviceToken> conflicts =
+                deviceTokenRepository.findValidConflicts(userId, request.deviceId(), request.pushToken());
+        if (conflicts.isEmpty()) {
+            return;
+        }
+
+        conflicts.forEach(DeviceToken::invalidate);
+        // 부분 유니크 인덱스(ux_device_tokens_token_valid / _device_id_valid) 위반을 피하려면
+        // 본인 행을 유효화하기 전에 회수 UPDATE 가 먼저 DB 에 반영돼야 한다.
+        deviceTokenRepository.flush();
+
+        log.info("Reclaimed {} conflicting device token(s) for deviceId={} token={}",
+                conflicts.size(), request.deviceId(), maskToken(request.pushToken()));
+    }
+
+    private String maskToken(String token) {
+        if (token == null || token.length() <= 8) {
+            return "***";
+        }
+        return token.substring(0, 8) + "...";
     }
 }

--- a/src/main/resources/db/migration/V54__dedupe_device_tokens.sql
+++ b/src/main/resources/db/migration/V54__dedupe_device_tokens.sql
@@ -1,0 +1,56 @@
+-- 이슈 #391: 같은 물리 기기에 여러 계정이 로그인하면 device_tokens 행이 계정 수만큼 쌓이고,
+--            동일 토큰이 여러 유저에 동시에 is_valid = true 로 남아 알림이 오배송된다.
+--            "유효한 토큰 행 1개 = 물리 기기 1대" 불변식을 부분 유니크 인덱스로 DB에 강제한다.
+--
+-- 프로덕션에는 이미 중복 데이터가 존재하므로 제약을 걸기 전에 반드시 정리한다.
+-- 정리 규칙: 가장 최근에 갱신된 행 하나만 유효로 남기고 나머지는 무효화한다(행 삭제는 하지 않는다).
+-- 무효화된 행은 해당 유저가 앱에서 재등록하면 refreshToken 으로 다시 유효해진다.
+
+-- 1) 같은 token 을 유효 상태로 공유하는 행 정리 (오배송의 직접 원인).
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY token
+               ORDER BY updated_at DESC, created_at DESC, id DESC
+           ) AS rn
+    FROM device_tokens
+    WHERE is_valid
+)
+UPDATE device_tokens d
+SET is_valid = false,
+    updated_at = now()
+FROM ranked r
+WHERE d.id = r.id
+  AND r.rn > 1;
+
+-- 2) 같은 device_id 를 유효 상태로 공유하는 행 정리 (토큰 값이 서로 달라진 경우까지 포함).
+WITH ranked AS (
+    SELECT id,
+           row_number() OVER (
+               PARTITION BY device_id
+               ORDER BY updated_at DESC, created_at DESC, id DESC
+           ) AS rn
+    FROM device_tokens
+    WHERE is_valid
+)
+UPDATE device_tokens d
+SET is_valid = false,
+    updated_at = now()
+FROM ranked r
+WHERE d.id = r.id
+  AND r.rn > 1;
+
+-- 3) 유효 행 한정 유니크 인덱스.
+--    무효 행은 이력으로 남겨야 하므로 전체 유니크가 아니라 부분 유니크로 건다.
+CREATE UNIQUE INDEX ux_device_tokens_token_valid
+    ON device_tokens (token)
+    WHERE is_valid;
+
+CREATE UNIQUE INDEX ux_device_tokens_device_id_valid
+    ON device_tokens (device_id)
+    WHERE is_valid;
+
+-- 4) 이슈 #392: 유효 토큰이 0개인 유저(알림이 끊긴 유저) 집계용 부분 인덱스.
+CREATE INDEX idx_device_tokens_user_valid
+    ON device_tokens (user_id)
+    WHERE is_valid;

--- a/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
@@ -1,0 +1,235 @@
+package com.mio.notification.service;
+
+import com.mio.notification.dto.DeviceTokenRegisterRequest;
+import com.mio.notification.dto.StaleDeviceTokenUserResponse;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.util.StreamUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 디바이스 토큰 정합성의 실제 DB 동작 검증 (이슈 #391, #392).
+ *
+ * <p>목으로는 확인할 수 없는 세 가지를 잡는다.
+ *
+ * <ul>
+ *   <li>V54 마이그레이션이 추가한 부분 유니크 인덱스는 "유효 토큰 1개 = 물리 기기 1대" 불변식을
+ *       DB 레벨에서 강제한다. 서비스 코드가 회수 UPDATE 를 먼저 flush 하지 않으면 등록이 제약
+ *       위반으로 터진다 — 이 순서는 실제 DB 없이는 검증되지 않는다.</li>
+ *   <li>프로덕션에는 이미 중복 행이 있으므로, 제약을 걸기 전 정리 UPDATE 가 빠지면 배포 시
+ *       마이그레이션 자체가 실패한다. 정리 SQL 을 마이그레이션 파일에서 그대로 읽어 복제 테이블에
+ *       돌려 본다.</li>
+ *   <li>유효 토큰 0개 유저 집계는 JPQL {@code having} 절이라 문법이 어긋나도 컴파일은 통과한다.</li>
+ * </ul>
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class DeviceTokenIntegrityIntegrationTest {
+
+    private static final String MIGRATION_PATH = "db/migration/V54__dedupe_device_tokens.sql";
+    private static final String PROBE_TABLE = "device_tokens_probe";
+
+    @Autowired private DeviceTokenService deviceTokenService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private User userA;
+    private User userB;
+
+    @BeforeEach
+    void setUp() {
+        userA = createUser();
+        userB = createUser();
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS " + PROBE_TABLE);
+        List.of(userA, userB).forEach(user -> {
+            jdbcTemplate.update("DELETE FROM device_tokens WHERE user_id = ?", user.getId());
+            jdbcTemplate.update("DELETE FROM users WHERE id = ?", user.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("같은 기기에서 계정을 전환하면 유효한 토큰 행은 마지막 계정 하나만 남는다")
+    void register_accountSwitchOnSameDevice_leavesSingleValidRow() {
+        String deviceId = "device-" + UUID.randomUUID();
+        String pushToken = "apns-" + UUID.randomUUID();
+
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceId, pushToken, "ios", "1.2.0"));
+        deviceTokenService.register(userB.getId(),
+                new DeviceTokenRegisterRequest(deviceId, pushToken, "ios", "1.2.0"));
+
+        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
+                "SELECT user_id, is_valid FROM device_tokens WHERE device_id = ?", deviceId);
+
+        assertThat(rows).hasSize(2);
+        assertThat(rows).filteredOn(row -> (boolean) row.get("is_valid"))
+                .singleElement()
+                .satisfies(row -> assertThat(row.get("user_id")).isEqualTo(userB.getId()));
+    }
+
+    @Test
+    @DisplayName("기기가 새 토큰을 발급받아도 같은 기기의 옛 유효 토큰은 회수된다")
+    void register_rotatedTokenOnSameDevice_reclaimsPreviousRow() {
+        String deviceId = "device-" + UUID.randomUUID();
+
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceId, "apns-old-" + UUID.randomUUID(), "ios", "1.2.0"));
+        deviceTokenService.register(userB.getId(),
+                new DeviceTokenRegisterRequest(deviceId, "apns-new-" + UUID.randomUUID(), "ios", "1.2.0"));
+
+        Long validCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM device_tokens WHERE device_id = ? AND is_valid", Long.class, deviceId);
+
+        assertThat(validCount).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("APNs 거절로 무효화된 토큰은 재등록하면 같은 행이 다시 유효해진다")
+    void register_afterInvalidation_revivesSameRow() {
+        String deviceId = "device-" + UUID.randomUUID();
+        String pushToken = "apns-" + UUID.randomUUID();
+
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceId, pushToken, "ios", "1.2.0"));
+        UUID rowId = jdbcTemplate.queryForObject(
+                "SELECT id FROM device_tokens WHERE device_id = ?", UUID.class, deviceId);
+
+        // APNs 410 Unregistered 로 무효화된 상태를 재현한다.
+        jdbcTemplate.update("UPDATE device_tokens SET is_valid = false WHERE id = ?", rowId);
+
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceId, pushToken, "ios", "1.3.0"));
+
+        Map<String, Object> row = jdbcTemplate.queryForMap(
+                "SELECT id, is_valid, app_version FROM device_tokens WHERE device_id = ?", deviceId);
+        assertThat(row.get("id")).isEqualTo(rowId);
+        assertThat(row.get("is_valid")).isEqualTo(true);
+        assertThat(row.get("app_version")).isEqualTo("1.3.0");
+    }
+
+    @Test
+    @DisplayName("부분 유니크 인덱스가 동일 토큰의 중복 유효 행을 DB에서 차단한다")
+    void partialUniqueIndex_rejectsDuplicateValidToken() {
+        String pushToken = "apns-" + UUID.randomUUID();
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest("device-" + UUID.randomUUID(), pushToken, "ios", "1.2.0"));
+
+        assertThatThrownBy(() -> jdbcTemplate.update("""
+                        INSERT INTO device_tokens (id, user_id, device_id, platform, token, is_valid)
+                        VALUES (gen_random_uuid(), ?, ?, 'ios', ?, true)
+                        """,
+                userB.getId(), "device-" + UUID.randomUUID(), pushToken))
+                .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("유효 토큰이 0개인 유저를 조회할 수 있다")
+    void findUsersWithoutValidToken_returnsUsersWithOnlyInvalidTokens() {
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest("device-" + UUID.randomUUID(),
+                        "apns-" + UUID.randomUUID(), "ios", "1.2.0"));
+        deviceTokenService.register(userB.getId(),
+                new DeviceTokenRegisterRequest("device-" + UUID.randomUUID(),
+                        "apns-" + UUID.randomUUID(), "ios", "1.2.0"));
+        jdbcTemplate.update("UPDATE device_tokens SET is_valid = false WHERE user_id = ?", userA.getId());
+
+        List<StaleDeviceTokenUserResponse> stale = deviceTokenService.findUsersWithoutValidToken();
+
+        assertThat(stale).extracting(StaleDeviceTokenUserResponse::userId).contains(userA.getId());
+        assertThat(stale).extracting(StaleDeviceTokenUserResponse::userId).doesNotContain(userB.getId());
+        assertThat(stale).filteredOn(row -> row.userId().equals(userA.getId()))
+                .singleElement()
+                .satisfies(row -> assertThat(row.invalidTokenCount()).isEqualTo(1L));
+    }
+
+    /**
+     * V54 마이그레이션을 device_tokens 복제 테이블에 그대로 실행해, 기존 중복 데이터에서도 실패하지
+     * 않는지(정리 → 제약 추가 순서) 검증한다. 실제 테이블에는 이미 제약이 걸려 중복을 만들 수 없으므로
+     * 마이그레이션 이전 상태를 복제 테이블로 재현한다.
+     */
+    @Test
+    @DisplayName("V54 마이그레이션은 중복을 정리한 뒤 제약을 걸어 기존 데이터에서 실패하지 않는다")
+    void migration_cleansDuplicatesBeforeAddingConstraint() throws Exception {
+        jdbcTemplate.execute(
+                "CREATE TABLE " + PROBE_TABLE + " (LIKE device_tokens INCLUDING DEFAULTS)");
+
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        UUID sharedTokenOld = insertProbeRow("dev-1", "tok-shared", true, base.minusHours(2));
+        UUID sharedTokenNew = insertProbeRow("dev-2", "tok-shared", true, base.minusHours(1));
+        UUID sharedDeviceOld = insertProbeRow("dev-3", "tok-a", true, base.minusHours(3));
+        UUID sharedDeviceNew = insertProbeRow("dev-3", "tok-b", true, base.minusHours(1));
+        UUID alreadyInvalid = insertProbeRow("dev-4", "tok-c", false, base);
+        UUID untouched = insertProbeRow("dev-5", "tok-d", true, base);
+
+        // 정리 UPDATE 와 CREATE UNIQUE INDEX 를 마이그레이션 파일 그대로 실행한다.
+        // 정리가 빠졌다면 인덱스 생성에서 unique violation 으로 즉시 실패한다.
+        for (String statement : loadMigrationStatements()) {
+            jdbcTemplate.execute(statement);
+        }
+
+        assertThat(probeValidIds()).containsExactlyInAnyOrder(sharedTokenNew, sharedDeviceNew, untouched);
+        assertThat(probeValidIds()).doesNotContain(sharedTokenOld, sharedDeviceOld, alreadyInvalid);
+    }
+
+    private List<String> loadMigrationStatements() throws Exception {
+        String script;
+        try (var input = new ClassPathResource(MIGRATION_PATH).getInputStream()) {
+            script = StreamUtils.copyToString(input, StandardCharsets.UTF_8);
+        }
+        // 실제 테이블 대신 복제 테이블을 대상으로 돌린다. 인덱스 이름도 함께 치환돼 충돌하지 않는다.
+        String rewritten = script.replaceAll("(?m)^\\s*--.*$", "")
+                .replace("device_tokens", PROBE_TABLE);
+        return Arrays.stream(rewritten.split(";"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
+    }
+
+    private UUID insertProbeRow(String deviceId, String token, boolean isValid, OffsetDateTime updatedAt) {
+        UUID id = UUID.randomUUID();
+        jdbcTemplate.update("INSERT INTO " + PROBE_TABLE
+                        + " (id, user_id, device_id, platform, token, is_valid, created_at, updated_at)"
+                        + " VALUES (?, ?, ?, 'ios', ?, ?, ?, ?)",
+                id, userA.getId(), deviceId, token, isValid, updatedAt, updatedAt);
+        return id;
+    }
+
+    private List<UUID> probeValidIds() {
+        return jdbcTemplate.queryForList(
+                "SELECT id FROM " + PROBE_TABLE + " WHERE is_valid", UUID.class);
+    }
+
+    private User createUser() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("device-token-it-" + UUID.randomUUID())
+                .privacyConsent(true)
+                .build();
+        user.completeOnboarding("mio");
+        return userRepository.save(user);
+    }
+}

--- a/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
@@ -1,5 +1,7 @@
 package com.mio.notification.service;
 
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
 import com.mio.notification.dto.DeviceTokenRegisterRequest;
 import com.mio.notification.dto.StaleDeviceTokenUserResponse;
 import com.mio.user.domain.User;
@@ -23,6 +25,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -144,6 +151,82 @@ class DeviceTokenIntegrityIntegrationTest {
                         """,
                 userB.getId(), "device-" + UUID.randomUUID(), pushToken))
                 .isInstanceOf(DuplicateKeyException.class);
+    }
+
+    @Test
+    @DisplayName("한 유저가 기기 2대에 등록하면 둘 다 유효하게 유지된다")
+    void register_sameUserTwoDevices_bothStayValid() {
+        String deviceOne = "device-" + UUID.randomUUID();
+        String deviceTwo = "device-" + UUID.randomUUID();
+
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceOne, "apns-" + UUID.randomUUID(), "ios", "1.2.0"));
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest(deviceTwo, "apns-" + UUID.randomUUID(), "android", "1.2.0"));
+
+        Long validCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM device_tokens WHERE user_id = ? AND is_valid", Long.class, userA.getId());
+
+        assertThat(validCount).isEqualTo(2L);
+    }
+
+    /**
+     * 두 계정이 같은 기기 토큰을 동시에 등록하는 경합. 서로의 미커밋 행을 볼 수 없어 나중에 커밋하는
+     * 쪽이 부분 유니크 인덱스를 위반한다. 재시도 없이는 그 요청이 500 으로 새면서 등록이 유실된다.
+     */
+    @Test
+    @DisplayName("두 계정이 같은 기기 토큰을 동시에 등록해도 500 없이 유효 행이 하나만 남는다")
+    void register_concurrentSameDevice_doesNotLeak500() throws Exception {
+        String deviceId = "device-" + UUID.randomUUID();
+        String pushToken = "apns-" + UUID.randomUUID();
+        CyclicBarrier startLine = new CyclicBarrier(2);
+        ExecutorService pool = Executors.newFixedThreadPool(2);
+
+        try {
+            List<Future<Throwable>> results = List.of(userA, userB).stream()
+                    .map(user -> pool.submit(() -> {
+                        try {
+                            startLine.await(5, TimeUnit.SECONDS);
+                            deviceTokenService.register(user.getId(),
+                                    new DeviceTokenRegisterRequest(deviceId, pushToken, "ios", "1.2.0"));
+                            return (Throwable) null;
+                        } catch (Throwable t) {
+                            return t;
+                        }
+                    }))
+                    .toList();
+
+            for (Future<Throwable> result : results) {
+                Throwable failure = result.get(20, TimeUnit.SECONDS);
+                // 경합에서 밀렸다면 재시도 가능한 409 여야 하고, 500 으로 새는 원시 예외는 허용하지 않는다.
+                if (failure != null) {
+                    assertThat(failure).isInstanceOf(BusinessException.class);
+                    assertThat(((BusinessException) failure).getErrorCode())
+                            .isEqualTo(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);
+                }
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+
+        Long validCount = jdbcTemplate.queryForObject(
+                "SELECT count(*) FROM device_tokens WHERE device_id = ? AND is_valid", Long.class, deviceId);
+        assertThat(validCount).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("탈퇴한 유저는 유효 토큰이 0개여도 조회 대상에서 빠진다")
+    void findUsersWithoutValidToken_excludesWithdrawnUsers() {
+        deviceTokenService.register(userA.getId(),
+                new DeviceTokenRegisterRequest("device-" + UUID.randomUUID(),
+                        "apns-" + UUID.randomUUID(), "ios", "1.2.0"));
+        jdbcTemplate.update("UPDATE device_tokens SET is_valid = false WHERE user_id = ?", userA.getId());
+        jdbcTemplate.update(
+                "UPDATE users SET status = 'DELETED', deleted_at = now() WHERE id = ?", userA.getId());
+
+        List<StaleDeviceTokenUserResponse> stale = deviceTokenService.findUsersWithoutValidToken();
+
+        assertThat(stale).extracting(StaleDeviceTokenUserResponse::userId).doesNotContain(userA.getId());
     }
 
     @Test

--- a/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
@@ -5,6 +5,7 @@ import com.mio.common.error.ErrorCode;
 import com.mio.notification.domain.DeviceToken;
 import com.mio.notification.dto.DeviceTokenRegisterRequest;
 import com.mio.notification.dto.DeviceTokenResponse;
+import com.mio.notification.dto.StaleDeviceTokenUserResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -12,9 +13,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -104,6 +108,96 @@ class DeviceTokenServiceTest {
     }
 
     @Test
+    @DisplayName("같은 기기를 쓰던 다른 계정의 유효 토큰은 등록 시점에 무효화된다")
+    void register_conflictingOtherUserToken_isInvalidated() {
+        User otherUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("other-social-id")
+                .privacyConsent(true)
+                .build();
+        setUserId(otherUser, UUID.randomUUID());
+
+        DeviceToken otherUsersToken = DeviceToken.builder()
+                .user(otherUser)
+                .deviceId("device-shared")
+                .platform("ios")
+                .token("apns-token")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findValidConflicts(userId, "device-shared", "apns-token"))
+                .thenReturn(List.of(otherUsersToken));
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-shared"))
+                .thenReturn(Optional.empty());
+        when(deviceTokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-shared", "apns-token", "ios", "1.2.0"));
+
+        assertThat(otherUsersToken.isValid()).isFalse();
+        // 부분 유니크 인덱스 위반을 피하려면 회수 UPDATE 가 본인 행보다 먼저 DB 에 반영돼야 한다.
+        InOrder inOrder = inOrder(deviceTokenRepository);
+        inOrder.verify(deviceTokenRepository).flush();
+        inOrder.verify(deviceTokenRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("충돌이 없으면 불필요한 flush를 호출하지 않는다")
+    void register_noConflict_doesNotFlush() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findValidConflicts(userId, "device-1", "token-abc"))
+                .thenReturn(List.of());
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-1"))
+                .thenReturn(Optional.empty());
+        when(deviceTokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-1", "token-abc", "ios", "1.2.0"));
+
+        verify(deviceTokenRepository, never()).flush();
+    }
+
+    @Test
+    @DisplayName("무효화된 본인 토큰은 재등록으로 다시 유효해진다")
+    void register_invalidatedOwnToken_isRevived() {
+        DeviceToken invalidated = DeviceToken.builder()
+                .user(user)
+                .deviceId("device-1")
+                .platform("ios")
+                .token("old-token")
+                .build();
+        invalidated.invalidate();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-1"))
+                .thenReturn(Optional.of(invalidated));
+
+        deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-1", "new-token", "ios", "1.3.0"));
+
+        assertThat(invalidated.isValid()).isTrue();
+        assertThat(invalidated.getToken()).isEqualTo("new-token");
+        assertThat(invalidated.getAppVersion()).isEqualTo("1.3.0");
+    }
+
+    @Test
+    @DisplayName("유효 토큰이 0개인 유저 조회 결과를 응답 DTO로 변환한다")
+    void findUsersWithoutValidToken_mapsProjection() {
+        UUID staleUserId = UUID.randomUUID();
+        OffsetDateTime lastUpdatedAt = OffsetDateTime.parse("2026-08-07T12:00:00Z");
+        when(deviceTokenRepository.findUsersWithoutValidToken())
+                .thenReturn(List.of(projection(staleUserId, lastUpdatedAt, 2L)));
+
+        List<StaleDeviceTokenUserResponse> result = deviceTokenService.findUsersWithoutValidToken();
+
+        assertThat(result).singleElement().satisfies(row -> {
+            assertThat(row.userId()).isEqualTo(staleUserId);
+            assertThat(row.lastTokenUpdatedAt()).isEqualTo(lastUpdatedAt);
+            assertThat(row.invalidTokenCount()).isEqualTo(2L);
+        });
+    }
+
+    @Test
     @DisplayName("존재하지 않는 token으로 delete 시 DEVICE_TOKEN_NOT_FOUND 예외를 발생시킨다")
     void delete_tokenNotFound_throwsDeviceTokenNotFound() {
         when(deviceTokenRepository.findByUser_IdAndToken(userId, "token-abc")).thenReturn(Optional.empty());
@@ -128,6 +222,26 @@ class DeviceTokenServiceTest {
         deviceTokenService.deleteByToken(userId, "token-abc");
 
         assertThat(token.isValid()).isFalse();
+    }
+
+    private DeviceTokenRepository.UserWithoutValidToken projection(
+            UUID staleUserId, OffsetDateTime lastUpdatedAt, long invalidCount) {
+        return new DeviceTokenRepository.UserWithoutValidToken() {
+            @Override
+            public UUID getUserId() {
+                return staleUserId;
+            }
+
+            @Override
+            public OffsetDateTime getLastTokenUpdatedAt() {
+                return lastUpdatedAt;
+            }
+
+            @Override
+            public long getInvalidTokenCount() {
+                return invalidCount;
+            }
+        };
     }
 
     private void setUserId(User u, UUID id) {

--- a/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
@@ -234,7 +234,7 @@ class DeviceTokenServiceTest {
                     assertThat(errorCode).isEqualTo(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);
                     assertThat(errorCode.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
                 });
-        verify(deviceTokenRepository, times(3)).save(any());
+        verify(deviceTokenRepository, times(5)).save(any());
     }
 
     @Test

--- a/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenServiceTest.java
@@ -16,6 +16,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -39,7 +46,8 @@ class DeviceTokenServiceTest {
 
     @BeforeEach
     void setUp() {
-        deviceTokenService = new DeviceTokenService(deviceTokenRepository, userRepository);
+        deviceTokenService = new DeviceTokenService(
+                deviceTokenRepository, userRepository, directTransactionTemplate());
         userId = UUID.randomUUID();
         user = User.builder()
                 .socialProvider("kakao")
@@ -142,8 +150,8 @@ class DeviceTokenServiceTest {
     }
 
     @Test
-    @DisplayName("충돌이 없으면 불필요한 flush를 호출하지 않는다")
-    void register_noConflict_doesNotFlush() {
+    @DisplayName("충돌이 없으면 회수용 flush 없이 쓰기 확정 flush만 호출한다")
+    void register_noConflict_flushesOnlyOnce() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(deviceTokenRepository.findValidConflicts(userId, "device-1", "token-abc"))
                 .thenReturn(List.of());
@@ -154,7 +162,8 @@ class DeviceTokenServiceTest {
         deviceTokenService.register(userId,
                 new DeviceTokenRegisterRequest("device-1", "token-abc", "ios", "1.2.0"));
 
-        verify(deviceTokenRepository, never()).flush();
+        // 마지막 flush 는 제약 위반을 커밋 시점이 아니라 재시도 루프 안에서 드러내기 위한 것이다.
+        verify(deviceTokenRepository, times(1)).flush();
     }
 
     @Test
@@ -178,6 +187,73 @@ class DeviceTokenServiceTest {
         assertThat(invalidated.isValid()).isTrue();
         assertThat(invalidated.getToken()).isEqualTo("new-token");
         assertThat(invalidated.getAppVersion()).isEqualTo("1.3.0");
+    }
+
+    @Test
+    @DisplayName("동시 등록으로 유니크 제약을 위반하면 재시도해서 등록을 살린다")
+    void register_uniqueViolation_retriesAndSucceeds() {
+        DeviceToken saved = DeviceToken.builder()
+                .user(user)
+                .deviceId("device-1")
+                .platform("ios")
+                .token("token-abc")
+                .build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-1"))
+                .thenReturn(Optional.empty());
+        when(deviceTokenRepository.save(any()))
+                // 첫 시도는 상대 트랜잭션이 먼저 커밋해 부분 유니크 인덱스를 위반한 상황
+                .thenThrow(new DataIntegrityViolationException("ux_device_tokens_token_valid"))
+                .thenReturn(saved);
+
+        DeviceTokenResponse response = deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-1", "token-abc", "ios", "1.2.0"));
+
+        assertThat(response.success()).isTrue();
+        assertThat(response.deviceId()).isEqualTo("device-1");
+        verify(deviceTokenRepository, times(2)).save(any());
+        // 재시도는 새 트랜잭션에서 충돌 상대를 다시 확인한다.
+        verify(deviceTokenRepository, times(2)).findValidConflicts(userId, "device-1", "token-abc");
+    }
+
+    @Test
+    @DisplayName("재시도를 모두 소진하면 500이 아니라 409 DEVICE_TOKEN_REGISTER_CONFLICT로 응답한다")
+    void register_uniqueViolationExhausted_throwsConflict() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-1"))
+                .thenReturn(Optional.empty());
+        when(deviceTokenRepository.save(any()))
+                .thenThrow(new DataIntegrityViolationException("ux_device_tokens_token_valid"));
+
+        assertThatThrownBy(() -> deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-1", "token-abc", "ios", "1.2.0")))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> {
+                    ErrorCode errorCode = ((BusinessException) e).getErrorCode();
+                    assertThat(errorCode).isEqualTo(ErrorCode.DEVICE_TOKEN_REGISTER_CONFLICT);
+                    assertThat(errorCode.getHttpStatus()).isEqualTo(HttpStatus.CONFLICT);
+                });
+        verify(deviceTokenRepository, times(3)).save(any());
+    }
+
+    @Test
+    @DisplayName("한 유저가 기기 2대를 쓰면 서로를 회수하지 않는다")
+    void register_sameUserDifferentDevices_doesNotReclaimEachOther() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findValidConflicts(userId, "device-2", "token-2"))
+                .thenReturn(List.of());
+        when(deviceTokenRepository.findByUser_IdAndDeviceId(userId, "device-2"))
+                .thenReturn(Optional.empty());
+        when(deviceTokenRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        deviceTokenService.register(userId,
+                new DeviceTokenRegisterRequest("device-2", "token-2", "ios", "1.2.0"));
+
+        // 같은 유저의 다른 기기 행은 회수 대상 조회에서 애초에 걸러져야 한다 (쿼리 조건 회귀 방지).
+        verify(deviceTokenRepository).findValidConflicts(userId, "device-2", "token-2");
+        // 회수용 flush 가 없으므로 쓰기 확정 flush 1회뿐이다.
+        verify(deviceTokenRepository, times(1)).flush();
     }
 
     @Test
@@ -222,6 +298,31 @@ class DeviceTokenServiceTest {
         deviceTokenService.deleteByToken(userId, "token-abc");
 
         assertThat(token.isValid()).isFalse();
+    }
+
+    /**
+     * 콜백을 그대로 실행하는 트랜잭션 템플릿.
+     *
+     * <p>서비스가 재시도를 위해 트랜잭션 경계를 메서드 밖으로 꺼냈으므로, 단위 테스트도 그 경계를
+     * 흉내 내야 한다. 커밋/롤백은 통합 테스트에서 실 DB 로 검증한다.
+     */
+    private static TransactionTemplate directTransactionTemplate() {
+        return new TransactionTemplate(new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+                // no-op
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+                // no-op
+            }
+        });
     }
 
     private DeviceTokenRepository.UserWithoutValidToken projection(


### PR DESCRIPTION
## 요약
같은 물리 기기를 여러 계정이 돌려 쓰면 `device_tokens` 에 계정 수만큼 행이 쌓이고 이전 계정 행이 유효한 채로 남는다. `token` 에 유니크 제약도 없어 **완전히 동일한 토큰이 두 유저에게 동시에 `is_valid=true`** 로 존재했고(프로덕션 실측), 그 상태에서는 A 계정 알림이 지금 B 가 쓰는 기기로 배달된다(오배송). "유효 토큰 1개 = 물리 기기 1대" 불변식을 서비스와 DB 양쪽에서 강제한다.

함께, APNs 거절로 토큰이 무효화된 뒤 재등록이 없어 알림이 영구히 끊긴 유저를 볼 방법이 없던 문제도 해결한다. 무효화 자체는 올바른 동작이므로 그대로 두고, **끊긴 유저를 관측**할 수 있게 만들고 재등록 복구 경로를 테스트로 고정한다.

## 관련 이슈
- Closes #391
- Closes #392

## 변경 사항
- `DeviceTokenService.register` 가 본인 행을 유효화하기 전에 `device_id` 또는 `token` 이 겹치는 **타 행을 무효화하고 flush** 한다. 회수 UPDATE 가 먼저 DB 에 반영돼야 부분 유니크 인덱스를 위반하지 않는다.
- `DeviceTokenRepository.findValidConflicts` 추가 — 등록 대상 본인 행(`userId` + `deviceId` 동시 일치)만 제외하고 충돌하는 유효 행을 조회한다.
- `V54__dedupe_device_tokens.sql` — **기존 중복 정리 → 부분 유니크 인덱스 추가** 순서. `ux_device_tokens_token_valid`, `ux_device_tokens_device_id_valid` (둘 다 `WHERE is_valid`), 집계용 `idx_device_tokens_user_valid`.
- `DeviceTokenRepository.findUsersWithoutValidToken` + `StaleDeviceTokenUserResponse` + `GET /v1/admin/notifications/device-tokens/stale-users` (ROLE_ADMIN) — 토큰을 등록한 적은 있으나 현재 유효 토큰이 0개인 유저 조회 (#392).
- 로그아웃(`deleteByToken`)은 기존대로 `userId` 로 한정해 본인 행만 무효화한다(같은 기기의 다른 계정 행에 영향 없음). 의도를 주석으로 명시했다.
- 토큰 값은 로그에 원문으로 남기지 않는다(`maskToken`, 앞 8자 + `...`).
- **동시 등록 경합 처리** — `register` 의 트랜잭션 경계를 `TransactionTemplate` 으로 메서드 밖에 두고, `DataIntegrityViolationException` 발생 시 짧은 backoff(`20ms × 회차 + 0~20ms 지터`) 후 **새 트랜잭션에서 최대 5회 재시도**한다. 소진 시에만 `DEVICE_TOKEN_REGISTER_CONFLICT`(409). `ErrorCode` 에 Notification 그룹으로 추가했다.
- **`findUsersWithoutValidToken` 활성 유저 한정** — `users` 를 조인해 `deleted_at IS NULL AND status NOT IN ('DELETED','SUSPENDED')` 로 거른다. 집계식도 `sum(case when d.isValid = false ...)` 로 바꿔 필드명(`invalidTokenCount`)과 일치시켰다.

**유니크 제약 설계**

전체 유니크가 아니라 **유효 행 한정 부분 유니크**를 쓴다. 무효화된 행은 이력이자 재등록 시 되살릴 대상이라 남겨야 하는데, 전체 유니크를 걸면 같은 토큰의 과거 행 때문에 재등록이 막힌다. `token` 과 `device_id` 두 축 모두에 건 이유는, 토큰이 회전한 경우(같은 기기, 다른 토큰)와 회전하지 않은 경우(다른 기기 취급, 같은 토큰)가 각각 다른 축에서만 잡히기 때문이다.

**기존 중복 데이터 정리 방식**

제약을 먼저 걸면 배포 시 마이그레이션이 unique violation 으로 실패한다. 그래서 ① `token` 기준, ② `device_id` 기준 순으로 `row_number() OVER (PARTITION BY ... ORDER BY updated_at DESC, created_at DESC, id DESC)` 를 매겨 **가장 최근 갱신 행 하나만 유효로 남기고 나머지를 `is_valid=false` 로 무효화**한 뒤 ③ 인덱스를 만든다. 행 삭제는 하지 않으므로 잘못 무효화된 유저도 앱 재등록 한 번으로 복구된다.

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

> **기존 응답 계약은 그대로다.** `POST /v1/notifications/devices` 의 200 본문(`success` / `device_id` / `platform`)과 `DELETE /v1/notifications/devices/{token}` 의 200 본문(`success`)은 필드명·타입·상태코드 모두 명세와 동일하며, `DeviceTokenController` · `DeviceTokenResponse` · `ApiResponse` · `GlobalExceptionHandler` 는 이 PR 에서 **한 줄도 바뀌지 않았다**. 다만 동시 등록 경합에서 재시도 5회를 모두 소진하는 극단적 경우에 한해 새 에러 코드 `DEVICE_TOKEN_REGISTER_CONFLICT`(409)가 나갈 수 있다(기존에는 같은 상황이 500). 그 외에 운영자 전용(ROLE_ADMIN) 조회 엔드포인트가 하나 추가된다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
./gradlew test --tests "com.mio.notification.service.DeviceTokenServiceTest" \
               --tests "com.mio.notification.service.DeviceTokenIntegrityIntegrationTest"
```

### 확인 내용
단위 테스트 (`DeviceTokenServiceTest`)
- 같은 기기를 쓰던 다른 계정의 유효 토큰이 등록 시점에 무효화되고, `flush()` 가 `save()` 보다 먼저 호출된다(`InOrder`).
- 충돌이 없으면 불필요한 `flush()` 를 호출하지 않는다.
- 무효화된 본인 토큰이 재등록으로 다시 유효해진다(`refreshToken` 이 `isValid=true` 로 되돌리는 동작 고정).
- 유효 토큰 0개 유저 조회 결과가 응답 DTO 로 변환된다.
- 유니크 제약 위반 시 재시도해서 2회차에 성공한다(`save` 2회, `findValidConflicts` 2회 호출).
- 재시도 5회를 모두 소진하면 500 이 아니라 409 `DEVICE_TOKEN_REGISTER_CONFLICT` 다(`save` 5회 호출 확인).
- 한 유저가 기기 2대를 쓰면 서로를 회수하지 않는다(회수 대상 조회에서 애초에 제외).

통합 테스트 (`DeviceTokenIntegrityIntegrationTest`, 실 PostgreSQL)
- 같은 기기에서 계정 A → B 전환 시 유효 행이 **하나만** 남고, 그 소유자가 B 다.
- 기기가 새 토큰을 발급받아 토큰 값이 달라져도 같은 기기의 옛 유효 행이 회수된다.
- APNs 거절로 무효화된 토큰이 재등록으로 **같은 행 그대로** 다시 유효해진다(행 id·app_version 확인).
- 부분 유니크 인덱스가 동일 토큰의 중복 유효 행 INSERT 를 DB 레벨에서 차단한다(`DuplicateKeyException`).
- 유효 토큰이 0개인 유저만 조회되고, **탈퇴(`DELETED`) 유저는 제외**된다.
- 한 유저가 기기 2대에 각각 다른 토큰으로 등록하면 **둘 다 유효**하게 유지된다(회귀 방지).
- 두 계정이 같은 기기 토큰을 **동시에** 등록해도(`CyclicBarrier` 로 동시 출발) 500 이 새지 않고 최종 유효 행은 1개다.
- **마이그레이션 검증**: `device_tokens` 복제 테이블(`LIKE`)에 마이그레이션 이전 상태(토큰 중복 2건, 기기 중복 2건, 이미 무효 1건, 정상 1건)를 재현한 뒤 **V54 파일을 그대로 읽어** 실행한다. 정리 UPDATE 가 빠지면 `CREATE UNIQUE INDEX` 에서 즉시 실패하므로 "정리 → 제약" 순서가 회귀 없이 고정된다. 생존 행이 가장 최근 갱신 행인지도 확인한다.

로컬 실 DB 에 V54 적용 확인 (기존 데이터 보유 상태에서 성공, 인덱스 3종 생성 확인).

> 참고: 로컬 `./gradlew build` 는 `MioApplicationTests` 하나가 실패했는데, 원인은 이 PR 과 무관한 로컬 DB 이력 어긋남(다른 PR 의 V53 이 로컬 DB 에만 적용된 상태 → `Detected applied migration not resolved locally: 53`)이다. 해당 검증만 우회하면 **966 테스트 전부 통과**한다. CI 는 매번 새 DB 라 재현되지 않는다.

## 중점 리뷰 포인트
- **동시성 처리 방식**: 부분 유니크 인덱스를 걸면 "두 계정이 같은 기기 토큰을 동시에 등록" 하는 경합에서 나중에 커밋하는 쪽이 제약을 위반한다. 각 트랜잭션은 상대의 미커밋 행을 볼 수 없어 `invalidateConflicts` 로는 막을 수 없는, DB 만이 판정할 수 있는 충돌이다. 처리 방식은 다음과 같다.
  1. `register` 는 더 이상 `@Transactional` 이 아니고, 실제 작업(`registerInTransaction`)을 `TransactionTemplate.execute` 안에서 실행한다. 재시도가 **깨끗한 새 트랜잭션·새 영속성 컨텍스트**에서 돌아야 하므로 경계를 밖으로 꺼냈다(프록시 self-invocation 회피 목적도 겸한다).
  2. `registerInTransaction` 끝에 `flush()` 를 명시해, 제약 위반이 커밋 시점(= 메서드 밖)이 아니라 **재시도 루프가 잡을 수 있는 지점**에서 드러나게 했다.
  3. 위반 시 `20ms × 회차 + 0~20ms 지터` 만큼 쉬었다가 재시도. 이때 상대는 이미 커밋됐으므로 `findValidConflicts` 가 그 행을 보고 정상 회수한다 — 즉 대부분 2회차에서 그대로 성공한다. 지터는 배포 직후처럼 다수 기기가 한꺼번에 재등록할 때 밀려난 요청들이 같은 타이밍에 깨어나 재충돌하는 것을 막는다.
  4. **5회** 소진 시에만 `DEVICE_TOKEN_REGISTER_CONFLICT`(**409**). 500 으로 새지 않으므로 클라이언트가 재시도 가능한 실패로 인식할 수 있다. 4회 재시도 기준 총 지연은 최악이라도 (20+40+60+80) + 최대 80 = **280ms** 로 요청 응답으로 체감되지 않는다.
  5. 409 는 명세에 없는 상태 코드이므로 도달 가능성을 최대한 낮추는 데 무게를 뒀다. 명세상 `POST /v1/notifications/devices` 는 **앱 시작 시마다 호출**되므로(10_Notification 명세서 "연동 시 주의사항"), 만에 하나 409 가 나가도 다음 앱 실행에서 자동 복구된다. 같은 문장이 #392 의 복구 경로(무효화된 토큰 → 재등록 → `isValid=true`)가 실제로 존재한다는 근거이기도 하다.
  - 통합 테스트가 `CyclicBarrier` 로 두 스레드를 동시에 출발시켜 실제 경합을 일으키고(실행 로그에 재시도 경고가 찍히는 것으로 확인), 예외가 나더라도 409 여야 하며 최종 유효 행은 정확히 1개임을 단언한다. 단위 테스트는 `save` 가 `DataIntegrityViolationException` 을 던지도록 강제해 ① 2회차 성공 ② 소진 시 409 를 결정적으로 검증한다.
- **활성 유저 판정 기준**: `deleted_at IS NULL AND status NOT IN ('DELETED','SUSPENDED')`. `users_status_check` 로 실제 상태값이 `PENDING/ACTIVE/SUSPENDED/DELETED` 임을 확인했고, 스케줄 발송 대상 조회(#388/PR #399)와 **동일한 술어**를 썼다. `PENDING` 을 남긴 이유는 그쪽 발송 대상에도 포함되기 때문 — 발송은 되는데 목록에는 없는 유저가 생기면 관측이 어긋난다.
- **회수 범위**: 충돌 행을 "무효화"로 처리했다(소유권 이전 아님). 이전 계정은 다음 로그인/앱 실행의 재등록으로 복구된다 — 이 트레이드오프가 맞는지.
- **flush 위치**: `invalidateConflicts` 안의 명시적 `flush()` 가 부분 유니크 인덱스 위반을 막는 핵심이다. Hibernate 는 한 flush 안에서 INSERT 를 UPDATE 보다 먼저 내보내므로 이 호출이 없으면 등록이 터진다.
- **마이그레이션 정렬 기준**: `updated_at DESC, created_at DESC, id DESC` — 동률일 때 결정적으로 하나만 남기기 위한 tie-breaker 다.
- **운영 엔드포인트 노출 범위**: 응답에 토큰 값은 담지 않고 `user_id` / `last_token_updated_at` / `invalid_token_count` 만 담았다.

## 배포 / 롤백
- **Rollout**: V54 가 배포 시 **기존 프로덕션 데이터를 정리**한다. 실측 기준 `479312ab`(유저 `1e9a6289` / `a003258c` 동일 토큰 동시 유효), `62d5105f`(유저 `520eac83` / `96097260` 토큰 공유) 같은 중복 기기에서 **가장 최근 갱신 행을 제외한 나머지가 `is_valid=false` 로 바뀐다.** 즉 밀려난 계정은 다음 재등록 전까지 푸시를 받지 못한다 — 이는 지금까지 남의 기기로 가던 오배송을 멈추는 의도된 결과이며, 앱이 토큰을 재등록하는 즉시 복구된다. 행 삭제가 없으므로 데이터 손실은 없다. 정리 후 대상자는 `GET /v1/admin/notifications/device-tokens/stale-users` 로 확인할 수 있다.
- **Rollback**: 애플리케이션은 이전 이미지로 되돌리면 된다. 스키마를 되돌려야 한다면 `DROP INDEX ux_device_tokens_token_valid, ux_device_tokens_device_id_valid, idx_device_tokens_user_valid;` 로 인덱스만 제거하면 구버전 코드와 호환된다(컬럼 변경 없음). 정리 UPDATE 로 무효화된 행은 자동 복구되지 않으니, 되돌릴 필요가 있으면 `updated_at` 기준으로 대상 행을 골라 수동 복구하거나 유저 재등록을 기다린다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
