### PR TITLE
feat: 푸시 알림 탭 시 체크인으로 이동하도록 라우팅 정보를 배포한다

### DIFF
--- a/src/main/java/com/mio/notification/service/NotificationMessageMapper.java
+++ b/src/main/java/com/mio/notification/service/NotificationMessageMapper.java
@@ -2,29 +2,82 @@ package com.mio.notification.service;
 
 import org.springframework.stereotype.Component;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 @Component
 public class NotificationMessageMapper {
+
+    /**
+     * 푸시 페이로드 data 키 — FE 라우팅 계약 (이슈 #409).
+     *
+     * <p>iOS 는 {@code aps} 와 형제 레벨(최상위), Android 는 {@code data} 에 동일한 키가 실린다.
+     */
+    public static final String DATA_KEY_TYPE = "type";
+    public static final String DATA_KEY_ROUTE = "route";
+    public static final String DATA_KEY_SLOT = "slot";
+
+    private static final String ROUTE_CHECKIN = "/checkin";
+    private static final String ROUTE_CHAT = "/chat";
+    private static final String ROUTE_TODO = "/todo";
+    private static final String ROUTE_REPORT = "/report";
+    private static final String ROUTE_HOME = "/home";
+
+    private static final String SLOT_MORNING = "morning";
+    private static final String SLOT_AFTERNOON = "afternoon";
+    private static final String SLOT_EVENING = "evening";
 
     public NotificationMessage messageFor(String triggerCode) {
         return switch (triggerCode) {
             case "checkin_reminder_morning" ->
-                    new NotificationMessage("아침 체크인", "오늘 기분은 어때요? 아침 체크인을 해보세요!");
+                    new NotificationMessage("아침 체크인", "오늘 기분은 어때요? 아침 체크인을 해보세요!",
+                            ROUTE_CHECKIN, SLOT_MORNING);
             case "checkin_reminder_afternoon" ->
-                    new NotificationMessage("점심 체크인", "오늘 오전은 어떠셨나요? 체크인을 해보세요!");
+                    new NotificationMessage("점심 체크인", "오늘 오전은 어떠셨나요? 체크인을 해보세요!",
+                            ROUTE_CHECKIN, SLOT_AFTERNOON);
             case "checkin_reminder_evening" ->
-                    new NotificationMessage("저녁 체크인", "오늘 하루 수고 많으셨어요. 저녁 체크인을 해보세요!");
+                    new NotificationMessage("저녁 체크인", "오늘 하루 수고 많으셨어요. 저녁 체크인을 해보세요!",
+                            ROUTE_CHECKIN, SLOT_EVENING);
             case "todo_incomplete" ->
-                    new NotificationMessage("오늘의 To-do", "아직 남은 할 일이 있어요. 가볍게 하나부터 해볼까요?");
+                    new NotificationMessage("오늘의 To-do", "아직 남은 할 일이 있어요. 가볍게 하나부터 해볼까요?",
+                            ROUTE_TODO, null);
+            // 연속 부정 감정·위기 감지는 "푸시 + 대화 시작"이 명세다
+            // (MIO-Proactive-002 / MIO-Proactive-012, 05_비동기_알림.md 18.3~18.4).
             case "negative_emotion_streak" ->
-                    new NotificationMessage("마음 살피기", "요즘 힘들어 보여서요. 잠깐 마음을 들여다볼까요?");
-            case "report_weekly" ->
-                    new NotificationMessage("주간 리포트", "이번 주 리포트가 준비됐어요. 지금 확인해보세요.");
+                    new NotificationMessage("마음 살피기", "요즘 힘들어 보여서요. 잠깐 마음을 들여다볼까요?",
+                            ROUTE_CHAT, null);
             case "crisis_detected" ->
-                    new NotificationMessage("마음이 걱정돼요", "미오가 함께할게요. 지금 대화를 시작해보세요.");
+                    new NotificationMessage("마음이 걱정돼요", "미오가 함께할게요. 지금 대화를 시작해보세요.",
+                            ROUTE_CHAT, null);
+            case "report_weekly" ->
+                    new NotificationMessage("주간 리포트", "이번 주 리포트가 준비됐어요. 지금 확인해보세요.",
+                            ROUTE_REPORT, null);
             default ->
-                    new NotificationMessage("Mio 알림", "새로운 알림이 도착했어요.");
+                    new NotificationMessage("Mio 알림", "새로운 알림이 도착했어요.", ROUTE_HOME, null);
         };
     }
 
-    public record NotificationMessage(String title, String body) {}
+    /**
+     * 푸시 페이로드에 실을 라우팅 data 를 만든다 (이슈 #409).
+     *
+     * <p>이 값이 없으면 앱은 알림 종류를 판별할 수 없어 OS 기본 동작(마지막 화면 복귀)으로 떨어진다.
+     * {@code slot} 은 체크인 리마인더에만 존재하므로 없을 때는 키 자체를 넣지 않는다 — FCM data 는
+     * null 값을 허용하지 않는다.
+     */
+    public Map<String, String> pushDataFor(String triggerCode) {
+        NotificationMessage message = messageFor(triggerCode);
+        Map<String, String> data = new LinkedHashMap<>();
+        data.put(DATA_KEY_TYPE, triggerCode);
+        data.put(DATA_KEY_ROUTE, message.route());
+        if (message.slot() != null) {
+            data.put(DATA_KEY_SLOT, message.slot());
+        }
+        return Map.copyOf(data);
+    }
+
+    /**
+     * @param route 알림 탭 시 이동할 앱 경로
+     * @param slot  체크인 슬롯 (체크인 리마인더 외에는 {@code null})
+     */
+    public record NotificationMessage(String title, String body, String route, String slot) {}
 }

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -39,6 +39,7 @@ import java.time.temporal.ChronoUnit;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -95,7 +96,8 @@ public class NotificationService {
         }
 
         for (DeviceToken token : tokens) {
-            PushSendResult result = pushSender.send(token.getToken(), token.getPlatform(), title, body);
+            // 테스트 푸시는 특정 trigger 가 없으므로 라우팅 data 없이 보낸다 — 앱은 기본 동작으로 연다.
+            PushSendResult result = pushSender.send(token.getToken(), token.getPlatform(), title, body, Map.of());
             if (result.invalidatesToken()) {
                 token.invalidate();
                 deviceTokenRepository.save(token);
@@ -180,7 +182,14 @@ public class NotificationService {
         } while (batch.hasNext());
     }
 
-    public void sendNotificationToUser(User user, String triggerCode, String title, String body, boolean countTowardDailyLimit) {
+    /**
+     * 알림을 발송한다.
+     *
+     * <p>문구(title/body)와 라우팅(route/slot)을 <b>모두 {@code triggerCode} 하나에서</b> 유도한다.
+     * 호출자가 문구와 코드를 따로 넘기면 "아침 체크인" 알림을 탭했는데 리포트로 가는 식의 어긋남이
+     * 생기므로, 애초에 그런 조합을 만들 수 없게 막았다 (이슈 #409).
+     */
+    public void sendNotificationToUser(User user, String triggerCode, boolean countTowardDailyLimit) {
         List<DeviceToken> tokens = deviceTokenRepository.findByUser_IdAndIsValidTrue(user.getId());
         if (tokens.isEmpty()) {
             // 보낸 것이 없으므로 SENT 로 기록하지 않는다 (미발송이 지표에 그대로 드러나야 한다).
@@ -195,12 +204,18 @@ public class NotificationService {
             return;
         }
 
+        NotificationMessageMapper.NotificationMessage message = notificationMessageMapper.messageFor(triggerCode);
+        String title = message.title();
+        String body = message.body();
+        // 알림 탭 시 이동할 화면 정보 (이슈 #409). 없으면 앱이 마지막 화면으로 복귀해버린다.
+        Map<String, String> pushData = notificationMessageMapper.pushDataFor(triggerCode);
+
         boolean anySucceeded = false;
         boolean anyAmbiguous = false;
         List<UUID> tokensToInvalidate = new java.util.ArrayList<>();
         List<String> failureReasons = new java.util.ArrayList<>();
         for (DeviceToken token : tokens) {
-            PushSendResult result = pushSender.send(token.getToken(), token.getPlatform(), title, body);
+            PushSendResult result = pushSender.send(token.getToken(), token.getPlatform(), title, body, pushData);
             if (result.isSent()) {
                 anySucceeded = true;
             } else {
@@ -253,8 +268,7 @@ public class NotificationService {
             return;
         }
 
-        NotificationMessageMapper.NotificationMessage message = notificationMessageMapper.messageFor(triggerCode);
-        sendNotificationToUser(setting.getUser(), triggerCode, message.title(), message.body(), true);
+        sendNotificationToUser(setting.getUser(), triggerCode, true);
     }
 
     private String determineTrigger(NotificationSetting setting, OffsetDateTime now) {

--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -32,6 +32,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Base64;
 import java.util.Date;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -43,6 +44,7 @@ public class PushSender {
     private static final String APNS_HOST_SANDBOX = "https://api.sandbox.push.apple.com";
     private static final long JWT_TTL_SECONDS = 3000;
     private static final String APNS_TOKEN_PATTERN = "[0-9a-fA-F]{64}";
+    private static final String APS_KEY = "aps";
 
     @Value("${apns.key-content:}")
     private String apnsKeyContent;
@@ -137,12 +139,20 @@ public class PushSender {
         }
     }
 
-    public PushSendResult send(String token, String platform, String title, String body) {
+    /**
+     * @param data 알림 탭 시 앱이 사용할 라우팅 정보 (이슈 #409). 비어 있으면 앱은 알림 종류를
+     *             판별할 수 없어 OS 기본 동작(마지막 화면 복귀)으로 떨어진다.
+     */
+    public PushSendResult send(String token, String platform, String title, String body, Map<String, String> data) {
         try {
+            // 복사는 반드시 try 안에서 한다 — data 에 null 값이 섞이면 Map.copyOf 가 NPE 를 던지는데,
+            // 이게 밖으로 새면 아래 catch 의 FAILED 분류를 건너뛰고 호출자의 단말 순회와
+            // 스케줄러 배치 전체를 중단시킨다(두 루프 모두 유저별 try 가 없다).
+            Map<String, String> payloadData = data == null ? Map.of() : Map.copyOf(data);
             if ("ios".equalsIgnoreCase(platform)) {
-                return sendApns(token, title, body);
+                return sendApns(token, title, body, payloadData);
             } else if ("android".equalsIgnoreCase(platform)) {
-                return sendFcm(token, title, body);
+                return sendFcm(token, title, body, payloadData);
             } else {
                 log.warn("Unknown platform '{}', skipping push", platform);
                 return PushSendResult.of(PushSendStatus.SKIPPED, "UNSUPPORTED_PLATFORM:" + platform);
@@ -158,7 +168,7 @@ public class PushSender {
         }
     }
 
-    private PushSendResult sendApns(String deviceToken, String title, String body) throws Exception {
+    private PushSendResult sendApns(String deviceToken, String title, String body, Map<String, String> data) throws Exception {
         if (!apnsEnabled) {
             log.debug("APNs disabled, skipping send");
             return PushSendResult.of(PushSendStatus.SKIPPED, "APNS_DISABLED");
@@ -170,7 +180,7 @@ public class PushSender {
 
         String host = apnsIsProduction ? APNS_HOST_PROD : APNS_HOST_SANDBOX;
         String url = host + "/3/device/" + deviceToken;
-        String payload = buildApnsPayload(title, body);
+        String payload = buildApnsPayload(title, body, data);
         String jwt = getOrRefreshApnsJwt();
 
         HttpRequest request = HttpRequest.newBuilder()
@@ -230,19 +240,13 @@ public class PushSender {
         }
     }
 
-    private PushSendResult sendFcm(String fcmToken, String title, String body) throws Exception {
+    private PushSendResult sendFcm(String fcmToken, String title, String body, Map<String, String> data) throws Exception {
         if (!fcmEnabled) {
             log.debug("FCM disabled, skipping send");
             return PushSendResult.of(PushSendStatus.SKIPPED, "FCM_DISABLED");
         }
 
-        Message message = Message.builder()
-                .setNotification(Notification.builder()
-                        .setTitle(title)
-                        .setBody(body)
-                        .build())
-                .setToken(fcmToken)
-                .build();
+        Message message = buildFcmMessage(fcmToken, title, body, data);
 
         try {
             FirebaseMessaging.getInstance().send(message);
@@ -285,11 +289,36 @@ public class PushSender {
         return jwt;
     }
 
-    private String buildApnsPayload(String title, String body) {
+    /**
+     * FCM 메시지를 만든다.
+     *
+     * <p>{@code notification} 과 별개로 {@code data} 에 라우팅 정보를 싣는다. 안드로이드는 백그라운드에서
+     * {@code onMessageReceived} 가 아니라 런처 Intent extras 로 이 값을 받는다.
+     */
+    Message buildFcmMessage(String fcmToken, String title, String body, Map<String, String> data) {
+        return Message.builder()
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .putAllData(data)
+                .setToken(fcmToken)
+                .build();
+    }
+
+    /**
+     * APNs 페이로드를 만든다.
+     *
+     * <p>라우팅용 커스텀 키는 {@code aps} 안이 아니라 <b>형제 레벨(최상위)</b> 에 놓아야 알림 탭 시
+     * {@code userInfo} 로 전달된다. {@code aps} 를 마지막에 넣어 커스텀 키가 이를 덮어쓰지 못하게 한다.
+     */
+    String buildApnsPayload(String title, String body, Map<String, String> data) {
         try {
             Map<String, Object> alert = Map.of("title", title, "body", body);
             Map<String, Object> aps = Map.of("alert", alert, "sound", "default");
-            return objectMapper.writeValueAsString(Map.of("aps", aps));
+            Map<String, Object> payload = new LinkedHashMap<>(data);
+            payload.put(APS_KEY, aps);
+            return objectMapper.writeValueAsString(payload);
         } catch (Exception e) {
             throw new IllegalStateException("Failed to build APNs payload", e);
         }

--- a/src/test/java/com/mio/notification/service/NotificationMessageMapperTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationMessageMapperTest.java
@@ -1,0 +1,83 @@
+package com.mio.notification.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("NotificationMessageMapper — 푸시 라우팅 매핑 (#409)")
+class NotificationMessageMapperTest {
+
+    private final NotificationMessageMapper mapper = new NotificationMessageMapper();
+
+    @ParameterizedTest
+    @CsvSource({
+            "checkin_reminder_morning,   /checkin, morning",
+            "checkin_reminder_afternoon, /checkin, afternoon",
+            "checkin_reminder_evening,   /checkin, evening"
+    })
+    @DisplayName("체크인 리마인더는 /checkin 으로 라우팅되고 슬롯을 함께 싣는다")
+    void pushDataFor_checkinReminders_carryRouteAndSlot(String triggerCode, String route, String slot) {
+        Map<String, String> data = mapper.pushDataFor(triggerCode);
+
+        assertThat(data).containsExactlyInAnyOrderEntriesOf(Map.of(
+                NotificationMessageMapper.DATA_KEY_TYPE, triggerCode,
+                NotificationMessageMapper.DATA_KEY_ROUTE, route,
+                NotificationMessageMapper.DATA_KEY_SLOT, slot
+        ));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "negative_emotion_streak, /chat",
+            "crisis_detected,         /chat",
+            "todo_incomplete,         /todo",
+            "report_weekly,           /report"
+    })
+    @DisplayName("체크인 외 트리거는 지정된 route 로 가고 slot 키를 넣지 않는다")
+    void pushDataFor_nonCheckinTriggers_omitSlot(String triggerCode, String route) {
+        Map<String, String> data = mapper.pushDataFor(triggerCode);
+
+        assertThat(data).containsEntry(NotificationMessageMapper.DATA_KEY_TYPE, triggerCode);
+        assertThat(data).containsEntry(NotificationMessageMapper.DATA_KEY_ROUTE, route);
+        assertThat(data).doesNotContainKey(NotificationMessageMapper.DATA_KEY_SLOT);
+    }
+
+    @Test
+    @DisplayName("미정의 trigger_code 는 /home 으로 폴백한다")
+    void pushDataFor_unknownTrigger_fallsBackToHome() {
+        Map<String, String> data = mapper.pushDataFor("something_new");
+
+        assertThat(data).containsEntry(NotificationMessageMapper.DATA_KEY_ROUTE, "/home");
+        assertThat(data).containsEntry(NotificationMessageMapper.DATA_KEY_TYPE, "something_new");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "checkin_reminder_morning", "checkin_reminder_afternoon", "checkin_reminder_evening",
+            "todo_incomplete", "negative_emotion_streak", "crisis_detected", "report_weekly"
+    })
+    @DisplayName("DB CHECK 제약 7종 전부 route 가 채워진다")
+    void messageFor_allTriggerCodes_haveRoute(String triggerCode) {
+        NotificationMessageMapper.NotificationMessage message = mapper.messageFor(triggerCode);
+
+        assertThat(message.route()).isNotBlank();
+        assertThat(message.title()).isNotBlank();
+        assertThat(message.body()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("반환된 data 는 불변이라 호출자가 변조할 수 없다")
+    void pushDataFor_returnsImmutableMap() {
+        Map<String, String> data = mapper.pushDataFor("checkin_reminder_morning");
+
+        assertThatThrownBy(() -> data.put("route", "/hacked"))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+}

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -36,6 +36,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -46,6 +47,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -56,6 +58,15 @@ class NotificationServiceTest {
 
     /** API 명세(10_Notification_알림.md §알림 수신 상태)에 고정된 노출값. 이 밖의 값은 나갈 수 없다. */
     private static final List<String> DOCUMENTED_STATUSES = List.of("SENT", "DELIVERED", "OPENED", "FAILED");
+
+    /**
+     * 알림 탭 라우팅 data (이슈 #409). 스텁이 이 값과 정확히 일치해야 통과하므로,
+     * 서비스가 trigger 에 맞는 route 를 실어 보내는지까지 함께 고정된다.
+     */
+    private static final Map<String, String> CHECKIN_MORNING_DATA =
+            Map.of("type", "checkin_reminder_morning", "route", "/checkin", "slot", "morning");
+    private static final Map<String, String> TODO_DATA =
+            Map.of("type", "todo_incomplete", "route", "/todo");
 
     @Mock private UserRepository userRepository;
     @Mock private DeviceTokenRepository deviceTokenRepository;
@@ -111,7 +122,7 @@ class NotificationServiceTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        when(pushSender.send("abcd1234", "ios", "제목", "본문"))
+        when(pushSender.send("abcd1234", "ios", "제목", "본문", Map.of()))
                 .thenReturn(PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, "APNS_410:Unregistered"));
 
         notificationService.sendTestNotification(userId, "제목", "본문");
@@ -273,7 +284,7 @@ class NotificationServiceTest {
         when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
         when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), eq("morning"))).thenReturn(false);
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        when(pushSender.send("fcm-token", "android", "아침 체크인", "오늘 기분은 어때요? 아침 체크인을 해보세요!"))
+        when(pushSender.send("fcm-token", "android", "아침 체크인", "오늘 기분은 어때요? 아침 체크인을 해보세요!", CHECKIN_MORNING_DATA))
                 .thenReturn(PushSendResult.sent());
 
         notificationService.processScheduledNotifications();
@@ -287,12 +298,52 @@ class NotificationServiceTest {
         );
     }
 
+    /**
+     * 라우팅 계약을 <b>전용 테스트로</b> 고정한다 (이슈 #409).
+     *
+     * <p>다른 테스트들의 스텁 인자에 기대 맵을 박아두면 라우팅이 깨졌을 때 "발송 결과 분류" 테스트가
+     * 대신 빨개져 원인을 가린다. 그러면 다음 사람이 스텁을 {@code anyMap()} 으로 완화하기 쉽고,
+     * 그 순간 라우팅 검증은 흔적 없이 사라진다.
+     */
+    @Test
+    @DisplayName("[#409] 체크인 리마인더는 /checkin 라우팅과 슬롯을 실어 보낸다")
+    void sendNotificationToUser_checkinReminder_carriesCheckinRoute() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("android").token("fcm-token").build();
+        setField(token, "id", UUID.randomUUID());
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
+
+        // 문구와 라우팅이 같은 triggerCode 에서 나왔음을 함께 고정한다
+        verify(pushSender).send(
+                eq("fcm-token"), eq("android"), eq("아침 체크인"), anyString(), eq(CHECKIN_MORNING_DATA));
+    }
+
+    @Test
+    @DisplayName("[#409] 체크인 외 트리거는 슬롯 없이 해당 화면 라우팅만 실어 보낸다")
+    void sendNotificationToUser_nonCheckinTrigger_carriesRouteWithoutSlot() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("ios").token("apns-token").build();
+        setField(token, "id", UUID.randomUUID());
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+
+        notificationService.sendNotificationToUser(user, "todo_incomplete", true);
+
+        verify(pushSender).send(
+                eq("apns-token"), eq("ios"), eq("오늘의 To-do"), anyString(), eq(TODO_DATA));
+    }
+
     @Test
     @DisplayName("[#387] 유효한 디바이스 토큰이 없으면 SENT가 아닌 NO_DEVICE로 기록한다")
     void sendNotificationToUser_noValidTokens_recordsNoDevice() {
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of());
 
-        notificationService.sendNotificationToUser(user, "checkin_reminder_evening", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "checkin_reminder_evening", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -316,10 +367,10 @@ class NotificationServiceTest {
         setField(token, "id", UUID.randomUUID());
 
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        when(pushSender.send("apns-token", "ios", "제목", "본문"))
+        when(pushSender.send(eq("apns-token"), eq("ios"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, "APNS_410:Unregistered"));
 
-        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -341,12 +392,12 @@ class NotificationServiceTest {
 
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId))
                 .thenReturn(List.of(iosToken, androidToken));
-        when(pushSender.send("apns-token", "ios", "제목", "본문"))
+        when(pushSender.send(eq("apns-token"), eq("ios"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, "APNS_410:Unregistered"));
-        when(pushSender.send("fcm-token", "android", "제목", "본문"))
+        when(pushSender.send(eq("fcm-token"), eq("android"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.sent());
 
-        notificationService.sendNotificationToUser(user, "todo_incomplete", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "todo_incomplete", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -544,10 +595,10 @@ class NotificationServiceTest {
         setField(token, "id", UUID.randomUUID());
 
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        when(pushSender.send("apns-token", "ios", "제목", "본문"))
+        when(pushSender.send(eq("apns-token"), eq("ios"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.AMBIGUOUS, "EXCEPTION:HttpTimeoutException"));
 
-        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -571,10 +622,10 @@ class NotificationServiceTest {
         setField(token, "id", UUID.randomUUID());
 
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        when(pushSender.send("apns-token", "ios", "제목", "본문"))
+        when(pushSender.send(eq("apns-token"), eq("ios"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, "APNS_410:Unregistered"));
 
-        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -597,12 +648,12 @@ class NotificationServiceTest {
 
         when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId))
                 .thenReturn(List.of(iosToken, androidToken));
-        when(pushSender.send("apns-token", "ios", "제목", "본문"))
+        when(pushSender.send(eq("apns-token"), eq("ios"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, "APNS_410:Unregistered"));
-        when(pushSender.send("fcm-token", "android", "제목", "본문"))
+        when(pushSender.send(eq("fcm-token"), eq("android"), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.of(PushSendStatus.AMBIGUOUS, "FCM_TRANSPORT_ERROR"));
 
-        notificationService.sendNotificationToUser(user, "todo_incomplete", "제목", "본문", true);
+        notificationService.sendNotificationToUser(user, "todo_incomplete", true);
 
         ArgumentCaptor<NotificationDeliveryResult> captor =
                 ArgumentCaptor.forClass(NotificationDeliveryResult.class);
@@ -944,7 +995,7 @@ class NotificationServiceTest {
                         && "evening".equals(invocation.getArgument(2)));
         lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any())).thenReturn(List.of());
         lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
-        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString()))
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.sent());
 
         service.processScheduledNotifications();

--- a/src/test/java/com/mio/notification/service/PushSenderTest.java
+++ b/src/test/java/com/mio/notification/service/PushSenderTest.java
@@ -8,16 +8,32 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.Message;
+import org.junit.jupiter.api.Nested;
+import org.mockito.ArgumentCaptor;
+
 import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPairGenerator;
 import java.security.PrivateKey;
 import java.security.spec.ECGenParameterSpec;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
@@ -55,7 +71,7 @@ class PushSenderTest {
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenThrow(new IOException("connection reset"));
 
-        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문");
+        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
 
         // 요청은 나갔는데 응답을 못 받았다 — APNs 가 이미 처리했을 수 있어 재발송하면 중복 도착이다
         assertThat(result.status()).isEqualTo(PushSendStatus.AMBIGUOUS);
@@ -69,7 +85,7 @@ class PushSenderTest {
         // JWT 서명 키가 없으면 getOrRefreshApnsJwt() 가 httpClient.send() 이전에 터진다
         ReflectionTestUtils.setField(pushSender, "apnsPrivateKey", null);
 
-        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문");
+        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
 
         // 요청이 아예 나가지 않았으므로 불명이 아니다 — 억제되면 결정적 버그가 지표에서 가려진다
         assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
@@ -87,7 +103,7 @@ class PushSenderTest {
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(rejection);
 
-        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문");
+        PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
 
         assertThat(result.status()).isEqualTo(PushSendStatus.TOKEN_EXPIRED);
         assertThat(result.isAmbiguous()).isFalse();
@@ -98,7 +114,7 @@ class PushSenderTest {
     @Test
     @DisplayName("잘못된 형식의 토큰은 요청을 보내지 않고 INVALID_TOKEN으로 분류한다")
     void send_whenTokenMalformed_doesNotDispatch() {
-        PushSendResult result = pushSender.send("not-a-valid-token", "ios", "제목", "본문");
+        PushSendResult result = pushSender.send("not-a-valid-token", "ios", "제목", "본문", Map.of());
 
         assertThat(result.status()).isEqualTo(PushSendStatus.INVALID_TOKEN);
         assertThat(result.isAmbiguous()).isFalse();
@@ -106,10 +122,181 @@ class PushSenderTest {
         verifyNoInteractions(httpClient);
     }
 
+    /**
+     * 알림 탭 라우팅 data 가 APNs 페이로드의 올바른 위치에 실리는지 고정한다 (이슈 #409).
+     *
+     * <p>커스텀 키가 {@code aps} <b>안</b>으로 들어가면 알림 탭 시 {@code userInfo} 로 전달되지 않아,
+     * 앱이 알림 종류를 판별하지 못하고 OS 기본 동작(마지막 화면 복귀)으로 떨어진다.
+     */
+    @Nested
+    @DisplayName("APNs 페이로드 라우팅 data")
+    class ApnsPayloadRouting {
+
+        private final ObjectMapper objectMapper = new ObjectMapper();
+
+        @Test
+        @DisplayName("라우팅 data 는 aps 가 아니라 형제 레벨(최상위)에 실린다")
+        void buildApnsPayload_putsCustomKeysAtTopLevel() throws Exception {
+            Map<String, String> data = Map.of(
+                    "type", "checkin_reminder_morning",
+                    "route", "/checkin",
+                    "slot", "morning"
+            );
+
+            JsonNode payload = objectMapper.readTree(
+                    pushSender.buildApnsPayload("아침 체크인", "오늘 기분은 어때요?", data)
+            );
+
+            assertThat(payload.get("type").asText()).isEqualTo("checkin_reminder_morning");
+            assertThat(payload.get("route").asText()).isEqualTo("/checkin");
+            assertThat(payload.get("slot").asText()).isEqualTo("morning");
+            assertThat(payload.get("aps").has("route")).isFalse();
+        }
+
+        @Test
+        @DisplayName("alert 제목·본문과 sound 는 그대로 유지된다")
+        void buildApnsPayload_keepsApsBlockIntact() throws Exception {
+            JsonNode payload = objectMapper.readTree(
+                    pushSender.buildApnsPayload("제목", "본문", Map.of("route", "/checkin"))
+            );
+
+            JsonNode aps = payload.get("aps");
+            assertThat(aps.get("alert").get("title").asText()).isEqualTo("제목");
+            assertThat(aps.get("alert").get("body").asText()).isEqualTo("본문");
+            assertThat(aps.get("sound").asText()).isEqualTo("default");
+        }
+
+        @Test
+        @DisplayName("data 가 비면 기존과 동일하게 aps 만 담는다")
+        void buildApnsPayload_withEmptyData_producesApsOnly() throws Exception {
+            JsonNode payload = objectMapper.readTree(
+                    pushSender.buildApnsPayload("제목", "본문", Map.of())
+            );
+
+            assertThat(payload.properties()).hasSize(1);
+            assertThat(payload.has("aps")).isTrue();
+        }
+
+        /**
+         * 빌더가 아니라 <b>실제 전송 경로</b>를 지난다.
+         *
+         * <p>{@code buildApnsPayload} 를 직접 호출하는 테스트는 "올바른 JSON 을 만들 수 있다"만 보증할
+         * 뿐 "올바른 JSON 을 보낸다"는 보증하지 않는다. 이 테스트가 없으면 {@code sendApns} 가
+         * {@code data} 를 빈 맵으로 바꿔 넘겨도 스위트가 통과한다 — 이 PR 이 막으려는 증상 그대로다.
+         */
+        @Test
+        @DisplayName("[배선] send() 로 넘긴 라우팅 data 가 실제 전송되는 요청 본문에 실린다")
+        void send_carriesRoutingDataIntoDispatchedRequest() throws Exception {
+            ReflectionTestUtils.setField(pushSender, "apnsPrivateKey", generateEcPrivateKey());
+            // 200 경로는 body 를 읽지 않으므로 상태 코드만 스텁한다
+            HttpResponse<String> accepted = stubStatusOnlyResponse(200);
+            when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenReturn(accepted);
+
+            PushSendResult result = pushSender.send(
+                    VALID_APNS_TOKEN, "ios", "아침 체크인", "본문",
+                    Map.of("type", "checkin_reminder_morning", "route", "/checkin", "slot", "morning"));
+
+            assertThat(result.isSent()).isTrue();
+            ArgumentCaptor<HttpRequest> captor = ArgumentCaptor.forClass(HttpRequest.class);
+            verify(httpClient).send(captor.capture(), any(HttpResponse.BodyHandler.class));
+
+            JsonNode dispatched = objectMapper.readTree(bodyOf(captor.getValue()));
+            assertThat(dispatched.get("route").asText()).isEqualTo("/checkin");
+            assertThat(dispatched.get("slot").asText()).isEqualTo("morning");
+            assertThat(dispatched.get("type").asText()).isEqualTo("checkin_reminder_morning");
+            assertThat(dispatched.get("aps").get("alert").get("title").asText()).isEqualTo("아침 체크인");
+        }
+
+        @Test
+        @DisplayName("data 에 aps 키가 섞여 들어와도 실제 aps 블록을 덮어쓰지 못한다")
+        void buildApnsPayload_dataCannotOverrideAps() throws Exception {
+            Map<String, String> hostile = new LinkedHashMap<>();
+            hostile.put("aps", "overwritten");
+            hostile.put("route", "/checkin");
+
+            JsonNode payload = objectMapper.readTree(
+                    pushSender.buildApnsPayload("제목", "본문", hostile)
+            );
+
+            assertThat(payload.get("aps").isObject()).isTrue();
+            assertThat(payload.get("aps").get("alert").get("title").asText()).isEqualTo("제목");
+            assertThat(payload.get("route").asText()).isEqualTo("/checkin");
+        }
+    }
+
+    /**
+     * FCM 은 실제 발송에 Firebase 정적 싱글턴이 필요해 전송까지는 태울 수 없다. 대신 메시지 조립을
+     * 분리해 검증한다 — {@code putAllData} 가 빠지면 안드로이드 전 기기에서 라우팅이 죽는데,
+     * 이 테스트가 없으면 그 회귀가 CI 를 그대로 통과한다.
+     */
+    @Nested
+    @DisplayName("FCM 메시지 라우팅 data")
+    class FcmMessageRouting {
+
+        /** Firebase Message 는 getter 를 노출하지 않으므로 필드 가시성을 열어 직렬화로 확인한다. */
+        private final ObjectMapper fieldReadingMapper = new ObjectMapper()
+                .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+
+        @Test
+        @DisplayName("라우팅 data 가 FCM 메시지의 data 에 실린다")
+        void buildFcmMessage_attachesRoutingData() {
+            Message message = pushSender.buildFcmMessage(
+                    "fcm-token", "아침 체크인", "본문",
+                    Map.of("type", "checkin_reminder_morning", "route", "/checkin", "slot", "morning"));
+
+            JsonNode data = fieldReadingMapper.valueToTree(message).get("data");
+            assertThat(data.get("route").asText()).isEqualTo("/checkin");
+            assertThat(data.get("slot").asText()).isEqualTo("morning");
+            assertThat(data.get("type").asText()).isEqualTo("checkin_reminder_morning");
+        }
+
+        @Test
+        @DisplayName("notification 제목·본문은 data 와 별개로 유지된다")
+        void buildFcmMessage_keepsNotificationBlock() {
+            Message message = pushSender.buildFcmMessage("fcm-token", "제목", "본문", Map.of("route", "/todo"));
+
+            JsonNode tree = fieldReadingMapper.valueToTree(message);
+            assertThat(tree.get("notification").get("title").asText()).isEqualTo("제목");
+            assertThat(tree.get("notification").get("body").asText()).isEqualTo("본문");
+            assertThat(tree.get("data").get("route").asText()).isEqualTo("/todo");
+        }
+    }
+
+    /** 전송된 요청의 본문을 문자열로 되돌린다. BodyPublisher 는 스트림이라 구독해서 읽어야 한다. */
+    private String bodyOf(HttpRequest request) throws Exception {
+        HttpRequest.BodyPublisher publisher = request.bodyPublisher().orElseThrow();
+        StringBuilder collected = new StringBuilder();
+        CountDownLatch done = new CountDownLatch(1);
+        publisher.subscribe(new Flow.Subscriber<>() {
+            @Override public void onSubscribe(Flow.Subscription subscription) {
+                subscription.request(Long.MAX_VALUE);
+            }
+            @Override public void onNext(ByteBuffer item) {
+                collected.append(StandardCharsets.UTF_8.decode(item));
+            }
+            @Override public void onError(Throwable throwable) {
+                done.countDown();
+            }
+            @Override public void onComplete() {
+                done.countDown();
+            }
+        });
+        done.await(5, TimeUnit.SECONDS);
+        return collected.toString();
+    }
+
     private PrivateKey generateEcPrivateKey() throws Exception {
         KeyPairGenerator generator = KeyPairGenerator.getInstance("EC");
         generator.initialize(new ECGenParameterSpec("secp256r1"));
         return generator.generateKeyPair().getPrivate();
+    }
+
+    @SuppressWarnings("unchecked")
+    private HttpResponse<String> stubStatusOnlyResponse(int statusCode) {
+        HttpResponse<String> response = org.mockito.Mockito.mock(HttpResponse.class);
+        when(response.statusCode()).thenReturn(statusCode);
+        return response;
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
## 요약

푸시 알림을 탭해도 앱이 마지막으로 보던 화면으로 복귀하는 문제를 배포한다. 푸시 페이로드에 라우팅 정보가 전혀 없어 앱이 알림 종류를 판별할 수 없었고, OS 기본 동작으로 떨어지고 있었다.

`develop` 기준 커밋 1개(#410)만 포함한다.

## 관련 이슈

- Closes #409

## 변경 사항

- `PushSender.send()` 에 `Map<String, String> data` 파라미터 추가. APNs 는 `aps` 와 **형제 레벨(최상위)**, FCM 은 `putAllData` 로 싣는다
- `NotificationMessageMapper` 에 `trigger_code` → `route` / `slot` 매핑과 `pushDataFor()` 추가
- `NotificationService.sendNotificationToUser()` 가 `title`/`body` 를 받지 않고 `triggerCode` 하나에서 문구와 라우팅을 함께 유도 — 알림 내용과 탭 목적지가 어긋나는 조합을 만들 수 없게 했다
- `PushSender.send()` 의 방어적 복사를 `try` 안으로 이동 — NPE 가 `catch` 의 `FAILED` 분류를 건너뛰고 새면 스케줄러 배치 전체가 중단된다

### route 매핑

| trigger_code | route | slot |
|---|---|---|
| `checkin_reminder_morning` / `_afternoon` / `_evening` | `/checkin` | 슬롯명 |
| `negative_emotion_streak` / `crisis_detected` | `/chat` | — |
| `todo_incomplete` | `/todo` | — |
| `report_weekly` | `/report` | — |
| (미정의) | `/home` | — |

## 영향 범위

- [x] API 스펙 또는 응답 형식이 변경됩니다. — **REST 응답이 아니라 푸시 페이로드 스키마 추가.** 기존 필드 변경·삭제 없음
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `ProactiveCareJob` 발송 경로를 지나지만 발송 결과 분류·토큰 무효화·일일 발송 제한 동작은 불변
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다. — 구버전 앱은 추가된 키를 무시하고 기존과 동일하게 동작한다

## 테스트

### 실행 커맨드

```bash
./gradlew build
```

### 확인 내용

`develop` 에서 CI 통과 확인 완료. 리뷰 중 뮤테이션 테스트로 초기 구현의 테스트 공백을 발견해 보강했다.

| 구현을 망가뜨림 | 보강 전 | 보강 후 |
|---|---|---|
| `sendApns` 가 빈 맵을 넘김 | 🟢 통과 | 🔴 실패 |
| `sendFcm` 의 `putAllData` 삭제 | 🟢 통과 | 🔴 실패 |
| `buildApnsPayload` 가 `aps` 를 먼저 put | 🔴 실패 | 🔴 실패 |
| 모든 route 를 `/home` 으로 | 🔴 15건 | 🔴 15건 |
| 서비스가 라우팅 data 대신 빈 맵 전달 | 🔴 6건 | 🔴 6건 |

- APNs 는 200 응답 경로를 태워 `ArgumentCaptor<HttpRequest>` 로 실제 전송 본문을 검증
- FCM 은 메시지 조립을 분리해 직렬화로 `data` 검증
- 라우팅 계약은 `verify` 기반 전용 테스트로 분리

## 중점 리뷰 포인트

- **이 배포만으로는 사용자 체감 변화가 없다.** 앱이 `route` 를 읽어 라우팅해야 완결되므로 FE 릴리스와 짝을 이룬다
- route 문자열이 FE 라우터와 일치하는지 (불일치 시 `NotificationMessageMapper` 의 `ROUTE_*` 상수만 수정)

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 페이로드에 키가 실린다. DB 마이그레이션·설정 변경 없음
- **Rollback**: 서버만 되돌리면 된다. 앱은 키가 사라져도 기존 동작(마지막 화면 복귀)으로 돌아갈 뿐 깨지지 않는다

## FE 연동 필수 사항

1. 탭 핸들러에서 `type` 하드코딩이 아니라 **`route` 기준으로 라우팅**. `slot` 이 있으면 해당 체크인 슬롯으로 진입
2. **Android 는 `getIntent().getExtras()` 경로 필수** — 백그라운드·종료 상태에서 `data` 는 `onMessageReceived` 가 아니라 런처 Intent extras 로 온다. 이것만 빠지면 포그라운드 테스트는 통과하는데 실사용 대부분인 백그라운드 탭이 동작하지 않는다
3. `notification_id` 존재 여부 분기를 **이번 앱 릴리스에 미리 포함** — 현재 서버는 보내지 않지만, 추후 푸시 오픈율 집계를 켤 때 앱 재릴리스 없이 동작한다

## 후속 이슈

- #411 — APNs 400 을 사유 구분 없이 토큰 무효화로 처리하는 문제. 롤백 단위가 엉키는 것을 피하려 이번 범위에서 제외했다

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 푸시 페이로드 스펙과 FE 처리 규약은 Notion 으로 공유됨 (`docs/` 는 gitignore 대상)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
