### PR TITLE
fix: APNs 400 중 토큰이 무효인 사유만 토큰을 폐기한다

### DIFF
--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -34,6 +34,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
@@ -45,6 +46,25 @@ public class PushSender {
     private static final long JWT_TTL_SECONDS = 3000;
     private static final String APNS_TOKEN_PATTERN = "[0-9a-fA-F]{64}";
     private static final String APS_KEY = "aps";
+
+    /**
+     * 400 응답 중 <b>토큰 자체가 무효</b>임을 뜻하는 사유 (이슈 #411).
+     *
+     * <p>이전에는 400 이면 사유와 무관하게 토큰을 폐기했다. 그런데 400 에는 {@code TopicDisallowed},
+     * {@code BadPriority}, {@code InvalidPushType} 처럼 <b>요청·설정</b> 문제인 사유가 다수 포함된다.
+     * {@code apns-topic} 이 설정값({@code apnsBundleId})이라 잘못 배포되면 모든 요청이 같은 400 을
+     * 받고, 스케줄러 한 사이클에 정상 사용자 토큰이 전량 무효화된다.
+     *
+     * <p>{@code DeviceTokenNotForTopic} 은 <b>제외</b>했다. 토큰이 다른 앱·토픽용일 수도, 우리 토픽
+     * 설정이 틀렸을 수도 있어 구분이 불가능한데, 후자면 전 유저가 한꺼번에 죽는다.
+     *
+     * <p>알려지지 않은 사유도 폐기하지 않는다 — Apple 이 사유를 추가했을 때 조용히 토큰을 죽이는
+     * 것보다 발송 실패로 남기는 편이 복구 가능하다.
+     *
+     * <p><b>남은 한계</b>: {@code BadDeviceToken} 은 sandbox 토큰을 production 으로 보낼 때도
+     * 발생한다. {@code apns.is-production} 설정이 틀리면 이 사유로 전량 무효화될 수 있다.
+     */
+    private static final Set<String> TOKEN_INVALIDATING_APNS_REASONS = Set.of("BadDeviceToken");
 
     @Value("${apns.key-content:}")
     private String apnsKeyContent;
@@ -216,7 +236,17 @@ public class PushSender {
             return PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, failureReason);
         }
         if (response.statusCode() == 400) {
-            return PushSendResult.of(PushSendStatus.INVALID_TOKEN, failureReason);
+            // reason 은 본문이 비거나 파싱 실패하면 null 이다. Set.of() 는 contains(null) 에서
+            // NPE 를 던지므로 반드시 먼저 거른다.
+            String reason = extractApnsReason(response.body());
+            if (reason != null && TOKEN_INVALIDATING_APNS_REASONS.contains(reason)) {
+                return PushSendResult.of(PushSendStatus.INVALID_TOKEN, failureReason);
+            }
+            // 토큰이 아니라 우리 요청·설정이 틀렸을 가능성이 높다. 전 요청이 같은 사유로 400 을 받는
+            // 상황이므로 개별 토큰 문제로 오인하지 않도록 ERROR 로 남긴다.
+            log.error("APNs rejected with non-token reason — keeping device token. reason={} token={}",
+                    reason, maskToken(deviceToken));
+            return PushSendResult.of(PushSendStatus.FAILED, failureReason);
         }
         return PushSendResult.of(PushSendStatus.FAILED, failureReason);
     }

--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -230,30 +230,31 @@ public class PushSender {
             return PushSendResult.sent();
         }
 
-        log.warn("APNs rejected token {}: status={} body={}", maskToken(deviceToken), response.statusCode(), response.body());
-        String failureReason = buildApnsFailureReason(response.statusCode(), response.body());
+        // reason 은 본문이 비거나 파싱 실패하면 null 이다. 폐기 판정의 입력이므로 한 번만 파싱해
+        // 아래 분기와 로그가 같은 값을 보게 한다.
+        String reason = extractApnsReason(response.body());
+        String failureReason = buildApnsFailureReason(response.statusCode(), reason);
+
         if (response.statusCode() == 410) {
+            log.warn("APNs token no longer valid — discarding. reason={} token={}", reason, maskToken(deviceToken));
             return PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, failureReason);
         }
