### PR TITLE
ci: 배포에 기동 헬스 게이트를 추가한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -130,9 +130,63 @@ jobs:
 
             docker image prune -f
 
-            sleep 45
-            echo "=== app logs ==="
-            docker compose -f docker-compose.prod.yml logs app --tail=80
+            # ── 기동 헬스 게이트 (이슈 #375) ─────────────────────────────
+            # 이전에는 sleep 45 후 로그만 덤프했다. 2026-08-07 배포에서 앱이 크래시 루프에
+            # 빠져 스택트레이스가 이 출력에 그대로 찍혔는데도, 결과를 종료 코드에 반영하지
+            # 않아 워크플로우가 success 로 끝났다. 장애를 파이프라인이 아니라 사람이 뒤늦게
+            # 발견했다.
+            #
+            # 관리 포트(9090)는 외부에서 도달할 수 없도록 의도적으로 publish 하지 않으므로
+            # (application.yml 참고) 컨테이너 안에서 조회한다. 8080 은 인증이 걸려 있어
+            # 401 이 오기 때문에 헬스 판정에 쓸 수 없다.
+            HEALTH_ATTEMPTS=${HEALTH_ATTEMPTS:-36}   # 5초 간격 × 36 = 최대 180초
+            HEALTH_INTERVAL=${HEALTH_INTERVAL:-5}
+            healthy=0
+            for i in $(seq 1 $HEALTH_ATTEMPTS); do
+              cid=$(docker compose -f docker-compose.prod.yml ps -q app)
+              if [ -z "$cid" ]; then
+                echo "[health] app 컨테이너가 없다 (attempt $i)"
+                sleep "$HEALTH_INTERVAL"
+                continue
+              fi
+
+              state=$(docker inspect -f '{{.State.Status}}' "$cid")
+              # RestartCount 는 .State 가 아니라 최상위 필드다. 경로를 틀리면 빈 문자열이 나오고
+              # 아래 정수 비교가 조용히 실패해 크래시 루프 감지가 통째로 무력화된다.
+              restarts=$(docker inspect -f '{{.RestartCount}}' "$cid" 2>/dev/null || echo 0)
+              restarts=${restarts:-0}
+              # up -d 로 재생성된 컨테이너의 RestartCount 는 0 에서 시작한다.
+              # 0 보다 크면 이번 배포 이후 크래시했다는 뜻이므로 더 기다릴 이유가 없다.
+              if [ "$state" = "restarting" ] || [ "$restarts" -gt 0 ]; then
+                echo "[health] 크래시 루프 감지 — state=$state restarts=$restarts"
+                break
+              fi
+
+              if docker compose -f docker-compose.prod.yml exec -T app \
+                   wget -qO- --timeout=3 http://127.0.0.1:9090/actuator/health 2>/dev/null \
+                   | grep -q '"status":"UP"'; then
+                echo "[health] UP (attempt $i)"
+                healthy=1
+                break
+              fi
+              sleep "$HEALTH_INTERVAL"
+            done
+
+            if [ "$healthy" != "1" ]; then
+              echo "::error::기동 헬스 게이트 실패 — 배포를 실패로 처리한다"
+              echo "=== container state ==="
+              docker compose -f docker-compose.prod.yml ps app || true
+              cid=$(docker compose -f docker-compose.prod.yml ps -q app || true)
+              if [ -n "$cid" ]; then
+                docker inspect -f 'status={{.State.Status}} restarts={{.RestartCount}} exit={{.State.ExitCode}}' "$cid" || true
+              fi
+              echo "=== app logs (tail 200) ==="
+              docker compose -f docker-compose.prod.yml logs app --tail=200 || true
+              exit 1
+            fi
+
+            echo "=== app logs (tail 40) ==="
+            docker compose -f docker-compose.prod.yml logs app --tail=40
 
       - name: Close SSH on security group (always runs)
         if: always()

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,85 +108,138 @@ jobs:
           APP_BELIEF_IDENTITY_HMAC_KEY: ${{ secrets.APP_BELIEF_IDENTITY_HMAC_KEY }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
+          # 기동 헬스 게이트가 "새 이미지가 실제로 돌고 있는지" 확인하는 데 쓴다 (이슈 #375).
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          HEALTH_ATTEMPTS: "36"
+          HEALTH_INTERVAL: "5"
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: ENV_FILE,APP_BELIEF_IDENTITY_HMAC_KEY,GHCR_TOKEN,GHCR_ACTOR
+          envs: ENV_FILE,APP_BELIEF_IDENTITY_HMAC_KEY,GHCR_TOKEN,GHCR_ACTOR,IMAGE_DIGEST,IMAGE_REF,HEALTH_ATTEMPTS,HEALTH_INTERVAL
           script: |
-            cd ~/mio
+            set -u
+            COMPOSE="docker compose -f docker-compose.prod.yml"
+
+            cd ~/mio || { echo "::error::~/mio 로 이동 실패"; exit 1; }
 
             printf '%s\nAPP_BELIEF_IDENTITY_HMAC_KEY=%s\n' \
               "$ENV_FILE" "$APP_BELIEF_IDENTITY_HMAC_KEY" > .env
 
-            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+            # ── 배포 전 기준선 (이슈 #375) ─────────────────────────────
+            # RestartCount 는 컨테이너를 재생성해야 0 으로 돌아간다. up -d 가 항상 재생성하는 것은
+            # 아니어서(같은 digest 재배포, pull 실패 등) 기존 값을 기준선으로 잡지 않으면
+            # "과거에 한 번 재시작했지만 지금 정상" 인 컨테이너를 크래시로 오판한다.
+            prev_cid=$($COMPOSE ps -aq app 2>/dev/null || true)
+            prev_restarts=0
+            if [ -n "$prev_cid" ]; then
+              prev_restarts=$(docker inspect -f '{{.RestartCount}}' "$prev_cid" 2>/dev/null || echo 0)
+            fi
+            echo "[deploy] 기준선 cid=${prev_cid:-none} restarts=$prev_restarts"
 
-            docker compose -f docker-compose.prod.yml pull
+            # 아래 세 단계는 실패하면 즉시 중단해야 한다. ssh-action 의 script_stop 기본값이
+            # false 라 스크립트는 첫 실패에서 멈추지 않는다. 그대로 진행하면 로컬에 남아 있는
+            # :latest 로 기존 컨테이너가 유지되고, 헬스 게이트가 "구 코드"에서 UP 을 받아
+            # 배포를 초록불로 끝낸다.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin \
+              || { echo "::error::GHCR 로그인 실패"; exit 1; }
+
+            $COMPOSE pull || { echo "::error::이미지 pull 실패 — 구 이미지로 배포하지 않는다"; exit 1; }
 
             # up -d: 이미지가 갱신된 app 컨테이너만 재생성하고 postgres/redis 볼륨은 보존한다.
             # (과거 'down -v'는 매 배포마다 named volume을 삭제해 DB가 전부 초기화되는 문제가 있었음.
             #  비밀번호 변경 등으로 볼륨 리셋이 필요하면 워크플로우가 아니라 수동 1회 작업으로 수행한다.)
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
-
-            docker image prune -f
+            $COMPOSE up -d --remove-orphans || { echo "::error::compose up 실패"; exit 1; }
 
             # ── 기동 헬스 게이트 (이슈 #375) ─────────────────────────────
-            # 이전에는 sleep 45 후 로그만 덤프했다. 2026-08-07 배포에서 앱이 크래시 루프에
-            # 빠져 스택트레이스가 이 출력에 그대로 찍혔는데도, 결과를 종료 코드에 반영하지
-            # 않아 워크플로우가 success 로 끝났다. 장애를 파이프라인이 아니라 사람이 뒤늦게
-            # 발견했다.
+            # 이전에는 sleep 45 후 로그만 덤프하고 결과를 종료 코드에 반영하지 않았다. 2026-08-07
+            # 배포에서 앱이 크래시 루프에 빠졌는데도 워크플로우가 success 로 끝나, 장애를
+            # 파이프라인이 아니라 사람이 뒤늦게 발견했다.
             #
-            # 관리 포트(9090)는 외부에서 도달할 수 없도록 의도적으로 publish 하지 않으므로
-            # (application.yml 참고) 컨테이너 안에서 조회한다. 8080 은 인증이 걸려 있어
-            # 401 이 오기 때문에 헬스 판정에 쓸 수 없다.
-            HEALTH_ATTEMPTS=${HEALTH_ATTEMPTS:-36}   # 5초 간격 × 36 = 최대 180초
-            HEALTH_INTERVAL=${HEALTH_INTERVAL:-5}
+            # 헬스는 컨테이너 안에서 관리 포트(9090)로 조회한다. 이 포트는 외부에서 도달할 수
+            # 없도록 의도적으로 publish 하지 않으며, 8080 은 인증이 걸려 401 이 오므로 판정에
+            # 쓸 수 없다.
+            started_at=$(date +%s)
             healthy=0
-            for i in $(seq 1 $HEALTH_ATTEMPTS); do
-              cid=$(docker compose -f docker-compose.prod.yml ps -q app)
+            fail_reason=""
+            for i in $(seq 1 "$HEALTH_ATTEMPTS"); do
+              # -aq 로 조회한다. 기동 실패로 exited 상태인 컨테이너는 -q 에 잡히지 않아
+              # 진단이 정확히 필요한 순간에 비어버린다.
+              cid=$($COMPOSE ps -aq app 2>/dev/null || true)
               if [ -z "$cid" ]; then
                 echo "[health] app 컨테이너가 없다 (attempt $i)"
                 sleep "$HEALTH_INTERVAL"
                 continue
               fi
 
-              state=$(docker inspect -f '{{.State.Status}}' "$cid")
+              state=$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || echo unknown)
               # RestartCount 는 .State 가 아니라 최상위 필드다. 경로를 틀리면 빈 문자열이 나오고
