### PR TITLE
feat: 세션당 AI 비용 조회 API (#433)

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminSessionController.java
+++ b/src/main/java/com/mio/admin/controller/AdminSessionController.java
@@ -1,6 +1,8 @@
 package com.mio.admin.controller;
 
+import com.mio.admin.dto.SessionCostResponse;
 import com.mio.admin.dto.SessionTimelineResponse;
+import com.mio.admin.service.AdminSessionCostService;
 import com.mio.admin.service.AdminSessionService;
 import com.mio.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +26,15 @@ import java.util.UUID;
 public class AdminSessionController {
 
     private final AdminSessionService adminSessionService;
+    private final AdminSessionCostService adminSessionCostService;
 
     @GetMapping("/{sessionId}")
     public ResponseEntity<ApiResponse<SessionTimelineResponse>> getTimeline(@PathVariable UUID sessionId) {
         return ResponseEntity.ok(ApiResponse.ok(adminSessionService.getTimeline(sessionId)));
+    }
+
+    @GetMapping("/{sessionId}/cost")
+    public ResponseEntity<ApiResponse<SessionCostResponse>> getCost(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminSessionCostService.getCost(sessionId)));
     }
 }

--- a/src/main/java/com/mio/admin/dto/SessionCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionCostResponse.java
@@ -1,0 +1,24 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 세션당 비용 조회 응답 (이슈 #433).
+ *
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 AWS Cost Explorer 연동이
+ * 아직 없어 {@code null}이다 — 0으로 채우면 "인프라 비용이 없다"로 오독되므로, 모르는 값은
+ * 비워서 API 응답 자체가 미지원임을 드러낸다("모르는 것을 0으로 감추지 않는다" 원칙).
+ */
+public record SessionCostResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("user_id") UUID userId,
+        @JsonProperty("direct_variable_cost_usd") BigDecimal directVariableCostUsd,
+        @JsonProperty("unpriced_events") long unpricedEvents,
+        @JsonProperty("all_priced") boolean allPriced,
+        @JsonProperty("allocated_fixed_infra_usd_estimate") BigDecimal allocatedFixedInfraUsdEstimate,
+        @JsonProperty("total_usd") BigDecimal totalUsd
+) {
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionCostService.java
@@ -1,0 +1,48 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.SessionCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 운영자용 세션당 비용 조회 (이슈 #433, #431의 후속).
+ *
+ * <p>AI 비용({@code ai_cost_events} 합산)만 반영한다. 비-AI 인프라 비용 배분(AWS Cost Explorer
+ * 연동, 옵션 A 시간 비례)은 별도 이슈에서 채운다 — 그 전까지 {@code allocated_fixed_infra_usd_estimate}/
+ * {@code total_usd}는 {@code null}로 비워 "인프라 비용 미지원"을 명시적으로 드러낸다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSessionCostService {
+
+    private final SessionRepository sessionRepository;
+    private final AiCostEventRepository aiCostEventRepository;
+
+    public SessionCostResponse getCost(UUID sessionId) {
+        var session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        AiCostAggregate aggregate = aiCostEventRepository.aggregateBySessionId(sessionId);
+
+        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — 0이 아니라 null로 비운다.
+        // 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 연동해도 과거 조회 결과와 구분이 안 된다.
+        return new SessionCostResponse(
+                sessionId,
+                session.getUser().getId(),
+                aggregate.totalCostUsd(),
+                aggregate.unpricedCount(),
+                aggregate.allPriced(),
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
@@ -1,0 +1,90 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.SessionCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #433 — AI 비용만 먼저 노출하고, 인프라 배분은 null로 비워 미지원을 드러내는지 검증. */
+@ExtendWith(MockitoExtension.class)
+class AdminSessionCostServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private AiCostEventRepository aiCostEventRepository;
+
+    private AdminSessionCostService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션이면 SESSION_NOT_FOUND")
+    void getCost_sessionNotFound_throws() {
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCost(sessionId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("전부 단가가 있으면 direct_variable_cost_usd가 채워지고 인프라·합계는 null이다")
+    void getCost_allPriced_infraStillNull() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.013"), 0L, 2L));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.sessionId()).isEqualTo(sessionId);
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.directVariableCostUsd()).isEqualByComparingTo(new BigDecimal("0.013"));
+        assertThat(response.unpricedEvents()).isZero();
+        assertThat(response.allPriced()).isTrue();
+        assertThat(response.allocatedFixedInfraUsdEstimate())
+                .as("AWS Cost Explorer 연동 전까지는 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
+                .isNull();
+        assertThat(response.totalUsd()).isNull();
+    }
+
+    @Test
+    @DisplayName("단가 미등록 이벤트가 섞여 있으면 allPriced=false와 unpricedEvents가 그대로 노출된다")
+    void getCost_partiallyUnpriced_revealsIncompleteness() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.01"), 1L, 2L));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.allPriced()).isFalse();
+        assertThat(response.unpricedEvents()).isEqualTo(1L);
+    }
+}


### PR DESCRIPTION
## 요약
`GET /v1/admin/sessions/{sessionId}/cost` — 세션당 AI 비용(`ai_cost_events` 합산)을 조회하는 API를 추가합니다. 인프라 비용 배분(AWS Cost Explorer 연동)은 별도 IAM 권한이 필요해 이번 스코프에서 뺐고, 관련 필드는 `null`로 비워 미지원을 명시합니다.

## 관련 이슈
- Closes #433

## 변경 사항
- `SessionCostResponse` DTO 신설 — `direct_variable_cost_usd`, `unpriced_events`, `all_priced`, `allocated_fixed_infra_usd_estimate`(null), `total_usd`(null)
- `AdminSessionCostService` 신설 — 세션 존재 확인(`SESSION_NOT_FOUND`) + `AiCostEventRepository.aggregateBySessionId()` 소비
- `AdminSessionController`에 `GET /{sessionId}/cost` 엔드포인트 추가 — 기존 `/v1/admin/**` 권한(`ROLE_ADMIN`) 그대로 적용

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (신규 엔드포인트)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test
```
### 확인 내용
- `AdminSessionCostServiceTest` 3건 신규 — 세션 없음(404), 전부 단가 있음(인프라 필드는 여전히 null), 일부 단가 미등록(`all_priced=false`, `unpriced_events` 노출)
- 전체 스위트 그린

## 중점 리뷰 포인트
- `allocated_fixed_infra_usd_estimate`/`total_usd`를 0이 아니라 `null`로 비운 설계 — AWS Cost Explorer 연동(별도 이슈, IAM 권한 선행 필요) 전까지 "인프라 비용 0원"으로 오독되지 않게 하려는 의도. 인프라 연동 추가 시 이 두 필드만 채우면 되고 스키마 변경은 불필요
- `direct_variable_cost_usd`가 단가 미등록 이벤트를 제외한 부분합일 수 있음을 `all_priced`/`unpriced_events`로 같이 노출 — 호출측이 두 필드를 무시하면 과소계상된 비용을 완전한 값으로 오해할 수 있음

## 배포 / 롤백
- Rollout: 코드 배포만, 스키마 변경 없음(#431의 `ai_cost_events` 테이블 재사용)
- Rollback: 이 커밋만 되돌리면 됨, 데이터 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `feat/#431-session-ai-cost-events`입니다 — #433이 #431(`ai_cost_events`/`AiCostEventRepository`)에 의존하는데 #431(PR #432)이 아직 머지되지 않았기 때문입니다. #431이 머지되면 이 PR의 base를 `develop`으로 옮기겠습니다(일반 머지 커밋이라 diff는 깨끗하게 정리됩니다).