-        if (response.statusCode() == 400) {
-            // reason 은 본문이 비거나 파싱 실패하면 null 이다. Set.of() 는 contains(null) 에서
-            // NPE 를 던지므로 반드시 먼저 거른다.
-            String reason = extractApnsReason(response.body());
-            if (reason != null && TOKEN_INVALIDATING_APNS_REASONS.contains(reason)) {
-                return PushSendResult.of(PushSendStatus.INVALID_TOKEN, failureReason);
-            }
-            // 토큰이 아니라 우리 요청·설정이 틀렸을 가능성이 높다. 전 요청이 같은 사유로 400 을 받는
-            // 상황이므로 개별 토큰 문제로 오인하지 않도록 ERROR 로 남긴다.
-            log.error("APNs rejected with non-token reason — keeping device token. reason={} token={}",
-                    reason, maskToken(deviceToken));
-            return PushSendResult.of(PushSendStatus.FAILED, failureReason);
+        // Set.of() 는 contains(null) 에서 NPE 를 던지므로 null 을 먼저 거른다.
+        if (response.statusCode() == 400 && reason != null && TOKEN_INVALIDATING_APNS_REASONS.contains(reason)) {
+            log.warn("APNs rejected device token — discarding. reason={} token={}", reason, maskToken(deviceToken));
+            return PushSendResult.of(PushSendStatus.INVALID_TOKEN, failureReason);
         }
+
+        // 여기 오는 응답은 토큰이 아니라 우리 요청·설정·게이트웨이 상태 문제다. 모든 요청이 같은
+        // 사유로 실패하는 상황이므로 개별 토큰 문제로 오인되지 않게 ERROR 로 남긴다.
+        // 특히 403(ExpiredProviderToken 등)은 JWT 캐시 때문에 전 발송이 한꺼번에 죽는다.
+        log.error("APNs rejected for non-token reason — keeping device token. status={} reason={} token={}",
+                response.statusCode(), reason, maskToken(deviceToken));
         return PushSendResult.of(PushSendStatus.FAILED, failureReason);
     }
 
     /** APNs 응답에서 사후 추적용 사유를 만든다. 토큰 등 민감 정보는 포함하지 않는다. */