-              # 아래 정수 비교가 조용히 실패해 크래시 루프 감지가 통째로 무력화된다.
+              # 아래 정수 비교가 조용히 실패해 크래시 감지가 통째로 무력화된다.
               restarts=$(docker inspect -f '{{.RestartCount}}' "$cid" 2>/dev/null || echo 0)
               restarts=${restarts:-0}
-              # up -d 로 재생성된 컨테이너의 RestartCount 는 0 에서 시작한다.
-              # 0 보다 크면 이번 배포 이후 크래시했다는 뜻이므로 더 기다릴 이유가 없다.
-              if [ "$state" = "restarting" ] || [ "$restarts" -gt 0 ]; then
-                echo "[health] 크래시 루프 감지 — state=$state restarts=$restarts"
-                break
+
+              # 컨테이너가 교체됐으면 0 부터, 유지됐으면 기준선부터 증가분만 본다.
+              base=0
+              if [ "$cid" = "$prev_cid" ]; then base=$prev_restarts; fi
+
+              case "$state" in
+                exited|dead)
+                  fail_reason="컨테이너가 종료됨 (state=$state)"; break ;;
+              esac
+              if [ "$state" = "restarting" ] || [ "$restarts" -gt "$base" ]; then
+                fail_reason="크래시 루프 감지 (state=$state restarts=$restarts base=$base)"; break
               fi
 
