### PR TITLE
release: v1.0.0 — 1차 릴리즈 (베타)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.mio"
-version = "0.0.1-SNAPSHOT"
+version = "1.0.0"
 
 java {
     toolchain {


### PR DESCRIPTION
## 요약

**1차 릴리즈 (v1.0.0)** — 베타 테스트 대상 버전을 확정한다.

이 PR 자체는 버전 문자열 한 줄 변경이다. 머지 후 `main` 에 `v1.0.0` 태그를 달고 GitHub Release 를 작성한다. 태그가 가리키는 것은 **지금까지 개발된 전체**이며, 이 PR 은 그 선언을 코드에 남기는 마지막 단계다.

## 관련 이슈

- Closes #423

## 변경 사항

- `build.gradle.kts` — `version = "0.0.1-SNAPSHOT"` → `"1.0.0"`

## v1.0.0 이 포함하는 범위

| | |
|---|---|
| 기간 | 2026-05-14 ~ 2026-08-11 |
| 커밋 | 493 |
| 머지된 PR | 196 |
| Flyway 마이그레이션 | 53 |

REST API(인증·세션·체크인·데일리테스트·투두·리포트·알림·위기·캐릭터·온보딩·마이페이지), AI 파이프라인(SafetyL1·InputJudge·PolicyEngine·메모리 서브시스템), 비동기 처리, 푸시 알림, 운영 인프라를 포함한다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

**동작 변화 없음.** 빌드 산출물 이름만 `mio-0.0.1-SNAPSHOT.jar` → `mio-1.0.0.jar` 로 바뀐다.

## 테스트

```bash
./gradlew build
./gradlew clean bootJar --no-daemon -x test
```

`Dockerfile:17` 의 `COPY --from=builder /app/build/libs/*.jar app.jar` 글롭이 다중 매칭이면 실패하므로, 빌더 스테이지(`bootJar` 만 실행) 산출물이 **`mio-1.0.0.jar` 하나뿐**임을 확인했다.

## 배포 / 롤백

- **Rollout**: 서버 배포만으로 적용. 어제 도입한 기동 헬스 게이트(#375)가 이 배포에서도 동작한다
- **Rollback**: 서버만 되돌리면 된다. 스키마·설정 변경이 없다

## 직전 배포(#422)에서 나간 것

이번 릴리즈 태그에 포함되지만 코드는 이미 프로덕션에 있다.

| # | 내용 |
|---|---|
| #413 | 데이터 부족 유저에게 리포트 완료 알림이 가던 문제 (**QA 제보**) |
| #408 | 억제된 트리거가 나머지 알림까지 차단하던 문제 |
| #411 | APNs 400 을 사유 구분 없이 토큰 무효화하던 문제 |
| #415 | 집계 job 이 실행 요일에 의존해 주차를 계산하던 문제 |
| #375 | CD 기동 헬스 게이트 부재 |

## 릴리즈 후 남는 작업

| 항목 | 계획 |
|---|---|
| FE 푸시 라우팅 연동 | 서버는 배포 완료(#409). 앱 릴리스 대기 — QA 제보 ② |
| AI 파이프라인 P0 (#364 #365 #369 #371) | **1.1.x** 로 분리. PR 4건이 이미 열려 있다 |
| #419 리포트 내러티브 배치 전환 | FE 가 `narrative` 를 표시 중인지 확인 후 착수 |
| 알림 정책 결정 2건 | 저녁 슬롯 기아, 무단말 유저 폴스루 — 이슈 미등록 |

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. — 버전 문자열이라 테스트 대상이 없다. 이미지 빌드 영향을 직접 확인했다
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 해당 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
