### PR TITLE
fix: 발송되지 않은 알림을 이력 목록에서 제외한다

### DIFF
--- a/src/main/java/com/mio/notification/domain/ProactiveCareLog.java
+++ b/src/main/java/com/mio/notification/domain/ProactiveCareLog.java
@@ -54,6 +54,32 @@ public class ProactiveCareLog {
     public static final Set<String> SUPPRESSING_STATUSES =
             Set.of(STATUS_SENT, STATUS_DELIVERED, STATUS_OPENED, STATUS_UNCONFIRMED);
 
+    /**
+     * <b>API 명세에 없는 내부 전용</b> 상태 집합 — 외부 경계를 그대로 통과해서는 안 된다.
+     *
+     * <p>명세({@code 10_Notification_알림.md} §알림 수신 상태, {@code State_공통상태값정의.md} §19)의
+     * 상태값은 {@code SENT / DELIVERED / OPENED / FAILED} 4종이다. 여기 담긴 값들은 발송 결과를
+     * 내부적으로 더 잘게 나누려고 추가한 것이므로(이슈 #387, #389, #390) 문서에 존재하지 않는다.
+     *
+     * <p>이 집합이 API 경계에서 두 가지로 쓰인다. 둘 다 "발송된 적이 없거나 발송 여부를 확인할 수
+     * 없는 건"이라는 <b>같은 사실</b>에서 나오므로 목록을 하나로 유지한다.
+     * <ul>
+     *   <li><b>이력 목록에서 제외</b>({@code ProactiveCareLogRepository} 의 이력 조회) — 유저 입장에서
+     *       존재한 적 없는(또는 받았다고 단정할 수 없는) 알림을 목록에 올리면, 앱에는 알림이 있는데
+     *       푸시는 오지 않은 불일치가 된다 (이슈 #397).</li>
+     *   <li><b>단건 응답에서 {@code FAILED} 로 접기</b>({@code NotificationStatusView}) — 목록에서
+     *       빠져도 {@code PATCH /v1/notifications/{id}/read} 처럼 id 로 직접 도달하는 경로가 남아 있어,
+     *       문서에 없는 값이 FE 분기로 새어 나가는 것을 막아야 한다.</li>
+     * </ul>
+     *
+     * <p>새 상태를 추가할 때는 반드시 이 목록에 넣을지 먼저 정한다. 목록에 넣지 않으면 그 값은
+     * 명세에 있는 값이라는 뜻이고, 곧바로 이력에 노출되며 FE 분기 대상이 된다.
+     *
+     * <p>{@code FAILED} 는 <b>포함하지 않는다</b>. 명세에 정의된 값이고 "재시도 불가 안내 UI"가
+     * 이미 FE 에 있으므로 이력에 그대로 노출한다.
+     */
+    public static final Set<String> INTERNAL_ONLY_STATUSES = Set.of(STATUS_NO_DEVICE, STATUS_UNCONFIRMED);
+
     /** {@code OPENED} 로 전이할 수 있는 상태 — 실제로 발송된 알림만 열람될 수 있다. */
     private static final Set<String> OPENABLE_STATUSES = Set.of(STATUS_SENT, STATUS_DELIVERED);
 

--- a/src/main/java/com/mio/notification/dto/NotificationStatusView.java
+++ b/src/main/java/com/mio/notification/dto/NotificationStatusView.java
@@ -2,8 +2,6 @@ package com.mio.notification.dto;
 
 import com.mio.notification.domain.ProactiveCareLog;
 
-import java.util.Set;
-
 /**
  * {@code notification_status} 의 내부값 → 노출값 변환. API 경계의 유일한 매핑 지점이다.
  *
@@ -20,20 +18,18 @@ import java.util.Set;
  *
  * <p>즉 구분은 DB·내부 로직에만 남기고, 계약은 그대로 지킨다. 새 상태값을 FE 에 노출하려면
  * 명세와 공통 상태값 정의를 먼저 개정해야 한다.
+ *
+ * <p>대상 목록은 {@link ProactiveCareLog#INTERNAL_ONLY_STATUSES} 하나뿐이다. 이력 목록에서
+ * 제외하는 기준(이슈 #397)과 같은 목록을 쓴다 — 상태가 늘었을 때 한쪽만 갱신되면
+ * "목록에는 보이는데 값은 접힌다"(또는 그 반대)로 갈라진다.
  */
 final class NotificationStatusView {
-
-    /** 명세에 없는 내부 전용 상태 — 응답에서는 모두 {@code FAILED} 로 접는다. */
-    private static final Set<String> INTERNAL_ONLY_STATUSES = Set.of(
-            ProactiveCareLog.STATUS_NO_DEVICE,
-            ProactiveCareLog.STATUS_UNCONFIRMED
-    );
 
     private NotificationStatusView() {
     }
 
     static String of(String internalStatus) {
-        return INTERNAL_ONLY_STATUSES.contains(internalStatus)
+        return ProactiveCareLog.INTERNAL_ONLY_STATUSES.contains(internalStatus)
                 ? ProactiveCareLog.STATUS_FAILED
                 : internalStatus;
     }

--- a/src/main/java/com/mio/notification/repository/ProactiveCareLogRepository.java
+++ b/src/main/java/com/mio/notification/repository/ProactiveCareLogRepository.java
@@ -35,29 +35,42 @@ public interface ProactiveCareLogRepository extends JpaRepository<ProactiveCareL
             OffsetDateTime to
     );
 
+    /**
+     * 알림 이력 첫 페이지. {@code excludedStatuses}(= {@link ProactiveCareLog#INTERNAL_ONLY_STATUSES})
+     * 에 해당하는 이력은 <b>쿼리에서</b> 걸러낸다 (이슈 #397).
+     *
+     * <p>애플리케이션 레이어에서 거르면 안 된다. 호출부는 {@code pageSize + 1} 건을 읽어
+     * {@code hasMore} 를 판정하는데, 읽어온 뒤에 거르면 페이지가 요청 크기보다 작아지거나
+     * ("60건 중 안 보이는 게 55건"이면 첫 페이지가 통째로 빈다) {@code hasMore} 가 틀어진다.
+     */
     @Query("""
             SELECT log
             FROM ProactiveCareLog log
             WHERE log.user.id = :userId
+              AND log.notificationStatus NOT IN :excludedStatuses
             ORDER BY log.sentAt DESC, log.id DESC
             """)
-    List<ProactiveCareLog> findPageByUserId(
+    List<ProactiveCareLog> findVisiblePageByUserId(
             @Param("userId") UUID userId,
+            @Param("excludedStatuses") Collection<String> excludedStatuses,
             Pageable pageable
     );
 
+    /** 알림 이력 다음 페이지. 제외 기준은 {@link #findVisiblePageByUserId} 와 같다. */
     @Query("""
             SELECT log
             FROM ProactiveCareLog log
             WHERE log.user.id = :userId
+              AND log.notificationStatus NOT IN :excludedStatuses
               AND (
                     log.sentAt < :sentAt
                     OR (log.sentAt = :sentAt AND log.id < :cursorId)
               )
             ORDER BY log.sentAt DESC, log.id DESC
             """)
-    List<ProactiveCareLog> findPageByUserIdAfterCursor(
+    List<ProactiveCareLog> findVisiblePageByUserIdAfterCursor(
             @Param("userId") UUID userId,
+            @Param("excludedStatuses") Collection<String> excludedStatuses,
             @Param("sentAt") OffsetDateTime sentAt,
             @Param("cursorId") UUID cursorId,
             Pageable pageable

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -93,17 +93,35 @@ public class NotificationService {
         }
     }
 
+    /**
+     * 알림 이력 조회. <b>실제로 유저에게 도달했거나 도달을 시도한 알림만</b> 내려준다 (이슈 #397).
+     *
+     * <p>제외 대상은 {@link ProactiveCareLog#INTERNAL_ONLY_STATUSES} — 보낼 단말이 없어 시도조차
+     * 안 한 건({@code NO_DEVICE})과 발송 여부가 불명인 건({@code UNCONFIRMED})이다. 이들이 목록에
+     * 남으면 앱에는 알림이 있는데 푸시는 오지 않은 불일치가 된다.
+     *
+     * <p>{@code FAILED} 는 <b>제외하지 않는다</b>. 명세가 "{@code FAILED} 항목은 이력 화면에서
+     * 재시도 불가 안내 UI 처리 권장"이라고 규정해 FE 에 이미 표시 경로가 있다.
+     *
+     * <p>제외는 반드시 쿼리에서 이뤄진다 — 아래 {@code pageSize + 1} 판정이 조회 결과를
+     * 그대로 신뢰하기 때문이다.
+     */
     @Transactional(readOnly = true)
     public NotificationHistoryResponse getNotificationHistory(UUID userId, String cursor, Integer limit) {
         int pageSize = normalizeLimit(limit);
         List<ProactiveCareLog> logs;
 
         if (cursor == null) {
-            logs = proactiveCareLogRepository.findPageByUserId(userId, PageRequest.of(0, pageSize + 1));
+            logs = proactiveCareLogRepository.findVisiblePageByUserId(
+                    userId,
+                    ProactiveCareLog.INTERNAL_ONLY_STATUSES,
+                    PageRequest.of(0, pageSize + 1)
+            );
         } else {
             NotificationCursor notificationCursor = decodeCursor(userId, cursor);
-            logs = proactiveCareLogRepository.findPageByUserIdAfterCursor(
+            logs = proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(
                     userId,
+                    ProactiveCareLog.INTERNAL_ONLY_STATUSES,
                     notificationCursor.sentAt(),
                     notificationCursor.id(),
                     PageRequest.of(0, pageSize + 1)
@@ -416,6 +434,10 @@ public class NotificationService {
             return new NotificationCursor(OffsetDateTime.parse(parts[0]), UUID.fromString(parts[1]));
         } catch (IllegalArgumentException ignored) {
             try {
+                // 커서는 "값"이 아니라 정렬상의 "위치"다. 그래서 여기서는 이력에서 제외되는 상태
+                // (INTERNAL_ONLY_STATUSES)의 로그도 그대로 위치로 받아들인다. 제외는 결과 집합에
+                // 걸리므로 그 뒤 페이지에 미발송 건이 섞이지 않고, 반대로 여기서 거부해 버리면
+                // 수정 이전 응답으로 받은 legacy 커서를 들고 있는 클라이언트가 400 을 맞는다.
                 ProactiveCareLog legacyCursorLog = proactiveCareLogRepository.findByIdAndUser_Id(UUID.fromString(cursor), userId)
                         .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
                 return new NotificationCursor(legacyCursorLog.getSentAt(), legacyCursorLog.getId());

--- a/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
@@ -1,0 +1,213 @@
+package com.mio.notification.service;
+
+import com.mio.notification.domain.ProactiveCareLog;
+import com.mio.notification.dto.NotificationHistoryItemResponse;
+import com.mio.notification.dto.NotificationHistoryResponse;
+import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 알림 이력 조회가 <b>실제로 발송된 알림만</b> 내려주는지 실 Postgres 로 검증한다 (이슈 #397).
+ *
+ * <p>목으로는 "리포지터리에 어떤 인자가 전달되는가"까지만 확인된다. 여기서 고정하려는 것은
+ * 그 다음 두 가지다.
+ *
+ * <ul>
+ *   <li>제외 대상({@link ProactiveCareLog#INTERNAL_ONLY_STATUSES})이 <b>쿼리에서</b> 빠지는가 —
+ *       {@code NOT IN} 절이 실제로 행을 걸러내야 한다.</li>
+ *   <li>제외 대상이 사이사이 섞여 있어도 <b>커서 페이지네이션이 정확한가</b> — 애플리케이션
+ *       레이어에서 걸렀다면 페이지가 요청 크기보다 작아지거나 {@code hasMore} 가 틀어진다.</li>
+ * </ul>
+ *
+ * <p>가장 중요한 회귀 가드는 <b>{@code FAILED} 가 남아 있는 것</b>이다. 명세가 이력 화면의
+ * {@code FAILED} 표시를 규정하고 있으므로 과필터링은 그 자체가 계약 위반이다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class NotificationHistoryIntegrationTest {
+
+    private static final String TRIGGER_CODE = "checkin_reminder_morning";
+
+    @Autowired private NotificationService notificationService;
+    @Autowired private ProactiveCareLogRepository proactiveCareLogRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private User user;
+    private OffsetDateTime now;
+
+    @BeforeEach
+    void setUp() {
+        User newUser = User.builder()
+                .socialProvider("kakao")
+                .socialId("notification-history-it-" + UUID.randomUUID())
+                .privacyConsent(true)
+                .build();
+        newUser.completeOnboarding("mio");
+        user = userRepository.save(newUser);
+        now = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    @AfterEach
+    void tearDown() {
+        jdbcTemplate.update("DELETE FROM proactive_care_logs WHERE user_id = ?", user.getId());
+        userRepository.deleteById(user.getId());
+    }
+
+    @Test
+    @DisplayName("[#397] 발송 시도조차 없던 NO_DEVICE 이력은 목록에 노출되지 않는다")
+    void history_excludesNoDeviceLogs() {
+        UUID sentId = saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(1));
+        UUID noDeviceId = saveLog(ProactiveCareLog.STATUS_NO_DEVICE, now.minusMinutes(2));
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 20);
+
+        assertThat(idsOf(response)).containsExactly(sentId).doesNotContain(noDeviceId);
+    }
+
+    @Test
+    @DisplayName("[#397] 발송 여부가 불명인 UNCONFIRMED 이력은 목록에 노출되지 않는다")
+    void history_excludesUnconfirmedLogs() {
+        UUID sentId = saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(1));
+        UUID unconfirmedId = saveLog(ProactiveCareLog.STATUS_UNCONFIRMED, now.minusMinutes(2));
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 20);
+
+        assertThat(idsOf(response)).containsExactly(sentId).doesNotContain(unconfirmedId);
+    }
+
+    @Test
+    @DisplayName("[#397] FAILED 이력은 그대로 노출된다 — 명세가 이력 화면 표시를 규정한다")
+    void history_keepsFailedLogs() {
+        UUID failedId = saveLog(ProactiveCareLog.STATUS_FAILED, now.minusMinutes(1));
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 20);
+
+        assertThat(idsOf(response)).containsExactly(failedId);
+        assertThat(response.items().get(0).notificationStatus()).isEqualTo(ProactiveCareLog.STATUS_FAILED);
+    }
+
+    @Test
+    @DisplayName("[#397] SENT·DELIVERED·OPENED·FAILED 는 노출하고 내부 전용 상태만 제외한다")
+    void history_exposesDocumentedStatusesOnly() {
+        UUID sentId = saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(1));
+        UUID deliveredId = saveLog(ProactiveCareLog.STATUS_DELIVERED, now.minusMinutes(2));
+        UUID openedId = saveLog(ProactiveCareLog.STATUS_OPENED, now.minusMinutes(3));
+        UUID failedId = saveLog(ProactiveCareLog.STATUS_FAILED, now.minusMinutes(4));
+        saveLog(ProactiveCareLog.STATUS_NO_DEVICE, now.minusMinutes(5));
+        saveLog(ProactiveCareLog.STATUS_UNCONFIRMED, now.minusMinutes(6));
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 20);
+
+        assertThat(idsOf(response)).containsExactly(sentId, deliveredId, openedId, failedId);
+        assertThat(response.hasMore()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("[#397] 제외 대상이 사이사이 섞여 있어도 페이지가 요청 크기만큼 채워진다")
+    void history_paginationFillsPageDespiteInterleavedHiddenLogs() {
+        // 노출 5건 사이사이에 제외 대상 5건을 끼워 넣는다. 애플리케이션 레이어에서 걸렀다면
+        // pageSize + 1(=6)건을 읽어 3건만 남는 식으로 페이지가 비어 버린다.
+        List<UUID> visibleIds = new ArrayList<>();
+        for (int i = 0; i < 5; i++) {
+            visibleIds.add(saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(i * 2L)));
+            saveLog(i % 2 == 0 ? ProactiveCareLog.STATUS_NO_DEVICE : ProactiveCareLog.STATUS_UNCONFIRMED,
+                    now.minusMinutes(i * 2L + 1));
+        }
+        UUID sixthVisibleId = saveLog(ProactiveCareLog.STATUS_FAILED, now.minusMinutes(20));
+
+        NotificationHistoryResponse firstPage = notificationService.getNotificationHistory(user.getId(), null, 5);
+
+        assertThat(idsOf(firstPage)).containsExactlyElementsOf(visibleIds);
+        assertThat(firstPage.hasMore()).isTrue();
+        assertThat(firstPage.nextCursor()).isNotNull();
+
+        NotificationHistoryResponse secondPage =
+                notificationService.getNotificationHistory(user.getId(), firstPage.nextCursor(), 5);
+
+        assertThat(idsOf(secondPage)).containsExactly(sixthVisibleId);
+        assertThat(secondPage.hasMore()).isFalse();
+        assertThat(secondPage.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("[#397] 남은 이력이 전부 제외 대상이면 hasMore 는 false 이고 다음 커서가 없다")
+    void history_hasMoreIsFalseWhenOnlyHiddenLogsRemain() {
+        List<UUID> visibleIds = List.of(
+                saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(1)),
+                saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(2))
+        );
+        for (int i = 0; i < 5; i++) {
+            saveLog(ProactiveCareLog.STATUS_NO_DEVICE, now.minusMinutes(10L + i));
+        }
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 2);
+
+        assertThat(idsOf(response)).containsExactlyElementsOf(visibleIds);
+        // 뒤에 남은 5건이 전부 제외 대상이므로 "다음 페이지 있음"으로 응답하면 빈 페이지를 유도한다.
+        assertThat(response.hasMore()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("[#397] 발송이 한 건도 없는 유저의 이력은 비어 있다")
+    void history_isEmptyWhenNothingWasEverSent() {
+        for (int i = 0; i < 3; i++) {
+            saveLog(ProactiveCareLog.STATUS_NO_DEVICE, now.minusMinutes(i));
+        }
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(user.getId(), null, 20);
+
+        assertThat(response.items()).isEmpty();
+        assertThat(response.hasMore()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("[#397] 제외 대상 로그 id 를 legacy 커서로 받아도 그 위치부터 노출분만 이어진다")
+    void history_legacyCursorOnHiddenLog_stillPagesVisibleItems() {
+        saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(1));
+        UUID hiddenId = saveLog(ProactiveCareLog.STATUS_NO_DEVICE, now.minusMinutes(2));
+        UUID olderVisibleId = saveLog(ProactiveCareLog.STATUS_SENT, now.minusMinutes(3));
+
+        NotificationHistoryResponse response =
+                notificationService.getNotificationHistory(user.getId(), hiddenId.toString(), 20);
+
+        assertThat(idsOf(response)).containsExactly(olderVisibleId);
+    }
+
+    private List<UUID> idsOf(NotificationHistoryResponse response) {
+        return response.items().stream()
+                .map(NotificationHistoryItemResponse::notificationId)
+                .toList();
+    }
+
+    private UUID saveLog(String status, OffsetDateTime sentAt) {
+        return proactiveCareLogRepository.save(
+                ProactiveCareLog.builder()
+                        .user(user)
+                        .triggerCode(TRIGGER_CODE)
+                        .notificationStatus(status)
+                        .sentAt(sentAt)
+                        .build()
+        ).getId();
+    }
+}

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -138,7 +138,7 @@ class NotificationServiceTest {
                 .sentAt(OffsetDateTime.now().minusMinutes(1))
                 .build();
 
-        when(proactiveCareLogRepository.findPageByUserId(eq(userId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserId(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), any(Pageable.class)))
                 .thenReturn(List.of(first, second));
 
         NotificationHistoryResponse response = notificationService.getNotificationHistory(userId, null, 1);
@@ -231,7 +231,7 @@ class NotificationServiceTest {
                 .sentAt(now.minusMinutes(1))
                 .build();
 
-        when(proactiveCareLogRepository.findPageByUserIdAfterCursor(eq(userId), eq(first.getSentAt()), eq(first.getId()), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), eq(first.getSentAt()), eq(first.getId()), any(Pageable.class)))
                 .thenReturn(List.of(second));
 
         NotificationHistoryResponse response = notificationService.getNotificationHistory(
@@ -412,7 +412,7 @@ class NotificationServiceTest {
                 .notificationStatus(ProactiveCareLog.STATUS_NO_DEVICE)
                 .sentAt(OffsetDateTime.now(fixedClock))
                 .build();
-        when(proactiveCareLogRepository.findPageByUserId(eq(userId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserId(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), any(Pageable.class)))
                 .thenReturn(List.of(noDeviceLog));
 
         NotificationHistoryResponse response = notificationService.getNotificationHistory(userId, null, 20);
@@ -441,7 +441,7 @@ class NotificationServiceTest {
                 .notificationStatus(ProactiveCareLog.STATUS_OPENED)
                 .sentAt(OffsetDateTime.now(fixedClock).minusMinutes(1))
                 .build();
-        when(proactiveCareLogRepository.findPageByUserId(eq(userId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserId(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), any(Pageable.class)))
                 .thenReturn(List.of(sentLog, openedLog));
 
         NotificationHistoryResponse response = notificationService.getNotificationHistory(userId, null, 20);
@@ -623,7 +623,7 @@ class NotificationServiceTest {
                 .notificationStatus(ProactiveCareLog.STATUS_UNCONFIRMED)
                 .sentAt(OffsetDateTime.now(fixedClock))
                 .build();
-        when(proactiveCareLogRepository.findPageByUserId(eq(userId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserId(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), any(Pageable.class)))
                 .thenReturn(List.of(unconfirmedLog));
 
         NotificationHistoryResponse response = notificationService.getNotificationHistory(userId, null, 20);
@@ -680,9 +680,9 @@ class NotificationServiceTest {
                 .sentAt(sentAt)
                 .build();
 
-        when(proactiveCareLogRepository.findPageByUserId(eq(userId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserId(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), any(Pageable.class)))
                 .thenReturn(List.of(first, second));
-        when(proactiveCareLogRepository.findPageByUserIdAfterCursor(eq(userId), eq(sentAt), eq(firstId), any(Pageable.class)))
+        when(proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), eq(sentAt), eq(firstId), any(Pageable.class)))
                 .thenReturn(List.of(second));
 
         NotificationHistoryResponse firstPage = notificationService.getNotificationHistory(userId, null, 1);


### PR DESCRIPTION
## 요약
`GET /v1/notifications`(알림 이력)가 `proactive_care_logs` 를 상태 필터 없이 읽어 내려주기 때문에, **실제로 발송된 적이 없는 알림이 목록에 노출됐다.** 유효 토큰이 없어 발송 시도조차 못 한 건(`NO_DEVICE`)과 게이트웨이 응답을 받지 못해 발송 여부가 불명인 건(`UNCONFIRMED`)이 그대로 내려가, 앱에는 알림이 쌓여 있는데 푸시는 오지 않은 불일치가 생긴다(실제 발송 0건인 계정에 60건 노출).

명세에 정의된 상태(`SENT`/`DELIVERED`/`OPENED`/`FAILED`)만 이력에 남기고, 명세에 없는 **내부 전용 상태만** 제외한다. `FAILED` 는 명세가 "이력 화면에서 재시도 불가 안내 UI 처리 권장"이라고 규정해 FE 에 표시 경로가 이미 있으므로 **그대로 노출한다.**

**응답 형식(JSON 필드·타입·상태코드·쿼리 파라미터)은 하나도 바뀌지 않는다. 바뀌는 것은 목록에 담기는 항목 수뿐이다.** FE 는 아래를 알고 있어야 한다.
- 같은 유저의 이력 건수가 줄어들 수 있다(미발송분이 빠지므로). 특히 오랫동안 토큰이 없던 계정은 목록이 크게 줄거나 비게 된다.
- `hasMore`/`nextCursor` 계산 기준도 노출분만으로 바뀐다. 페이지 크기·커서 사용 방식은 그대로다.
- 목록에서 빠진 항목의 id 로 `PATCH /v1/notifications/{id}/read` 를 호출하는 경로는 건드리지 않았다(#401 의 `markOpened` 가드가 이미 no-op 처리).

## 관련 이슈
- Closes #397

## 변경 사항
- `ProactiveCareLog.INTERNAL_ONLY_STATUSES` 추가 — 명세에 없는 내부 전용 상태(`NO_DEVICE`, `UNCONFIRMED`)의 **단일 출처**. 이력 제외 기준과 응답값 접기 기준이 같은 사실("발송된 적 없거나 확인 불가")에서 나오므로 목록을 하나로 유지한다.
- `NotificationStatusView` 가 자체 목록 대신 위 상수를 참조하도록 변경 — 상태가 추가될 때 한쪽만 갱신되어 "목록에는 보이는데 값은 접힌다"로 갈라지는 것을 막는다.
- `ProactiveCareLogRepository` 의 이력 조회 두 메서드에 `notification_status NOT IN :excludedStatuses` 를 추가하고 `findVisiblePageByUserId` / `findVisiblePageByUserIdAfterCursor` 로 이름을 바꿔 필터링 사실을 시그니처에 드러냈다.
- `NotificationService#getNotificationHistory` 가 제외 집합을 넘기도록 수정. legacy 커서(raw UUID) 경로는 그대로 둔다 — 커서는 값이 아니라 정렬상의 위치이고, 여기서 거부하면 수정 이전 응답으로 받은 커서를 든 클라이언트가 400 을 맞는다. 판단 근거를 주석으로 남겼다.
- `NotificationHistoryIntegrationTest` 추가(실 Postgres), 기존 `NotificationServiceTest` 스텁을 새 시그니처에 맞춤.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

> 응답 **형식**은 불변이라 위 항목은 모두 해당 없음. 다만 응답 **내용**(목록 항목 수)이 줄어드는 동작 변경이므로 위 요약의 FE 유의사항을 확인해 주세요.

## 테스트
### 실행 커맨드
```bash
./gradlew build
```

### 확인 내용
- `NotificationHistoryIntegrationTest`(실 Postgres, `integration-test` 프로파일) 8건 신규:
  - `NO_DEVICE` / `UNCONFIRMED` 이력이 목록에 나오지 않는다.
  - **`FAILED` 이력은 그대로 나오고 상태값도 `FAILED` 로 유지된다** — 과필터링 회귀 가드.
  - `SENT`/`DELIVERED`/`OPENED`/`FAILED` 4종만 노출되고 내부 전용 상태만 빠진다.
  - **제외 대상이 사이사이 끼어 있어도 pageSize 5 조회가 5건을 채우고, `hasMore`·`nextCursor` 가 정확하며 다음 페이지가 이어진다.**
  - 뒤에 남은 이력이 전부 제외 대상이면 `hasMore=false`, `nextCursor=null`(빈 페이지를 유도하지 않는다).
  - 발송이 한 건도 없는 유저의 이력은 비어 있다.
  - 제외 대상 로그 id 를 legacy 커서로 받아도 그 위치부터 노출분만 이어진다.
- 전체 `./gradlew build` 통과(1,027건, 실패 0).

## 중점 리뷰 포인트
- **필터 위치**: 애플리케이션 레이어가 아닌 쿼리 레벨. 호출부가 `pageSize + 1` 로 `hasMore` 를 판정하므로, 읽어온 뒤에 거르면 페이지가 요청 크기보다 작아지고 `hasMore` 도 틀어진다.
- **단일 출처 판단**: 이력 제외 기준과 `NotificationStatusView` 의 접기 기준을 같은 상수로 묶은 것이 타당한지. 두 쓰임의 근거를 `INTERNAL_ONLY_STATUSES` javadoc 에 적어 뒀다.
- **`FAILED` 를 남긴 것**: 정책상 의도된 선택이다(명세 §알림 수신 상태).

## 배포 / 롤백
- Rollout: 스키마·설정 변경 없음. 배포 즉시 적용된다. 기존 데이터 보정도 필요 없다(조회 시점 필터).
- Rollback: 이전 이미지로 되돌리면 즉시 원복된다. 데이터 변경이 없으므로 역마이그레이션이 필요 없다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
