### PR TITLE
release: 1.0.0 — 알림 신뢰성 수정 4건과 배포 헬스 게이트를 배포한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -108,31 +108,138 @@ jobs:
           APP_BELIEF_IDENTITY_HMAC_KEY: ${{ secrets.APP_BELIEF_IDENTITY_HMAC_KEY }}
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GHCR_ACTOR: ${{ github.actor }}
+          # 기동 헬스 게이트가 "새 이미지가 실제로 돌고 있는지" 확인하는 데 쓴다 (이슈 #375).
+          IMAGE_DIGEST: ${{ needs.build-and-push.outputs.image-digest }}
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          HEALTH_ATTEMPTS: "36"
+          HEALTH_INTERVAL: "5"
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          envs: ENV_FILE,APP_BELIEF_IDENTITY_HMAC_KEY,GHCR_TOKEN,GHCR_ACTOR
+          envs: ENV_FILE,APP_BELIEF_IDENTITY_HMAC_KEY,GHCR_TOKEN,GHCR_ACTOR,IMAGE_DIGEST,IMAGE_REF,HEALTH_ATTEMPTS,HEALTH_INTERVAL
           script: |
-            cd ~/mio
+            set -u
+            COMPOSE="docker compose -f docker-compose.prod.yml"
+
+            cd ~/mio || { echo "::error::~/mio 로 이동 실패"; exit 1; }
 
             printf '%s\nAPP_BELIEF_IDENTITY_HMAC_KEY=%s\n' \
               "$ENV_FILE" "$APP_BELIEF_IDENTITY_HMAC_KEY" > .env
 
-            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin
+            # ── 배포 전 기준선 (이슈 #375) ─────────────────────────────
+            # RestartCount 는 컨테이너를 재생성해야 0 으로 돌아간다. up -d 가 항상 재생성하는 것은
+            # 아니어서(같은 digest 재배포, pull 실패 등) 기존 값을 기준선으로 잡지 않으면
+            # "과거에 한 번 재시작했지만 지금 정상" 인 컨테이너를 크래시로 오판한다.
+            prev_cid=$($COMPOSE ps -aq app 2>/dev/null || true)
+            prev_restarts=0
+            if [ -n "$prev_cid" ]; then
+              prev_restarts=$(docker inspect -f '{{.RestartCount}}' "$prev_cid" 2>/dev/null || echo 0)
+            fi
+            echo "[deploy] 기준선 cid=${prev_cid:-none} restarts=$prev_restarts"
 
-            docker compose -f docker-compose.prod.yml pull
+            # 아래 세 단계는 실패하면 즉시 중단해야 한다. ssh-action 의 script_stop 기본값이
+            # false 라 스크립트는 첫 실패에서 멈추지 않는다. 그대로 진행하면 로컬에 남아 있는
+            # :latest 로 기존 컨테이너가 유지되고, 헬스 게이트가 "구 코드"에서 UP 을 받아
+            # 배포를 초록불로 끝낸다.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_ACTOR" --password-stdin \
+              || { echo "::error::GHCR 로그인 실패"; exit 1; }
+
+            $COMPOSE pull || { echo "::error::이미지 pull 실패 — 구 이미지로 배포하지 않는다"; exit 1; }
 
             # up -d: 이미지가 갱신된 app 컨테이너만 재생성하고 postgres/redis 볼륨은 보존한다.
             # (과거 'down -v'는 매 배포마다 named volume을 삭제해 DB가 전부 초기화되는 문제가 있었음.
             #  비밀번호 변경 등으로 볼륨 리셋이 필요하면 워크플로우가 아니라 수동 1회 작업으로 수행한다.)
-            docker compose -f docker-compose.prod.yml up -d --remove-orphans
+            $COMPOSE up -d --remove-orphans || { echo "::error::compose up 실패"; exit 1; }
 
+            # ── 기동 헬스 게이트 (이슈 #375) ─────────────────────────────
+            # 이전에는 sleep 45 후 로그만 덤프하고 결과를 종료 코드에 반영하지 않았다. 2026-08-07
+            # 배포에서 앱이 크래시 루프에 빠졌는데도 워크플로우가 success 로 끝나, 장애를
+            # 파이프라인이 아니라 사람이 뒤늦게 발견했다.
+            #
+            # 헬스는 컨테이너 안에서 관리 포트(9090)로 조회한다. 이 포트는 외부에서 도달할 수
+            # 없도록 의도적으로 publish 하지 않으며, 8080 은 인증이 걸려 401 이 오므로 판정에
+            # 쓸 수 없다.
+            started_at=$(date +%s)
+            healthy=0
+            fail_reason=""
+            for i in $(seq 1 "$HEALTH_ATTEMPTS"); do
+              # -aq 로 조회한다. 기동 실패로 exited 상태인 컨테이너는 -q 에 잡히지 않아
+              # 진단이 정확히 필요한 순간에 비어버린다.
+              cid=$($COMPOSE ps -aq app 2>/dev/null || true)
+              if [ -z "$cid" ]; then
+                echo "[health] app 컨테이너가 없다 (attempt $i)"
+                sleep "$HEALTH_INTERVAL"
+                continue
+              fi
+
+              state=$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || echo unknown)
+              # RestartCount 는 .State 가 아니라 최상위 필드다. 경로를 틀리면 빈 문자열이 나오고
+              # 아래 정수 비교가 조용히 실패해 크래시 감지가 통째로 무력화된다.
+              restarts=$(docker inspect -f '{{.RestartCount}}' "$cid" 2>/dev/null || echo 0)
+              restarts=${restarts:-0}
+
+              # 컨테이너가 교체됐으면 0 부터, 유지됐으면 기준선부터 증가분만 본다.
+              base=0
+              if [ "$cid" = "$prev_cid" ]; then base=$prev_restarts; fi
+
+              case "$state" in
+                exited|dead)
+                  fail_reason="컨테이너가 종료됨 (state=$state)"; break ;;
+              esac
+              if [ "$state" = "restarting" ] || [ "$restarts" -gt "$base" ]; then
+                fail_reason="크래시 루프 감지 (state=$state restarts=$restarts base=$base)"; break
+              fi
+
+              # 최상위 status 만 본다. show-details 로 하위 컴포넌트 status 가 함께 실리므로
+              # 앵커 없이 매칭하면 최상위가 UNKNOWN(HTTP 200)인데 통과할 수 있다.
+              if $COMPOSE exec -T app \
+                   wget -qO- --timeout=3 http://127.0.0.1:9090/actuator/health 2>/dev/null \
+                   | grep -q '^{"status":"UP"'; then
+                healthy=1
+                break
+              fi
+              sleep "$HEALTH_INTERVAL"
+            done
+            elapsed=$(( $(date +%s) - started_at ))
+
+            # 살아 있는 것만으로는 부족하다 — 새 이미지가 돌고 있는지 확인한다.
+            if [ "$healthy" = "1" ] && [ -n "${IMAGE_DIGEST:-}" ]; then
+              running_image=$(docker inspect -f '{{.Image}}' "$cid" 2>/dev/null || echo "")
+              if [ -n "$running_image" ] && \
+                 ! docker image inspect "$running_image" -f '{{join .RepoDigests "\n"}}' 2>/dev/null \
+                     | grep -q "$IMAGE_DIGEST"; then
+                healthy=0
+                fail_reason="실행 중 이미지가 이번 빌드와 다르다 (기대 digest=$IMAGE_DIGEST)"
+              fi
+            fi
+
+            if [ "$healthy" != "1" ]; then
+              echo "::error::기동 헬스 게이트 실패 (${elapsed}s) — ${fail_reason:-타임아웃}"
+              echo "=== container state ==="
+              $COMPOSE ps -a app || true
+              if [ -n "${cid:-}" ]; then
+                docker inspect -f 'status={{.State.Status}} restarts={{.RestartCount}} exit={{.State.ExitCode}} oom={{.State.OOMKilled}}' "$cid" || true
+              fi
+              # app 로그는 여기서 볼 수 없다. logging.driver 가 awslogs 이고 awslogs 는 읽기를
+              # 지원하지 않아 docker logs / compose logs 가 아무것도 반환하지 않는다(compose 는
+              # 경고만 남기고 exit 0 이라 조용히 비어 보인다). CloudWatch 에서 확인해야 한다.
+              echo "=== app logs ==="
+              echo "로그는 CloudWatch 로그 그룹 /mio/app 에서 확인한다 (awslogs 는 docker logs 미지원)."
+              echo "  aws logs tail /mio/app --since 10m --region ap-northeast-2"
+              echo "=== 수동 롤백 ==="
+              echo "  직전 성공 커밋의 sha- 태그로 되돌린다:"
+              echo "  docker pull $IMAGE_REF:sha-<PREV_SHA>"
+              echo "  docker tag $IMAGE_REF:sha-<PREV_SHA> $IMAGE_REF:latest"
+              echo "  docker compose -f docker-compose.prod.yml up -d app"
+              exit 1
+            fi
+
+            echo "[health] UP (${elapsed}s, attempt $i)"
+
+            # prune 은 게이트 통과 후에 한다. 게이트 전에 돌리면 방금 밀려난 이전 :latest 가
+            # dangling 으로 지워져, 실패를 선언한 시점에 되돌릴 로컬 이미지가 남지 않는다.
             docker image prune -f
-
-            sleep 45
-            echo "=== app logs ==="
-            docker compose -f docker-compose.prod.yml logs app --tail=80
 
       - name: Close SSH on security group (always runs)
         if: always()

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -14,6 +14,7 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.ReportWeek;
 import com.mio.report.domain.WeeklyReport;
 import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.domain.BehaviorTask;
