### PR TITLE
chore: 릴리즈 버전을 1.0.0으로 올린다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.mio"
-version = "0.0.1-SNAPSHOT"
+version = "1.0.0"
 
 java {
     toolchain {


### PR DESCRIPTION
## 요약

베타 테스트 대상인 **1차 릴리즈**를 선언한다. 지금까지 버전은 Spring Initializr 기본값 `0.0.1-SNAPSHOT` 그대로였고, 저장소에 태그와 GitHub 릴리즈가 하나도 없었다.

이후 AI 파이프라인 작업을 `1.1.x` 로 분리하기로 했는데 그 기준선이 코드에 없었다.

## 관련 이슈

- Closes #423

## 변경 사항

- `build.gradle.kts` — `version = "0.0.1-SNAPSHOT"` → `"1.0.0"`

한 줄이다. `0.0.1-SNAPSHOT` 을 참조하는 곳은 이 파일뿐이다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

빌드 산출물 이름이 `mio-0.0.1-SNAPSHOT.jar` → `mio-1.0.0.jar` 로 바뀐다.

## 테스트

```bash
./gradlew build
./gradlew clean bootJar --no-daemon -x test
```

**이미지 빌드가 깨지지 않는지 확인했다.** `Dockerfile:17` 이 `COPY --from=builder /app/build/libs/*.jar app.jar` 로 글롭을 쓰는데, 다중 매칭이면 COPY 가 실패한다.

- `./gradlew build` 는 `mio-1.0.0.jar` 와 `mio-1.0.0-plain.jar` 를 함께 만든다
- 그러나 빌더 스테이지는 `bootJar` 만 실행한다 (`Dockerfile:12`)
- `clean bootJar` 실행 결과 산출물은 **`mio-1.0.0.jar` 하나뿐**임을 확인했다

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용. 동작 변화 없음
- **Rollback**: 서버만 되돌리면 된다

## 후속

머지 후 develop → main 릴리즈 PR, `v1.0.0` 태그, GitHub Release 순으로 진행한다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. — 버전 문자열 변경이라 테스트 대상이 없다. 대신 이미지 빌드 영향을 직접 확인했다
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 해당 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 1.0.0, marking the first stable release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->