-              if docker compose -f docker-compose.prod.yml exec -T app \
+              # 최상위 status 만 본다. show-details 로 하위 컴포넌트 status 가 함께 실리므로
+              # 앵커 없이 매칭하면 최상위가 UNKNOWN(HTTP 200)인데 통과할 수 있다.
+              if $COMPOSE exec -T app \
                    wget -qO- --timeout=3 http://127.0.0.1:9090/actuator/health 2>/dev/null \
-                   | grep -q '"status":"UP"'; then
-                echo "[health] UP (attempt $i)"
+                   | grep -q '^{"status":"UP"'; then
                 healthy=1
                 break
               fi
               sleep "$HEALTH_INTERVAL"
             done
+            elapsed=$(( $(date +%s) - started_at ))
+
+            # 살아 있는 것만으로는 부족하다 — 새 이미지가 돌고 있는지 확인한다.
+            if [ "$healthy" = "1" ] && [ -n "${IMAGE_DIGEST:-}" ]; then
+              running_image=$(docker inspect -f '{{.Image}}' "$cid" 2>/dev/null || echo "")
+              if [ -n "$running_image" ] && \
+                 ! docker image inspect "$running_image" -f '{{join .RepoDigests "\n"}}' 2>/dev/null \
+                     | grep -q "$IMAGE_DIGEST"; then
+                healthy=0
+                fail_reason="실행 중 이미지가 이번 빌드와 다르다 (기대 digest=$IMAGE_DIGEST)"
+              fi
+            fi
 
             if [ "$healthy" != "1" ]; then
