### PR TITLE
fix: 리포트가 생성된 유저에게만 주간 리포트 알림을 발송한다

### DIFF
--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -384,10 +384,22 @@ public class NotificationService {
      * 알릴 이유가 없다.
      */
     private boolean hasGeneratedWeeklyReport(UUID userId, LocalDate occurrenceDate) {
-        return weeklyReportRepository
-                .findByUser_IdAndWeekStart(userId, occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS))
-                .filter(report -> WeeklyReport.STATUS_GENERATED.equals(report.getStatus()))
-                .isPresent();
+        LocalDate weekStart = occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS);
+        Optional<WeeklyReport> report = weeklyReportRepository.findByUser_IdAndWeekStart(userId, weekStart);
+
+        if (report.isEmpty()) {
+            // 정상(체크인 0건)일 수도, 집계 job 장애일 수도 있다. 후자면 그 주 전 유저가 조용히
+            // 무발송이 되므로 구분 가능한 흔적을 남긴다 — "오발송을 고치다 전면 미발송"을 놓치지 않기 위해.
+            log.info("Weekly report row absent — skipping notification. user={} weekStart={}", userId, weekStart);
+            return false;
+        }
+        String status = report.get().getStatus();
+        if (!WeeklyReport.STATUS_GENERATED.equals(status)) {
+            log.debug("Weekly report not generated — skipping notification. user={} weekStart={} status={}",
+                    userId, weekStart, status);
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -14,6 +14,8 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.repository.BehaviorTaskRepository;
@@ -52,6 +54,8 @@ public class NotificationService {
 
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
+    /** 월요일 발송분이 대상으로 삼는 주차는 발송일 7일 전 월요일이다. */
+    private static final int WEEKLY_REPORT_PERIOD_DAYS = 7;
     private static final LocalTime SERVER_INITIATED_WINDOW_START = LocalTime.of(8, 0);
     private static final LocalTime SERVER_INITIATED_WINDOW_END = LocalTime.of(22, 0);
     private static final int DAILY_SEND_LIMIT = 3;
@@ -84,6 +88,7 @@ public class NotificationService {
     private final NotificationMessageMapper notificationMessageMapper;
     private final PushSender pushSender;
     private final NotificationPersistenceService notificationPersistenceService;
+    private final WeeklyReportRepository weeklyReportRepository;
 
     public void sendTestNotification(UUID userId, String title, String body) {
         userRepository.findById(userId)
@@ -284,8 +289,11 @@ public class NotificationService {
                 return checkinTrigger;
             }
         }
-        if (setting.isReportEnabled() && serverInitiatedAllowed && isWeeklyReportDue(now)) {
-            return "report_weekly";
+        if (setting.isReportEnabled() && serverInitiatedAllowed) {
+            Optional<LocalDate> reportDue = weeklyReportDueDate(now);
+            if (reportDue.isPresent() && hasGeneratedWeeklyReport(userId, reportDue.get())) {
+                return "report_weekly";
+            }
         }
         if (setting.isCharacterEnabled() && setting.isTodoReminderOn() && serverInitiatedAllowed) {
             Optional<LocalDate> todoDue = dueOccurrenceDate(TODO_REMINDER_TIME, now);
@@ -357,9 +365,28 @@ public class NotificationService {
      * 현재 {@code WEEKLY_REPORT_TIME} 은 08:00 이라 창이 자정을 넘지 않지만,
      * 시각이 바뀌어도 요일 판정이 어긋나지 않도록 발생일에 맞춰 둔다.
      */
-    private boolean isWeeklyReportDue(OffsetDateTime now) {
+    private Optional<LocalDate> weeklyReportDueDate(OffsetDateTime now) {
         return dueOccurrenceDate(WEEKLY_REPORT_TIME, now)
-                .filter(occurrenceDate -> occurrenceDate.getDayOfWeek().getValue() == 1)
+                .filter(occurrenceDate -> occurrenceDate.getDayOfWeek().getValue() == 1);
+    }
+
+    /**
+     * 리포트가 <b>실제로 생성됐을 때만</b> 알림을 보낸다 (이슈 #413).
+     *
+     * <p>이 확인이 없으면 체크인이 부족해 리포트가 만들어지지 않은 유저에게도 "리포트가 준비됐어요"
+     * 가 나간다. 프로덕션에서 실제 발송 3건 중 2건이 그런 오발송이었다.
+     *
+     * <p>대상 주차는 <b>발송일 − 7일</b> 이다. {@link com.mio.report.job.ReportAggregationJob} 이 같은
+     * 월요일 03:00 에 {@code weekEnd = 어제(일)}, {@code weekStart = weekEnd − 6일} 로 집계하므로
+     * 발송 시점에는 이미 판정이 끝나 있다.
+     *
+     * <p>행이 아예 없는 경우(집계 job 실패·미실행)도 발송하지 않는다 — 존재하지 않는 리포트를
+     * 알릴 이유가 없다.
+     */
+    private boolean hasGeneratedWeeklyReport(UUID userId, LocalDate occurrenceDate) {
+        return weeklyReportRepository
+                .findByUser_IdAndWeekStart(userId, occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS))
+                .filter(report -> WeeklyReport.STATUS_GENERATED.equals(report.getStatus()))
                 .isPresent();
     }
 

--- a/src/main/java/com/mio/report/domain/WeeklyReport.java
+++ b/src/main/java/com/mio/report/domain/WeeklyReport.java
@@ -65,10 +65,14 @@ public class WeeklyReport {
     @Column(name = "coaching_direction")
     private String coachingDirection;
 
-    /** PENDING / GENERATED / INSUFFICIENT_DATA */
+    public static final String STATUS_PENDING = "PENDING";
+    public static final String STATUS_GENERATED = "GENERATED";
+    public static final String STATUS_INSUFFICIENT_DATA = "INSUFFICIENT_DATA";
+
+    /** {@link #STATUS_PENDING} / {@link #STATUS_GENERATED} / {@link #STATUS_INSUFFICIENT_DATA} */
     @Column(name = "status", nullable = false)
     @Builder.Default
-    private String status = "PENDING";
+    private String status = STATUS_PENDING;
 
     @Column(name = "is_partial", nullable = false)
     private boolean isPartial;
@@ -82,27 +86,27 @@ public class WeeklyReport {
         this.avgEmotionScore = avgEmotionScore;
         this.emotionScores = emotionScores != null ? emotionScores : "{}";
         this.distortionDistribution = distortionDistribution != null ? distortionDistribution : "{}";
-        this.status = "GENERATED";
+        this.status = STATUS_GENERATED;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void markAsInsufficientData(int checkinCount) {
         this.checkinCount = checkinCount;
-        this.status = "INSUFFICIENT_DATA";
+        this.status = STATUS_INSUFFICIENT_DATA;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     /** @deprecated use markAsGenerated(int, Double, String, String) */
     @Deprecated
     public void markAsGenerated() {
-        this.status = "GENERATED";
+        this.status = STATUS_GENERATED;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     /** @deprecated use markAsInsufficientData(int) */
     @Deprecated
     public void markAsInsufficientData() {
-        this.status = "INSUFFICIENT_DATA";
+        this.status = STATUS_INSUFFICIENT_DATA;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 

--- a/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
@@ -8,6 +8,7 @@ import com.mio.notification.dto.NotificationHistoryResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -84,7 +85,7 @@ class NotificationCursorDecodingTest {
     @Mock private StringRedisTemplate stringRedisTemplate;
     @Mock private PushSender pushSender;
     @Mock private NotificationPersistenceService notificationPersistenceService;
-    @Mock private com.mio.report.repository.WeeklyReportRepository weeklyReportRepository;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
 
     private NotificationService notificationService;
     private Clock fixedClock;

--- a/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
@@ -84,6 +84,7 @@ class NotificationCursorDecodingTest {
     @Mock private StringRedisTemplate stringRedisTemplate;
     @Mock private PushSender pushSender;
     @Mock private NotificationPersistenceService notificationPersistenceService;
+    @Mock private com.mio.report.repository.WeeklyReportRepository weeklyReportRepository;
 
     private NotificationService notificationService;
     private Clock fixedClock;
@@ -104,7 +105,8 @@ class NotificationCursorDecodingTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
         userId = UUID.randomUUID();
         user = User.builder()

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -311,13 +313,6 @@ class NotificationServiceTest {
     }
 
     /**
-     * 라우팅 계약을 <b>전용 테스트로</b> 고정한다 (이슈 #409).
-     *
-     * <p>다른 테스트들의 스텁 인자에 기대 맵을 박아두면 라우팅이 깨졌을 때 "발송 결과 분류" 테스트가
-     * 대신 빨개져 원인을 가린다. 그러면 다음 사람이 스텁을 {@code anyMap()} 으로 완화하기 쉽고,
-     * 그 순간 라우팅 검증은 흔적 없이 사라진다.
-     */
-    /**
      * 주간 리포트 알림은 <b>리포트가 실제로 생성됐을 때만</b> 나가야 한다 (이슈 #413).
      *
      * <p>기존 구현은 "월요일 08시인가"만 보고 발송해, 체크인 부족으로 리포트가 없는 유저에게도
@@ -334,18 +329,51 @@ class NotificationServiceTest {
         notificationServiceAtWeeklyReportTime().processScheduledNotifications();
 
         verify(notificationPersistenceService).persistNotificationResult(
-                eq(userId), eq("report_weekly"), any(), any(), eq(true));
+                eq(userId),
+                eq("report_weekly"),
+                eq(NotificationDeliveryResult.sent()),
+                eq(List.of()),
+                eq(true));
     }
 
-    @Test
-    @DisplayName("[#413] 데이터 부족으로 리포트가 없으면 주간 리포트 알림을 보내지 않는다")
-    void processScheduledNotifications_insufficientData_skipsWeeklyReport() {
+    /**
+     * 발송 조건은 <b>화이트리스트</b>(GENERATED 만 발송)여야 한다.
+     *
+     * <p>INSUFFICIENT_DATA 만 막는 블랙리스트로 구현하면 {@code PENDING} 행이 통과해 "리포트가
+     * 준비됐어요" 가 나간다. PENDING 은 스키마 기본값이자 CHECK 제약에 있는 정식 상태라
+     * (V5__init_todo_report.sql), 집계가 아직 안 끝난 행이 그대로 걸린다.
+     */
+    @ParameterizedTest(name = "status={0} 이면 발송하지 않는다")
+    @ValueSource(strings = {"INSUFFICIENT_DATA", "PENDING"})
+    @DisplayName("[#413] GENERATED 가 아닌 리포트 상태는 모두 발송에서 제외한다")
+    void processScheduledNotifications_nonGeneratedStatus_skipsWeeklyReport(String status) {
         stubWeeklyReportSchedule();
         when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
-                .thenReturn(Optional.of(weeklyReportWithStatus("INSUFFICIENT_DATA")));
+                .thenReturn(Optional.of(weeklyReportWithStatus(status)));
 
         notificationServiceAtWeeklyReportTime().processScheduledNotifications();
 
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    /**
+     * 월요일 조건이 실제로 발송을 가른다는 것을 고정한다.
+     *
+     * <p>이 테스트가 없으면 요일 필터를 없애도 스위트가 통과한다 — 지금은 {@code -7일} 조회가
+     * 우연히 월요일 행만 찾아내 필터를 대신하고 있기 때문이다. 조회 방식이 바뀌는 순간
+     * (예: 최신 리포트 조회) 매일 08:00 에 푸시가 나가게 된다.
+     */
+    @Test
+    @DisplayName("[#413] 월요일이 아니면 리포트가 생성돼 있어도 주간 리포트 알림을 보내지 않는다")
+    void processScheduledNotifications_notMonday_skipsWeeklyReport() {
+        stubWeeklyReportSchedule();
+
+        // 화요일 08:00 KST — 리포트 존재 여부와 무관하게 트리거 자체가 열리지 않아야 한다
+        serviceAt(Clock.fixed(WEEKLY_REPORT_INSTANT.plus(1, ChronoUnit.DAYS), ZoneOffset.of("+09:00")))
+                .processScheduledNotifications();
+
+        verifyNoInteractions(weeklyReportRepository);
         verifyNoInteractions(pushSender);
         verifyNoInteractions(notificationPersistenceService);
     }
@@ -363,6 +391,13 @@ class NotificationServiceTest {
         verifyNoInteractions(notificationPersistenceService);
     }
 
+    /**
+     * 라우팅 계약을 <b>전용 테스트로</b> 고정한다 (이슈 #409).
+     *
+     * <p>다른 테스트들의 스텁 인자에 기대 맵을 박아두면 라우팅이 깨졌을 때 "발송 결과 분류" 테스트가
+     * 대신 빨개져 원인을 가린다. 그러면 다음 사람이 스텁을 {@code anyMap()} 으로 완화하기 쉽고,
+     * 그 순간 라우팅 검증은 흔적 없이 사라진다.
+     */
     @Test
     @DisplayName("[#409] 체크인 리마인더는 /checkin 라우팅과 슬롯을 실어 보낸다")
     void sendNotificationToUser_checkinReminder_carriesCheckinRoute() {
@@ -1079,8 +1114,12 @@ class NotificationServiceTest {
 
     /** 월요일 08:00 KST 시점의 서비스. 주간 리포트 발송 조건을 만족하는 유일한 시각이다. */
     private NotificationService notificationServiceAtWeeklyReportTime() {
+        return serviceAt(Clock.fixed(WEEKLY_REPORT_INSTANT, ZoneOffset.of("+09:00")));
+    }
+
+    private NotificationService serviceAt(Clock clock) {
         return new NotificationService(
-                Clock.fixed(WEEKLY_REPORT_INSTANT, ZoneOffset.of("+09:00")),
+                clock,
                 userRepository,
                 deviceTokenRepository,
                 notificationSettingRepository,

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -11,6 +11,8 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -68,6 +70,14 @@ class NotificationServiceTest {
     private static final Map<String, String> TODO_DATA =
             Map.of("type", "todo_incomplete", "route", "/todo");
 
+    /**
+     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는 <b>발생일 − 7일</b> 이다.
+     * {@code ReportAggregationJob} 이 월요일에 weekEnd=어제(일), weekStart=weekEnd−6 으로 집계하므로
+     * 발송일 기준 7일 전 월요일과 맞물린다. (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
+     */
+    private static final Instant WEEKLY_REPORT_INSTANT = Instant.parse("2026-08-09T23:00:00Z");
+    private static final LocalDate REPORT_WEEK_START = LocalDate.of(2026, 8, 3);
+
     @Mock private UserRepository userRepository;
     @Mock private DeviceTokenRepository deviceTokenRepository;
     @Mock private NotificationSettingRepository notificationSettingRepository;
@@ -78,6 +88,7 @@ class NotificationServiceTest {
     @Mock private ValueOperations<String, String> valueOperations;
     @Mock private PushSender pushSender;
     @Mock private NotificationPersistenceService notificationPersistenceService;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
 
     private NotificationService notificationService;
     private UUID userId;
@@ -98,7 +109,8 @@ class NotificationServiceTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
         lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         userId = UUID.randomUUID();
@@ -305,6 +317,52 @@ class NotificationServiceTest {
      * 대신 빨개져 원인을 가린다. 그러면 다음 사람이 스텁을 {@code anyMap()} 으로 완화하기 쉽고,
      * 그 순간 라우팅 검증은 흔적 없이 사라진다.
      */
+    /**
+     * 주간 리포트 알림은 <b>리포트가 실제로 생성됐을 때만</b> 나가야 한다 (이슈 #413).
+     *
+     * <p>기존 구현은 "월요일 08시인가"만 보고 발송해, 체크인 부족으로 리포트가 없는 유저에게도
+     * "리포트가 준비됐어요" 를 보냈다. 프로덕션에서 실제 발송 3건 중 2건이 오발송이었다.
+     * {@code ReportAggregationJob} 이 같은 날 03:00 에 판정을 끝내 두므로 조회만 하면 된다.
+     */
+    @Test
+    @DisplayName("[#413] 리포트가 생성된 유저에게만 주간 리포트 알림을 발송한다")
+    void processScheduledNotifications_reportGenerated_sendsWeeklyReport() {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.of(weeklyReportWithStatus("GENERATED")));
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("report_weekly"), any(), any(), eq(true));
+    }
+
+    @Test
+    @DisplayName("[#413] 데이터 부족으로 리포트가 없으면 주간 리포트 알림을 보내지 않는다")
+    void processScheduledNotifications_insufficientData_skipsWeeklyReport() {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.of(weeklyReportWithStatus("INSUFFICIENT_DATA")));
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    @Test
+    @DisplayName("[#413] 리포트 행 자체가 없으면(집계 미실행) 주간 리포트 알림을 보내지 않는다")
+    void processScheduledNotifications_noReportRow_skipsWeeklyReport() {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.empty());
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
     @Test
     @DisplayName("[#409] 체크인 리마인더는 /checkin 라우팅과 슬롯을 실어 보낸다")
     void sendNotificationToUser_checkinReminder_carriesCheckinRoute() {
@@ -968,7 +1026,8 @@ class NotificationServiceTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
 
         NotificationSetting setting = NotificationSetting.builder().user(user).build();
@@ -1016,6 +1075,57 @@ class NotificationServiceTest {
         verify(notificationPersistenceService, never()).persistNotificationResult(
                 any(), anyString(), any(), any(), anyBoolean()
         );
+    }
+
+    /** 월요일 08:00 KST 시점의 서비스. 주간 리포트 발송 조건을 만족하는 유일한 시각이다. */
+    private NotificationService notificationServiceAtWeeklyReportTime() {
+        return new NotificationService(
+                Clock.fixed(WEEKLY_REPORT_INSTANT, ZoneOffset.of("+09:00")),
+                userRepository,
+                deviceTokenRepository,
+                notificationSettingRepository,
+                proactiveCareLogRepository,
+                checkinRepository,
+                behaviorTaskRepository,
+                stringRedisTemplate,
+                new NotificationMessageMapper(),
+                pushSender,
+                notificationPersistenceService,
+                weeklyReportRepository
+        );
+    }
+
+    /** 리포트 발송 직전까지의 조건을 모두 통과시켜, 리포트 상태만이 결과를 가르게 한다. */
+    private void stubWeeklyReportSchedule() {
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
+                new org.springframework.data.domain.SliceImpl<>(List.of(setting)));
+        lenient().when(valueOperations.get(anyString())).thenReturn(null);
+        lenient().when(proactiveCareLogRepository.countByUser_IdAndNotificationStatusInAndSentAtBetween(
+                eq(userId), any(), any(), any())).thenReturn(0L);
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(false);
+        // 체크인·To-do 트리거가 먼저 잡히지 않도록 비운다
+        lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(true);
+        lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(
+                DeviceToken.builder().user(user).deviceId("device-1").platform("android").token("fcm-token").build()));
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+    }
+
+    private WeeklyReport weeklyReportWithStatus(String status) {
+        WeeklyReport report = WeeklyReport.builder()
+                .user(user)
+                .weekStart(REPORT_WEEK_START)
+                .weekEnd(REPORT_WEEK_START.plusDays(6))
+                .build();
+        setField(report, "status", status);
+        return report;
     }
 
     private void setUserId(User u, UUID id) {


### PR DESCRIPTION
## 요약

체크인이 부족해 주간 리포트가 생성되지 않은 유저에게도 **"이번 주 리포트가 준비됐어요"** 알림이 발송되던 문제를 수정한다. QA 제보로 확인했고 프로덕션 데이터로 재현을 확증했다.

`determineTrigger` 가 리포트 존재 여부를 보지 않고 **달력 조건(월요일 08:00)만으로** `report_weekly` 를 반환하고 있었다.

## 관련 이슈

- Closes #413

## 변경 사항

- `report_weekly` 발송 조건에 **해당 주차 리포트가 `GENERATED` 인지** 확인 추가
- `isWeeklyReportDue(...)` → `weeklyReportDueDate(...)` 로 변경해 발생일을 반환하도록 하고, 그 날짜로 대상 주차를 계산
- `WeeklyReport` 의 상태 문자열을 상수(`STATUS_PENDING` / `STATUS_GENERATED` / `STATUS_INSUFFICIENT_DATA`)로 추출 — 알림 도메인에서도 참조하게 되어 리터럴이 흩어지면 오타가 조용한 오작동이 된다

### 판정 기준

| 그 주 `weekly_reports.status` | 알림 |
|---|---|
| `GENERATED` | 발송 |
| `INSUFFICIENT_DATA` (체크인 3회 미만) | 발송 안 함 |
| 행 없음 (집계 job 미실행·실패) | 발송 안 함 |

대상 주차는 **발송일 − 7일** 이다. `ReportAggregationJob` 이 월요일에 `weekEnd = 어제(일)`, `weekStart = weekEnd − 6일` 로 집계하는 것과 맞물린다. 프로덕션 데이터로 확인했다 — 2026-08-10 발송분의 `week_start` 는 `2026-08-03`.

정보가 없어서 못 하던 것이 아니다. `ReportAggregationJob` 이 **같은 날 03:00** 에 판정을 끝내 두므로 08:00 발송 시점에는 이미 5시간 전에 결과가 DB 에 있었다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `report_weekly` 트리거 조건이 좁아진다
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

**발송량 감소는 의도된 것이다.** 프로덕션 `weekly_reports` 분포가 `INSUFFICIENT_DATA` 8건 대 `GENERATED` 1건이라 `report_weekly` 발송이 크게 줄어든다. 지금까지 대부분이 오발송이었다는 뜻이다.

## 테스트

### 실행 커맨드

```bash
./gradlew build
```

### 확인 내용

TDD 로 진행했다. 테스트를 먼저 작성해 컴파일 실패(RED)를 확인하고 구현했다.

- `GENERATED` → 발송된다
- `INSUFFICIENT_DATA` → `pushSender` / `persistNotificationResult` 모두 호출되지 않는다
- 리포트 행 없음 → 동일하게 발송되지 않는다

**뮤테이션 검증**: 구현에서 `.filter(report -> STATUS_GENERATED.equals(...))` 한 줄을 제거해 버그를 되살렸을 때 `[#413] 데이터 부족으로 리포트가 없으면 주간 리포트 알림을 보내지 않는다` 가 실패하는 것을 확인했다. 테스트가 실제로 이 회귀를 잡는다.

기존 알림 테스트 전부 통과.

## 중점 리뷰 포인트

- **대상 주차 계산(`발송일 − 7일`)이 `ReportAggregationJob` 과 어긋나지 않는지.** 두 곳이 독립적으로 주차를 계산하므로 한쪽 스케줄이 바뀌면 조용히 어긋난다. 프로덕션 데이터로 현재 일치는 확인했으나, 상수로 묶을지 검토가 필요하면 의견 부탁드린다
- 리포트 행이 없을 때 발송하지 않는 선택 — 집계 job 장애 시 알림도 함께 멈춘다. 알림이 오지 않는 것보다 없는 리포트를 알리는 쪽이 나쁘다고 판단했다

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용된다. 다음 월요일 08:00 발송분부터 반영
- **Rollback**: 서버만 되돌리면 이전 동작(전원 발송)으로 복귀

## 함께 검토한 것 — API 명세 대조

명세(`10_Notification_알림.md`)와 현재 코드를 대조했다. **엔드포인트 6종과 요청·응답 필드는 모두 일치**한다. 아래 3건은 코드에는 있으나 명세에 없던 내용이라 문서를 갱신했다(문서는 `docs/` 가 gitignore 대상이라 이 PR 에는 포함되지 않는다).

1. **이력에 노출되지 않는 내부 상태** — `NO_DEVICE` / `UNCONFIRMED` 는 `proactive_care_logs` 에 기록되지만 `GET /v1/notifications` 응답에서 제외된다. 명세에 없어 FE 가 "발송 이력 건수 = 이력 API 건수" 로 기대할 수 있다
2. **`DELIVERED` 는 현재 기록되지 않는다** — 도달 콜백 미연동. 명세에는 정상 상태값으로 적혀 있었다
3. **`report_weekly` 발송 조건** — 이번 변경 내용

`POST /v1/notifications/test` 는 명세에 없으나 `notification.test-endpoint-enabled` 로 게이트된 개발용이라 그대로 두었다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for weekly report notifications when the scheduled Monday occurrence is due and a report has been successfully generated for the target week.
  * Weekly reports now clearly distinguish pending, generated, and insufficient-data states.

* **Bug Fixes**
  * Prevented notifications from being sent when the weekly report is missing or does not contain sufficient data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->