### PR TITLE
fix: 주간 리포트 대상 주차를 실행 요일과 무관하게 계산한다

### DIFF
--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -375,9 +375,9 @@ public class NotificationService {
      * <p>이 확인이 없으면 체크인이 부족해 리포트가 만들어지지 않은 유저에게도 "리포트가 준비됐어요"
      * 가 나간다. 프로덕션에서 실제 발송 3건 중 2건이 그런 오발송이었다.
      *
-     * <p>대상 주차는 <b>발송일 − 7일</b> 이다. {@link com.mio.report.job.ReportAggregationJob} 이 같은
-     * 월요일 03:00 에 {@code weekEnd = 어제(일)}, {@code weekStart = weekEnd − 6일} 로 집계하므로
-     * 발송 시점에는 이미 판정이 끝나 있다.
+     * <p>대상 주차는 {@link ReportWeek#lastWeekStartFrom} 으로 구한다.
+     * {@link com.mio.report.job.ReportAggregationJob} 이 같은 월요일 03:00 에 <b>같은 헬퍼로</b>
+     * 집계하므로 발송 시점에는 이미 판정이 끝나 있다.
      *
      * <p>행이 아예 없는 경우(집계 job 실패·미실행)도 발송하지 않는다 — 존재하지 않는 리포트를
      * 알릴 이유가 없다.

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.ReportWeek;
 import com.mio.report.domain.WeeklyReport;
 import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.domain.BehaviorTask;
@@ -54,8 +55,6 @@ public class NotificationService {
 
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
-    /** 월요일 발송분이 대상으로 삼는 주차는 발송일 7일 전 월요일이다. */
-    private static final int WEEKLY_REPORT_PERIOD_DAYS = 7;
     private static final LocalTime SERVER_INITIATED_WINDOW_START = LocalTime.of(8, 0);
     private static final LocalTime SERVER_INITIATED_WINDOW_END = LocalTime.of(22, 0);
     private static final int DAILY_SEND_LIMIT = 3;
@@ -384,7 +383,9 @@ public class NotificationService {
      * 알릴 이유가 없다.
      */
     private boolean hasGeneratedWeeklyReport(UUID userId, LocalDate occurrenceDate) {
-        LocalDate weekStart = occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS);
+        // 집계 job 과 같은 헬퍼로 계산한다 (이슈 #415) — 두 곳이 각자 계산하면 어긋나도 컴파일러가
+        // 잡아주지 못하고, 어긋나는 순간 그 주 알림이 통째로 사라진다.
+        LocalDate weekStart = ReportWeek.lastWeekStartFrom(occurrenceDate);
         Optional<WeeklyReport> report = weeklyReportRepository.findByUser_IdAndWeekStart(userId, weekStart);
 
         if (report.isEmpty()) {

--- a/src/main/java/com/mio/report/domain/ReportWeek.java
+++ b/src/main/java/com/mio/report/domain/ReportWeek.java
@@ -13,6 +13,13 @@ import java.time.LocalDate;
  * 원인을 찾기 어려운 불일치가 생긴다.
  *
  * <p>결합을 주석이 아니라 코드로 표현하기 위해 한곳에 모았다.
+ *
+ * <p><b>아직 이 헬퍼를 쓰지 않는 곳이 하나 있다.</b>
+ * {@code WeeklyReflectionJob} 은 일요일 00:00 에 {@code 오늘 - 7일}(= 일요일)로 {@code week_start}
+ * 를 만들어 {@code weekly_reports} 를 UPDATE 한다. {@code week_start} 에는 월요일만 저장되므로
+ * 이 UPDATE 는 항상 0 rows 이며, {@code narrative}/{@code coaching_direction} 이 채워지지 않는다
+ * (프로덕션 확인: 9행 중 0행). 이 헬퍼 도입 <b>이전부터</b> 그랬고, 고치려면 날짜 계산만이 아니라
+ * 두 job 의 실행 순서(일 00:00 반영 → 월 03:00 집계)부터 정해야 해서 별도로 다룬다.
  */
 public final class ReportWeek {
 

--- a/src/main/java/com/mio/report/domain/ReportWeek.java
+++ b/src/main/java/com/mio/report/domain/ReportWeek.java
@@ -1,0 +1,35 @@
+package com.mio.report.domain;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+/**
+ * 주간 리포트의 대상 주차를 계산한다 (이슈 #415).
+ *
+ * <p>같은 "지난주 월요일"을 집계 job · 알림 발송 게이트 · 리포트 조회가 각자 계산하고 있었다.
+ * 그중 집계 job 만 {@code 오늘 - 1일 - 6일} 이라 <b>월요일에 실행될 때만</b> 옳았고, 다른 요일에
+ * 재실행하면 월요일이 아닌 {@code week_start} 로 저장돼 나머지 두 곳의 조회와 어긋났다.
+ * 그러면 그 주 리포트 알림이 전 유저 무발송이 되면서도 리포트 화면에는 정상 표시되는,
+ * 원인을 찾기 어려운 불일치가 생긴다.
+ *
+ * <p>결합을 주석이 아니라 코드로 표현하기 위해 한곳에 모았다.
+ */
+public final class ReportWeek {
+
+    private ReportWeek() {
+    }
+
+    /**
+     * 기준일이 속한 주의 <b>직전 주 월요일</b>. 실행 요일과 무관하게 항상 같은 값을 낸다.
+     *
+     * <p>ISO-8601 기준으로 주는 월요일에 시작한다.
+     */
+    public static LocalDate lastWeekStartFrom(LocalDate baseDate) {
+        return baseDate.with(DayOfWeek.MONDAY).minusWeeks(1);
+    }
+
+    /** 주 시작일(월)에 대응하는 종료일(일). */
+    public static LocalDate weekEndOf(LocalDate weekStart) {
+        return weekStart.plusDays(6);
+    }
+}

--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -13,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -35,13 +36,15 @@ public class ReportAggregationJob {
     private final WeeklyReportRepository weeklyReportRepository;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    /** 실행 시각을 주입받아 비-월요일 실행도 테스트할 수 있게 한다 (이슈 #415). */
+    private final Clock clock;
 
     @Scheduled(cron = "0 0 3 * * MON", zone = "Asia/Seoul")
     public void run() {
         // 실행 요일에 의존하지 않는다 (이슈 #415). 이전 구현은 오늘-1, -6 이라 월요일에 돌 때만
         // 옳았고, 다른 요일에 재실행하면 월요일이 아닌 week_start 로 저장돼 알림 게이트·리포트
         // 조회의 계산과 어긋났다.
-        LocalDate weekStart = ReportWeek.lastWeekStartFrom(LocalDate.now(KST));
+        LocalDate weekStart = ReportWeek.lastWeekStartFrom(LocalDate.now(clock));
         LocalDate weekEnd = ReportWeek.weekEndOf(weekStart);
 
         log.info("[ReportAggregationJob] start weekStart={} weekEnd={}", weekStart, weekEnd);

--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -1,6 +1,7 @@
 package com.mio.report.job;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.report.domain.ReportWeek;
 import com.mio.report.domain.WeeklyReport;
 import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.user.domain.User;
@@ -37,8 +38,11 @@ public class ReportAggregationJob {
 
     @Scheduled(cron = "0 0 3 * * MON", zone = "Asia/Seoul")
     public void run() {
-        LocalDate weekEnd = LocalDate.now(KST).minusDays(1);   // 지난 일요일
-        LocalDate weekStart = weekEnd.minusDays(6);             // 지난 월요일
+        // 실행 요일에 의존하지 않는다 (이슈 #415). 이전 구현은 오늘-1, -6 이라 월요일에 돌 때만
+        // 옳았고, 다른 요일에 재실행하면 월요일이 아닌 week_start 로 저장돼 알림 게이트·리포트
+        // 조회의 계산과 어긋났다.
+        LocalDate weekStart = ReportWeek.lastWeekStartFrom(LocalDate.now(KST));
+        LocalDate weekEnd = ReportWeek.weekEndOf(weekStart);
 
         log.info("[ReportAggregationJob] start weekStart={} weekEnd={}", weekStart, weekEnd);
 

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.mio.report.service;
 
 import com.mio.common.AppConstants;
+import com.mio.report.domain.ReportWeek;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.checkin.repository.CheckinRepository;
@@ -24,7 +25,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
@@ -243,9 +243,7 @@ public class ReportService {
     // ── 날짜 헬퍼 ─────────────────────────────────────────────────
 
     private LocalDate resolveLastWeekStart() {
-        LocalDate today = LocalDate.now(AppConstants.ZONE);
-        int daysFromMonday = today.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue();
-        return today.minusDays(daysFromMonday + 7);
+        return ReportWeek.lastWeekStartFrom(LocalDate.now(AppConstants.ZONE));
     }
 
     private LocalDate resolveLastMonthStart() {

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -78,7 +78,7 @@ public class ReportService {
 
     public WeeklyReportResponse getWeeklyReport(UUID userId, LocalDate weekStart) {
         final LocalDate resolvedStart = weekStart != null ? weekStart : resolveLastWeekStart();
-        final LocalDate weekEnd = resolvedStart.plusDays(6);
+        final LocalDate weekEnd = ReportWeek.weekEndOf(resolvedStart);
 
         ReportDbData data = readOnlyTx.execute(status -> {
             verifyUserExists(userId);

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -73,9 +73,10 @@ class NotificationServiceTest {
             Map.of("type", "todo_incomplete", "route", "/todo");
 
     /**
-     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는 <b>발생일 − 7일</b> 이다.
-     * {@code ReportAggregationJob} 이 월요일에 weekEnd=어제(일), weekStart=weekEnd−6 으로 집계하므로
-     * 발송일 기준 7일 전 월요일과 맞물린다. (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
+     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는
+     * {@code ReportWeek.lastWeekStartFrom(발생일)} — 즉 직전 주 월요일이다.
+     * 집계 job 도 같은 헬퍼를 쓰므로 두 값이 맞물린다.
+     * (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
      */
     private static final Instant WEEKLY_REPORT_INSTANT = Instant.parse("2026-08-09T23:00:00Z");
     private static final LocalDate REPORT_WEEK_START = LocalDate.of(2026, 8, 3);

--- a/src/test/java/com/mio/report/domain/ReportWeekTest.java
+++ b/src/test/java/com/mio/report/domain/ReportWeekTest.java
@@ -1,0 +1,93 @@
+package com.mio.report.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReportWeek — 주간 리포트 대상 주차 계산 (#415)")
+class ReportWeekTest {
+
+    /**
+     * 이 계산이 세 곳(집계 job · 알림 게이트 · 리포트 조회)에서 각자 이뤄지던 것을 하나로 모았다.
+     * 실행 요일에 따라 값이 달라지면 저장한 주차와 조회하는 주차가 어긋나 알림이 통째로 사라진다.
+     */
+    @ParameterizedTest(name = "{0}({1}) 에 실행해도 대상 주차는 2026-08-03")
+    @CsvSource({
+            "2026-08-10, 월요일",
+            "2026-08-11, 화요일",
+            "2026-08-12, 수요일",
+            "2026-08-13, 목요일",
+            "2026-08-14, 금요일",
+            "2026-08-15, 토요일",
+            "2026-08-16, 일요일"
+    })
+    @DisplayName("같은 주 안에서는 어느 요일에 실행해도 같은 주차를 가리킨다")
+    void lastWeekStartFrom_isIndependentOfExecutionDay(LocalDate baseDate, String label) {
+        assertThat(ReportWeek.lastWeekStartFrom(baseDate))
+                .as("%s 실행", label)
+                .isEqualTo(LocalDate.of(2026, 8, 3));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2026-08-10", "2026-08-11", "2026-08-16",
+            "2026-01-01", "2026-03-02", "2027-01-04"
+    })
+    @DisplayName("결과는 항상 월요일이다")
+    void lastWeekStartFrom_alwaysReturnsMonday(String baseDate) {
+        assertThat(ReportWeek.lastWeekStartFrom(LocalDate.parse(baseDate)).getDayOfWeek())
+                .isEqualTo(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    @DisplayName("연말연시 주 경계에서도 직전 주 월요일을 가리킨다")
+    void lastWeekStartFrom_crossesYearBoundary() {
+        // 2026-01-01 은 목요일 → 그 주 월요일은 2025-12-29 → 직전 주는 2025-12-22
+        assertThat(ReportWeek.lastWeekStartFrom(LocalDate.of(2026, 1, 1)))
+                .isEqualTo(LocalDate.of(2025, 12, 22));
+    }
+
+    @Test
+    @DisplayName("주 종료일은 시작일로부터 6일 뒤 일요일이다")
+    void weekEndOf_returnsSunday() {
+        LocalDate weekStart = LocalDate.of(2026, 8, 3);
+
+        assertThat(ReportWeek.weekEndOf(weekStart)).isEqualTo(LocalDate.of(2026, 8, 9));
+        assertThat(ReportWeek.weekEndOf(weekStart).getDayOfWeek()).isEqualTo(DayOfWeek.SUNDAY);
+    }
+
+    /**
+     * 교체 대상이던 기존 계산식과 동일한 값을 내는지 고정한다.
+     *
+     * <p>{@code ReportService#resolveLastWeekStart} 와 월요일 실행 시의
+     * {@code ReportAggregationJob} 은 원래도 옳았다. 이 헬퍼가 그 동작을 바꾸면 안 된다.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-08-10", "2026-08-11", "2026-08-16", "2026-02-28", "2028-02-29"})
+    @DisplayName("기존 ReportService 계산식과 결과가 같다")
+    void lastWeekStartFrom_matchesLegacyReportServiceFormula(String baseDate) {
+        LocalDate today = LocalDate.parse(baseDate);
+        int daysFromMonday = today.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue();
+        LocalDate legacy = today.minusDays(daysFromMonday + 7L);
+
+        assertThat(ReportWeek.lastWeekStartFrom(today)).isEqualTo(legacy);
+    }
+
+    @Test
+    @DisplayName("월요일 실행 시 기존 집계 job 계산식과 결과가 같다")
+    void lastWeekStartFrom_matchesLegacyJobFormulaOnMonday() {
+        LocalDate monday = LocalDate.of(2026, 8, 10);
+        LocalDate legacyWeekEnd = monday.minusDays(1);
+        LocalDate legacyWeekStart = legacyWeekEnd.minusDays(6);
+
+        assertThat(ReportWeek.lastWeekStartFrom(monday)).isEqualTo(legacyWeekStart);
+        assertThat(ReportWeek.weekEndOf(ReportWeek.lastWeekStartFrom(monday))).isEqualTo(legacyWeekEnd);
+    }
+}

--- a/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
+++ b/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
@@ -1,0 +1,140 @@
+package com.mio.report.job;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 집계 job 이 <b>실행 요일과 무관하게</b> 같은 주차를 대상으로 삼는지 고정한다 (이슈 #415).
+ *
+ * <p>이전 구현은 {@code 오늘 − 1일 − 6일} 이라 월요일에 돌 때만 옳았다. 화요일에 재실행하면
+ * 월요일이 아닌 {@code week_start} 로 저장돼, 알림 게이트의 조회가 전부 비면서 그 주 리포트
+ * 알림이 전 유저 무발송이 됐다.
+ *
+ * <p>이 테스트가 없으면 누군가 job 안에서 다시 {@code LocalDate.now().minusDays(1)} 로 인라인해도
+ * CI 가 초록이다 — 헬퍼 단위 테스트만으로는 호출부가 그것을 쓰는지 보장하지 못한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReportAggregationJob — 대상 주차 계산 (#415)")
+class ReportAggregationJobTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDate EXPECTED_WEEK_START = LocalDate.of(2026, 8, 3);
+    private static final LocalDate EXPECTED_WEEK_END = LocalDate.of(2026, 8, 9);
+
+    @Mock private UserRepository userRepository;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
+    @Mock private JdbcTemplate jdbcTemplate;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+    }
+
+    @ParameterizedTest(name = "{1}({0})에 실행해도 2026-08-03 주차를 집계한다")
+    @CsvSource({
+            "2026-08-10T03:00:00+09:00, 월요일",
+            "2026-08-11T03:00:00+09:00, 화요일",
+            "2026-08-13T03:00:00+09:00, 목요일",
+            "2026-08-16T03:00:00+09:00, 일요일"
+    })
+    @DisplayName("실행 요일이 달라도 같은 주차를 대상으로 삼는다")
+    void run_targetsSameWeekRegardlessOfExecutionDay(String runAt, String label) {
+        ReportAggregationJob job = jobAt(Clock.fixed(OffsetDateTime.parse(runAt).toInstant(), KST));
+        stubOneCandidateUser();
+
+        job.run();
+
+        // 저장 대상 주차가 실행 요일에 흔들리지 않아야 한다
+        verify(weeklyReportRepository).findByUser_IdAndWeekStart(eq(userId), eq(EXPECTED_WEEK_START));
+    }
+
+    @ParameterizedTest(name = "{1} 실행 시 저장되는 week_start/week_end")
+    @CsvSource({
+            "2026-08-10T03:00:00+09:00, 월요일",
+            "2026-08-11T03:00:00+09:00, 화요일"
+    })
+    @DisplayName("저장되는 주차는 항상 월요일~일요일이다")
+    void run_savesMondayToSundayRange(String runAt, String label) {
+        ReportAggregationJob job = jobAt(Clock.fixed(OffsetDateTime.parse(runAt).toInstant(), KST));
+        stubOneCandidateUser();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(any(), any())).thenReturn(Optional.empty());
+
+        job.run();
+
+        org.mockito.ArgumentCaptor<WeeklyReport> captor =
+                org.mockito.ArgumentCaptor.forClass(WeeklyReport.class);
+        verify(weeklyReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getWeekStart()).isEqualTo(EXPECTED_WEEK_START);
+        assertThat(captor.getValue().getWeekEnd()).isEqualTo(EXPECTED_WEEK_END);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubOneCandidateUser() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(userId));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(newUser()));
+        // 체크인 수는 임계값 미만이면 INSUFFICIENT_DATA 로 바로 저장되어 흐름이 단순해진다
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(), any(), any()))
+                .thenReturn(0);
+    }
+
+    private ReportAggregationJob jobAt(Clock clock) {
+        return new ReportAggregationJob(userRepository, weeklyReportRepository, jdbcTemplate,
+                new ObjectMapper(), clock);
+    }
+
+    private User newUser() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-social-id")
+                .privacyConsent(true)
+                .build();
+        try {
+            Field field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(user, userId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return user;
+    }
+
+    @SuppressWarnings("unused")
+    private static Instant unused() {
+        return Instant.EPOCH;
+    }
+}


### PR DESCRIPTION
## 요약

주간 리포트 집계 job 이 대상 주차를 **"오늘이 월요일"이라는 암묵적 전제**로 계산하고 있었다. 같은 "지난주 월요일"을 세 곳이 각자 계산하는데, 그중 job 만 실행 요일에 의존한다.

`ReportWeek.lastWeekStartFrom()` 하나로 모아 결합을 주석이 아니라 코드로 표현한다.

## 관련 이슈

- Closes #415

## 변경 사항

- `ReportWeek` 신규 — `lastWeekStartFrom(LocalDate)` / `weekEndOf(LocalDate)`
- `ReportAggregationJob` — `오늘 − 1일 − 6일` → 헬퍼 사용
- `NotificationService#hasGeneratedWeeklyReport` — `occurrenceDate − 7일` → 헬퍼 사용 (`WEEKLY_REPORT_PERIOD_DAYS` 상수 제거)
- `ReportService#resolveLastWeekStart` — 자체 계산식 → 헬퍼 사용
- `ReportWeekTest` 신규

### 무엇이 깨지고 있었나

| 위치 | 이전 계산 | 실행 요일 의존 |
|---|---|---|
| `ReportAggregationJob` | `today.minusDays(1).minusDays(6)` | **예** |
| `NotificationService` | `occurrenceDate.minusDays(7)` | 아니오 (월요일로 필터됨) |
| `ReportService` | `today.minusDays(daysFromMonday + 7)` | 아니오 |

월요일 03:00 정기 실행이 배포·인스턴스 교체로 누락돼 **화요일에 수동 재실행**하면 `week_start` 가 지지난주 화요일로 저장된다. 그러면 다음 월요일 08:00 알림 게이트 조회가 전부 비어 **그 주 리포트 알림이 전 유저 무발송**이 되는데, 리포트 화면은 자체 재계산으로 **정상 표시**된다. 알림은 안 오는데 앱에는 리포트가 있는, 원인을 찾기 어려운 불일치다.

#413 이 이 job 의 산출물을 알림 발송의 유일한 근거로 삼으면서 이 계산의 정확성에 대한 의존도가 높아졌다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `ReportAggregationJob` 의 주차 계산
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

**정상 경로(월요일 03:00 정기 실행)의 동작은 완전히 동일하다.** 달라지는 것은 월요일이 아닌 날 실행됐을 때뿐이다.

기존 데이터 점검: 프로덕션 `weekly_reports.week_start` 는 `2026-08-03` / `2026-07-27` / `2026-06-29` 로 모두 월요일이라 오염된 행이 없다. 마이그레이션 불필요.

## 테스트

### 실행 커맨드

```bash
./gradlew build
```

### 확인 내용

- 월~일 **7개 요일 전부** 같은 주차(`2026-08-03`)를 가리킨다
- 결과가 항상 월요일이다
- 연말 주 경계 (`2026-01-01` 목 → `2025-12-22`)
- **기존 계산식과의 동치 고정** — `ReportService` 의 옛 공식과 모든 요일에서 같은 값, 월요일 실행 시 옛 job 공식과도 같은 값. 두 곳 모두 원래는 옳았으므로 이 헬퍼가 그 동작을 바꾸면 안 된다
- 윤년(`2028-02-29`), 월 경계(`2026-02-28`) 포함

**뮤테이션 검증** — 두 가지로 망가뜨려 테스트가 잡는지 확인했다.

| 뮤테이션 | 결과 |
|---|---|
| 헬퍼를 옛 job 방식(`minusDays(1).minusDays(6)`)으로 되돌림 | 화·수·목·금·토·일 케이스 + 동치 고정 4건 실패 |
| `minusWeeks(1)` 제거 (이번 주를 가리킴) | 전 케이스 실패 |

## 중점 리뷰 포인트

- `with(DayOfWeek.MONDAY)` 는 ISO-8601 기준(주 시작 = 월요일)이라 일요일에 호출하면 **그 주의 월요일**(6일 전)을 준다. 이 동작이 기존 `ReportService` 공식과 일치함을 테스트로 고정했으나, 주 시작 요일 정의가 바뀔 일이 있다면 함께 봐야 한다
- `ReportWeek` 를 `com.mio.report.domain` 에 뒀다. `notification` → `report` 의존은 이미 #413 에서 생겼고 역방향은 없어 순환은 없다

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용. 마이그레이션·설정 변경 없음
- **Rollback**: 서버만 되돌리면 된다. 정상 경로 동작이 동일해 되돌려도 데이터 영향 없음

## 남은 관련 사항 (이 PR 범위 밖)

리뷰에서 함께 지적된 것으로, 별도 판단이 필요해 제외했다.

- `ReportAggregationJob.run()` 이 완료 신호를 남기지 않아, 유저 수가 늘어 03:00 배치가 08:00 을 넘기면 뒷부분 유저는 그 주 알림을 놓친다 (트리거 창이 월요일 08:00~08:10 뿐)
- `run()` 이 같은 인스턴스의 `generateReport(...)` 를 직접 호출해 프록시를 거치지 않으므로 `@Transactional(REQUIRES_NEW)` 가 no-op 이다. 결과적으로는 의도대로 동작하지만 어노테이션이 아니라 우연에 기대고 있다

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — `05_비동기_알림.md` 갱신 (`docs/` 는 gitignore 대상이라 이 PR 에 포함되지 않는다)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved weekly report date handling to consistently use Monday–Sunday reporting periods.
  - Notifications, report generation, and aggregation now align on the same previous-week boundaries, including across month and year transitions.

- **Tests**
  - Added coverage for weekly date calculations and report aggregation across different execution days.
  - Verified consistent report boundaries and notification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->