@@ -54,8 +55,6 @@ public class NotificationService {
 
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
-    /** 월요일 발송분이 대상으로 삼는 주차는 발송일 7일 전 월요일이다. */
-    private static final int WEEKLY_REPORT_PERIOD_DAYS = 7;
     private static final LocalTime SERVER_INITIATED_WINDOW_START = LocalTime.of(8, 0);
     private static final LocalTime SERVER_INITIATED_WINDOW_END = LocalTime.of(22, 0);
     private static final int DAILY_SEND_LIMIT = 3;
@@ -376,15 +375,17 @@ public class NotificationService {
      * <p>이 확인이 없으면 체크인이 부족해 리포트가 만들어지지 않은 유저에게도 "리포트가 준비됐어요"
      * 가 나간다. 프로덕션에서 실제 발송 3건 중 2건이 그런 오발송이었다.
      *
-     * <p>대상 주차는 <b>발송일 − 7일</b> 이다. {@link com.mio.report.job.ReportAggregationJob} 이 같은
-     * 월요일 03:00 에 {@code weekEnd = 어제(일)}, {@code weekStart = weekEnd − 6일} 로 집계하므로
-     * 발송 시점에는 이미 판정이 끝나 있다.
+     * <p>대상 주차는 {@link ReportWeek#lastWeekStartFrom} 으로 구한다.
+     * {@link com.mio.report.job.ReportAggregationJob} 이 같은 월요일 03:00 에 <b>같은 헬퍼로</b>
+     * 집계하므로 발송 시점에는 이미 판정이 끝나 있다.
      *
      * <p>행이 아예 없는 경우(집계 job 실패·미실행)도 발송하지 않는다 — 존재하지 않는 리포트를
      * 알릴 이유가 없다.
      */
     private boolean hasGeneratedWeeklyReport(UUID userId, LocalDate occurrenceDate) {
-        LocalDate weekStart = occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS);
+        // 집계 job 과 같은 헬퍼로 계산한다 (이슈 #415) — 두 곳이 각자 계산하면 어긋나도 컴파일러가
+        // 잡아주지 못하고, 어긋나는 순간 그 주 알림이 통째로 사라진다.
+        LocalDate weekStart = ReportWeek.lastWeekStartFrom(occurrenceDate);
         Optional<WeeklyReport> report = weeklyReportRepository.findByUser_IdAndWeekStart(userId, weekStart);
 
         if (report.isEmpty()) {

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -267,64 +267,81 @@ public class NotificationService {
             return;
         }
 
-        String triggerCode = determineTrigger(setting, now);
-        if (triggerCode == null || shouldSuppressTrigger(userId, triggerCode, now)) {
-            return;
+        // 억제된 트리거는 그것만 건너뛰고 다음 후보를 이어서 본다 (이슈 #408).
+        // 억제는 "이 트리거를 지금 보내지 않는다" 는 뜻이지 "이 유저에게 아무것도 보내지 않는다" 가 아니다.
+        for (String triggerCode : determineTriggerCandidates(setting, now)) {
+            if (shouldSuppressTrigger(userId, triggerCode, now)) {
+                continue;
+            }
+            sendNotificationToUser(setting.getUser(), triggerCode, true);
+            return;   // 한 틱에 한 건만 발송한다
         }
-
-        sendNotificationToUser(setting.getUser(), triggerCode, true);
     }
 
-    private String determineTrigger(NotificationSetting setting, OffsetDateTime now) {
+    /**
+     * 지금 발송 조건을 만족하는 트리거를 <b>우선순위 순서대로 전부</b> 모은다 (이슈 #408).
+     *
+     * <p>하나만 반환하면 그것이 억제됐을 때 뒤 트리거가 평가조차 되지 않는다. 특히
+     * {@code negative_emotion_streak} 는 시각 조건이 없어 조건이 참인 동안 매 틱 선택되므로,
+     * 한 번 발송 후 24시간 억제에 들어가면 체크인 리마인더가 그 동안 전부 막힌다.
+     *
+     * <p>쿼리 비용: 각 후보의 시각 조건({@code dueOccurrenceDate})은 DB 조회 없는 순수 계산이라
+     * 창에 들어온 트리거에 대해서만 존재 확인 쿼리가 나간다. 다만 <b>조기 return 이 없어지면서</b>
+     * 상위 후보가 이미 매치된 틱에서도 리포트·To-do 조회가 실행된다 — 각각 월요일 08:00~08:09,
+     * 매일 21:00~21:09 창에 한정된다. 억제 검사도 후보 수만큼(최대 6회) 나간다.
+     */
+    private List<String> determineTriggerCandidates(NotificationSetting setting, OffsetDateTime now) {
         UUID userId = setting.getUser().getId();
         boolean serverInitiatedAllowed = isWithinServerInitiatedWindow(now);
+        List<String> candidates = new java.util.ArrayList<>();
 
         if (setting.isCheckinEnabled() && serverInitiatedAllowed && hasNegativeEmotionStreak(userId)) {
-            return "negative_emotion_streak";
+            candidates.add("negative_emotion_streak");
         }
         if (setting.isCheckinEnabled()) {
-            String checkinTrigger = determineCheckinReminder(setting, userId, now);
-            if (checkinTrigger != null) {
-                return checkinTrigger;
-            }
+            candidates.addAll(dueCheckinReminders(setting, userId, now));
         }
         if (setting.isReportEnabled() && serverInitiatedAllowed) {
             Optional<LocalDate> reportDue = weeklyReportDueDate(now);
             if (reportDue.isPresent() && hasGeneratedWeeklyReport(userId, reportDue.get())) {
-                return "report_weekly";
+                candidates.add("report_weekly");
             }
         }
         if (setting.isCharacterEnabled() && setting.isTodoReminderOn() && serverInitiatedAllowed) {
             Optional<LocalDate> todoDue = dueOccurrenceDate(TODO_REMINDER_TIME, now);
             if (todoDue.isPresent() && hasIncompleteTodo(userId, todoDue.get())) {
-                return "todo_incomplete";
+                candidates.add("todo_incomplete");
             }
         }
-        return null;
+        return List.copyOf(candidates);
     }
 
     /**
-     * 체크인 리마인더는 유저가 직접 고른 시각이므로 발송 시간대 제한을 두지 않는다.
+     * 판정 창 안에 도래한 체크인 리마인더를 <b>전부</b> 모은다 (이슈 #408).
+     *
+     * <p>체크인 리마인더는 유저가 직접 고른 시각이므로 발송 시간대 제한을 두지 않는다.
+     *
+     * <p>슬롯 시각이 가깝게 설정되면 한 창에 둘 이상이 함께 도래한다(프로덕션 실측: morning 22:50,
+     * afternoon 22:51). 하나만 반환하면 앞 슬롯 발송 후 억제되는 순간 뒤 슬롯이 영영 막힌다.
      *
      * <p>완료 여부는 반드시 <b>판정 시점의 날짜가 아니라 목표 시각의 발생일</b>로 조회한다.
      * 예를 들어 저녁 체크인을 {@code 23:58} 로 설정한 유저가 그날 23:56 에 체크인을 마쳤다면,
      * 다음 날 {@code 00:00} 틱에서도 판정 창(10분)은 아직 열려 있다. 이때 판정 시점 날짜로
      * 조회하면 전날 남긴 완료 기록을 놓쳐 이미 체크인한 유저에게 리마인더를 보내게 된다.
      */
-    private String determineCheckinReminder(NotificationSetting setting, UUID userId, OffsetDateTime now) {
-        Optional<LocalDate> morning = dueOccurrenceDate(setting.getCheckinMorningTime(), now);
-        if (morning.isPresent() && !hasCompletedCheckin(userId, morning.get(), "morning")) {
-            return "checkin_reminder_morning";
-        }
-        Optional<LocalDate> afternoon = dueOccurrenceDate(setting.getCheckinAfternoonTime(), now);
-        if (afternoon.isPresent() && !hasCompletedCheckin(userId, afternoon.get(), "afternoon")) {
-            return "checkin_reminder_afternoon";
-        }
-        Optional<LocalDate> evening = dueOccurrenceDate(setting.getCheckinEveningTime(), now);
-        if (evening.isPresent() && !hasCompletedCheckin(userId, evening.get(), "evening")) {
-            return "checkin_reminder_evening";
-        }
-        return null;
+    private List<String> dueCheckinReminders(NotificationSetting setting, UUID userId, OffsetDateTime now) {
+        List<String> due = new java.util.ArrayList<>();
+        addIfDue(due, setting.getCheckinMorningTime(), userId, now, "morning", "checkin_reminder_morning");
+        addIfDue(due, setting.getCheckinAfternoonTime(), userId, now, "afternoon", "checkin_reminder_afternoon");
+        addIfDue(due, setting.getCheckinEveningTime(), userId, now, "evening", "checkin_reminder_evening");
+        return due;
+    }
+
+    private void addIfDue(List<String> due, LocalTime slotTime, UUID userId, OffsetDateTime now,
+                          String timeOfDay, String triggerCode) {
+        dueOccurrenceDate(slotTime, now)
+                .filter(occurrenceDate -> !hasCompletedCheckin(userId, occurrenceDate, timeOfDay))
+                .ifPresent(occurrenceDate -> due.add(triggerCode));
     }
 
     /**

--- a/src/main/java/com/mio/notification/service/NotificationService.java
+++ b/src/main/java/com/mio/notification/service/NotificationService.java
@@ -14,6 +14,8 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.repository.BehaviorTaskRepository;
@@ -52,6 +54,8 @@ public class NotificationService {
 
     private static final LocalTime TODO_REMINDER_TIME = LocalTime.of(21, 0);
     private static final LocalTime WEEKLY_REPORT_TIME = LocalTime.of(8, 0);
+    /** 월요일 발송분이 대상으로 삼는 주차는 발송일 7일 전 월요일이다. */
+    private static final int WEEKLY_REPORT_PERIOD_DAYS = 7;
     private static final LocalTime SERVER_INITIATED_WINDOW_START = LocalTime.of(8, 0);
     private static final LocalTime SERVER_INITIATED_WINDOW_END = LocalTime.of(22, 0);
     private static final int DAILY_SEND_LIMIT = 3;
@@ -84,6 +88,7 @@ public class NotificationService {
     private final NotificationMessageMapper notificationMessageMapper;
     private final PushSender pushSender;
     private final NotificationPersistenceService notificationPersistenceService;
+    private final WeeklyReportRepository weeklyReportRepository;
 
     public void sendTestNotification(UUID userId, String title, String body) {
         userRepository.findById(userId)
@@ -284,8 +289,11 @@ public class NotificationService {
                 return checkinTrigger;
             }
         }
-        if (setting.isReportEnabled() && serverInitiatedAllowed && isWeeklyReportDue(now)) {
-            return "report_weekly";
+        if (setting.isReportEnabled() && serverInitiatedAllowed) {
+            Optional<LocalDate> reportDue = weeklyReportDueDate(now);
+            if (reportDue.isPresent() && hasGeneratedWeeklyReport(userId, reportDue.get())) {
+                return "report_weekly";
+            }
         }
         if (setting.isCharacterEnabled() && setting.isTodoReminderOn() && serverInitiatedAllowed) {
             Optional<LocalDate> todoDue = dueOccurrenceDate(TODO_REMINDER_TIME, now);
@@ -357,10 +365,41 @@ public class NotificationService {
      * 현재 {@code WEEKLY_REPORT_TIME} 은 08:00 이라 창이 자정을 넘지 않지만,
      * 시각이 바뀌어도 요일 판정이 어긋나지 않도록 발생일에 맞춰 둔다.
      */
-    private boolean isWeeklyReportDue(OffsetDateTime now) {
+    private Optional<LocalDate> weeklyReportDueDate(OffsetDateTime now) {
         return dueOccurrenceDate(WEEKLY_REPORT_TIME, now)
-                .filter(occurrenceDate -> occurrenceDate.getDayOfWeek().getValue() == 1)
-                .isPresent();
+                .filter(occurrenceDate -> occurrenceDate.getDayOfWeek().getValue() == 1);
+    }
+
+    /**
+     * 리포트가 <b>실제로 생성됐을 때만</b> 알림을 보낸다 (이슈 #413).
+     *
+     * <p>이 확인이 없으면 체크인이 부족해 리포트가 만들어지지 않은 유저에게도 "리포트가 준비됐어요"
+     * 가 나간다. 프로덕션에서 실제 발송 3건 중 2건이 그런 오발송이었다.
+     *
+     * <p>대상 주차는 <b>발송일 − 7일</b> 이다. {@link com.mio.report.job.ReportAggregationJob} 이 같은
+     * 월요일 03:00 에 {@code weekEnd = 어제(일)}, {@code weekStart = weekEnd − 6일} 로 집계하므로
+     * 발송 시점에는 이미 판정이 끝나 있다.
+     *
+     * <p>행이 아예 없는 경우(집계 job 실패·미실행)도 발송하지 않는다 — 존재하지 않는 리포트를
+     * 알릴 이유가 없다.
+     */
+    private boolean hasGeneratedWeeklyReport(UUID userId, LocalDate occurrenceDate) {
+        LocalDate weekStart = occurrenceDate.minusDays(WEEKLY_REPORT_PERIOD_DAYS);
+        Optional<WeeklyReport> report = weeklyReportRepository.findByUser_IdAndWeekStart(userId, weekStart);
+
+        if (report.isEmpty()) {
+            // 정상(체크인 0건)일 수도, 집계 job 장애일 수도 있다. 후자면 그 주 전 유저가 조용히
+            // 무발송이 되므로 구분 가능한 흔적을 남긴다 — "오발송을 고치다 전면 미발송"을 놓치지 않기 위해.
+            log.info("Weekly report row absent — skipping notification. user={} weekStart={}", userId, weekStart);
+            return false;
+        }
+        String status = report.get().getStatus();
+        if (!WeeklyReport.STATUS_GENERATED.equals(status)) {
+            log.debug("Weekly report not generated — skipping notification. user={} weekStart={} status={}",
+                    userId, weekStart, status);
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/com/mio/notification/service/PushSender.java
+++ b/src/main/java/com/mio/notification/service/PushSender.java
@@ -34,6 +34,7 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
@@ -45,6 +46,25 @@ public class PushSender {
     private static final long JWT_TTL_SECONDS = 3000;
     private static final String APNS_TOKEN_PATTERN = "[0-9a-fA-F]{64}";
     private static final String APS_KEY = "aps";
+
+    /**
+     * 400 응답 중 <b>토큰 자체가 무효</b>임을 뜻하는 사유 (이슈 #411).
+     *
+     * <p>이전에는 400 이면 사유와 무관하게 토큰을 폐기했다. 그런데 400 에는 {@code TopicDisallowed},
+     * {@code BadPriority}, {@code InvalidPushType} 처럼 <b>요청·설정</b> 문제인 사유가 다수 포함된다.
+     * {@code apns-topic} 이 설정값({@code apnsBundleId})이라 잘못 배포되면 모든 요청이 같은 400 을
+     * 받고, 스케줄러 한 사이클에 정상 사용자 토큰이 전량 무효화된다.
+     *
+     * <p>{@code DeviceTokenNotForTopic} 은 <b>제외</b>했다. 토큰이 다른 앱·토픽용일 수도, 우리 토픽
+     * 설정이 틀렸을 수도 있어 구분이 불가능한데, 후자면 전 유저가 한꺼번에 죽는다.
+     *
+     * <p>알려지지 않은 사유도 폐기하지 않는다 — Apple 이 사유를 추가했을 때 조용히 토큰을 죽이는
+     * 것보다 발송 실패로 남기는 편이 복구 가능하다.
+     *
+     * <p><b>남은 한계</b>: {@code BadDeviceToken} 은 sandbox 토큰을 production 으로 보낼 때도
+     * 발생한다. {@code apns.is-production} 설정이 틀리면 이 사유로 전량 무효화될 수 있다.
+     */
+    private static final Set<String> TOKEN_INVALIDATING_APNS_REASONS = Set.of("BadDeviceToken");
 
     @Value("${apns.key-content:}")
     private String apnsKeyContent;
@@ -210,20 +230,31 @@ public class PushSender {
             return PushSendResult.sent();
         }
 
-        log.warn("APNs rejected token {}: status={} body={}", maskToken(deviceToken), response.statusCode(), response.body());
-        String failureReason = buildApnsFailureReason(response.statusCode(), response.body());
+        // reason 은 본문이 비거나 파싱 실패하면 null 이다. 폐기 판정의 입력이므로 한 번만 파싱해
+        // 아래 분기와 로그가 같은 값을 보게 한다.
+        String reason = extractApnsReason(response.body());
+        String failureReason = buildApnsFailureReason(response.statusCode(), reason);
+
         if (response.statusCode() == 410) {
+            log.warn("APNs token no longer valid — discarding. reason={} token={}", reason, maskToken(deviceToken));
             return PushSendResult.of(PushSendStatus.TOKEN_EXPIRED, failureReason);
         }
-        if (response.statusCode() == 400) {
+        // Set.of() 는 contains(null) 에서 NPE 를 던지므로 null 을 먼저 거른다.
+        if (response.statusCode() == 400 && reason != null && TOKEN_INVALIDATING_APNS_REASONS.contains(reason)) {
+            log.warn("APNs rejected device token — discarding. reason={} token={}", reason, maskToken(deviceToken));
             return PushSendResult.of(PushSendStatus.INVALID_TOKEN, failureReason);
         }
+
+        // 여기 오는 응답은 토큰이 아니라 우리 요청·설정·게이트웨이 상태 문제다. 모든 요청이 같은
+        // 사유로 실패하는 상황이므로 개별 토큰 문제로 오인되지 않게 ERROR 로 남긴다.
+        // 특히 403(ExpiredProviderToken 등)은 JWT 캐시 때문에 전 발송이 한꺼번에 죽는다.
+        log.error("APNs rejected for non-token reason — keeping device token. status={} reason={} token={}",
+                response.statusCode(), reason, maskToken(deviceToken));
         return PushSendResult.of(PushSendStatus.FAILED, failureReason);
     }
 
     /** APNs 응답에서 사후 추적용 사유를 만든다. 토큰 등 민감 정보는 포함하지 않는다. */
-    private String buildApnsFailureReason(int statusCode, String responseBody) {
-        String reason = extractApnsReason(responseBody);
+    private String buildApnsFailureReason(int statusCode, String reason) {
         return reason == null ? "APNS_" + statusCode : "APNS_" + statusCode + ":" + reason;
     }
 

--- a/src/main/java/com/mio/report/domain/ReportWeek.java
+++ b/src/main/java/com/mio/report/domain/ReportWeek.java
@@ -1,0 +1,42 @@
+package com.mio.report.domain;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+/**
+ * 주간 리포트의 대상 주차를 계산한다 (이슈 #415).
+ *
+ * <p>같은 "지난주 월요일"을 집계 job · 알림 발송 게이트 · 리포트 조회가 각자 계산하고 있었다.
+ * 그중 집계 job 만 {@code 오늘 - 1일 - 6일} 이라 <b>월요일에 실행될 때만</b> 옳았고, 다른 요일에
+ * 재실행하면 월요일이 아닌 {@code week_start} 로 저장돼 나머지 두 곳의 조회와 어긋났다.
+ * 그러면 그 주 리포트 알림이 전 유저 무발송이 되면서도 리포트 화면에는 정상 표시되는,
+ * 원인을 찾기 어려운 불일치가 생긴다.
+ *
+ * <p>결합을 주석이 아니라 코드로 표현하기 위해 한곳에 모았다.
+ *
+ * <p><b>아직 이 헬퍼를 쓰지 않는 곳이 하나 있다.</b>
+ * {@code WeeklyReflectionJob} 은 일요일 00:00 에 {@code 오늘 - 7일}(= 일요일)로 {@code week_start}
+ * 를 만들어 {@code weekly_reports} 를 UPDATE 한다. {@code week_start} 에는 월요일만 저장되므로
+ * 이 UPDATE 는 항상 0 rows 이며, {@code narrative}/{@code coaching_direction} 이 채워지지 않는다
+ * (프로덕션 확인: 9행 중 0행). 이 헬퍼 도입 <b>이전부터</b> 그랬고, 고치려면 날짜 계산만이 아니라
+ * 두 job 의 실행 순서(일 00:00 반영 → 월 03:00 집계)부터 정해야 해서 별도로 다룬다.
+ */
+public final class ReportWeek {
+
+    private ReportWeek() {
+    }
+
+    /**
+     * 기준일이 속한 주의 <b>직전 주 월요일</b>. 실행 요일과 무관하게 항상 같은 값을 낸다.
+     *
+     * <p>ISO-8601 기준으로 주는 월요일에 시작한다.
+     */
+    public static LocalDate lastWeekStartFrom(LocalDate baseDate) {
+        return baseDate.with(DayOfWeek.MONDAY).minusWeeks(1);
+    }
+
+    /** 주 시작일(월)에 대응하는 종료일(일). */
+    public static LocalDate weekEndOf(LocalDate weekStart) {
+        return weekStart.plusDays(6);
+    }
+}

--- a/src/main/java/com/mio/report/domain/WeeklyReport.java
+++ b/src/main/java/com/mio/report/domain/WeeklyReport.java
@@ -65,10 +65,14 @@ public class WeeklyReport {
     @Column(name = "coaching_direction")
     private String coachingDirection;
 
-    /** PENDING / GENERATED / INSUFFICIENT_DATA */
+    public static final String STATUS_PENDING = "PENDING";
+    public static final String STATUS_GENERATED = "GENERATED";
+    public static final String STATUS_INSUFFICIENT_DATA = "INSUFFICIENT_DATA";
+
+    /** {@link #STATUS_PENDING} / {@link #STATUS_GENERATED} / {@link #STATUS_INSUFFICIENT_DATA} */
     @Column(name = "status", nullable = false)
     @Builder.Default
-    private String status = "PENDING";
+    private String status = STATUS_PENDING;
 
     @Column(name = "is_partial", nullable = false)
     private boolean isPartial;
@@ -82,27 +86,27 @@ public class WeeklyReport {
         this.avgEmotionScore = avgEmotionScore;
         this.emotionScores = emotionScores != null ? emotionScores : "{}";
         this.distortionDistribution = distortionDistribution != null ? distortionDistribution : "{}";
-        this.status = "GENERATED";
+        this.status = STATUS_GENERATED;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     public void markAsInsufficientData(int checkinCount) {
         this.checkinCount = checkinCount;
-        this.status = "INSUFFICIENT_DATA";
+        this.status = STATUS_INSUFFICIENT_DATA;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     /** @deprecated use markAsGenerated(int, Double, String, String) */
     @Deprecated
     public void markAsGenerated() {
-        this.status = "GENERATED";
+        this.status = STATUS_GENERATED;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 
     /** @deprecated use markAsInsufficientData(int) */
     @Deprecated
     public void markAsInsufficientData() {
-        this.status = "INSUFFICIENT_DATA";
+        this.status = STATUS_INSUFFICIENT_DATA;
         this.generatedAt = OffsetDateTime.now(ZoneOffset.UTC);
     }
 

--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -1,6 +1,7 @@
 package com.mio.report.job;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.report.domain.ReportWeek;
 import com.mio.report.domain.WeeklyReport;
 import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.user.domain.User;
@@ -12,6 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Clock;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -34,11 +36,16 @@ public class ReportAggregationJob {
     private final WeeklyReportRepository weeklyReportRepository;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper objectMapper;
+    /** 실행 시각을 주입받아 비-월요일 실행도 테스트할 수 있게 한다 (이슈 #415). */
+    private final Clock clock;
 
     @Scheduled(cron = "0 0 3 * * MON", zone = "Asia/Seoul")
     public void run() {
-        LocalDate weekEnd = LocalDate.now(KST).minusDays(1);   // 지난 일요일
-        LocalDate weekStart = weekEnd.minusDays(6);             // 지난 월요일
+        // 실행 요일에 의존하지 않는다 (이슈 #415). 이전 구현은 오늘-1, -6 이라 월요일에 돌 때만
+        // 옳았고, 다른 요일에 재실행하면 월요일이 아닌 week_start 로 저장돼 알림 게이트·리포트
+        // 조회의 계산과 어긋났다.
+        LocalDate weekStart = ReportWeek.lastWeekStartFrom(LocalDate.now(clock));
+        LocalDate weekEnd = ReportWeek.weekEndOf(weekStart);
 
         log.info("[ReportAggregationJob] start weekStart={} weekEnd={}", weekStart, weekEnd);
 

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.mio.report.service;
 
 import com.mio.common.AppConstants;
+import com.mio.report.domain.ReportWeek;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.checkin.repository.CheckinRepository;
@@ -24,7 +25,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
@@ -78,7 +78,7 @@ public class ReportService {
 
     public WeeklyReportResponse getWeeklyReport(UUID userId, LocalDate weekStart) {
         final LocalDate resolvedStart = weekStart != null ? weekStart : resolveLastWeekStart();
-        final LocalDate weekEnd = resolvedStart.plusDays(6);
+        final LocalDate weekEnd = ReportWeek.weekEndOf(resolvedStart);
 
         ReportDbData data = readOnlyTx.execute(status -> {
             verifyUserExists(userId);
@@ -243,9 +243,7 @@ public class ReportService {
     // ── 날짜 헬퍼 ─────────────────────────────────────────────────
 
     private LocalDate resolveLastWeekStart() {
-        LocalDate today = LocalDate.now(AppConstants.ZONE);
-        int daysFromMonday = today.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue();
-        return today.minusDays(daysFromMonday + 7);
+        return ReportWeek.lastWeekStartFrom(LocalDate.now(AppConstants.ZONE));
     }
 
     private LocalDate resolveLastMonthStart() {

--- a/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationCursorDecodingTest.java
@@ -8,6 +8,7 @@ import com.mio.notification.dto.NotificationHistoryResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -84,6 +85,7 @@ class NotificationCursorDecodingTest {
     @Mock private StringRedisTemplate stringRedisTemplate;
     @Mock private PushSender pushSender;
     @Mock private NotificationPersistenceService notificationPersistenceService;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
 
     private NotificationService notificationService;
     private Clock fixedClock;
@@ -104,7 +106,8 @@ class NotificationCursorDecodingTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
         userId = UUID.randomUUID();
         user = User.builder()

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -314,6 +314,53 @@ class NotificationServiceTest {
     }
 
     /**
+     * 토큰을 폐기하지 않는 실패({@code FAILED})에서 토큰이 살아남는지 <b>호출부에서</b> 고정한다 (이슈 #411).
+     *
+     * <p>#411 은 설정 오류로 인한 400 이 토큰을 죽이지 않도록 {@code PushSender} 안에서 좁혔다.
+     * 그런데 무효화를 실제로 수행하는 건 이쪽이다. 여기 조건이 넓어지면
+     * ({@code invalidatesToken()} 대신 "성공이 아니면 폐기" 같은 형태) 대량 무효화가 그대로
+     * 되살아나는데, {@code FAILED} 를 스텁하는 테스트가 없으면 빌드는 초록이다.
+     */
+    @Test
+    @DisplayName("[#411] 토큰을 폐기하지 않는 실패에서는 디바이스 토큰을 유지한다")
+    void sendNotificationToUser_nonInvalidatingFailure_keepsToken() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("ios").token("apns-token").build();
+        setField(token, "id", UUID.randomUUID());
+
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.of(PushSendStatus.FAILED, "APNS_400:TopicDisallowed"));
+
+        notificationService.sendNotificationToUser(user, "checkin_reminder_morning", true);
+
+        assertThat(token.isValid()).isTrue();
+        ArgumentCaptor<NotificationDeliveryResult> captor =
+                ArgumentCaptor.forClass(NotificationDeliveryResult.class);
+        // 무효화 대상 목록이 비어 있어야 한다 — 여기에 토큰이 실리면 영구 폐기된다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_morning"), captor.capture(), eq(List.of()), eq(true));
+        assertThat(captor.getValue().failureReason()).isEqualTo("APNS_400:TopicDisallowed");
+    }
+
+    @Test
+    @DisplayName("[#411] 테스트 푸시에서도 폐기 대상이 아닌 실패는 토큰을 유지한다")
+    void sendTestNotification_nonInvalidatingFailure_keepsToken() {
+        DeviceToken token = DeviceToken.builder()
+                .user(user).deviceId("device-1").platform("ios").token("apns-token").build();
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(token));
+        when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.of(PushSendStatus.FAILED, "APNS_403:InvalidProviderToken"));
+
+        notificationService.sendTestNotification(userId, "제목", "본문");
+
+        assertThat(token.isValid()).isTrue();
+        verify(deviceTokenRepository, never()).save(token);
+    }
+
+    /**
      * 주간 리포트 알림은 <b>리포트가 실제로 생성됐을 때만</b> 나가야 한다 (이슈 #413).
      *
      * <p>기존 구현은 "월요일 08시인가"만 보고 발송해, 체크인 부족으로 리포트가 없는 유저에게도

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -42,6 +42,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import com.mio.common.error.BusinessException;
@@ -311,6 +312,194 @@ class NotificationServiceTest {
                 eq(List.of()),
                 eq(true)
         );
+    }
+
+    /**
+     * 억제된 트리거는 <b>그 트리거만</b> 건너뛰고 다음 후보를 이어서 평가해야 한다 (이슈 #408).
+     *
+     * <p>기존 구현은 후보를 하나만 뽑아 그것이 억제되면 곧바로 종료했다. 그래서 우선순위가 높은
+     * 트리거가 24시간 억제에 들어가면 그 동안 뒤 트리거가 전부 차단됐다. 특히
+     * {@code negative_emotion_streak} 는 시각 조건이 없어 조건이 참인 동안 매 틱 선택되므로,
+     * <b>체크인 리마인더를 가장 필요로 하는 상태의 유저가 리마인더를 못 받게 된다.</b>
+     */
+    @Test
+    @DisplayName("[#408] 상위 트리거가 억제되면 다음 후보를 이어서 평가한다")
+    void processScheduledNotifications_suppressedTopTrigger_fallsThroughToNext() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        setField(setting, "checkinMorningTime", now.toLocalTime().truncatedTo(ChronoUnit.MINUTES));
+        stubSchedulerBasics(setting);
+
+        // 부정 감정 3연속 → negative_emotion_streak 가 최우선 후보로 잡힌다
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        // 그런데 이미 발송돼 24시간 억제 중이다
+        suppressOnly("negative_emotion_streak");
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        // 유저 전체가 막히지 않고 아침 체크인 리마인더가 나가야 한다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_morning"), any(), any(), eq(true));
+    }
+
+    /**
+     * 케이스 B — 같은 판정 창 안에 두 체크인 슬롯이 함께 도래하는 경우.
+     * 프로덕션에서 morning 22:50 / afternoon 22:51 설정으로 실측된 증상이다.
+     */
+    @Test
+    @DisplayName("[#408] 같은 창에 두 체크인 슬롯이 도래하면 앞 슬롯 발송 후 뒤 슬롯도 발송한다")
+    void processScheduledNotifications_twoCheckinSlotsDue_sendsSecondAfterFirstSuppressed() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        // 두 슬롯을 1분 차로 두고 판정 창(10분) 안의 틱에서 평가한다.
+        // 프로덕션 실측은 morning 22:50 / afternoon 22:51 이었으나, 22:55 는 서버 주도 발송 창
+        // (08:00~22:00) 밖이라 streak·report·todo 후보가 아예 생기지 않는다. 폴스루 자체를
+        // 보려면 창 안이어야 하므로 시각만 옮겼다 — 슬롯 간격과 창 폭은 실측과 동일하다.
+        LocalTime morningSlot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", morningSlot);
+        setField(setting, "checkinAfternoonTime", morningSlot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        // 아침은 이미 발송됨 → 억제. 오후는 아직
+        suppressOnly("checkin_reminder_morning");
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_afternoon"), any(), any(), eq(true));
+    }
+
+    /**
+     * 후보가 여럿 살아 있어도 <b>한 틱에 한 건</b>만, 그리고 <b>가장 높은 우선순위</b>가 나가야 한다.
+     *
+     * <p>이 두 성질이 #408 이 새로 허용하게 된 위험의 정확한 반대편이다. 루프의 {@code return} 이
+     * 빠지면 한 틱에 여러 건이 나가고, 일일 한도는 루프 진입 전에 한 번만 검사되므로 틱 안에서
+     * 우회된다. 후보 순서가 뒤집히면 항상 최하위 우선순위가 선택된다.
+     *
+     * <p>단일 후보만 있는 테스트로는 둘 다 잡히지 않는다 — 루프가 두 번째 기회를 갖지 못하기 때문이다.
+     */
+    @Test
+    @DisplayName("[#408] 억제 없는 후보가 둘이면 상위 우선순위 하나만 발송한다")
+    void processScheduledNotifications_multipleUnsuppressed_sendsOnlyHighestPriority() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        setField(setting, "checkinMorningTime", now.toLocalTime().truncatedTo(ChronoUnit.MINUTES));
+        stubSchedulerBasics(setting);
+
+        // streak(최우선) 과 morning 이 모두 후보가 되고 어느 것도 억제되지 않는다
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(false);
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        // 정확히 1건 — return 이 빠지면 morning 까지 나가 2건이 된다
+        verify(notificationPersistenceService, times(1))
+                .persistNotificationResult(any(), anyString(), any(), any(), anyBoolean());
+        // 그 1건은 상위 우선순위여야 한다 — 순서가 뒤집히면 morning 이 나간다
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("negative_emotion_streak"), any(), any(), eq(true));
+    }
+
+    /**
+     * 억제 검사가 <b>모든</b> 후보에 적용되는지 고정한다.
+     *
+     * <p>#408 이전에는 틱당 억제 검사가 1회였는데 이제 후보 수만큼이다. 첫 후보에만 적용하도록
+     * 바꿔도 결과가 같아 보이는 경우가 있어, 검사 호출 횟수를 직접 센다. 여기가 깨지면
+     * 24시간 억제가 무력화돼 같은 알림이 중복 도착한다 — #389 가 막으려던 실패다.
+     */
+    @Test
+    @DisplayName("[#408] 후보가 전부 억제되면 각 후보를 모두 검사하고 아무것도 발송하지 않는다")
+    void processScheduledNotifications_allCandidatesSuppressed_checksEachAndSendsNothing() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        // streak + morning + afternoon = 후보 3개, 전부 억제
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(true);
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        // 후보가 3개인데 1개만 검사하고 끝나면 억제 우회 버그다
+        verify(proactiveCareLogRepository, times(3))
+                .existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any());
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    /**
+     * 상위 후보가 아니라 <b>두 번째</b> 후보가 억제된 경우에도 정상 동작해야 한다.
+     * 첫 후보에만 억제를 적용하는 구현은 여기서 두 번째를 그대로 발송해버린다.
+     */
+    /**
+     * 슬롯별 {@code timeOfDay} 라벨이 트리거 코드와 짝이 맞는지 고정한다.
+     *
+     * <p>리팩터링으로 세 슬롯이 {@code addIfDue(..., timeOfDay, triggerCode)} 헬퍼를 공유하게 되면서
+     * 두 문자열이 독립 인자가 됐다. 짝이 어긋나면 이미 오후 체크인을 한 유저에게 오후 리마인더가
+     * 나가거나, 반대로 하지 않은 유저에게 조용히 나가지 않는다.
+     */
+    @Test
+    @DisplayName("[#408] 오후 체크인을 완료했으면 오후 리마인더만 후보에서 빠진다")
+    void processScheduledNotifications_afternoonCompleted_skipsOnlyAfternoon() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        // morning 만 억제 → 정상이면 afternoon 이 다음 후보지만, 오후 체크인을 이미 했으므로 후보가 아니다
+        suppressOnly("checkin_reminder_morning");
+        stubCheckinCompletion(Set.of("afternoon"));
+
+        notificationService.processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    @Test
+    @DisplayName("[#408] 두 번째 후보가 억제되면 그것을 건너뛰고 세 번째를 발송한다")
+    void processScheduledNotifications_secondCandidateSuppressed_skipsToThird() {
+        OffsetDateTime now = OffsetDateTime.now(fixedClock).withHour(9).withMinute(0).withSecond(0).withNano(0);
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+        LocalTime slot = now.toLocalTime().truncatedTo(ChronoUnit.MINUTES).minusMinutes(5);
+        setField(setting, "checkinMorningTime", slot);
+        setField(setting, "checkinAfternoonTime", slot.plusMinutes(1));
+        stubSchedulerBasics(setting);
+
+        // 후보: streak, morning, afternoon — 앞의 둘이 억제
+        when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId))
+                .thenReturn(List.of(negativeCheckin(), negativeCheckin(), negativeCheckin()));
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any()))
+                .thenAnswer(invocation -> {
+                    String code = invocation.getArgument(1);
+                    return "negative_emotion_streak".equals(code) || "checkin_reminder_morning".equals(code);
+                });
+        stubCheckinCompletion(Set.of());
+
+        notificationService.processScheduledNotifications();
+
+        verify(notificationPersistenceService, times(1))
+                .persistNotificationResult(any(), anyString(), any(), any(), anyBoolean());
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId), eq("checkin_reminder_afternoon"), any(), any(), eq(true));
     }
 
     /**
@@ -1158,6 +1347,38 @@ class NotificationServiceTest {
         verify(notificationPersistenceService, never()).persistNotificationResult(
                 any(), anyString(), any(), any(), anyBoolean()
         );
+    }
+
+    /** 트리거 판정 직전까지의 공통 조건을 통과시킨다 — 트리거 선택만이 결과를 가르게 한다. */
+    private void stubSchedulerBasics(NotificationSetting setting) {
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
+                new org.springframework.data.domain.SliceImpl<>(List.of(setting)));
+        lenient().when(valueOperations.get(anyString())).thenReturn(null);
+        lenient().when(proactiveCareLogRepository.countByUser_IdAndNotificationStatusInAndSentAtBetween(
+                eq(userId), any(), any(), any())).thenReturn(0L);
+        lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(
+                DeviceToken.builder().user(user).deviceId("device-1").platform("android").token("fcm-token").build()));
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+    }
+
+    /**
+     * 완료된 체크인 슬롯을 지정한다. 스텁이 <b>실제 slot 인자에 반응</b>하므로,
+     * 구현이 슬롯별 {@code timeOfDay} 라벨을 잘못 넘기면(예: afternoon 을 "morning" 으로 조회)
+     * 결과가 달라져 테스트가 깨진다. {@code anyString() → false} 로 두면 그 구분이 사라진다.
+     */
+    private void stubCheckinCompletion(Set<String> completedSlots) {
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenAnswer(invocation -> completedSlots.contains(invocation.<String>getArgument(2)));
+    }
+
+    /** 지정한 트리거만 억제 상태로 만든다. 나머지는 발송 가능. */
+    private void suppressOnly(String suppressedTriggerCode) {
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                        eq(userId), anyString(), any(), any()))
+                .thenAnswer(invocation -> suppressedTriggerCode.equals(invocation.getArgument(1)));
     }
 
     /** 월요일 08:00 KST 시점의 서비스. 주간 리포트 발송 조건을 만족하는 유일한 시각이다. */

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -11,6 +11,8 @@ import com.mio.notification.dto.NotificationReadResponse;
 import com.mio.notification.repository.DeviceTokenRepository;
 import com.mio.notification.repository.NotificationSettingRepository;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
@@ -18,6 +20,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -68,6 +72,14 @@ class NotificationServiceTest {
     private static final Map<String, String> TODO_DATA =
             Map.of("type", "todo_incomplete", "route", "/todo");
 
+    /**
+     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는 <b>발생일 − 7일</b> 이다.
+     * {@code ReportAggregationJob} 이 월요일에 weekEnd=어제(일), weekStart=weekEnd−6 으로 집계하므로
+     * 발송일 기준 7일 전 월요일과 맞물린다. (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
+     */
+    private static final Instant WEEKLY_REPORT_INSTANT = Instant.parse("2026-08-09T23:00:00Z");
+    private static final LocalDate REPORT_WEEK_START = LocalDate.of(2026, 8, 3);
+
     @Mock private UserRepository userRepository;
     @Mock private DeviceTokenRepository deviceTokenRepository;
     @Mock private NotificationSettingRepository notificationSettingRepository;
@@ -78,6 +90,7 @@ class NotificationServiceTest {
     @Mock private ValueOperations<String, String> valueOperations;
     @Mock private PushSender pushSender;
     @Mock private NotificationPersistenceService notificationPersistenceService;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
 
     private NotificationService notificationService;
     private UUID userId;
@@ -98,7 +111,8 @@ class NotificationServiceTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
         lenient().when(stringRedisTemplate.opsForValue()).thenReturn(valueOperations);
         userId = UUID.randomUUID();
@@ -296,6 +310,85 @@ class NotificationServiceTest {
                 eq(List.of()),
                 eq(true)
         );
+    }
+
+    /**
+     * 주간 리포트 알림은 <b>리포트가 실제로 생성됐을 때만</b> 나가야 한다 (이슈 #413).
+     *
+     * <p>기존 구현은 "월요일 08시인가"만 보고 발송해, 체크인 부족으로 리포트가 없는 유저에게도
+     * "리포트가 준비됐어요" 를 보냈다. 프로덕션에서 실제 발송 3건 중 2건이 오발송이었다.
+     * {@code ReportAggregationJob} 이 같은 날 03:00 에 판정을 끝내 두므로 조회만 하면 된다.
+     */
+    @Test
+    @DisplayName("[#413] 리포트가 생성된 유저에게만 주간 리포트 알림을 발송한다")
+    void processScheduledNotifications_reportGenerated_sendsWeeklyReport() {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.of(weeklyReportWithStatus("GENERATED")));
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verify(notificationPersistenceService).persistNotificationResult(
+                eq(userId),
+                eq("report_weekly"),
+                eq(NotificationDeliveryResult.sent()),
+                eq(List.of()),
+                eq(true));
+    }
+
+    /**
+     * 발송 조건은 <b>화이트리스트</b>(GENERATED 만 발송)여야 한다.
+     *
+     * <p>INSUFFICIENT_DATA 만 막는 블랙리스트로 구현하면 {@code PENDING} 행이 통과해 "리포트가
+     * 준비됐어요" 가 나간다. PENDING 은 스키마 기본값이자 CHECK 제약에 있는 정식 상태라
+     * (V5__init_todo_report.sql), 집계가 아직 안 끝난 행이 그대로 걸린다.
+     */
+    @ParameterizedTest(name = "status={0} 이면 발송하지 않는다")
+    @ValueSource(strings = {"INSUFFICIENT_DATA", "PENDING"})
+    @DisplayName("[#413] GENERATED 가 아닌 리포트 상태는 모두 발송에서 제외한다")
+    void processScheduledNotifications_nonGeneratedStatus_skipsWeeklyReport(String status) {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.of(weeklyReportWithStatus(status)));
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    /**
+     * 월요일 조건이 실제로 발송을 가른다는 것을 고정한다.
+     *
+     * <p>이 테스트가 없으면 요일 필터를 없애도 스위트가 통과한다 — 지금은 {@code -7일} 조회가
+     * 우연히 월요일 행만 찾아내 필터를 대신하고 있기 때문이다. 조회 방식이 바뀌는 순간
+     * (예: 최신 리포트 조회) 매일 08:00 에 푸시가 나가게 된다.
+     */
+    @Test
+    @DisplayName("[#413] 월요일이 아니면 리포트가 생성돼 있어도 주간 리포트 알림을 보내지 않는다")
+    void processScheduledNotifications_notMonday_skipsWeeklyReport() {
+        stubWeeklyReportSchedule();
+
+        // 화요일 08:00 KST — 리포트 존재 여부와 무관하게 트리거 자체가 열리지 않아야 한다
+        serviceAt(Clock.fixed(WEEKLY_REPORT_INSTANT.plus(1, ChronoUnit.DAYS), ZoneOffset.of("+09:00")))
+                .processScheduledNotifications();
+
+        verifyNoInteractions(weeklyReportRepository);
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
+    }
+
+    @Test
+    @DisplayName("[#413] 리포트 행 자체가 없으면(집계 미실행) 주간 리포트 알림을 보내지 않는다")
+    void processScheduledNotifications_noReportRow_skipsWeeklyReport() {
+        stubWeeklyReportSchedule();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), eq(REPORT_WEEK_START)))
+                .thenReturn(Optional.empty());
+
+        notificationServiceAtWeeklyReportTime().processScheduledNotifications();
+
+        verifyNoInteractions(pushSender);
+        verifyNoInteractions(notificationPersistenceService);
     }
 
     /**
@@ -968,7 +1061,8 @@ class NotificationServiceTest {
                 stringRedisTemplate,
                 new NotificationMessageMapper(),
                 pushSender,
-                notificationPersistenceService
+                notificationPersistenceService,
+                weeklyReportRepository
         );
 
         NotificationSetting setting = NotificationSetting.builder().user(user).build();
@@ -1016,6 +1110,61 @@ class NotificationServiceTest {
         verify(notificationPersistenceService, never()).persistNotificationResult(
                 any(), anyString(), any(), any(), anyBoolean()
         );
+    }
+
+    /** 월요일 08:00 KST 시점의 서비스. 주간 리포트 발송 조건을 만족하는 유일한 시각이다. */
+    private NotificationService notificationServiceAtWeeklyReportTime() {
+        return serviceAt(Clock.fixed(WEEKLY_REPORT_INSTANT, ZoneOffset.of("+09:00")));
+    }
+
+    private NotificationService serviceAt(Clock clock) {
+        return new NotificationService(
+                clock,
+                userRepository,
+                deviceTokenRepository,
+                notificationSettingRepository,
+                proactiveCareLogRepository,
+                checkinRepository,
+                behaviorTaskRepository,
+                stringRedisTemplate,
+                new NotificationMessageMapper(),
+                pushSender,
+                notificationPersistenceService,
+                weeklyReportRepository
+        );
+    }
+
+    /** 리포트 발송 직전까지의 조건을 모두 통과시켜, 리포트 상태만이 결과를 가르게 한다. */
+    private void stubWeeklyReportSchedule() {
+        NotificationSetting setting = NotificationSetting.builder().user(user).build();
+
+        when(notificationSettingRepository.findSendableTargets(any())).thenReturn(
+                new org.springframework.data.domain.SliceImpl<>(List.of(setting)));
+        lenient().when(valueOperations.get(anyString())).thenReturn(null);
+        lenient().when(proactiveCareLogRepository.countByUser_IdAndNotificationStatusInAndSentAtBetween(
+                eq(userId), any(), any(), any())).thenReturn(0L);
+        lenient().when(proactiveCareLogRepository.existsByUser_IdAndTriggerCodeAndNotificationStatusInAndSentAtAfter(
+                eq(userId), anyString(), any(), any())).thenReturn(false);
+        // 체크인·To-do 트리거가 먼저 잡히지 않도록 비운다
+        lenient().when(checkinRepository.findTop3ByUser_IdOrderByCreatedAtDesc(userId)).thenReturn(List.of());
+        lenient().when(checkinRepository.existsByUser_IdAndCheckinDateAndTimeOfDay(eq(userId), any(), anyString()))
+                .thenReturn(true);
+        lenient().when(behaviorTaskRepository.findByUser_IdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(List.of());
+        lenient().when(deviceTokenRepository.findByUser_IdAndIsValidTrue(userId)).thenReturn(List.of(
+                DeviceToken.builder().user(user).deviceId("device-1").platform("android").token("fcm-token").build()));
+        lenient().when(pushSender.send(anyString(), anyString(), anyString(), anyString(), anyMap()))
+                .thenReturn(PushSendResult.sent());
+    }
+
+    private WeeklyReport weeklyReportWithStatus(String status) {
+        WeeklyReport report = WeeklyReport.builder()
+                .user(user)
+                .weekStart(REPORT_WEEK_START)
+                .weekEnd(REPORT_WEEK_START.plusDays(6))
+                .build();
+        setField(report, "status", status);
+        return report;
     }
 
     private void setUserId(User u, UUID id) {

--- a/src/test/java/com/mio/notification/service/NotificationServiceTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationServiceTest.java
@@ -73,9 +73,10 @@ class NotificationServiceTest {
             Map.of("type", "todo_incomplete", "route", "/todo");
 
     /**
-     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는 <b>발생일 − 7일</b> 이다.
-     * {@code ReportAggregationJob} 이 월요일에 weekEnd=어제(일), weekStart=weekEnd−6 으로 집계하므로
-     * 발송일 기준 7일 전 월요일과 맞물린다. (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
+     * 주간 리포트 알림은 월요일 08:00 KST 발송분이며, 대상 주차는
+     * {@code ReportWeek.lastWeekStartFrom(발생일)} — 즉 직전 주 월요일이다.
+     * 집계 job 도 같은 헬퍼를 쓰므로 두 값이 맞물린다.
+     * (2026-08-10 발송 ↔ week_start 2026-08-03, 프로덕션 확인)
      */
     private static final Instant WEEKLY_REPORT_INSTANT = Instant.parse("2026-08-09T23:00:00Z");
     private static final LocalDate REPORT_WEEK_START = LocalDate.of(2026, 8, 3);

--- a/src/test/java/com/mio/notification/service/PushSenderTest.java
+++ b/src/test/java/com/mio/notification/service/PushSenderTest.java
@@ -14,6 +14,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.firebase.messaging.Message;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
 import java.io.IOException;
@@ -120,6 +123,158 @@ class PushSenderTest {
         assertThat(result.isAmbiguous()).isFalse();
         assertThat(result.failureReason()).isEqualTo("APNS_MALFORMED_TOKEN");
         verifyNoInteractions(httpClient);
+    }
+
+    /**
+     * 400 응답 중 <b>토큰 자체가 무효인 사유만</b> 토큰을 폐기한다 (이슈 #411).
+     *
+     * <p>이전에는 400 이면 사유와 무관하게 {@code INVALID_TOKEN} 이었다. 그런데 {@code apns-topic}
+     * 은 설정값이라 잘못 배포되면 <b>모든</b> 요청이 400 을 받고, 스케줄러 한 사이클에 정상 사용자
+     * 토큰이 전량 무효화된다. 복구는 유저가 앱을 다시 열어야 하는데 이 서비스에서는 푸시가 곧
+     * 재방문 유도 장치라 복구가 느리다.
+     */
+    @Nested
+    @DisplayName("APNs 400 사유별 토큰 폐기 판정")
+    class Apns400ReasonHandling {
+
+        @BeforeEach
+        void enableApns() throws Exception {
+            ReflectionTestUtils.setField(pushSender, "apnsPrivateKey", generateEcPrivateKey());
+        }
+
+        @ParameterizedTest(name = "{0} → 토큰 폐기")
+        @ValueSource(strings = {"BadDeviceToken"})
+        @DisplayName("토큰 자체가 무효인 사유는 토큰을 폐기한다")
+        void send_tokenSpecificReason_invalidatesToken(String reason) throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.INVALID_TOKEN);
+            assertThat(result.invalidatesToken()).isTrue();
+            assertThat(result.failureReason()).isEqualTo("APNS_400:" + reason);
+        }
+
+        /**
+         * 이 사유들은 토픽·우선순위·푸시타입 등 <b>요청 설정</b> 문제다. 토큰과 무관하므로 폐기하면
+         * 설정 오류 한 번에 전 유저 토큰이 죽는다.
+         */
+        @ParameterizedTest(name = "{0} → 토큰 유지")
+        @ValueSource(strings = {
+                "TopicDisallowed", "BadPriority", "InvalidPushType", "IdleTimeout",
+                "MissingDeviceToken", "BadExpirationDate", "BadTopic", "MissingTopic", "PayloadEmpty"
+        })
+        @DisplayName("설정·요청 문제인 사유는 토큰을 폐기하지 않는다")
+        void send_configurationReason_keepsToken(String reason) throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_400:" + reason);
+        }
+
+        /**
+         * 토큰이 다른 토픽·환경용일 수도, 우리 토픽 설정이 틀렸을 수도 있어 구분이 불가능하다.
+         * 후자면 전 유저가 한꺼번에 죽으므로 폐기하지 않는 쪽을 택한다.
+         */
+        @Test
+        @DisplayName("DeviceTokenNotForTopic 은 설정 오류와 구분되지 않으므로 토큰을 폐기하지 않는다")
+        void send_deviceTokenNotForTopic_keepsToken() throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"DeviceTokenNotForTopic\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+        }
+
+        @Test
+        @DisplayName("사유를 알 수 없는 400 은 보수적으로 토큰을 유지한다")
+        void send_unknownReason_keepsToken() throws Exception {
+            stubApnsResponse(400, "{\"reason\":\"SomeFutureReason\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+        }
+
+        @Test
+        @DisplayName("본문이 비어 사유를 못 읽는 400 도 토큰을 유지한다")
+        void send_emptyBody_keepsToken() throws Exception {
+            stubApnsResponse(400, "");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_400");
+            // null 가드가 빠지면 NPE 가 send() 의 catch-all 에 잡혀 EXCEPTION:... 으로 둔갑한다.
+            // 위 두 단언은 그 경로에서도 통과하므로 이 단언이 실제 검출력을 갖는다.
+            assertThat(result.failureReason()).doesNotStartWith("EXCEPTION");
+        }
+
+        @Test
+        @DisplayName("410 Unregistered 는 기존대로 토큰을 폐기한다")
+        void send_unregistered_stillInvalidates() throws Exception {
+            stubApnsResponse(410, "{\"reason\":\"Unregistered\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.TOKEN_EXPIRED);
+            assertThat(result.invalidatesToken()).isTrue();
+        }
+
+        /**
+         * 400·410 이 아닌 상태 코드도 토큰을 폐기해서는 안 된다.
+         *
+         * <p>이 경로가 고정되지 않으면 400 만 좁혀놓고 바로 옆 분기로 같은 대량 무효화가 되돌아온다.
+         * 특히 403 {@code ExpiredProviderToken} / {@code InvalidProviderToken} 은 키·팀 ID 오설정이라
+         * <b>모든</b> 요청이 받는다. JWT 가 캐시되므로 전 발송이 한꺼번에 죽는다.
+         */
+        @ParameterizedTest(name = "{0} {1} → 토큰 유지")
+        @CsvSource({
+                "403, InvalidProviderToken",
+                "403, ExpiredProviderToken",
+                "429, TooManyRequests",
+                "500, InternalServerError",
+                "503, ServiceUnavailable"
+        })
+        @DisplayName("400·410 외의 거절은 토큰을 폐기하지 않는다")
+        void send_nonTokenStatusCode_keepsToken(int statusCode, String reason) throws Exception {
+            stubApnsResponse(statusCode, "{\"reason\":\"" + reason + "\"}");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            assertThat(result.failureReason()).isEqualTo("APNS_" + statusCode + ":" + reason);
+        }
+
+        /**
+         * 응답 본문이 JSON 이 아닐 수 있다 (프록시·LB 가 HTML 오류 페이지를 반환하는 경우).
+         * {@code extractApnsReason} 은 이제 폐기 판정의 입력이므로 파싱 실패도 안전해야 한다.
+         */
+        @Test
+        @DisplayName("본문이 JSON 이 아니어도 파싱 실패로 죽지 않고 토큰을 유지한다")
+        void send_nonJsonBody_keepsToken() throws Exception {
+            stubApnsResponse(400, "<html><body>502 Bad Gateway</body></html>");
+
+            PushSendResult result = pushSender.send(VALID_APNS_TOKEN, "ios", "제목", "본문", Map.of());
+
+            assertThat(result.status()).isEqualTo(PushSendStatus.FAILED);
+            assertThat(result.invalidatesToken()).isFalse();
+            // 파싱 예외가 send() 의 catch-all 로 새면 EXCEPTION:... 이 된다 — 그 경로가 아님을 고정한다
+            assertThat(result.failureReason()).isEqualTo("APNS_400");
+        }
+
+        private void stubApnsResponse(int statusCode, String body) throws Exception {
+            HttpResponse<String> response = stubResponse(statusCode, body);
+            when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                    .thenReturn(response);
+        }
     }
 
     /**

--- a/src/test/java/com/mio/report/domain/ReportWeekTest.java
+++ b/src/test/java/com/mio/report/domain/ReportWeekTest.java
@@ -1,0 +1,93 @@
+package com.mio.report.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("ReportWeek — 주간 리포트 대상 주차 계산 (#415)")
+class ReportWeekTest {
+
+    /**
+     * 이 계산이 세 곳(집계 job · 알림 게이트 · 리포트 조회)에서 각자 이뤄지던 것을 하나로 모았다.
+     * 실행 요일에 따라 값이 달라지면 저장한 주차와 조회하는 주차가 어긋나 알림이 통째로 사라진다.
+     */
+    @ParameterizedTest(name = "{0}({1}) 에 실행해도 대상 주차는 2026-08-03")
+    @CsvSource({
+            "2026-08-10, 월요일",
+            "2026-08-11, 화요일",
+            "2026-08-12, 수요일",
+            "2026-08-13, 목요일",
+            "2026-08-14, 금요일",
+            "2026-08-15, 토요일",
+            "2026-08-16, 일요일"
+    })
+    @DisplayName("같은 주 안에서는 어느 요일에 실행해도 같은 주차를 가리킨다")
+    void lastWeekStartFrom_isIndependentOfExecutionDay(LocalDate baseDate, String label) {
+        assertThat(ReportWeek.lastWeekStartFrom(baseDate))
+                .as("%s 실행", label)
+                .isEqualTo(LocalDate.of(2026, 8, 3));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "2026-08-10", "2026-08-11", "2026-08-16",
+            "2026-01-01", "2026-03-02", "2027-01-04"
+    })
+    @DisplayName("결과는 항상 월요일이다")
+    void lastWeekStartFrom_alwaysReturnsMonday(String baseDate) {
+        assertThat(ReportWeek.lastWeekStartFrom(LocalDate.parse(baseDate)).getDayOfWeek())
+                .isEqualTo(DayOfWeek.MONDAY);
+    }
+
+    @Test
+    @DisplayName("연말연시 주 경계에서도 직전 주 월요일을 가리킨다")
+    void lastWeekStartFrom_crossesYearBoundary() {
+        // 2026-01-01 은 목요일 → 그 주 월요일은 2025-12-29 → 직전 주는 2025-12-22
+        assertThat(ReportWeek.lastWeekStartFrom(LocalDate.of(2026, 1, 1)))
+                .isEqualTo(LocalDate.of(2025, 12, 22));
+    }
+
+    @Test
+    @DisplayName("주 종료일은 시작일로부터 6일 뒤 일요일이다")
+    void weekEndOf_returnsSunday() {
+        LocalDate weekStart = LocalDate.of(2026, 8, 3);
+
+        assertThat(ReportWeek.weekEndOf(weekStart)).isEqualTo(LocalDate.of(2026, 8, 9));
+        assertThat(ReportWeek.weekEndOf(weekStart).getDayOfWeek()).isEqualTo(DayOfWeek.SUNDAY);
+    }
+
+    /**
+     * 교체 대상이던 기존 계산식과 동일한 값을 내는지 고정한다.
+     *
+     * <p>{@code ReportService#resolveLastWeekStart} 와 월요일 실행 시의
+     * {@code ReportAggregationJob} 은 원래도 옳았다. 이 헬퍼가 그 동작을 바꾸면 안 된다.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-08-10", "2026-08-11", "2026-08-16", "2026-02-28", "2028-02-29"})
+    @DisplayName("기존 ReportService 계산식과 결과가 같다")
+    void lastWeekStartFrom_matchesLegacyReportServiceFormula(String baseDate) {
+        LocalDate today = LocalDate.parse(baseDate);
+        int daysFromMonday = today.getDayOfWeek().getValue() - DayOfWeek.MONDAY.getValue();
+        LocalDate legacy = today.minusDays(daysFromMonday + 7L);
+
+        assertThat(ReportWeek.lastWeekStartFrom(today)).isEqualTo(legacy);
+    }
+
+    @Test
+    @DisplayName("월요일 실행 시 기존 집계 job 계산식과 결과가 같다")
+    void lastWeekStartFrom_matchesLegacyJobFormulaOnMonday() {
+        LocalDate monday = LocalDate.of(2026, 8, 10);
+        LocalDate legacyWeekEnd = monday.minusDays(1);
+        LocalDate legacyWeekStart = legacyWeekEnd.minusDays(6);
+
+        assertThat(ReportWeek.lastWeekStartFrom(monday)).isEqualTo(legacyWeekStart);
+        assertThat(ReportWeek.weekEndOf(ReportWeek.lastWeekStartFrom(monday))).isEqualTo(legacyWeekEnd);
+    }
+}

--- a/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
+++ b/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
@@ -1,0 +1,140 @@
+package com.mio.report.job;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.report.domain.WeeklyReport;
+import com.mio.report.repository.WeeklyReportRepository;
+import com.mio.user.domain.User;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.lang.reflect.Field;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 집계 job 이 <b>실행 요일과 무관하게</b> 같은 주차를 대상으로 삼는지 고정한다 (이슈 #415).
+ *
+ * <p>이전 구현은 {@code 오늘 − 1일 − 6일} 이라 월요일에 돌 때만 옳았다. 화요일에 재실행하면
+ * 월요일이 아닌 {@code week_start} 로 저장돼, 알림 게이트의 조회가 전부 비면서 그 주 리포트
+ * 알림이 전 유저 무발송이 됐다.
+ *
+ * <p>이 테스트가 없으면 누군가 job 안에서 다시 {@code LocalDate.now().minusDays(1)} 로 인라인해도
+ * CI 가 초록이다 — 헬퍼 단위 테스트만으로는 호출부가 그것을 쓰는지 보장하지 못한다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReportAggregationJob — 대상 주차 계산 (#415)")
+class ReportAggregationJobTest {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+    private static final LocalDate EXPECTED_WEEK_START = LocalDate.of(2026, 8, 3);
+    private static final LocalDate EXPECTED_WEEK_END = LocalDate.of(2026, 8, 9);
+
+    @Mock private UserRepository userRepository;
+    @Mock private WeeklyReportRepository weeklyReportRepository;
+    @Mock private JdbcTemplate jdbcTemplate;
+
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+    }
+
+    @ParameterizedTest(name = "{1}({0})에 실행해도 2026-08-03 주차를 집계한다")
+    @CsvSource({
+            "2026-08-10T03:00:00+09:00, 월요일",
+            "2026-08-11T03:00:00+09:00, 화요일",
+            "2026-08-13T03:00:00+09:00, 목요일",
+            "2026-08-16T03:00:00+09:00, 일요일"
+    })
+    @DisplayName("실행 요일이 달라도 같은 주차를 대상으로 삼는다")
+    void run_targetsSameWeekRegardlessOfExecutionDay(String runAt, String label) {
+        ReportAggregationJob job = jobAt(Clock.fixed(OffsetDateTime.parse(runAt).toInstant(), KST));
+        stubOneCandidateUser();
+
+        job.run();
+
+        // 저장 대상 주차가 실행 요일에 흔들리지 않아야 한다
+        verify(weeklyReportRepository).findByUser_IdAndWeekStart(eq(userId), eq(EXPECTED_WEEK_START));
+    }
+
+    @ParameterizedTest(name = "{1} 실행 시 저장되는 week_start/week_end")
+    @CsvSource({
+            "2026-08-10T03:00:00+09:00, 월요일",
+            "2026-08-11T03:00:00+09:00, 화요일"
+    })
+    @DisplayName("저장되는 주차는 항상 월요일~일요일이다")
+    void run_savesMondayToSundayRange(String runAt, String label) {
+        ReportAggregationJob job = jobAt(Clock.fixed(OffsetDateTime.parse(runAt).toInstant(), KST));
+        stubOneCandidateUser();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(any(), any())).thenReturn(Optional.empty());
+
+        job.run();
+
+        org.mockito.ArgumentCaptor<WeeklyReport> captor =
+                org.mockito.ArgumentCaptor.forClass(WeeklyReport.class);
+        verify(weeklyReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getWeekStart()).isEqualTo(EXPECTED_WEEK_START);
+        assertThat(captor.getValue().getWeekEnd()).isEqualTo(EXPECTED_WEEK_END);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubOneCandidateUser() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(userId));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(newUser()));
+        // 체크인 수는 임계값 미만이면 INSUFFICIENT_DATA 로 바로 저장되어 흐름이 단순해진다
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(), any(), any()))
+                .thenReturn(0);
+    }
+
+    private ReportAggregationJob jobAt(Clock clock) {
+        return new ReportAggregationJob(userRepository, weeklyReportRepository, jdbcTemplate,
+                new ObjectMapper(), clock);
+    }
+
+    private User newUser() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-social-id")
+                .privacyConsent(true)
+                .build();
+        try {
+            Field field = User.class.getDeclaredField("id");
+            field.setAccessible(true);
+            field.set(user, userId);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        return user;
+    }
+
+    @SuppressWarnings("unused")
+    private static Instant unused() {
+        return Instant.EPOCH;
+    }
+}


### PR DESCRIPTION
## 요약

**1.0.0 릴리즈.** QA 제보 대응 1건과, 그 리뷰 과정에서 발견된 알림 신뢰성 문제 3건, 배포 안전망 1건을 배포한다.

AI 파이프라인 작업(P0 등)은 **1.1.x 로 분리**하므로 이 릴리즈에 포함하지 않는다.

## 관련 이슈

- Closes #413 — 데이터 부족인데 리포트 완료 알림 발송 (**QA 제보**)
- Closes #415 — 집계 job 이 실행 요일에 의존해 대상 주차를 계산
- Closes #411 — APNs 400 을 사유 구분 없이 토큰 무효화
- Closes #408 — 억제된 트리거가 나머지 알림까지 차단
- Closes #375 — CD 에 기동 헬스 게이트 부재

## 변경 사항

| # | 내용 | 사용자 체감 |
|---|---|---|
| #413 | 리포트가 `GENERATED` 인 경우에만 주간 리포트 알림 발송 | **QA 제보 해소** — 데이터 부족 유저에게 "리포트가 준비됐어요" 가 더 이상 가지 않는다 |
| #408 | 억제된 트리거는 그것만 건너뛰고 다음 후보를 평가 | 차단돼 있던 체크인 리마인더가 정상화된다 |
| #411 | 400 중 `BadDeviceToken` 만 토큰 폐기 | 설정 오류 시 전 유저 토큰이 죽는 경로 차단 |
| #415 | 주차 계산을 `ReportWeek` 한 곳으로 통일 | 없음 (정상 경로 동작 동일) |
| #375 | 배포 기동 헬스 게이트 | 없음 (파이프라인) |

### 앞선 배포(#412)와의 관계

푸시 라우팅(#409)은 이미 `980cd25` 로 프로덕션에 나가 있다. **이번 릴리즈는 그 후속 리뷰에서 파생된 것들이다.**

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다. — **REST 계약 변경 없음**
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다. — 배포 실패 판정, APNs 비토큰 400 을 ERROR 로
- [ ] Breaking change 가 있습니다.

### 발송량 변화 (의도된 것)

| 트리거 | 방향 | 이유 |
|---|---|---|
| `report_weekly` | **크게 감소** | 프로덕션 `weekly_reports` 가 `INSUFFICIENT_DATA` 8건 / `GENERATED` 1건. 지금까지 대부분이 오발송이었다 |
| 체크인 리마인더 | **증가** | 억제로 차단되던 것이 정상화. 일일 한도 3건과 24시간 트리거별 억제는 그대로라 상한은 불변 |

## 테스트

```bash
./gradlew build
```

전 커밋 CI 통과. 각 PR 은 리뷰 후 뮤테이션으로 검출력을 확인했다.

| 항목 | 검증 |
|---|---|
| #413 상태 게이트 | 화이트리스트(`GENERATED` 만) — 블랙리스트로 바꾸면 `PENDING` 케이스 실패 |
| #415 주차 계산 | 1990~2069년 **29,220일** 을 기존 3개 공식과 대조, 차이 0건 |
| #408 폴스루 | 한 틱 1건·우선순위·억제 검사 횟수·슬롯 라벨 4종 뮤테이션 전부 검출 |
| #411 토큰 폐기 | 사유별 판정 + fall-through 분기 + 호출부까지 고정 |
| #375 헬스 게이트 | 로컬 5개 시나리오 (정상 / UNKNOWN / exited / 오탐 재현 / 기준선 통과), shellcheck 클린 |

## 중점 리뷰 포인트

- **#375 헬스 게이트가 이번 배포부터 실제로 동작한다.** 기동 실패 시 워크플로우가 `failure` 로 끝난다. 정상 기동은 약 22초라 타임아웃 180초는 여유가 있다
- 게이트 실패 시 **app 로그는 CD 출력에 나오지 않는다** — `logging.driver` 가 `awslogs` 라 읽기를 지원하지 않는다. 대신 CloudWatch 조회 명령과 수동 롤백 절차를 출력한다
- `report_weekly` 발송량 급감이 정상임을 배포 후 지표에서 오인하지 않도록 공유 필요

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용. DB 마이그레이션·설정 변경 없음
- **Rollback**: 서버만 되돌리면 된다. 스키마 변경이 없어 데이터 영향 없음
- **배포 후 확인**: 다음 월요일 08:00 KST 발송분에서 `INSUFFICIENT_DATA` 유저에게 `report_weekly` 가 나가지 않는지 `proactive_care_logs` 로 확인

## FE 연동 대기 사항 (서버는 이미 배포됨)

푸시 라우팅(#409)은 프로덕션에 나가 있으나 **앱이 `route` 를 읽어야 사용자 체감이 생긴다.** QA 가 "알림이 떠도 라우팅이 안 된다" 고 제보한 부분이다.

1. 탭 핸들러에서 `type` 하드코딩이 아니라 **`route` 기준** 분기
2. **Android 는 `getIntent().getExtras()` 경로 필수** — 백그라운드·종료 상태에서 `onMessageReceived` 가 호출되지 않는다. 포그라운드 테스트만 하면 정상으로 보인다
3. `notification_id` 존재 여부 분기를 미리 넣어두면 추후 오픈율 집계 전환 시 앱 재릴리스가 불필요하다

상세는 `api 명세서/10_Notification_알림.md` v1.4.0 「푸시 페이로드」 절.

## 이번 릴리즈에 넣지 않은 것

| 이슈 | 사유 |
|---|---|
| #419 리포트 내러티브 배치 전환 | 비용 문제이고 사용자 증상이 아니다. FE 가 `narrative` 를 표시 중인지 확인이 선행돼야 한다 |
| AI 파이프라인 P0 (#364 #365 #369 #371) | **1.1.x 로 버전 분리** |
| 저녁 슬롯 기아 (일일 한도 선착순 소진) | 정책 결정 필요 — #408 리뷰에서 제기 |
| 무단말 유저 폴스루 미적용 | `NO_DEVICE` 를 억제 대상으로 볼지 결정 필요 — #408 리뷰에서 제기 |

## 문서

`docs/` 는 gitignore 대상이라 이 PR 에 포함되지 않는다. 아래 4건을 갱신했다.

- `api 명세서/10_Notification_알림.md` v1.4.0 — 푸시 페이로드 스키마, `report_weekly` 발송 조건, 이력 미노출 내부 상태, `DELIVERED` 미기록, FE 라우팅 참고사항
- `api 명세서/08_Report_리포트.md` v1.5.0 — 명세와 코드가 어긋나 있던 3건 정정 (`narrative` 는 null 이 아님 / `PENDING` 미노출 / `report_id` 항상 null)
- `05_비동기_알림.md` — 발송 조건, 주차 계산 통일, `ReportNarrativeJob` 미구현 표기
- `04_AI_파이프라인_v2.4.md` — `WeeklyReflectionJob` 스케줄 모순 기재

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