-    private String buildApnsFailureReason(int statusCode, String responseBody) {
-        String reason = extractApnsReason(responseBody);
+    private String buildApnsFailureReason(int statusCode, String reason) {
         return reason == null ? "APNS_" + statusCode : "APNS_" + statusCode + ":" + reason;
     }
 

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -314,6 +314,53 @@ class NotificationServiceTest {
     }
 
     /**
+     * 토큰을 폐기하지 않는 실패({@code FAILED})에서 토큰이 살아남는지 <b>호출부에서</b> 고정한다 (이슈 #411).
+     *
+     * <p>#411 은 설정 오류로 인한 400 이 토큰을 죽이지 않도록 {@code PushSender} 안에서 좁혔다.
+     * 그런데 무효화를 실제로 수행하는 건 이쪽이다. 여기 조건이 넓어지면
+     * ({@code invalidatesToken()} 대신 "성공이 아니면 폐기" 같은 형태) 대량 무효화가 그대로
+     * 되살아나는데, {@code FAILED} 를 스텁하는 테스트가 없으면 빌드는 초록이다.
+     */
+    @Test
+    @DisplayName("[#411] 토큰을 폐기하지 않는 실패에서는 디바이스 토큰을 유지한다")
+    void sendNotificationToUser_nonInvalidatingFailure_keepsToken() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("ios").token("apns-token").build();
+        setField(token, "id", UUID.randomUUID());
+
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.of(PushSendStatus.FAILED, "APNS_400:TopicDisallowed"));
+
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
+
+        assertThat(token.isValid()).isTrue();
+        ArgumentCaptor<NotificationDeliveryResult> captor =
+                ArgumentCaptor.forClass(NotificationDeliveryResult.class);
+        // 무효화 대상 목록이 비어 있어야 한다 — 여기에 토큰이 실리면 영구 폐기된다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_morning"), captor.capture(), eq(List.of()), eq(true));
+        assertThat(captor.getValue().failureReason()).isEqualTo("APNS_400:TopicDisallowed");
+    }
+
+    @Test
+    @DisplayName("[#411] 테스트 푸시에서도 폐기 대상이 아닌 실패는 토큰을 유지한다")
+    void sendTestNotification_nonInvalidatingFailure_keepsToken() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("ios").token("apns-token").build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.of(PushSendStatus.FAILED, "APNS_403:InvalidProviderToken"));
+
+        notificationService.sendTestNotification(userId, "제목", "본문");
+
+        assertThat(token.isValid()).isTrue();
+        verify(deviceTokenRepository, never()).save(token);
+    }
+
+    /**
      * 주간 리포트 알림은 <b>리포트가 실제로 생성됐을 때만</b> 나가야 한다 (이슈 #413).
      *
      * <p>기존 구현은 "월요일 08시인가"만 보고 발송해, 체크인 부족으로 리포트가 없는 유저에게도

--- a/src/test/java/com/mio/notification/service/PushSenderTest.java
+++ b/src/test/java/com/mio/notification/service/PushSenderTest.java
@@ -15,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.Message;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
@@ -210,6 +211,9 @@ class PushSenderTest {
             assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
             assertThat(result.invalidatesToken()).isFalse();
             assertThat(result.failureReason()).isEqualTo("APNS_400");
+            // null 가드가 빠지면 NPE 가 send() 의 catch-all 에 잡혀 EXCEPTION:... 으로 둔갑한다.
+            // 위 두 단언은 그 경로에서도 통과하므로 이 단언이 실제 검출력을 갖는다.
+            assertThat(result.failureReason()).doesNotStartWith("EXCEPTION");
         }
 
         @Test
@@ -221,6 +225,49 @@ class PushSenderTest {
 
             assertThat(result.status()).isEqualTo(PushSendStatus.TOKEN_EXPIRED);
             assertThat(result.invalidatesToken()).isTrue();
+        }
+
+        /**
+         * 400·410 이 아닌 상태 코드도 토큰을 폐기해서는 안 된다.
+         *
+         * <p>이 경로가 고정되지 않으면 400 만 좁혀놓고 바로 옆 분기로 같은 대량 무효화가 되돌아온다.
+         * 특히 403 {@code ExpiredProviderToken} / {@code InvalidProviderToken} 은 키·팀 ID 오설정이라
+         * <b>모든</b> 요청이 받는다. JWT 가 캐시되므로 전 발송이 한꺼번에 죽는다.
+         */
+        @ParameterizedTest(name = "{0} {1} → 토큰 유지")
+        @CsvSource({
+                "403, InvalidProviderToken",
+                "403, ExpiredProviderToken",
+                "429, TooManyRequests",
+                "500, InternalServerError",
+                "503, ServiceUnavailable"
+        })
+        @DisplayName("400·410 외의 거절은 토큰을 폐기하지 않는다")
+        void send_nonTokenStatusCode_keepsToken(int statusCode, String reason) throws Exception {
+            stubApnsResponse(statusCode, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_" + statusCode + ":" + reason);
+        }
+
+        /**
+         * 응답 본문이 JSON 이 아닐 수 있다 (프록시·LB 가 HTML 오류 페이지를 반환하는 경우).
+         * {@code extractApnsReason} 은 이제 폐기 판정의 입력이므로 파싱 실패도 안전해야 한다.
+         */
+        @Test
+        @DisplayName("본문이 JSON 이 아니어도 파싱 실패로 죽지 않고 토큰을 유지한다")
+        void send_nonJsonBody_keepsToken() throws Exception {
+            stubApnsResponse(400, "<html><body>502 Bad Gateway</body></html>");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            // 파싱 예외가 send() 의 catch-all 로 새면 EXCEPTION:... 이 된다 — 그 경로가 아님을 고정한다
+            assertThat(result.failureReason()).isEqualTo("APNS_400");
         }
 
         private void stubApnsResponse(int statusCode, String body) throws Exception {

--- a/src/test/java/com/mio/notification/service/PushSenderTest.java
+++ b/src/test/java/com/mio/notification/service/PushSenderTest.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.Message;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -120,6 +122,112 @@ class PushSenderTest {
         assertThat(result.isAmbiguous()).isFalse();
         assertThat(result.failureReason()).isEqualTo("APNS_MALFORMED_TOKEN");
         verifyNoInteractions(httpClient);
+    }
+
+    /**
+     * 400 응답 중 <b>토큰 자체가 무효인 사유만</b> 토큰을 폐기한다 (이슈 #411).
+     *
+     * <p>이전에는 400 이면 사유와 무관하게 {@code INVALID_TOKEN} 이었다. 그런데 {@code apns-topic}
+     * 은 설정값이라 잘못 배포되면 <b>모든</b> 요청이 400 을 받고, 스케줄러 한 사이클에 정상 사용자
+     * 토큰이 전량 무효화된다. 복구는 유저가 앱을 다시 열어야 하는데 이 서비스에서는 푸시가 곧
+     * 재방문 유도 장치라 복구가 느리다.
+     */
+    @Nested
+    @DisplayName("APNs 400 사유별 토큰 폐기 판정")
+    class Apns400ReasonHandling {
+
+        @BeforeEach
+        void enableApns() throws Exception {
+            ReflectionTestUtils.setField(pushSender, "apnsPrivateKey", generateEcPrivateKey());
+        }
+
+        @ParameterizedTest(name = "{0} → 토큰 폐기")
+        @ValueSource(strings = {"BadDeviceToken"})
+        @DisplayName("토큰 자체가 무효인 사유는 토큰을 폐기한다")
+        void send_tokenSpecificReason_invalidatesToken(String reason) throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.INVALID_TOKEN);
+            assertThat(result.invalidatesToken()).isTrue();
+            assertThat(result.failureReason()).isEqualTo("APNS_400:" + reason);
+        }
+
+        /**
+         * 이 사유들은 토픽·우선순위·푸시타입 등 <b>요청 설정</b> 문제다. 토큰과 무관하므로 폐기하면
+         * 설정 오류 한 번에 전 유저 토큰이 죽는다.
+         */
+        @ParameterizedTest(name = "{0} → 토큰 유지")
+        @ValueSource(strings = {
+                "TopicDisallowed", "BadPriority", "InvalidPushType", "IdleTimeout",
+                "MissingDeviceToken", "BadExpirationDate", "BadTopic", "MissingTopic", "PayloadEmpty"
+        })
+        @DisplayName("설정·요청 문제인 사유는 토큰을 폐기하지 않는다")
+        void send_configurationReason_keepsToken(String reason) throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_400:" + reason);
+        }
+
+        /**
+         * 토큰이 다른 토픽·환경용일 수도, 우리 토픽 설정이 틀렸을 수도 있어 구분이 불가능하다.
+         * 후자면 전 유저가 한꺼번에 죽으므로 폐기하지 않는 쪽을 택한다.
+         */
+        @Test
+        @DisplayName("DeviceTokenNotForTopic 은 설정 오류와 구분되지 않으므로 토큰을 폐기하지 않는다")
+        void send_deviceTokenNotForTopic_keepsToken() throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"DeviceTokenNotForTopic\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+        }
+
+        @Test
+        @DisplayName("사유를 알 수 없는 400 은 보수적으로 토큰을 유지한다")
+        void send_unknownReason_keepsToken() throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"SomeFutureReason\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+        }
+
+        @Test
+        @DisplayName("본문이 비어 사유를 못 읽는 400 도 토큰을 유지한다")
+        void send_emptyBody_keepsToken() throws Exception {
+            stubApnsResponse(400, "");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_400");
+        }
+
+        @Test
+        @DisplayName("410 Unregistered 는 기존대로 토큰을 폐기한다")
+        void send_unregistered_stillInvalidates() throws Exception {
+            stubApnsResponse(410, "{\"reason\":\"Unregistered\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.TOKEN_EXPIRED);
+            assertThat(result.invalidatesToken()).isTrue();
+        }
+
+        private void stubApnsResponse(int statusCode, String body) throws Exception {
+            HttpResponse<String> response = stubResponse(statusCode, body);
+            when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenReturn(response);
+        }
     }
 
     /**


### PR DESCRIPTION
## 요약

APNs 가 400 을 반환하면 **사유와 무관하게** 디바이스 토큰을 영구 무효화하고 있었다. 400 에는 토큰과 무관한 요청·설정 문제가 다수 포함되어, 설정 하나가 틀리면 정상 사용자 토큰이 전량 무효화된다.

## 관련 이슈

- Closes #411

## 변경 사항

- `TOKEN_INVALIDATING_APNS_REASONS` 도입 — 400 응답의 `reason` 을 보고 토큰 폐기 여부를 결정
- 토큰과 무관한 400 은 `FAILED` 로만 기록하고 `log.error` 로 남긴다 (배포 사고가 개별 토큰 문제로 오인되지 않도록)
- `410 Unregistered` 는 기존대로 폐기

### 판정 기준

| APNs 응답 | 처리 |
|---|---|
| `410 Unregistered` | 토큰 폐기 (기존 유지) |
| `400 BadDeviceToken` | 토큰 폐기 |
| `400 DeviceTokenNotForTopic` | **유지** |
| `400 TopicDisallowed` / `BadPriority` / `InvalidPushType` / `IdleTimeout` / `MissingDeviceToken` / `BadExpirationDate` / `BadTopic` / `MissingTopic` / `PayloadEmpty` | 유지 |
| `400` + 알 수 없는 사유 / 본문 없음 | 유지 |

**`DeviceTokenNotForTopic` 을 제외한 이유**: 토큰이 다른 앱·토픽용일 수도, 우리 토픽 설정이 틀렸을 수도 있어 구분이 불가능하다. 후자면 전 유저가 한꺼번에 죽는다. Apple 포럼도 멀티 토픽·환경 운영 시에는 토큰을 지우지 말고 컨텍스트로 관리하라고 안내한다.

**알 수 없는 사유도 유지하는 이유**: Apple 이 사유를 추가했을 때 조용히 토큰을 죽이는 것보다, 발송 실패로 남겨 복구 가능한 상태로 두는 편이 낫다.

### 왜 개별 유저 문제가 아닌가

`apns-topic` 헤더는 설정값(`apnsBundleId`)이라 **모든 요청에 동일하게 적용**된다. 번들 ID 나 환경을 잘못 배포하면 스케줄러 한 사이클 안에 iOS 토큰 **전체**가 무효화된다.

복구는 유저가 앱을 다시 열어 재등록하는 것에 의존한다(#392 에서 `refreshToken` 이 되살리도록 유지). 그런데 이 서비스에서는 **푸시가 곧 재방문 유도 장치**라 알림이 끊긴 유저일수록 앱을 열지 않는다. 설정 오류 한 번이 조용한 장기 이탈로 이어진다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — 토큰 무효화 조건이 좁아진다
- [x] 로깅 / 모니터링 포인트가 변경됩니다. — 토큰과 무관한 400 을 `log.error` 로 승격
- [ ] Breaking change 가 있습니다.

무효화가 줄어드는 방향이므로 기존에 살아 있던 토큰이 죽는 일은 없다. 반대로 진짜 죽은 토큰이 조금 더 오래 남을 수 있으나, 발송 시 계속 실패로 기록되고 `410` 이 오면 폐기된다.

## 테스트

### 실행 커맨드

```bash
./gradlew build
```

### 확인 내용

TDD 로 진행했다. 사유별 판정을 파라미터화해 고정했다.

- `BadDeviceToken` → `INVALID_TOKEN`, `invalidatesToken() == true`
- 설정성 사유 9종 → `FAILED`, `invalidatesToken() == false`
- `DeviceTokenNotForTopic` → 유지 (별도 테스트로 의도를 명시)
- 알 수 없는 사유 / 빈 본문 → 유지
- `410 Unregistered` → 기존대로 폐기 (회귀 방지)

**테스트가 구현 버그를 하나 잡았다.** 빈 본문일 때 `reason` 이 `null` 인데 `Set.of()` 는 `contains(null)` 에서 NPE 를 던진다. null 을 먼저 거르도록 수정했다.

## 중점 리뷰 포인트

- **`BadDeviceToken` 을 폐기 대상에 남긴 판단.** Apple 포럼에 따르면 이 사유는 sandbox 토큰을 production 환경으로 보낼 때도 발생한다. 즉 `apns.is-production` 이 틀리면 이 사유로도 전량 무효화가 가능해 이 PR 이 그 경로까지 막지는 못한다. 상수 javadoc 에 한계로 명시했다. 더 근본적으로는 "한 사이클에서 무효화가 급증하면 개별 토큰 문제가 아니라 배포 사고" 라는 서킷 브레이커가 필요한데, 별도 설계라 범위에서 뺐다
- 폐기 대상 사유 목록이 적절한지 (설정성 사유를 더 넣거나 뺄 필요가 있는지)

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용. 마이그레이션·설정 변경 없음
- **Rollback**: 서버만 되돌리면 이전 동작(400 전량 폐기)으로 복귀

## 참고

- [Which apns errors should cause us to remove the tokens from our server's db? (Apple Developer Forums)](https://developer.apple.com/forums/thread/807380)
- [What should your server do when apns returns a 410 Unregistered error (Apple Developer Forums)](https://developer.apple.com/forums/thread/806522)
- [Fix DeviceTokenNotForTopic errors (AWS re:Post)](https://repost.aws/knowledge-center/sns-pinpoint-apns-devicetokennotfortopic)

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 스펙 변경 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Apple Push Notification Service failures.
  * Invalidates device tokens only when the service confirms they are invalid.
  * Preserves tokens for configuration, request, unknown, or incomplete error responses.
  * Retains existing handling for unregistered devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->