### PR TITLE
fix: 억제된 트리거가 나머지 알림까지 막지 않게 한다

### DIFF
--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -285,8 +285,10 @@ public class NotificationService {
      * {@code negative_emotion_streak} 는 시각 조건이 없어 조건이 참인 동안 매 틱 선택되므로,
      * 한 번 발송 후 24시간 억제에 들어가면 체크인 리마인더가 그 동안 전부 막힌다.
      *
-     * <p>각 후보의 시각 조건({@code dueOccurrenceDate})은 DB 조회 없는 순수 계산이라, 창에 들어온
-     * 트리거에 대해서만 존재 확인 쿼리가 나간다. 후보를 모두 모아도 쿼리 수는 사실상 그대로다.
+     * <p>쿼리 비용: 각 후보의 시각 조건({@code dueOccurrenceDate})은 DB 조회 없는 순수 계산이라
+     * 창에 들어온 트리거에 대해서만 존재 확인 쿼리가 나간다. 다만 <b>조기 return 이 없어지면서</b>
+     * 상위 후보가 이미 매치된 틱에서도 리포트·To-do 조회가 실행된다 — 각각 월요일 08:00~08:09,
+     * 매일 21:00~21:09 창에 한정된다. 억제 검사도 후보 수만큼(최대 6회) 나간다.
      */
     private List<String> determineTriggerCandidates(NotificationSetting setting, OffsetDateTime now) {
         UUID userId = setting.getUser().getId();
@@ -315,18 +317,17 @@ public class NotificationService {
     }
 
     /**
-     * 체크인 리마인더는 유저가 직접 고른 시각이므로 발송 시간대 제한을 두지 않는다.
+     * 판정 창 안에 도래한 체크인 리마인더를 <b>전부</b> 모은다 (이슈 #408).
+     *
+     * <p>체크인 리마인더는 유저가 직접 고른 시각이므로 발송 시간대 제한을 두지 않는다.
+     *
+     * <p>슬롯 시각이 가깝게 설정되면 한 창에 둘 이상이 함께 도래한다(프로덕션 실측: morning 22:50,
+     * afternoon 22:51). 하나만 반환하면 앞 슬롯 발송 후 억제되는 순간 뒤 슬롯이 영영 막힌다.
      *
      * <p>완료 여부는 반드시 <b>판정 시점의 날짜가 아니라 목표 시각의 발생일</b>로 조회한다.
      * 예를 들어 저녁 체크인을 {@code 23:58} 로 설정한 유저가 그날 23:56 에 체크인을 마쳤다면,
      * 다음 날 {@code 00:00} 틱에서도 판정 창(10분)은 아직 열려 있다. 이때 판정 시점 날짜로
      * 조회하면 전날 남긴 완료 기록을 놓쳐 이미 체크인한 유저에게 리마인더를 보내게 된다.
-     */
-    /**
-     * 판정 창 안에 도래한 체크인 리마인더를 <b>전부</b> 모은다 (이슈 #408).
-     *
-     * <p>슬롯 시각이 가깝게 설정되면 한 창에 둘 이상이 함께 도래한다(프로덕션 실측: morning 22:50,
-     * afternoon 22:51). 하나만 반환하면 앞 슬롯 발송 후 억제되는 순간 뒤 슬롯이 영영 막힌다.
      */
     private List<String> dueCheckinReminders(NotificationSetting setting, UUID userId, OffsetDateTime now) {
         List<String> due = new java.util.ArrayList<>();

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -267,40 +267,51 @@ public class NotificationService {
             return;
         }
 
-        String triggerCode = determineTrigger(setting, now);
-        if (triggerCode == null || shouldSuppressTrigger(userId, triggerCode, now)) {
-            return;
+        // 억제된 트리거는 그것만 건너뛰고 다음 후보를 이어서 본다 (이슈 #408).
+        // 억제는 "이 트리거를 지금 보내지 않는다" 는 뜻이지 "이 유저에게 아무것도 보내지 않는다" 가 아니다.
+        for (String triggerCode : determineTriggerCandidates(setting, now)) {
+            if (shouldSuppressTrigger(userId, triggerCode, now)) {
+                continue;
+            }
+            sendNotificationToUser(setting.getUser(), triggerCode, true);
+            return;   // 한 틱에 한 건만 발송한다
         }
-
-        sendNotificationToUser(setting.getUser(), triggerCode, true);
     }
 
-    private String determineTrigger(NotificationSetting setting, OffsetDateTime now) {
+    /**
+     * 지금 발송 조건을 만족하는 트리거를 <b>우선순위 순서대로 전부</b> 모은다 (이슈 #408).
+     *
+     * <p>하나만 반환하면 그것이 억제됐을 때 뒤 트리거가 평가조차 되지 않는다. 특히
+     * {@code negative_emotion_streak} 는 시각 조건이 없어 조건이 참인 동안 매 틱 선택되므로,
+     * 한 번 발송 후 24시간 억제에 들어가면 체크인 리마인더가 그 동안 전부 막힌다.
+     *
+     * <p>각 후보의 시각 조건({@code dueOccurrenceDate})은 DB 조회 없는 순수 계산이라, 창에 들어온
+     * 트리거에 대해서만 존재 확인 쿼리가 나간다. 후보를 모두 모아도 쿼리 수는 사실상 그대로다.
+     */
+    private List<String> determineTriggerCandidates(NotificationSetting setting, OffsetDateTime now) {
         UUID userId = setting.getUser().getId();
         boolean serverInitiatedAllowed = isWithinServerInitiatedWindow(now);
+        List<String> candidates = new java.util.ArrayList<>();
 
         if (setting.isCheckinEnabled() && serverInitiatedAllowed && hasNegativeEmotionStreak(userId)) {
-            return "negative_emotion_streak";
+            candidates.add("negative_emotion_streak");
         }
         if (setting.isCheckinEnabled()) {
-            String checkinTrigger = determineCheckinReminder(setting, userId, now);
-            if (checkinTrigger != null) {
-                return checkinTrigger;
-            }
+            candidates.addAll(dueCheckinReminders(setting, userId, now));
         }
         if (setting.isReportEnabled() && serverInitiatedAllowed) {
             Optional<LocalDate> reportDue = weeklyReportDueDate(now);
             if (reportDue.isPresent() && hasGeneratedWeeklyReport(userId, reportDue.get())) {
-                return "report_weekly";
+                candidates.add("report_weekly");
             }
         }
         if (setting.isCharacterEnabled() && setting.isTodoReminderOn() && serverInitiatedAllowed) {
             Optional<LocalDate> todoDue = dueOccurrenceDate(TODO_REMINDER_TIME, now);
             if (todoDue.isPresent() && hasIncompleteTodo(userId, todoDue.get())) {
-                return "todo_incomplete";
+                candidates.add("todo_incomplete");
             }
         }
-        return null;
+        return List.copyOf(candidates);
     }
 
     /**
@@ -311,20 +322,25 @@ public class NotificationService {
      * 다음 날 {@code 00:00} 틱에서도 판정 창(10분)은 아직 열려 있다. 이때 판정 시점 날짜로
      * 조회하면 전날 남긴 완료 기록을 놓쳐 이미 체크인한 유저에게 리마인더를 보내게 된다.
      */
-    private String determineCheckinReminder(NotificationSetting setting, UUID userId, OffsetDateTime now) {
-        Optional<LocalDate> morning = dueOccurrenceDate(setting.getCheckinMorningTime(), now);
-        if (morning.isPresent() && !hasCompletedCheckin(userId, morning.get(), "morning")) {
-            return "checkin_reminder_morning";
-        }
-        Optional<LocalDate> afternoon = dueOccurrenceDate(setting.getCheckinAfternoonTime(), now);
-        if (afternoon.isPresent() && !hasCompletedCheckin(userId, afternoon.get(), "afternoon")) {
-            return "checkin_reminder_afternoon";
-        }
-        Optional<LocalDate> evening = dueOccurrenceDate(setting.getCheckinEveningTime(), now);
-        if (evening.isPresent() && !hasCompletedCheckin(userId, evening.get(), "evening")) {
-            return "checkin_reminder_evening";
-        }
-        return null;
+    /**
+     * 판정 창 안에 도래한 체크인 리마인더를 <b>전부</b> 모은다 (이슈 #408).
+     *
+     * <p>슬롯 시각이 가깝게 설정되면 한 창에 둘 이상이 함께 도래한다(프로덕션 실측: morning 22:50,
+     * afternoon 22:51). 하나만 반환하면 앞 슬롯 발송 후 억제되는 순간 뒤 슬롯이 영영 막힌다.
+     */
+    private List<String> dueCheckinReminders(NotificationSetting setting, UUID userId, OffsetDateTime now) {
+        List<String> due = new java.util.ArrayList<>();
+        addIfDue(due, setting.getCheckinMorningTime(), userId, now, "morning", "checkin_reminder_morning");
+        addIfDue(due, setting.getCheckinAfternoonTime(), userId, now, "afternoon", "checkin_reminder_afternoon");
+        addIfDue(due, setting.getCheckinEveningTime(), userId, now, "evening", "checkin_reminder_evening");
+        return due;
+    }
+
+    private void addIfDue(List<String> due, LocalTime slotTime, UUID userId, OffsetDateTime now,
+                          String timeOfDay, String triggerCode) {
+        dueOccurrenceDate(slotTime, now)
+                .filter(occurrenceDate -> !hasCompletedCheckin(userId, occurrenceDate, timeOfDay))
+                .ifPresent(occurrenceDate -> due.add(triggerCode));
     }
 
     /**

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -314,6 +314,84 @@ class NotificationServiceTest {
     }
 
     /**
+     * 억제된 트리거는 <b>그 트리거만</b> 건너뛰고 다음 후보를 이어서 평가해야 한다 (이슈 #408).
+     *
+     * <p>기존 구현은 후보를 하나만 뽑아 그것이 억제되면 곧바로 종료했다. 그래서 우선순위가 높은
+     * 트리거가 24시간 억제에 들어가면 그 동안 뒤 트리거가 전부 차단됐다. 특히
+     * {@code negative_emotion_streak} 는 시각 조건이 없어 조건이 참인 동안 매 틱 선택되므로,
+     * <b>체크인 리마인더를 가장 필요로 하는 상태의 유저가 리마인더를 못 받게 된다.</b>
+     */
+    @Test
+    @DisplayName("[#408] 상위 트리거가 억제되면 다음 후보를 이어서 평가한다")
+    void processScheduledNotifications_suppressedTopTrigger_fallsThroughToNext() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        setField(setting, "checkinMorningTime", now.toLocalTime().truncatedTo(ChronoUnit.MINUTES));
+        stubSchedulerBasics(setting);
+
+        // 부정 감정 3연속 → negative_emotion_streak 가 최우선 후보로 잡힌다
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        // 그런데 이미 발송돼 24시간 억제 중이다
+        suppressOnly("negative_emotion_streak");
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(false);
+
+        notificationService.processScheduledNotifications();
+
+        // 유저 전체가 막히지 않고 아침 체크인 리마인더가 나가야 한다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_morning"), any(), any(), eq(true));
+    }
+
+    /**
+     * 케이스 B — 같은 판정 창 안에 두 체크인 슬롯이 함께 도래하는 경우.
+     * 프로덕션에서 morning 22:50 / afternoon 22:51 설정으로 실측된 증상이다.
+     */
+    @Test
+    @DisplayName("[#408] 같은 창에 두 체크인 슬롯이 도래하면 앞 슬롯 발송 후 뒤 슬롯도 발송한다")
+    void processScheduledNotifications_twoCheckinSlotsDue_sendsSecondAfterFirstSuppressed() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        // 프로덕션 실측 케이스: morning 22:50 / afternoon 22:51 에 22:55 틱 → 둘 다 판정 창 안
+        LocalTime morningSlot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", morningSlot);
+        setField(setting, "checkinAfternoonTime", morningSlot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        // 아침은 이미 발송됨 → 억제. 오후는 아직
+        suppressOnly("checkin_reminder_morning");
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(false);
+
+        notificationService.processScheduledNotifications();
+
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_afternoon"), any(), any(), eq(true));
+    }
+
+    @Test
+    @DisplayName("[#408] 후보가 전부 억제되면 아무것도 발송하지 않는다")
+    void processScheduledNotifications_allCandidatesSuppressed_sendsNothing() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        setField(setting, "checkinMorningTime", now.toLocalTime().truncatedTo(ChronoUnit.MINUTES));
+        stubSchedulerBasics(setting);
+
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(true);
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(false);
+
+        notificationService.processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    /**
      * 토큰을 폐기하지 않는 실패({@code FAILED})에서 토큰이 살아남는지 <b>호출부에서</b> 고정한다 (이슈 #411).
      *
      * <p>#411 은 설정 오류로 인한 400 이 토큰을 죽이지 않도록 {@code PushSender} 안에서 좁혔다.
@@ -1158,6 +1236,28 @@ class NotificationServiceTest {
         verify(notificationPersistenceService, never()).persistNotificationResult(
                 any(), anyString(), any(), any(), anyBoolean()
         );
+    }
+
+    /** 트리거 판정 직전까지의 공통 조건을 통과시킨다 — 트리거 선택만이 결과를 가르게 한다. */
+    private void stubSchedulerBasics(NotificationSetting setting) {
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
+                new org.springframework.data.domain.SliceImpl<>(List.of(setting)));
+        lenient().when(valueOperations.get(anyString())).thenReturn(null);
+        lenient().when(proactiveCareLogRepository.countByUser_IdAndNotificationStatusInAndSentAtBetween(
+                eq(userId), any(), any(), any())).thenReturn(0L);
+        lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(
+                DeviceToken.builder().user(user).deviceId("device-1").platform("android").token("fcm-token").build()));
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+    }
+
+    /** 지정한 트리거만 억제 상태로 만든다. 나머지는 발송 가능. */
+    private void suppressOnly(String suppressedTriggerCode) {
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any()))
+                .thenAnswer(invocation -> suppressedTriggerCode.equals(invocation.getArgument(1)));
     }
 
     /** 월요일 08:00 KST 시점의 서비스. 주간 리포트 발송 조건을 만족하는 유일한 시각이다. */

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.mio.common.error.BusinessException;
@@ -334,8 +335,7 @@ class NotificationServiceTest {
                 .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
         // 그런데 이미 발송돼 24시간 억제 중이다
         suppressOnly("negative_emotion_streak");
-        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
-                .thenReturn(false);
+        stubCheckinCompletion(Set.of());
 
         notificationService.processScheduledNotifications();
 
@@ -353,7 +353,10 @@ class NotificationServiceTest {
     void processScheduledNotifications_twoCheckinSlotsDue_sendsSecondAfterFirstSuppressed() {
         OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
         NotificationSetting setting = NotificationSetting.builder().user(user).build();
-        // 프로덕션 실측 케이스: morning 22:50 / afternoon 22:51 에 22:55 틱 → 둘 다 판정 창 안
+        // 두 슬롯을 1분 차로 두고 판정 창(10분) 안의 틱에서 평가한다.
+        // 프로덕션 실측은 morning 22:50 / afternoon 22:51 이었으나, 22:55 는 서버 주도 발송 창
+        // (08:00~22:00) 밖이라 streak·report·todo 후보가 아예 생기지 않는다. 폴스루 자체를
+        // 보려면 창 안이어야 하므로 시각만 옮겼다 — 슬롯 간격과 창 폭은 실측과 동일하다.
         LocalTime morningSlot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
         setField(setting, "checkinMorningTime", morningSlot);
         setField(setting, "checkinAfternoonTime", morningSlot.plusMinutes(1));
@@ -362,8 +365,7 @@ class NotificationServiceTest {
         when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
         // 아침은 이미 발송됨 → 억제. 오후는 아직
         suppressOnly("checkin_reminder_morning");
-        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
-                .thenReturn(false);
+        stubCheckinCompletion(Set.of());
 
         notificationService.processScheduledNotifications();
 
@@ -371,24 +373,133 @@ class NotificationServiceTest {
                 eq(userId), eq("checkin_reminder_afternoon"), any(), any(), eq(true));
     }
 
+    /**
+     * 후보가 여럿 살아 있어도 <b>한 틱에 한 건</b>만, 그리고 <b>가장 높은 우선순위</b>가 나가야 한다.
+     *
+     * <p>이 두 성질이 #408 이 새로 허용하게 된 위험의 정확한 반대편이다. 루프의 {@code return} 이
+     * 빠지면 한 틱에 여러 건이 나가고, 일일 한도는 루프 진입 전에 한 번만 검사되므로 틱 안에서
+     * 우회된다. 후보 순서가 뒤집히면 항상 최하위 우선순위가 선택된다.
+     *
+     * <p>단일 후보만 있는 테스트로는 둘 다 잡히지 않는다 — 루프가 두 번째 기회를 갖지 못하기 때문이다.
+     */
     @Test
-    @DisplayName("[#408] 후보가 전부 억제되면 아무것도 발송하지 않는다")
-    void processScheduledNotifications_allCandidatesSuppressed_sendsNothing() {
+    @DisplayName("[#408] 억제 없는 후보가 둘이면 상위 우선순위 하나만 발송한다")
+    void processScheduledNotifications_multipleUnsuppressed_sendsOnlyHighestPriority() {
         OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
         NotificationSetting setting = NotificationSetting.builder().user(user).build();
         setField(setting, "checkinMorningTime", now.toLocalTime().truncatedTo(ChronoUnit.MINUTES));
         stubSchedulerBasics(setting);
 
-        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        // streak(최우선) 과 morning 이 모두 후보가 되고 어느 것도 억제되지 않는다
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(false);
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        // 정확히 1건 — return 이 빠지면 morning 까지 나가 2건이 된다
+        verify(notificationPersistenceService, times(1))
+                .persistNotificationResult(any(), anyString(), any(), any(), anyBoolean());
+        // 그 1건은 상위 우선순위여야 한다 — 순서가 뒤집히면 morning 이 나간다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("negative_emotion_streak"), any(), any(), eq(true));
+    }
+
+    /**
+     * 억제 검사가 <b>모든</b> 후보에 적용되는지 고정한다.
+     *
+     * <p>#408 이전에는 틱당 억제 검사가 1회였는데 이제 후보 수만큼이다. 첫 후보에만 적용하도록
+     * 바꿔도 결과가 같아 보이는 경우가 있어, 검사 호출 횟수를 직접 센다. 여기가 깨지면
+     * 24시간 억제가 무력화돼 같은 알림이 중복 도착한다 — #389 가 막으려던 실패다.
+     */
+    @Test
+    @DisplayName("[#408] 후보가 전부 억제되면 각 후보를 모두 검사하고 아무것도 발송하지 않는다")
+    void processScheduledNotifications_allCandidatesSuppressed_checksEachAndSendsNothing() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        // streak + morning + afternoon = 후보 3개, 전부 억제
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
         lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
                 eq(userId), anyString(), any(), any())).thenReturn(true);
-        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
-                .thenReturn(false);
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        // 후보가 3개인데 1개만 검사하고 끝나면 억제 우회 버그다
+        verify(proactiveCareLogRepository, times(3))
+                .existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any());
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    /**
+     * 상위 후보가 아니라 <b>두 번째</b> 후보가 억제된 경우에도 정상 동작해야 한다.
+     * 첫 후보에만 억제를 적용하는 구현은 여기서 두 번째를 그대로 발송해버린다.
+     */
+    /**
+     * 슬롯별 {@code timeOfDay} 라벨이 트리거 코드와 짝이 맞는지 고정한다.
+     *
+     * <p>리팩터링으로 세 슬롯이 {@code addIfDue(..., timeOfDay, triggerCode)} 헬퍼를 공유하게 되면서
+     * 두 문자열이 독립 인자가 됐다. 짝이 어긋나면 이미 오후 체크인을 한 유저에게 오후 리마인더가
+     * 나가거나, 반대로 하지 않은 유저에게 조용히 나가지 않는다.
+     */
+    @Test
+    @DisplayName("[#408] 오후 체크인을 완료했으면 오후 리마인더만 후보에서 빠진다")
+    void processScheduledNotifications_afternoonCompleted_skipsOnlyAfternoon() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        // morning 만 억제 → 정상이면 afternoon 이 다음 후보지만, 오후 체크인을 이미 했으므로 후보가 아니다
+        suppressOnly("checkin_reminder_morning");
+        stubCheckinCompletion(Set.of("afternoon"));
 
         notificationService.processScheduledNotifications();
 
         verifyNoInteractions(pushSender);
         verifyNoInteractions(notificationPersistenceService);
+    }
+
+    @Test
+    @DisplayName("[#408] 두 번째 후보가 억제되면 그것을 건너뛰고 세 번째를 발송한다")
+    void processScheduledNotifications_secondCandidateSuppressed_skipsToThird() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        // 후보: streak, morning, afternoon — 앞의 둘이 억제
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any()))
+                .thenAnswer(invocation -> {
+                    String code = invocation.getArgument(1);
+                    return "negative_emotion_streak".equals(code) || "checkin_reminder_morning".equals(code);
+                });
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        verify(notificationPersistenceService, times(1))
+                .persistNotificationResult(any(), anyString(), any(), any(), anyBoolean());
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_afternoon"), any(), any(), eq(true));
     }
 
     /**
@@ -1251,6 +1362,16 @@ class NotificationServiceTest {
                 DeviceToken.builder().user(user).deviceId("device-1").platform("android").token("fcm-token").build()));
         lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
                 .thenReturn(PushSendResult.sent());
+    }
+
+    /**
+     * 완료된 체크인 슬롯을 지정한다. 스텁이 <b>실제 slot 인자에 반응</b>하므로,
+     * 구현이 슬롯별 {@code timeOfDay} 라벨을 잘못 넘기면(예: afternoon 을 "morning" 으로 조회)
+     * 결과가 달라져 테스트가 깨진다. {@code anyString() → false} 로 두면 그 구분이 사라진다.
+     */
+    private void stubCheckinCompletion(Set<String> completedSlots) {
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenAnswer(invocation -> completedSlots.contains(invocation.<String>getArgument(2)));
     }
 
     /** 지정한 트리거만 억제 상태로 만든다. 나머지는 발송 가능. */