-              echo "::error::기동 헬스 게이트 실패 — 배포를 실패로 처리한다"
+              echo "::error::기동 헬스 게이트 실패 (${elapsed}s) — ${fail_reason:-타임아웃}"
               echo "=== container state ==="
-              docker compose -f docker-compose.prod.yml ps app || true
-              cid=$(docker compose -f docker-compose.prod.yml ps -q app || true)
-              if [ -n "$cid" ]; then
-                docker inspect -f 'status={{.State.Status}} restarts={{.RestartCount}} exit={{.State.ExitCode}}' "$cid" || true
+              $COMPOSE ps -a app || true
+              if [ -n "${cid:-}" ]; then
+                docker inspect -f 'status={{.State.Status}} restarts={{.RestartCount}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' "$cid" || true
               fi
-              echo "=== app logs (tail 200) ==="
-              docker compose -f docker-compose.prod.yml logs app --tail=200 || true
+              # app 로그는 여기서 볼 수 없다. logging.driver 가 awslogs 이고 awslogs 는 읽기를
+              # 지원하지 않아 docker logs / compose logs 가 아무것도 반환하지 않는다(compose 는
+              # 경고만 남기고 exit 0 이라 조용히 비어 보인다). CloudWatch 에서 확인해야 한다.
+              echo "=== app logs ==="
+              echo "로그는 CloudWatch 로그 그룹 /mio/app 에서 확인한다 (awslogs 는 docker logs 미지원)."
+              echo "  aws logs tail /mio/app --since 10m --region ap-northeast-2"
+              echo "=== 수동 롤백 ==="
+              echo "  직전 성공 커밋의 sha- 태그로 되돌린다:"
+              echo "  docker pull $IMAGE_REF:sha-<PREV_SHA>"
+              echo "  docker tag $IMAGE_REF:sha-<PREV_SHA> $IMAGE_REF:latest"
+              echo "  docker compose -f docker-compose.prod.yml up -d app"
               exit 1
             fi
 
-            echo "=== app logs (tail 40) ==="
-            docker compose -f docker-compose.prod.yml logs app --tail=40
+            echo "[health] UP (${elapsed}s, attempt $i)"
+
+            # prune 은 게이트 통과 후에 한다. 게이트 전에 돌리면 방금 밀려난 이전 :latest 가
+            # dangling 으로 지워져, 실패를 선언한 시점에 되돌릴 로컬 이미지가 남지 않는다.
+            docker image prune -f
 
       - name: Close SSH on security group (always runs)
         if: always()


### PR DESCRIPTION
## 요약

2026-08-07 배포에서 앱이 크래시 루프에 빠졌는데도 워크플로우가 `success` 로 끝났다. 배포 스텝이 `sleep 45` 후 로그를 덤프하고 있어 **크래시 스택트레이스가 CD 출력에 그대로 찍혀 있었는데도** 종료 코드에 반영하지 않았다.

고정 대기를 헬스 폴링으로 바꾸고, 통과하지 못하면 배포를 실패로 끝낸다.

