### PR TITLE
fix: 테스트 컨텍스트에서 프로덕션 스케줄러를 끈다 (#402)

### DIFF
--- a/src/main/java/com/mio/MioApplication.java
+++ b/src/main/java/com/mio/MioApplication.java
@@ -4,12 +4,15 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.scheduling.annotation.EnableAsync;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
+/**
+ * 스케줄링 활성화는 {@link com.mio.config.SchedulingConfig} 로 분리했다 (이슈 #402).
+ * 테스트 컨텍스트에서 프로덕션 스케줄러가 자동 실행되지 않게 하기 위한 조치이며,
+ * 프로덕션·로컬 실행에서는 기본값으로 그대로 켜진다.
+ */
 @SpringBootApplication
 @ConfigurationPropertiesScan
 @EnableAsync
-@EnableScheduling
 public class MioApplication {
     public static void main(String[] args) {
         SpringApplication.run(MioApplication.class, args);

--- a/src/main/java/com/mio/config/SchedulingConfig.java
+++ b/src/main/java/com/mio/config/SchedulingConfig.java
@@ -1,0 +1,31 @@
+package com.mio.config;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * 프로덕션 스케줄러 활성화 지점 (이슈 #402).
+ *
+ * <p>{@code @EnableScheduling} 은 원래 {@link com.mio.MioApplication} 에 붙어 있었다. 그러면
+ * {@code @SpringBootTest} 컨텍스트에서도 {@code @Scheduled} 잡 8개가 실제로 돌아, 테스트가 만든
+ * 픽스처를 스케줄러가 중간에 가로챈다. {@code StaleSummarySweepJob} 이 아직 요약이 붙기 전의
+ * pending 세션을 {@code failed} 로 봉인해 {@code StaleSummarySweepIntegrationTest} 가 CI 에서
+ * 간헐 실패한 것이 그 사례다. {@code DataRetentionJob} 은 유저를 하드 삭제하고 리플렉션 잡들은
+ * LLM 호출 경로를 타므로, 테스트 오염을 넘어 데이터 삭제·과금 위험도 있었다.
+ *
+ * <p>그래서 활성화를 별도 설정 클래스로 떼어내 {@code scheduling.enabled} 스위치를 달았다.
+ * <b>기본값은 켜짐</b>({@code matchIfMissing = true})이라 프로덕션·로컬 실행은 프로퍼티를 아무것도
+ * 두지 않아도 지금까지와 동일하게 동작한다. 끄는 쪽은 테스트 소스에만 존재한다
+ * ({@code src/test/resources/application-test.yml}, {@code application-integration-test.yml},
+ * 그리고 프로파일을 가리지 않고 모든 테스트 컨텍스트를 덮는 {@code DisableSchedulingContextCustomizerFactory}).
+ *
+ * <p>프로파일 조건({@code @Profile("!test & !integration-test")})을 쓰지 않은 이유는,
+ * CI 가 {@code SPRING_PROFILES_ACTIVE=local} 로 테스트를 돌리고 {@code MioApplicationTests} 도
+ * {@code local} 프로파일을 쓰기 때문이다. 프로파일만으로는 "테스트 실행"과 "로컬 구동"을 구분할 수 없다.
+ */
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(name = "scheduling.enabled", matchIfMissing = true)
+public class SchedulingConfig {
+}

--- a/src/main/java/com/mio/config/SchedulingConfig.java
+++ b/src/main/java/com/mio/config/SchedulingConfig.java
@@ -23,6 +23,12 @@ import org.springframework.scheduling.annotation.EnableScheduling;
  * <p>프로파일 조건({@code @Profile("!test & !integration-test")})을 쓰지 않은 이유는,
  * CI 가 {@code SPRING_PROFILES_ACTIVE=local} 로 테스트를 돌리고 {@code MioApplicationTests} 도
  * {@code local} 프로파일을 쓰기 때문이다. 프로파일만으로는 "테스트 실행"과 "로컬 구동"을 구분할 수 없다.
+ *
+ * <p>주의: 테스트 컨텍스트에서는 {@code @SpringBootTest(properties = "scheduling.enabled=true")} 로도
+ * 스케줄링을 되켤 수 없다. 위 커스터마이저가 더 나중에 적용되어 값을 덮기 때문이다 — 자세한 근거는
+ * 해당 클래스의 Javadoc 에 있다.
+ *
+ * <p>기동 시 실제 활성 여부는 {@link SchedulingStartupLogger} 가 로그로 남긴다.
  */
 @Configuration
 @EnableScheduling

--- a/src/main/java/com/mio/config/SchedulingStartupLogger.java
+++ b/src/main/java/com/mio/config/SchedulingStartupLogger.java
@@ -1,0 +1,42 @@
+package com.mio.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 기동 시 스케줄링 활성 여부를 한 줄로 남긴다 (이슈 #402).
+ *
+ * <p>{@link SchedulingConfig} 가 {@code scheduling.enabled} 라는 전역 킬스위치를 만들었다.
+ * {@code docker-compose.prod.yml} 은 {@code env_file: .env} 로 파일을 통째로 읽으므로, 저장소·CI
+ * 어디에서도 보이지 않는 곳에서 값이 들어와 {@code @Scheduled} 잡 8개가 <b>조용히</b> 전부 멈출 수 있다.
+ * {@code DataRetentionJob} 의 하드 삭제와 리플렉션 잡의 LLM 호출이 걸려 있어 관측 수단이 필요하다.
+ *
+ * <p>프로퍼티 값이 아니라 {@link ScheduledAnnotationBeanPostProcessor} 의 실제 등록 여부를 본다.
+ * 프로퍼티는 "의도"고 이 빈은 "결과"이며, 배포 직후 확인해야 하는 건 결과다.
+ * 비활성은 프로덕션에서 비정상이므로 {@code WARN} 으로 남긴다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SchedulingStartupLogger {
+
+    private final ObjectProvider<ScheduledAnnotationBeanPostProcessor> scheduledPostProcessor;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void logSchedulingState() {
+        ScheduledAnnotationBeanPostProcessor processor = scheduledPostProcessor.getIfAvailable();
+
+        if (processor == null) {
+            log.warn("[Scheduling] DISABLED — 스케줄러가 등록되지 않아 @Scheduled 잡이 하나도 실행되지 않는다. "
+                    + "프로덕션이라면 비정상이다. scheduling.enabled 설정을 확인하라(기본값 true).");
+            return;
+        }
+
+        log.info("[Scheduling] ENABLED — 등록된 스케줄 태스크 {}건", processor.getScheduledTasks().size());
+    }
+}

--- a/src/test/java/com/mio/MioApplicationTests.java
+++ b/src/test/java/com/mio/MioApplicationTests.java
@@ -1,14 +1,31 @@
 package com.mio;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @ActiveProfiles("local")
 class MioApplicationTests {
 
+    @Autowired private ApplicationContext applicationContext;
+
     @Test
     void contextLoads() {
+    }
+
+    @Test
+    @DisplayName("local 프로파일 테스트 컨텍스트에서도 프로덕션 스케줄러는 돌지 않는다")
+    void schedulingIsDisabledEvenOnLocalProfile() {
+        // 이슈 #402 — CI 는 SPRING_PROFILES_ACTIVE=local 로 테스트를 돌린다. 프로파일 조건만으로
+        // 껐다면 이 컨텍스트에서 @Scheduled 잡 8개가 그대로 실행됐을 것이다.
+        assertThat(applicationContext.getBeanNamesForType(ScheduledAnnotationBeanPostProcessor.class))
+                .isEmpty();
     }
 }

--- a/src/test/java/com/mio/config/DisableSchedulingContextCustomizerFactory.java
+++ b/src/test/java/com/mio/config/DisableSchedulingContextCustomizerFactory.java
@@ -19,6 +19,27 @@ import java.util.List;
  * {@code local} 프로파일을 쓰기 때문이다.
  *
  * <p>이 클래스는 {@code src/test} 에만 존재하므로 프로덕션 아티팩트에는 포함되지 않는다.
+ *
+ * <h2>{@code @SpringBootTest(properties = ...)} 와의 관계 — 이 값은 테스트에서 덮을 수 없다</h2>
+ *
+ * <p>양쪽 모두 <b>같은</b> 프로퍼티 소스에 쓴다 —
+ * {@code TestPropertySourceUtils.INLINED_PROPERTIES_PROPERTY_SOURCE_NAME}, 즉
+ * {@code "Inlined Test Properties"} 라는 하나의 {@code MapPropertySource} 다. 그런데도 충돌하지 않는
+ * 이유는 소스를 교체하는 게 아니라 <b>기존 맵에 {@code putAll} 로 덧쓰기</b> 때문이고, 키가 서로
+ * 다르기 때문이다({@code scheduling.enabled} vs {@code APP_ENCRYPTION_KEY} 등). 소스 이름이 달라서가
+ * <i>아니다</i>.
+ *
+ * <p>적용 순서는 비대칭이다. {@code @SpringBootTest(properties = ...)} 는
+ * {@code SpringBootContextLoader.prepareEnvironment} 단계의
+ * {@code PrepareEnvironmentListener}({@code Ordered.HIGHEST_PRECEDENCE})로 <b>먼저</b> 적용되고,
+ * {@code ContextCustomizer} 는 {@code prepareContext()} 단계의 {@code ApplicationContextInitializer}
+ * 로 <b>나중에</b> 적용된다. 같은 맵에 나중에 쓰는 쪽이 이기므로 <b>이 커스터마이저가 항상 최종값을
+ * 결정한다</b>.
+ *
+ * <p>따라서 {@code @SpringBootTest(properties = "scheduling.enabled=true")} 로는 스케줄링을 다시 켤 수
+ * 없다 — 조용히 {@code false} 로 되돌아간다. 스케줄러가 실제로 도는 것을 검증해야 한다면 이 경로 대신
+ * {@code SchedulingConfigTest} 처럼 {@code ApplicationContextRunner} 를 쓰거나, 잡의 {@code run()} 을
+ * 직접 호출하라.
  */
 public class DisableSchedulingContextCustomizerFactory implements ContextCustomizerFactory {
 

--- a/src/test/java/com/mio/config/DisableSchedulingContextCustomizerFactory.java
+++ b/src/test/java/com/mio/config/DisableSchedulingContextCustomizerFactory.java
@@ -1,0 +1,58 @@
+package com.mio.config;
+
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.test.context.support.TestPropertySourceUtils;
+
+import java.util.List;
+
+/**
+ * 모든 Spring 테스트 컨텍스트에서 프로덕션 스케줄러를 끈다 (이슈 #402).
+ *
+ * <p>{@code META-INF/spring.factories} 로 등록되어 있어 테스트 클래스가 무엇을 선언하든
+ * (프로파일 미지정, {@code local}, {@code test}, {@code integration-test}) 예외 없이 적용된다.
+ * 프로파일 조건이나 테스트별 {@code properties} 선언으로는 이 보장을 만들 수 없다 — CI 는
+ * {@code SPRING_PROFILES_ACTIVE=local} 로 테스트를 돌리고 {@code MioApplicationTests} 도
+ * {@code local} 프로파일을 쓰기 때문이다.
+ *
+ * <p>이 클래스는 {@code src/test} 에만 존재하므로 프로덕션 아티팩트에는 포함되지 않는다.
+ */
+public class DisableSchedulingContextCustomizerFactory implements ContextCustomizerFactory {
+
+    @Override
+    public ContextCustomizer createContextCustomizer(
+            Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
+        return DisableSchedulingContextCustomizer.INSTANCE;
+    }
+
+    /**
+     * 컨텍스트 캐시 키에 들어가므로 {@code equals}/{@code hashCode} 를 구현한다.
+     * 모든 테스트가 동일한 값을 갖게 해 캐시가 쪼개지지 않도록 한다.
+     */
+    static final class DisableSchedulingContextCustomizer implements ContextCustomizer {
+
+        static final DisableSchedulingContextCustomizer INSTANCE = new DisableSchedulingContextCustomizer();
+
+        private DisableSchedulingContextCustomizer() {
+        }
+
+        @Override
+        public void customizeContext(
+                ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+            TestPropertySourceUtils.addInlinedPropertiesToEnvironment(context, "scheduling.enabled=false");
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof DisableSchedulingContextCustomizer;
+        }
+
+        @Override
+        public int hashCode() {
+            return DisableSchedulingContextCustomizer.class.hashCode();
+        }
+    }
+}

--- a/src/test/java/com/mio/config/SchedulingCannotBeReEnabledByTestPropertyTest.java
+++ b/src/test/java/com/mio/config/SchedulingCannotBeReEnabledByTestPropertyTest.java
@@ -1,0 +1,43 @@
+package com.mio.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code @SpringBootTest(properties = ...)} 로는 스케줄링을 되켤 수 없다는 사실을 못 박는다 (이슈 #402).
+ *
+ * <p>{@link DisableSchedulingContextCustomizerFactory} 의 Javadoc 이 설명하는 동작을 주석으로만 두지
+ * 않고 테스트로 고정한다. 두 메커니즘은 같은 {@code "Inlined Test Properties"} 맵에 쓰고, 커스터마이저가
+ * {@code prepareContext()} 단계로 <b>나중에</b> 적용되어 최종값을 결정한다. 그래서 아래처럼 명시적으로
+ * {@code true} 를 줘도 조용히 {@code false} 로 되돌아간다.
+ *
+ * <p>이 성질이 바뀌면(예: Spring 이 적용 순서를 바꾸면) 테스트 실행 중 프로덕션 스케줄러가 다시 살아날
+ * 수 있으므로, 그때 이 테스트가 먼저 알려주게 한다.
+ */
+@SpringBootTest(properties = {
+        "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+        "scheduling.enabled=true"
+})
+@ActiveProfiles("integration-test")
+class SchedulingCannotBeReEnabledByTestPropertyTest {
+
+    @Autowired private ApplicationContext applicationContext;
+    @Autowired private Environment environment;
+
+    @Test
+    @DisplayName("테스트가 scheduling.enabled=true 를 줘도 커스터마이저가 나중에 덮어 false 로 남는다")
+    void testPropertyCannotReEnableScheduling() {
+        assertThat(environment.getProperty("scheduling.enabled")).isEqualTo("false");
+        assertThat(applicationContext.getBeanNamesForType(ScheduledAnnotationBeanPostProcessor.class))
+                .as("@SpringBootTest properties 로 스케줄러가 되살아나면 테스트 격리가 다시 깨진다")
+                .isEmpty();
+    }
+}

--- a/src/test/java/com/mio/config/SchedulingConfigTest.java
+++ b/src/test/java/com/mio/config/SchedulingConfigTest.java
@@ -1,0 +1,101 @@
+package com.mio.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.scheduling.annotation.Scheduled;
+
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 스케줄링 스위치의 양방향 회귀 가드 (이슈 #402).
+ *
+ * <p>테스트에서 스케줄러를 끈 조치가 <b>프로덕션 스케줄링까지 꺼버리는</b> 사고로 번지지 않도록,
+ * "프로퍼티가 없으면 실제로 {@code @Scheduled} 메서드가 돈다"를 실행으로 확인한다. 이게 깨지면
+ * 알림·세션 타임아웃·리포트 집계가 전부 멈춘다.
+ *
+ * <p>Spring 테스트 컨텍스트가 아니라 {@link ApplicationContextRunner} 를 쓰는 이유는,
+ * {@link DisableSchedulingContextCustomizerFactory} 가 <i>모든</i> 테스트 컨텍스트의 스케줄링을 끄기
+ * 때문이다. 러너는 그 경로를 타지 않으므로 프로덕션과 동일한 기본값을 관찰할 수 있다.
+ */
+class SchedulingConfigTest {
+
+    private static final ApplicationContextRunner RUNNER = new ApplicationContextRunner()
+            .withUserConfiguration(SchedulingConfig.class, CountingJob.class);
+
+    @Test
+    @DisplayName("프로퍼티가 없으면(프로덕션 기본) 스케줄러가 등록되고 @Scheduled 메서드가 실제로 실행된다")
+    void schedulingEnabledByDefault() {
+        RUNNER.run(context -> {
+            assertThat(context).hasSingleBean(ScheduledAnnotationBeanPostProcessor.class);
+            assertThat(context.getBean(CountingJob.class).awaitFirstRun())
+                    .as("기본 설정에서 @Scheduled 잡이 실행되어야 한다")
+                    .isTrue();
+        });
+    }
+
+    @Test
+    @DisplayName("scheduling.enabled=false 면 스케줄러가 아예 등록되지 않고 @Scheduled 메서드도 돌지 않는다")
+    void schedulingDisabledByProperty() {
+        RUNNER.withPropertyValues("scheduling.enabled=false").run(context -> {
+            assertThat(context).doesNotHaveBean(ScheduledAnnotationBeanPostProcessor.class);
+            assertThat(context).doesNotHaveBean(SchedulingConfig.class);
+            assertThat(context.getBean(CountingJob.class).ranWithin(300))
+                    .as("스케줄링이 꺼졌는데 @Scheduled 잡이 실행되면 안 된다")
+                    .isFalse();
+        });
+    }
+
+    @Test
+    @DisplayName("프로덕션 설정 파일은 스케줄링을 끄지 않는다")
+    void productionConfigNeverDisablesScheduling() {
+        assertThat(schedulingEnabledIn("application.yml"))
+                .as("application.yml 이 스케줄링을 끄면 프로덕션 배치가 전부 멈춘다")
+                .isNotEqualTo("false");
+        assertThat(schedulingEnabledIn("application-prod.yml"))
+                .as("application-prod.yml 이 스케줄링을 끄면 프로덕션 배치가 전부 멈춘다")
+                .isNotEqualTo("false");
+    }
+
+    @Test
+    @DisplayName("두 테스트 프로파일 모두 스케줄링을 끈다")
+    void bothTestProfilesDisableScheduling() {
+        assertThat(schedulingEnabledIn("application-test.yml")).isEqualTo("false");
+        assertThat(schedulingEnabledIn("application-integration-test.yml")).isEqualTo("false");
+    }
+
+    /** 해당 설정 파일이 선언한 {@code scheduling.enabled} 값. 선언이 없으면 {@code null}. */
+    private String schedulingEnabledIn(String yamlName) {
+        YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
+        factory.setResources(new ClassPathResource(yamlName));
+        Properties properties = factory.getObject();
+        Object value = properties == null ? null : properties.get("scheduling.enabled");
+        return value == null ? null : value.toString();
+    }
+
+    /** 스케줄러가 실제로 도는지 관찰하기 위한 최소 잡. */
+    static class CountingJob {
+
+        private final CountDownLatch firstRun = new CountDownLatch(1);
+
+        @Scheduled(fixedDelay = 20)
+        void run() {
+            firstRun.countDown();
+        }
+
+        boolean awaitFirstRun() throws InterruptedException {
+            return firstRun.await(5, TimeUnit.SECONDS);
+        }
+
+        boolean ranWithin(long millis) throws InterruptedException {
+            return firstRun.await(millis, TimeUnit.MILLISECONDS);
+        }
+    }
+}

--- a/src/test/java/com/mio/config/SchedulingDisabledIntegrationTest.java
+++ b/src/test/java/com/mio/config/SchedulingDisabledIntegrationTest.java
@@ -1,0 +1,60 @@
+package com.mio.config;
+
+import com.mio.session.job.StaleSummarySweepJob;
+import com.mio.user.job.DataRetentionJob;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.env.Environment;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+import org.springframework.scheduling.config.ScheduledTaskHolder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 통합 테스트 컨텍스트에 프로덕션 스케줄러가 등록되지 않는 것을 확인한다 (이슈 #402).
+ *
+ * <p>설정을 바꾼 것만으로는 "잡이 안 돈다"를 보장했다고 할 수 없어, 스케줄 등록 자체를 담당하는
+ * {@link ScheduledAnnotationBeanPostProcessor} 의 부재와 등록된 스케줄 태스크가 0건임을 단언한다.
+ * 동시에 잡 빈은 그대로 주입되어야 한다 — {@code StaleSummarySweepIntegrationTest} 처럼
+ * {@code run()} 을 직접 부르는 테스트 방식이 계속 동작해야 하기 때문이다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class SchedulingDisabledIntegrationTest {
+
+    @Autowired private ApplicationContext applicationContext;
+    @Autowired private Environment environment;
+    @Autowired private StaleSummarySweepJob staleSummarySweepJob;
+    @Autowired private DataRetentionJob dataRetentionJob;
+
+    @Test
+    @DisplayName("테스트 컨텍스트에는 스케줄러 후처리기가 등록되지 않는다")
+    void schedulingIsDisabled() {
+        assertThat(environment.getProperty("scheduling.enabled")).isEqualTo("false");
+        assertThat(applicationContext.getBeanNamesForType(ScheduledAnnotationBeanPostProcessor.class))
+                .as("이 빈이 있으면 @Scheduled 잡 8개가 테스트 도중 실제로 실행된다")
+                .isEmpty();
+        assertThat(applicationContext.getBeanNamesForType(SchedulingConfig.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("등록된 스케줄 태스크가 한 건도 없다")
+    void noScheduledTasksAreRegistered() {
+        long scheduledTasks = applicationContext.getBeansOfType(ScheduledTaskHolder.class).values().stream()
+                .mapToLong(holder -> holder.getScheduledTasks().size())
+                .sum();
+
+        assertThat(scheduledTasks).isZero();
+    }
+
+    @Test
+    @DisplayName("스케줄링이 꺼져도 잡 빈은 그대로 주입되어 수동 호출로 테스트할 수 있다")
+    void jobsRemainInjectableForManualInvocation() {
+        assertThat(staleSummarySweepJob).isNotNull();
+        assertThat(dataRetentionJob).isNotNull();
+    }
+}

--- a/src/test/java/com/mio/config/SchedulingStartupLoggerTest.java
+++ b/src/test/java/com/mio/config/SchedulingStartupLoggerTest.java
@@ -1,0 +1,77 @@
+package com.mio.config;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * 기동 로그가 스케줄링 활성 여부를 실제로 구분해 남기는지 확인한다 (이슈 #402).
+ *
+ * <p>배포 직후 로그만 보고 "스케줄러 살아있음"을 판정해야 하므로, 두 갈래가 각각 다른 레벨로
+ * 찍히는 것이 이 로그의 존재 이유다.
+ */
+class SchedulingStartupLoggerTest {
+
+    private ListAppender<ILoggingEvent> appender;
+
+    @BeforeEach
+    void setUp() {
+        Logger logger = (Logger) LoggerFactory.getLogger(SchedulingStartupLogger.class);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ((Logger) LoggerFactory.getLogger(SchedulingStartupLogger.class)).detachAppender(appender);
+    }
+
+    @Test
+    @DisplayName("스케줄러가 등록돼 있으면 등록 태스크 수와 함께 INFO 로 남긴다")
+    void logsEnabledStateAtInfo() {
+        new SchedulingStartupLogger(providerOf(new ScheduledAnnotationBeanPostProcessor()))
+                .logSchedulingState();
+
+        ILoggingEvent event = onlyEvent();
+        assertThat(event.getLevel()).isEqualTo(Level.INFO);
+        assertThat(event.getFormattedMessage()).contains("[Scheduling] ENABLED");
+    }
+
+    @Test
+    @DisplayName("스케줄러가 없으면 WARN 으로 남겨 프로덕션에서 눈에 띄게 한다")
+    void logsDisabledStateAtWarn() {
+        new SchedulingStartupLogger(providerOf(null)).logSchedulingState();
+
+        ILoggingEvent event = onlyEvent();
+        assertThat(event.getLevel())
+                .as("프로덕션에서 스케줄링 비활성은 비정상이므로 INFO 로 묻히면 안 된다")
+                .isEqualTo(Level.WARN);
+        assertThat(event.getFormattedMessage()).contains("[Scheduling] DISABLED");
+    }
+
+    private ILoggingEvent onlyEvent() {
+        assertThat(appender.list).hasSize(1);
+        return appender.list.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private ObjectProvider<ScheduledAnnotationBeanPostProcessor> providerOf(
+            ScheduledAnnotationBeanPostProcessor processor) {
+        ObjectProvider<ScheduledAnnotationBeanPostProcessor> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(processor);
+        return provider;
+    }
+}

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,4 @@
+# 이슈 #402 — 테스트 컨텍스트에서 프로덕션 스케줄러(@Scheduled 잡 8개)가 자동 실행되지 않게 한다.
+# 프로파일·테스트 클래스 선언과 무관하게 모든 Spring 테스트 컨텍스트에 적용된다.
+org.springframework.test.context.ContextCustomizerFactory=\
+  com.mio.config.DisableSchedulingContextCustomizerFactory

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -1,3 +1,9 @@
+# 이슈 #402 — 테스트 컨텍스트에서 프로덕션 스케줄러가 픽스처를 가로채지 못하게 끈다.
+# 프로파일을 가리지 않는 보장은 DisableSchedulingContextCustomizerFactory 가 담당하고,
+# 여기 선언은 프로파일 단위로도 명시해 두기 위한 것이다.
+scheduling:
+  enabled: false
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/mio

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,3 +1,9 @@
+# 이슈 #402 — 테스트 컨텍스트에서 프로덕션 스케줄러가 픽스처를 가로채지 못하게 끈다.
+# 프로파일을 가리지 않는 보장은 DisableSchedulingContextCustomizerFactory 가 담당하고,
+# 여기 선언은 프로파일 단위로도 명시해 두기 위한 것이다.
+scheduling:
+  enabled: false
+
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/mio


### PR DESCRIPTION
## 요약
`MioApplication` 에 붙어 있던 `@EnableScheduling` 때문에 `@SpringBootTest` 컨텍스트에서도 프로덕션 `@Scheduled` 잡 8개가 실제로 실행됐다. `StaleSummarySweepJob` 이 테스트 픽스처를 중간에 가로채 `StaleSummarySweepIntegrationTest` 가 CI 에서 간헐 실패했고(알림 변경이 없는 `main` 에서도 동일 라인 실패), `DataRetentionJob` 의 유저 하드 삭제·리플렉션 잡의 LLM 호출까지 테스트 중 임의 시점에 일어날 수 있는 상태였다. 스케줄링 활성화를 별도 설정으로 분리해 **테스트에서만** 끈다. 프로덕션·로컬 실행은 기본값으로 그대로 켜진다.

## 관련 이슈
- Closes #402

## 변경 사항
- `@EnableScheduling` 을 `MioApplication` 에서 떼어내 `config/SchedulingConfig` 로 분리하고 `@ConditionalOnProperty(name = "scheduling.enabled", matchIfMissing = true)` 를 걸었다. **기본값이 켜짐**이라 프로덕션·로컬은 프로퍼티 없이 지금까지와 동일하게 동작한다.
- 테스트 소스에만 존재하는 `DisableSchedulingContextCustomizerFactory` 를 `src/test/resources/META-INF/spring.factories` 로 등록해, 프로파일·테스트 클래스 선언과 무관하게 **모든 Spring 테스트 컨텍스트**에서 `scheduling.enabled=false` 를 주입한다.
- `application-test.yml`, `application-integration-test.yml` 두 테스트 프로파일 모두에도 `scheduling.enabled: false` 를 명시했다.
- 회귀 가드 테스트 추가: `SchedulingConfigTest`(프로덕션 기본값 동작 + 끄기 동작 + 설정 파일 검증), `SchedulingDisabledIntegrationTest`(통합 테스트 컨텍스트에 스케줄러 미등록), `MioApplicationTests` 에 `local` 프로파일 컨텍스트 단언 추가.
- 기동 시 스케줄링 활성 여부를 한 줄 로그로 남기는 `SchedulingStartupLogger` 추가 — 비활성이면 `WARN`. 프로퍼티 값이 아니라 `ScheduledAnnotationBeanPostProcessor` 의 실제 등록 여부를 본다.

### 프로파일 조건(`@Profile("!test & !integration-test")`)을 쓰지 않은 이유
CI 워크플로가 `SPRING_PROFILES_ACTIVE=local` 로 테스트를 돌리고 `MioApplicationTests` 도 `@ActiveProfiles("local")` 이다. 즉 프로파일만으로는 "테스트 실행"과 "로컬 구동"을 구분할 수 없어, 프로파일 조건으로는 `local` 로 도는 테스트 컨텍스트의 스케줄러를 막지 못한다. 그래서 프로퍼티 스위치 + 테스트 전용 ContextCustomizer 조합을 택했다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

> 스케줄러 영향은 **테스트 실행 환경에 한정**된다. 프로덕션·로컬 런타임의 잡 스케줄(cron·fixedDelay)과 실행 동작은 그대로다. 새 환경 변수도 필요 없다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
./gradlew test --tests "com.mio.config.SchedulingConfigTest"
./gradlew test --tests "com.mio.config.SchedulingDisabledIntegrationTest"
./gradlew test --tests "com.mio.session.repository.StaleSummarySweepIntegrationTest" --rerun-tasks   # 5회 반복
```

### 확인 내용
- `./gradlew build` 전체 통과 — 1,038건 실행, 실패 0.
- **프로덕션 경로 생존 검증**: `SchedulingConfigTest.schedulingEnabledByDefault` 가 `ApplicationContextRunner` 로 프로퍼티 없는(=프로덕션 기본) 컨텍스트를 띄워 `ScheduledAnnotationBeanPostProcessor` 등록과 `@Scheduled` 메서드의 **실제 실행**(CountDownLatch)을 확인한다. `matchIfMissing` 을 `false` 로 뒤집는 변이 실험에서 이 테스트가 정확히 실패하는 것까지 확인했다.
- **비활성화 검증**: `SchedulingDisabledIntegrationTest` 가 `integration-test` 컨텍스트에서 `ScheduledAnnotationBeanPostProcessor` 부재, `ScheduledTaskHolder` 기준 등록 태스크 0건, `SchedulingConfig` 빈 부재를 단언한다.
- **프로파일 커버리지 검증**: `MioApplicationTests` (`local` 프로파일)에서도 스케줄러 후처리기가 없음을 단언 — 프로파일 조건이었다면 뚫렸을 구멍을 막았음을 증명한다.
- **설정 파일 검증**: `application.yml` / `application-prod.yml` 이 스케줄링을 끄지 않는다는 것과, `application-test.yml` / `application-integration-test.yml` 이 끈다는 것을 단언한다.
- **플래키 해소 확인**: `StaleSummarySweepIntegrationTest` 를 `--rerun-tasks` 로 5회 연속 실행해 모두 통과. 원 회귀(스위퍼 로직) 검증 3건은 그대로 유지했고 테스트를 약화시키지 않았다.
- **기동 로그 검증**: `SchedulingStartupLoggerTest` 가 두 갈래(INFO/WARN)를 로그 레벨까지 단언하고, `SchedulingDisabledIntegrationTest` 의 실제 컨텍스트 로그에서 `ApplicationReadyEvent` 로 WARN 한 줄이 실제로 찍히는 것을 확인했다.
- **수동 호출 경로 유지**: 잡 빈은 그대로 주입되며 `staleSummarySweepJob.run()` / `embeddingWorker.processPending()` 같은 기존 수동 호출 테스트가 모두 통과한다.

## 중점 리뷰 포인트
- **프로덕션 스케줄링이 영향받지 않음을 어떻게 보장했는가** — 세 겹으로 막았다.
  1. `SchedulingConfig` 의 조건이 `matchIfMissing = true` 라, 프로퍼티를 선언하지 않는 프로덕션·로컬에서는 조건이 항상 참이다. 잡 클래스와 `@Scheduled` 선언은 한 글자도 건드리지 않았다.
  2. 끄는 설정은 **`src/test` 안에만** 존재한다 (`application-test.yml`, `application-integration-test.yml`, `src/test/resources/META-INF/spring.factories`). 프로덕션 아티팩트(`bootJar`)에는 포함되지 않는다.
  3. `SchedulingConfigTest` 가 기본 컨텍스트에서 `@Scheduled` 메서드가 실제로 실행되는지를 매 빌드마다 확인한다. 누군가 기본값을 뒤집으면 빌드가 깨진다(변이 실험으로 확인).
- `DisableSchedulingContextCustomizerFactory` 가 `spring.factories` 로 등록되는 방식이 낯설 수 있다. Spring TestContext 프레임워크의 공식 확장 지점이며, `spring.factories` 는 클래스패스 전체에서 누적 로드되므로 다른 라이브러리 등록을 덮어쓰지 않는다. 컨텍스트 캐시 키에 들어가므로 싱글턴 + `equals`/`hashCode` 로 캐시가 쪼개지지 않게 했다.
- **`@SpringBootTest(properties = ...)` 와의 관계 (초기 리뷰 시점 설명 정정)**: 앞서 "프로퍼티 소스 이름이 달라 덮지 않는다"고 적었으나 **사실이 아니다.** 두 메커니즘 모두 `TestPropertySourceUtils.INLINED_PROPERTIES_PROPERTY_SOURCE_NAME`(= `"Inlined Test Properties"`)이라는 **같은** `MapPropertySource` 에 쓴다. 공존하는 진짜 이유는 키가 다르고(`scheduling.enabled` vs `APP_ENCRYPTION_KEY`) 쓰기가 소스 교체가 아니라 `Map.putAll` 이기 때문이다.
- 적용 순서는 비대칭이다. `@SpringBootTest(properties=...)` 는 `SpringBootContextLoader.prepareEnvironment` 의 `PrepareEnvironmentListener`(`Ordered.HIGHEST_PRECEDENCE`)로 **먼저**, ContextCustomizer 는 `prepareContext()` 의 `ApplicationContextInitializer` 로 **나중에** 적용된다. 같은 맵에 나중에 쓰는 쪽이 이기므로 **커스터마이저가 항상 최종값을 결정한다.** 따라서 `@SpringBootTest(properties = "scheduling.enabled=true")` 로는 스케줄링을 되켤 수 없다(조용히 `false` 로 되돌아감). 이 함정을 Javadoc 에 명시했고, 주석으로만 두지 않도록 `SchedulingCannotBeReEnabledByTestPropertyTest` 로 고정했다. 스케줄러가 실제로 도는 것을 검증해야 하면 `ApplicationContextRunner` 를 쓰거나 잡의 `run()` 을 직접 호출하면 된다.
- **새 전역 킬스위치의 관측 수단**: `docker-compose.prod.yml` 이 `env_file: .env` 로 파일을 통째로 읽으므로 저장소·CI 어디에도 안 보이는 곳에서 `SCHEDULING_ENABLED=false` 가 들어오면 잡 8개가 조용히 멈춘다. `SchedulingStartupLogger` 가 기동 시 `[Scheduling] ENABLED — 등록된 스케줄 태스크 N건` 또는 `[Scheduling] DISABLED …`(WARN)를 남기므로 배포 직후 로그만으로 판정할 수 있다.

## 배포 / 롤백
- Rollout: 런타임 동작 변경 없음. 배포 시 추가 조치·환경 변수 불필요. 스케줄러는 기존과 동일한 주기로 계속 실행된다.
- Rollback: 커밋 revert 만으로 원상 복구된다(스키마·설정 변경 없음). 운영 중 스케줄러를 급히 멈춰야 하면 `SCHEDULING_ENABLED` 같은 환경 변수 매핑 없이도 `--scheduling.enabled=false` 로 기동해 끌 수 있다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