### PR DESCRIPTION
## 요약

`evaluateAndSend` 가 트리거 후보를 **하나만** 받아 그것이 억제되면 곧바로 종료했다. 억제는 "이 트리거를 지금 보내지 않는다" 는 뜻인데 **"이 유저에게 아무것도 보내지 않는다"** 로 동작했다.

## 관련 이슈

- Closes #408

## 변경 사항

- `determineTrigger` → `determineTriggerCandidates` — 조건을 만족하는 트리거를 **우선순위 순서대로 전부** 반환
- `evaluateAndSend` — 억제된 후보만 건너뛰고 다음을 평가. 첫 발송 가능한 트리거 하나를 보낸다
- `determineCheckinReminder` → `dueCheckinReminders` — 판정 창에 도래한 체크인 슬롯을 **전부** 수집

한 틱에 한 건만 발송한다는 기존 성질은 유지된다.

### 케이스 A — 서버 주도 트리거가 전부 가리는 경우

`negative_emotion_streak` 는 시각 조건이 없어 조건이 참인 동안 매 틱 최우선으로 선택된다. 한 번 발송되면 24시간 억제에 들어가고, 그 동안 체크인 리마인더·주간 리포트·Todo 리마인더가 전부 차단됐다.

판정이 `findTop3ByUser_IdOrderByCreatedAtDesc` 로 **날짜 무관 최근 3건**을 보므로, 체크인을 하지 않으면 조건이 계속 참으로 남는다. **체크인을 유도하는 알림이 막혀 있으니 그 상태를 벗어날 계기도 줄어든다** — 정서 코칭 서비스에서 리마인더가 가장 필요한 상태의 유저에게 리마인더가 끊긴다.