## 관련 이슈

- Closes #375

## 변경 사항

- `sleep 45` → 헬스 폴링 게이트 (5초 간격, 최대 180초). **정상 배포는 오히려 빨라진다** — UP 확인 즉시 넘어간다
- 컨테이너 상태·`RestartCount` 확인 — 크래시했으면 타임아웃까지 기다리지 않고 즉시 실패
- 실패 시 컨테이너 상태 + 로그 200줄을 출력하고 `exit 1`
- `HEALTH_ATTEMPTS` / `HEALTH_INTERVAL` 을 오버라이드 가능하게 해 검증 가능성 확보

### 헬스 조회 경로 선택

| 후보 | 결과 |
|---|---|
| 호스트 → `8080/actuator/health` | **401** (인증 필요) — 판정 불가 |
| 호스트 → `9090/actuator/health` | 연결 불가 — publish 하지 않음 |
| **컨테이너 내부 → `9090/actuator/health`** | `{"status":"UP",...}` ✅ |

관리 포트는 `application.yml` 주석에 **의도적으로 publish 하지 않는다**고 명시돼 있어 그 결정을 유지했다. 컨테이너에 `curl` 은 없고 `wget` 이 있어 `wget` 을 쓴다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. — 배포 실패 판정이 생긴다
- [ ] Breaking change 가 있습니다.

**게이트 추가 후에는 기동 실패 시 배포가 실패로 표시되므로, 기존에 조용히 넘어가던 문제가 드러날 수 있다.** 그게 목적이다.

## 테스트

프로덕션 서버가 아니라 **로컬 docker compose 로 4가지 시나리오를 재현**해 검증했다. 이 게이트의 핵심은 "실패했을 때 실패로 끝나는가" 인데, 그건 실패를 실제로 만들어봐야 확인된다.

| 시나리오 | 기대 | 결과 |
|---|---|---|
| 정상 기동 | exit 0 | ✅ `[health] UP (attempt 1)` |
| 즉시 크래시 반복 | exit 1 | ✅ `크래시 루프 감지 — state=restarting restarts=5` |
| 기동 후 크래시 | exit 1 | ✅ `크래시 루프 감지 — state=running restarts=1` |
| 기동됐으나 헬스 미응답 | exit 1 | ✅ 타임아웃 후 실패 |

### 검증에서 발견한 버그

초안은 `docker inspect -f '{{.State.RestartCount}}'` 를 썼는데 **`RestartCount` 는 `.State` 가 아니라 최상위 필드다.** 경로가 틀리면 빈 문자열이 반환되고 `[ "" -gt 0 ]` 이 `integer expression expected` 로 조용히 실패해 **크래시 감지가 통째로 무력화**돼 있었다. 정상 경로만 확인했다면 놓쳤을 버그다.

## 중점 리뷰 포인트

- 타임아웃 180초가 적절한지. 현재 프로덕션 기동은 약 22초다 (`Started MioApplication in 22.157 seconds`)
- `RestartCount > 0` 즉시 실패 판정 — `up -d` 로 재생성된 컨테이너는 0 에서 시작하므로 이번 배포 이후의 크래시만 잡는다고 판단했다
- 이슈의 선택 항목이던 **자동 롤백은 넣지 않았다.** 2026-08-07 장애는 빌드마다 결과가 달라지는 비결정적 실패라 롤백 성공을 보장할 수 없고, 실패를 드러내는 것이 우선이라고 봤다
- 워크플로우 실패 알림 경로는 미확인 상태로 남아 있다 (이슈 체크리스트 항목)

## 배포 / 롤백

- **Rollout**: main 머지 시 다음 배포부터 적용
- **Rollback**: 워크플로우 파일만 되돌리면 된다. 애플리케이션에는 영향 없음

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 해당 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment validation by waiting for the application container to become healthy before completing.
  * Added detection for missing containers and crash loops.
  * Deployment failures now provide diagnostic information when health checks fail.
  * Reduced routine deployment log output after successful health validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->