### PR TITLE
fix: 알림 커서 형식을 모양으로 판별해 비결정적 500 을 없앤다 (#405)

### DIFF
--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
+import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -41,6 +42,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -57,6 +59,14 @@ public class NotificationService {
     private static final int DEFAULT_HISTORY_LIMIT = 20;
     private static final int MAX_HISTORY_LIMIT = 50;
     private static final int SCHEDULER_BATCH_SIZE = 200;
+    /**
+     * legacy 커서(raw UUID) 판별 패턴 — 커서 형식을 <b>모양으로</b> 결정적으로 가른다 (이슈 #405).
+     *
+     * <p>{@link #encodeCursor} 가 만드는 커서는 base64url 이라 길이가 36자를 훌쩍 넘고 hex 밖의
+     * 문자를 포함하므로 이 패턴에 걸리지 않는다.
+     */
+    private static final Pattern LEGACY_UUID_CURSOR =
+            Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
     private static final Sort SCHEDULER_SORT = Sort.by(Sort.Direction.ASC, "id");
     private static final Set<String> NEGATIVE_EMOTIONS = Set.of(
             "anxious", "sad", "angry", "ashamed", "numb", "tired", "confused"
@@ -424,26 +434,63 @@ public class NotificationService {
         return "proactive:" + userId + ":daily_count";
     }
 
+    /**
+     * 커서를 정렬 위치로 되돌린다. 형식은 <b>모양으로</b> 판별한다 — 예외가 나는지 여부로 갈라서는 안 된다.
+     *
+     * <p>이전 구현은 base64 디코딩 실패를 legacy(raw UUID) 판별 기준으로 삼았다. 그런데 UUID 문자열은
+     * 36자에 구성 문자가 hex 와 {@code -} 뿐이고 {@code -} 는 base64url 문자이며 36 % 4 == 0 이라
+     * <b>디코딩이 항상 성공한다</b>. 그 결과 27바이트 쓰레기에 우연히 {@code |} 가 섞이면(무작위 UUID 의
+     * 약 9%) {@code OffsetDateTime.parse(<쓰레기>)} 가 불렸고, {@code DateTimeParseException} 은
+     * {@code IllegalArgumentException} 의 하위 타입이 아니라 그대로 500 이 됐다 (이슈 #405).
+     *
+     * <p>그래서 {@link #LEGACY_UUID_CURSOR} 로 먼저 모양을 확인해 경로를 <b>결정적으로</b> 고른다.
+     * {@link #encodeCursor} 가 만드는 커서는 {@code "<sentAt>|<id>"} 를 base64url 로 인코딩한 것이라
+     * 항상 36자보다 길고 hex 밖의 문자를 포함하므로 이 패턴과 겹치지 않는다.
+     */
     private NotificationCursor decodeCursor(UUID userId, String cursor) {
+        if (LEGACY_UUID_CURSOR.matcher(cursor).matches()) {
+            return resolveLegacyCursor(userId, UUID.fromString(cursor));
+        }
+        return decodeEncodedCursor(cursor);
+    }
+
+    /**
+     * legacy 커서(raw UUID) 를 위치로 해석한다.
+     *
+     * <p>커서는 "값"이 아니라 정렬상의 "위치"다. 그래서 여기서는 이력에서 제외되는 상태
+     * (INTERNAL_ONLY_STATUSES)의 로그도 그대로 위치로 받아들인다. 제외는 결과 집합에
+     * 걸리므로 그 뒤 페이지에 미발송 건이 섞이지 않고, 반대로 여기서 거부해 버리면
+     * 수정 이전 응답으로 받은 legacy 커서를 들고 있는 클라이언트가 400 을 맞는다.
+     */
+    private NotificationCursor resolveLegacyCursor(UUID userId, UUID legacyCursorId) {
+        ProactiveCareLog legacyCursorLog = proactiveCareLogRepository.findByIdAndUser_Id(legacyCursorId, userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
+        return new NotificationCursor(legacyCursorLog.getSentAt(), legacyCursorLog.getId());
+    }
+
+    /**
+     * {@link #encodeCursor} 가 만든 {@code base64url("<sentAt>|<id>")} 커서를 되돌린다.
+     *
+     * <p>단계마다 실패를 {@link ErrorCode#INVALID_INPUT} 으로 좁혀 잡는다. {@code Base64.decode} 와
+     * {@code UUID.fromString} 은 {@link IllegalArgumentException} 을, {@code OffsetDateTime.parse} 는
+     * {@link java.time.DateTimeException} 을 던지는데 둘은 상속 관계가 없어 한쪽만 잡으면 다른 쪽이
+     * 500 으로 샌다.
+     */
+    private NotificationCursor decodeEncodedCursor(String cursor) {
+        String decoded;
         try {
-            String decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
-            String[] parts = decoded.split("\\|", 2);
-            if (parts.length != 2) {
-                throw new IllegalArgumentException("Invalid cursor payload");
-            }
+            decoded = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        String[] parts = decoded.split("\\|", 2);
+        if (parts.length != 2) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        try {
             return new NotificationCursor(OffsetDateTime.parse(parts[0]), UUID.fromString(parts[1]));
-        } catch (IllegalArgumentException ignored) {
-            try {
-                // 커서는 "값"이 아니라 정렬상의 "위치"다. 그래서 여기서는 이력에서 제외되는 상태
-                // (INTERNAL_ONLY_STATUSES)의 로그도 그대로 위치로 받아들인다. 제외는 결과 집합에
-                // 걸리므로 그 뒤 페이지에 미발송 건이 섞이지 않고, 반대로 여기서 거부해 버리면
-                // 수정 이전 응답으로 받은 legacy 커서를 들고 있는 클라이언트가 400 을 맞는다.
-                ProactiveCareLog legacyCursorLog = proactiveCareLogRepository.findByIdAndUser_Id(UUID.fromString(cursor), userId)
-                        .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_INPUT));
-                return new NotificationCursor(legacyCursorLog.getSentAt(), legacyCursorLog.getId());
-            } catch (IllegalArgumentException e) {
-                throw new BusinessException(ErrorCode.INVALID_INPUT);
-            }
+        } catch (DateTimeException | IllegalArgumentException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
         }
     }
 

--- a/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
@@ -1,0 +1,251 @@
+package com.mio.notification.service;
+
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.notification.domain.ProactiveCareLog;
+import com.mio.notification.dto.NotificationHistoryResponse;
+import com.mio.notification.repository.DeviceTokenRepository;
+import com.mio.notification.repository.NotificationSettingRepository;
+import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.todo.repository.BehaviorTaskRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/**
+ * 알림 이력 커서 파싱이 <b>입력 내용과 무관하게 결정적인지</b> 고정한다 (이슈 #405).
+ *
+ * <p>고칠 결함은 "커서 형식을 예외 발생 여부로 판별한 것"이었다. legacy 커서(raw UUID)를 받으면
+ * base64 디코딩이 실패할 것이라 가정하고 그 실패를 legacy 진입 조건으로 삼았는데, UUID 문자열은
+ * 36자에 hex 와 {@code -} 뿐이고 {@code -} 는 base64url 문자이며 36 % 4 == 0 이라
+ * <b>디코딩이 항상 성공한다</b>. 디코딩 결과 27바이트 쓰레기에 우연히 {@code |} 가 섞이면
+ * {@code OffsetDateTime.parse(<쓰레기>)} 가 불리고, {@code DateTimeParseException} 은
+ * {@code IllegalArgumentException} 의 하위 타입이 아니라서 그대로 500 이 됐다.
+ *
+ * <p>그래서 여기서 검증하는 것은 사례가 아니라 <b>불변식</b>이다.
+ *
+ * <ol>
+ *   <li>raw UUID 형식이면 <b>항상</b> legacy 경로</li>
+ *   <li>{@code encodeCursor} 가 만든 커서면 <b>항상</b> 정상 경로</li>
+ *   <li>둘 다 아니면 <b>항상</b> {@link ErrorCode#INVALID_INPUT} — 500 은 절대 없다</li>
+ * </ol>
+ *
+ * <p>1번은 <b>시드 고정 난수로 다수를 돌려</b> 확인한다. UUID 하나만 넣는 테스트는 이 결함을
+ * 약 9% 확률로만 잡는다(실제로 CI 에서 통과/실패가 갈렸다). 표본을 {@link #UUID_SAMPLE_SIZE} 건
+ * 돌리면 수정 전 코드에서는 사실상 확실히 실패하고, 시드를 고정했으므로 실패하면 언제나 같은
+ * 방식으로 재현된다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class NotificationCursorDecodingTest {
+
+    /**
+     * legacy 커서 표본 수. 결함 재현 확률이 표본당 약 9% 이므로 이 개수면 수정 전 코드가 통과할
+     * 확률은 사실상 0 이다 (0.91^500).
+     */
+    private static final int UUID_SAMPLE_SIZE = 500;
+
+    /** 시드를 고정해 표본 시퀀스를 재현 가능하게 만든다 — 실패는 항상 같은 값에서 난다. */
+    private static final long UUID_SAMPLE_SEED = 405L;
+
+    @Mock private UserRepository userRepository;
+    @Mock private DeviceTokenRepository deviceTokenRepository;
+    @Mock private NotificationSettingRepository notificationSettingRepository;
+    @Mock private ProactiveCareLogRepository proactiveCareLogRepository;
+    @Mock private CheckinRepository checkinRepository;
+    @Mock private BehaviorTaskRepository behaviorTaskRepository;
+    @Mock private StringRedisTemplate stringRedisTemplate;
+    @Mock private PushSender pushSender;
+    @Mock private NotificationPersistenceService notificationPersistenceService;
+
+    private NotificationService notificationService;
+    private Clock fixedClock;
+    private UUID userId;
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        fixedClock = Clock.fixed(Instant.parse("2026-05-26T00:00:00Z"), ZoneOffset.of("+09:00"));
+        notificationService = new NotificationService(
+                fixedClock,
+                userRepository,
+                deviceTokenRepository,
+                notificationSettingRepository,
+                proactiveCareLogRepository,
+                checkinRepository,
+                behaviorTaskRepository,
+                stringRedisTemplate,
+                new NotificationMessageMapper(),
+                pushSender,
+                notificationPersistenceService
+        );
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .socialProvider("kakao")
+                .socialId("cursor-decoding-test")
+                .privacyConsent(true)
+                .build();
+    }
+
+    @Test
+    @DisplayName("[#405] legacy 커서는 어떤 UUID 든 예외 없이 legacy 경로로 해석된다")
+    void legacyCursor_anyUuid_alwaysResolvesThroughLegacyPath() {
+        // 표본 하나로는 이 결함을 약 9% 확률로만 잡는다 — UUID 문자열은 항상 유효한 base64url 이라
+        // 디코딩이 성공해 버리고, 그 쓰레기에 '|' 가 섞이는지가 UUID 의 무작위 비트에 달려 있기 때문이다.
+        Random random = new Random(UUID_SAMPLE_SEED);
+        OffsetDateTime sentAt = OffsetDateTime.now(fixedClock).minusMinutes(1);
+
+        for (int i = 0; i < UUID_SAMPLE_SIZE; i++) {
+            UUID legacyId = new UUID(random.nextLong(), random.nextLong());
+            ProactiveCareLog cursorLog = logWith(legacyId, sentAt);
+            ProactiveCareLog nextLog = logWith(UUID.randomUUID(), sentAt.minusMinutes(1));
+
+            when(proactiveCareLogRepository.findByIdAndUser_Id(legacyId, userId))
+                    .thenReturn(Optional.of(cursorLog));
+            when(proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(
+                    eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), eq(sentAt), eq(legacyId), any(Pageable.class)))
+                    .thenReturn(List.of(nextLog));
+
+            NotificationHistoryResponse response =
+                    notificationService.getNotificationHistory(userId, legacyId.toString(), 20);
+
+            assertThat(response.items())
+                    .as("legacy 커서 %s (표본 #%d) 는 그 위치부터 다음 페이지를 내려야 한다", legacyId, i)
+                    .hasSize(1);
+            assertThat(response.items().get(0).notificationId()).isEqualTo(nextLog.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("[#405] legacy 커서는 대문자 UUID 표기도 동일하게 해석한다")
+    void legacyCursor_upperCaseUuid_resolvesThroughLegacyPath() {
+        OffsetDateTime sentAt = OffsetDateTime.now(fixedClock).minusMinutes(1);
+        UUID legacyId = new UUID(0x53d8a4e644a74346L, 0xb66cd7dcadb93293L);
+        ProactiveCareLog nextLog = logWith(UUID.randomUUID(), sentAt.minusMinutes(1));
+
+        when(proactiveCareLogRepository.findByIdAndUser_Id(legacyId, userId))
+                .thenReturn(Optional.of(logWith(legacyId, sentAt)));
+        when(proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(
+                eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), eq(sentAt), eq(legacyId), any(Pageable.class)))
+                .thenReturn(List.of(nextLog));
+
+        NotificationHistoryResponse response = notificationService.getNotificationHistory(
+                userId, legacyId.toString().toUpperCase(), 20);
+
+        assertThat(response.items()).hasSize(1);
+        assertThat(response.items().get(0).notificationId()).isEqualTo(nextLog.getId());
+    }
+
+    @Test
+    @DisplayName("[#405] 존재하지 않는 legacy 커서는 기존대로 INVALID_INPUT 이다")
+    void legacyCursor_unknownId_isInvalidInput() {
+        UUID unknownId = new UUID(1L, 2L);
+        when(proactiveCareLogRepository.findByIdAndUser_Id(unknownId, userId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> notificationService.getNotificationHistory(userId, unknownId.toString(), 20))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode()).isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+
+    @Test
+    @DisplayName("[#405] encodeCursor 가 만든 커서는 어떤 값이든 항상 정상 경로로 해석된다")
+    void encodedCursor_anyPayload_alwaysResolvesThroughEncodedPath() {
+        // legacy 판별이 인코딩 커서를 가로채지 않는지도 같은 표본 수로 확인한다.
+        Random random = new Random(UUID_SAMPLE_SEED);
+        OffsetDateTime base = OffsetDateTime.now(fixedClock);
+
+        for (int i = 0; i < UUID_SAMPLE_SIZE; i++) {
+            UUID cursorId = new UUID(random.nextLong(), random.nextLong());
+            OffsetDateTime sentAt = base.minusMinutes(i);
+            ProactiveCareLog nextLog = logWith(UUID.randomUUID(), sentAt.minusSeconds(1));
+
+            when(proactiveCareLogRepository.findVisiblePageByUserIdAfterCursor(
+                    eq(userId), eq(ProactiveCareLog.INTERNAL_ONLY_STATUSES), eq(sentAt), eq(cursorId), any(Pageable.class)))
+                    .thenReturn(List.of(nextLog));
+
+            NotificationHistoryResponse response =
+                    notificationService.getNotificationHistory(userId, encodeCursor(sentAt, cursorId), 20);
+
+            assertThat(response.items())
+                    .as("인코딩 커서(표본 #%d) 는 sentAt·id 를 그대로 복원해야 한다", i)
+                    .hasSize(1);
+            assertThat(response.items().get(0).notificationId()).isEqualTo(nextLog.getId());
+        }
+    }
+
+    @Test
+    @DisplayName("[#405] 형식이 어긋난 커서는 어떤 모양이든 500 이 아니라 INVALID_INPUT 이다")
+    void malformedCursor_neverLeaksServerError() {
+        List<String> malformed = List.of(
+                "",                                                     // 빈 문자열
+                "   ",                                                  // 공백
+                "!!!not-a-cursor!!!",                                   // base64url 아님
+                "=====",                                                // 패딩만
+                base64("no-separator-here"),                            // 디코딩되지만 구분자가 없음
+                base64("|" + UUID.randomUUID()),                        // 구분자는 있으나 앞이 빈 값
+                base64("not-a-timestamp|" + UUID.randomUUID()),         // 앞부분이 날짜가 아님
+                base64("2026-05-26T00:00:00Z|not-a-uuid"),              // 뒷부분이 UUID 가 아님
+                base64("2026-13-45T99:99:99Z|" + UUID.randomUUID()),    // 날짜 범위 초과 (DateTimeException)
+                base64("2026-05-26|" + UUID.randomUUID()),              // 오프셋 없는 날짜
+                "53d8a4e6-44a7-4346-b66c-d7dcadb9329",                  // UUID 처럼 생겼지만 한 자 짧음
+                "53d8a4e6-44a7-4346-b66c-d7dcadb93293x",                // UUID 뒤에 잉여 문자
+                "g3d8a4e6-44a7-4346-b66c-d7dcadb93293"                  // hex 가 아닌 문자 포함
+        );
+
+        for (String cursor : malformed) {
+            assertThatThrownBy(() -> notificationService.getNotificationHistory(userId, cursor, 20))
+                    .as("커서 '%s' 는 INVALID_INPUT 으로 처리돼야 한다", cursor)
+                    .isInstanceOf(BusinessException.class)
+                    .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                            .isEqualTo(ErrorCode.INVALID_INPUT));
+        }
+    }
+
+    private ProactiveCareLog logWith(UUID id, OffsetDateTime sentAt) {
+        return ProactiveCareLog.builder()
+                .id(id)
+                .user(user)
+                .triggerCode("checkin_reminder_morning")
+                .notificationStatus(ProactiveCareLog.STATUS_SENT)
+                .sentAt(sentAt)
+                .build();
+    }
+
+    private static String base64(String payload) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(payload.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /** 프로덕션 {@code NotificationService#encodeCursor} 와 동일한 포맷 — 계약이므로 바뀌면 안 된다. */
+    private static String encodeCursor(OffsetDateTime sentAt, UUID notificationId) {
+        return Base64.getUrlEncoder()
+                .withoutPadding()
+                .encodeToString((sentAt + "|" + notificationId).getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
@@ -181,6 +181,14 @@ class NotificationHistoryIntegrationTest {
         assertThat(response.nextCursor()).isNull();
     }
 
+    /**
+     * 실 DB 로 확인하는 legacy 커서 대표 시나리오. 여기 쓰이는 id 는 DB 가 생성한 무작위 UUID 다.
+     *
+     * <p>예전에는 그 무작위성이 결과를 갈랐다 — 커서 형식을 예외 발생 여부로 판별해서 UUID 의
+     * 비트에 따라 약 9% 가 500 이 됐다(이슈 #405). 지금은 형식을 모양으로 판별하므로 어떤 UUID 든
+     * 같은 경로를 탄다. 그 불변식 자체는 {@code NotificationCursorDecodingTest} 가 시드 고정 표본으로
+     * 검증하고, 이 테스트는 "제외 대상 로그 id 도 위치로 받아들인다"는 계약만 실 DB 로 고정한다.
+     */
     @Test
     @DisplayName("[#397] 제외 대상 로그 id 를 legacy 커서로 받아도 그 위치부터 노출분만 이어진다")
     void history_legacyCursorOnHiddenLog_stillPagesVisibleItems() {


### PR DESCRIPTION
## 요약
`GET /v1/notifications` 의 legacy 커서(raw UUID)가 **약 9% 확률로 500** 을 내던 것을 고친다.

`NotificationService.decodeCursor` 가 **base64 디코딩 실패를 legacy 판별 기준**으로 삼은 것이 원인이다. UUID 문자열은 36자에 hex 와 `-` 뿐이고 `-` 는 base64url 문자이며 36 % 4 == 0 이라 **디코딩이 항상 성공한다**(UUID 10만개 실측 100.0%). 디코딩 결과 27바이트 쓰레기에 `|`(0x7C) 가 섞이면(실측 8.99%) `parts.length == 2` 가 되어 `OffsetDateTime.parse(<쓰레기>)` 가 호출되고, `DateTimeParseException` 은 `DateTimeException` → `RuntimeException` 계보라 `catch (IllegalArgumentException)` 에 걸리지 않고 그대로 500 이 됐다. 즉 성공 여부가 **UUID 의 무작위 비트에 좌우**됐다.

**이 결함은 #397(PR #403) 이 만든 것이 아니다.** `decodeCursor` 의 legacy 경로는 그 이전부터 있었고 #403 이 추가한 통합 테스트가 처음 드러냈을 뿐이다. 프로덕션에서도 legacy 커서를 쓰는 클라이언트는 같은 확률로 500 을 받아 왔다.

지금은 **배포 PR #404 의 CI 를 간헐적으로 실패시키고 있어** 배포가 막혀 있다. 이 PR 이 그 블로커를 푼다.

## 관련 이슈
- Closes #405

## 변경 사항
- `decodeCursor` 가 커서 형식을 **정규식(`LEGACY_UUID_CURSOR`)으로 명시 판별**하도록 바꿨다. raw UUID 모양이면 legacy 경로, 아니면 base64url 경로다. 예외 발생 여부를 분기 조건으로 쓰는 구조를 없앴다.
- legacy 해석과 인코딩 커서 해석을 `resolveLegacyCursor` / `decodeEncodedCursor` 로 분리하고, 두 경로 모두 파싱 실패를 `ErrorCode.INVALID_INPUT` 으로 좁혀 잡는다. `Base64.decode`·`UUID.fromString` 의 `IllegalArgumentException` 과 `OffsetDateTime.parse` 의 `DateTimeException` 은 상속 관계가 없어 **둘 다** 잡아야 500 이 새지 않는다.
- 불변식 단위 테스트 `NotificationCursorDecodingTest` 를 추가했다 (시드 고정 표본).
- `NotificationHistoryIntegrationTest` 의 legacy 커서 테스트에 왜 이제 무작위 id 로도 안정적인지 설명하는 주석을 달았다. 검증 의도와 단언은 그대로다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

응답 JSON 형태·필드명·타입, `encodeCursor` 가 만드는 커서 포맷, 오류 시 상태코드(`INVALID_INPUT`) 모두 무변경이다. 이전에 500 이던 입력이 정상 200 으로 바뀌는 것이 유일한 관측 가능한 차이다.

## 테스트
### 실행 커맨드
```bash
./gradlew build
# 신규 테스트만:
./gradlew test --tests "com.mio.notification.service.NotificationCursorDecodingTest"
```

### 확인 내용
- `./gradlew build` — **1032 tests, 0 failed**.
- **RED 확인**: 수정 전 구현으로 되돌려 신규 테스트를 돌리면 `legacy 커서는 어떤 UUID 든 …` 이 `DateTimeParseException` 으로, `형식이 어긋난 커서는 …` 이 함께 실패한다. 수정 후 전부 통과.
- 신규 테스트가 검증하는 불변식 — **사례가 아니라 성질**이다.
  1. raw UUID 형식은 **항상** legacy 경로 — 시드 고정 난수 UUID **500건** 전부. (표본당 재현 확률이 약 9% 이므로 수정 전 코드가 통과할 확률은 `0.91^500` ≈ 0)
  2. `encodeCursor` 가 만든 커서는 **항상** 정상 경로 — 같은 시드로 500건, `sentAt`·`id` 복원 확인.
  3. 형식이 어긋난 커서 **13종**(빈 문자열, 공백, base64 아님, 패딩만, 디코딩되지만 구분자 없음, 구분자는 있으나 앞이 빈 값/날짜 아님/범위 초과/오프셋 없음, 뒷부분이 UUID 아님, UUID 처럼 생겼지만 길이·문자가 어긋난 값)이 **전부** `INVALID_INPUT` — 500 없음.
  4. 대문자 UUID 표기, 존재하지 않는 legacy id(`INVALID_INPUT`) 도 함께 고정.

## 중점 리뷰 포인트
- **왜 매직 UUID 를 하드코딩하지 않았는지**: 수정 후에는 "문제를 일으키는 값"이라는 개념 자체가 없다(모든 UUID 가 같은 경로를 탄다). 표본 하나를 박아두면 동작이 아니라 역사를 테스트하게 되고, 인코딩 방식이 바뀌면 아무것도 보장하지 않는다. 그래서 시드 고정 난수 다수로 **성질**을 검증한다.
- **legacy 경로 동작 보존**: 이력에서 제외되는 상태(`INTERNAL_ONLY_STATUSES`)의 로그 id 도 그대로 "위치"로 받아들인다. 커서는 값이 아니라 정렬상의 위치이고, 여기서 거부하면 수정 이전 응답으로 받은 legacy 커서를 든 클라이언트가 400 을 맞는다. 근거 주석을 `resolveLegacyCursor` 로 옮겨 보존했다.
- **정규식이 정상 커서를 가로챌 수 없는지**: `encodeCursor` 결과는 base64url 이라 항상 36자를 훌쩍 넘고 hex 밖의 문자를 포함한다(실측 92자). 2번 불변식 테스트가 500건으로 이를 직접 확인한다.

## 배포 / 롤백
- Rollout: 코드 변경만. 마이그레이션·설정 변경 없음. develop 머지 후 일반 배포 경로로 나간다. 배포 PR #404 의 CI 블로커가 함께 풀린다.
- Rollback: 커밋 revert 만으로 원복된다. 상태나 저장 포맷을 바꾸지 않았으므로 잔여 영향이 없다(원복 시 9% 500 이 다시 살아난다).

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (해당 없음 — API 계약 무변경)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