### 케이스 B — 같은 창에 두 슬롯이 도래 (프로덕션 실측)

morning 22:50 / afternoon 22:51 설정에서 22:55 틱에 둘 다 판정 창 안이다. 앞 슬롯이 발송되어 억제되는 순간 뒤 슬롯이 영영 막혔다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — 트리거 선택 로직
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

**발송량이 늘어나는 방향이다.** 다만 일일 발송 한도(3회)와 24시간 트리거별 억제는 그대로라 상한은 변하지 않는다. 지금까지 차단되던 알림이 정상화되는 것이다.

## 테스트

```bash
./gradlew build
```

TDD 로 진행했다. 테스트를 먼저 작성해 2건 실패(RED)를 확인하고 구현했다.

- 상위 트리거 억제 시 다음 후보로 이어짐 (케이스 A)
- 같은 창 두 슬롯 중 앞이 억제되면 뒤가 발송됨 (케이스 B)
- 후보 전부 억제 시 아무것도 발송하지 않음

**뮤테이션 검증**

| 뮤테이션 | 결과 |
|---|---|
| 억제 시 `continue` → `return` (기존 버그 복원) | 🔴 2건 실패 |
| 체크인 슬롯을 첫 매칭에서 중단 (기존 동작 복원) | 🔴 1건 실패 |

## 중점 리뷰 포인트

- 후보를 모두 모으면서 쿼리가 늘지 않는지. 시각 조건(`dueOccurrenceDate`)은 DB 조회 없는 순수 계산이라 창에 들어온 트리거에 대해서만 존재 확인 쿼리가 나간다고 판단했다
- `negative_emotion_streak` 의 "날짜 무관 최근 3건" 판정 자체는 이 PR 범위 밖으로 뒀다. 조건이 계속 참으로 남는 성질은 그대로다

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용
- **Rollback**: 서버만 되돌리면 이전 동작으로 복귀

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 스펙 변경 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notification scheduling now skips individually suppressed triggers and can select an eligible lower-priority notification instead.
  * Multiple due, incomplete check-in time slots are now evaluated correctly.
  * Only one highest-priority eligible notification is sent per scheduling cycle.
  * Completion status is checked independently for each check-in time slot.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->