### PR TITLE
feat: 유저별 월간 누적 AI 비용 조회 API (#434)

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminUserController.java
+++ b/src/main/java/com/mio/admin/controller/AdminUserController.java
@@ -1,0 +1,36 @@
+package com.mio.admin.controller;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.admin.service.AdminUserCostService;
+import com.mio.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * 운영자용 유저 단위 조회 (이슈 #434).
+ *
+ * <p>{@code ROLE_ADMIN} 필요 — {@code /v1/admin/**} 전체가 {@code SecurityConfig}에서
+ * 일괄 게이트된다({@code AdminSessionController}와 동일).
+ */
+@RestController
+@RequestMapping("/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserCostService adminUserCostService;
+
+    /** @param month "yyyy-MM" 형식. 생략하면 이번 달(Asia/Seoul 기준) */
+    @GetMapping("/{userId}/cost-monthly")
+    public ResponseEntity<ApiResponse<UserMonthlyCostResponse>> getMonthlyCost(
+            @PathVariable UUID userId,
+            @RequestParam(required = false) String month) {
+        return ResponseEntity.ok(ApiResponse.ok(adminUserCostService.getMonthlyCost(userId, month)));
+    }
+}

--- a/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
@@ -1,0 +1,28 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 유저별 월간 누적 비용 조회 응답 (이슈 #434).
+ *
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는
+ * AWS Cost Explorer 연동이 아직 없어 {@code null}이다 — #433과 같은 원칙, 0으로 채우면
+ * "인프라 비용이 없다"로 오독된다.
+ *
+ * <p>{@code user_month_technical_cogs_usd}라는 이름에 "technical"을 붙인 이유: 앱스토어·결제
+ * 수수료, 부가세·환율, 무료 사용량·환불, CS 비용이 빠진 <b>기술 원가 일부</b>라는 걸 명시하기
+ * 위함 — 전체 수익성 지표로 오독되면 안 된다.
+ */
+public record UserMonthlyCostResponse(
+        @JsonProperty("user_id") UUID userId,
+        String month,
+        @JsonProperty("direct_variable_cost_usd") BigDecimal directVariableCostUsd,
+        @JsonProperty("unpriced_events") long unpricedEvents,
+        @JsonProperty("all_priced") boolean allPriced,
+        @JsonProperty("allocated_fixed_infra_usd_estimate") BigDecimal allocatedFixedInfraUsdEstimate,
+        @JsonProperty("user_month_technical_cogs_usd") BigDecimal userMonthTechnicalCogsUsd
+) {
+}

--- a/src/main/java/com/mio/admin/service/AdminUserCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminUserCostService.java
@@ -1,0 +1,67 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+
+/**
+ * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #433의 연장).
+ *
+ * <p>세션 단위였던 #433의 집계를 유저·월 단위로만 바꾼 것 — 신규 계측 없이
+ * {@code AiCostEventRepository.aggregateByUserIdAndCreatedAtBetween()}만 추가로 소비한다.
+ * 인프라 비용 배분은 #433과 동일하게 이번 스코프에서 뺐다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserCostService {
+
+    private final UserRepository userRepository;
+    private final AiCostEventRepository aiCostEventRepository;
+
+    public UserMonthlyCostResponse getMonthlyCost(UUID userId, String month) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        YearMonth yearMonth = parseOrCurrentMonth(month);
+        OffsetDateTime from = yearMonth.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = yearMonth.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+
+        AiCostAggregate aggregate = aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(userId, from, to);
+
+        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — #433과 같은 이유로 0이 아니라 null.
+        return new UserMonthlyCostResponse(
+                userId,
+                yearMonth.toString(),
+                aggregate.totalCostUsd(),
+                aggregate.unpricedCount(),
+                aggregate.allPriced(),
+                null,
+                null
+        );
+    }
+
+    private YearMonth parseOrCurrentMonth(String month) {
+        if (month == null || month.isBlank()) {
+            return YearMonth.now(AppConstants.ZONE);
+        }
+        try {
+            return YearMonth.parse(month);
+        } catch (DateTimeParseException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -1,0 +1,117 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #434 — #433과 같은 원칙(인프라 배분 null)으로 유저·월 단위 집계만 바뀐 것 검증. */
+@ExtendWith(MockitoExtension.class)
+class AdminUserCostServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private AiCostEventRepository aiCostEventRepository;
+
+    private AdminUserCostService service;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserCostService(userRepository, aiCostEventRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저면 USER_NOT_FOUND")
+    void getMonthlyCost_userNotFound_throws() {
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getMonthlyCost(userId, "2026-08"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("잘못된 month 형식이면 INVALID_INPUT")
+    void getMonthlyCost_invalidMonthFormat_throws() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.getMonthlyCost(userId, "not-a-month"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+
+    @Test
+    @DisplayName("month를 지정하면 해당 월의 [1일 00:00, 다음달 1일 00:00) 범위로 집계한다")
+    void getMonthlyCost_explicitMonth_queriesCorrectRange() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("1.5"), 0L, 3L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.month()).isEqualTo("2026-08");
+        assertThat(response.directVariableCostUsd()).isEqualByComparingTo(new BigDecimal("1.5"));
+
+        ArgumentCaptor<OffsetDateTime> fromCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        ArgumentCaptor<OffsetDateTime> toCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        org.mockito.Mockito.verify(aiCostEventRepository)
+                .aggregateByUserIdAndCreatedAtBetween(eq(userId), fromCaptor.capture(), toCaptor.capture());
+
+        YearMonth august = YearMonth.of(2026, 8);
+        assertThat(fromCaptor.getValue())
+                .isEqualTo(august.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime());
+        assertThat(toCaptor.getValue())
+                .isEqualTo(august.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime());
+    }
+
+    @Test
+    @DisplayName("month를 생략하면 이번 달(Asia/Seoul 기준)로 조회한다")
+    void getMonthlyCost_missingMonth_defaultsToCurrentMonth() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, null);
+
+        assertThat(response.month()).isEqualTo(YearMonth.now(AppConstants.ZONE).toString());
+    }
+
+    @Test
+    @DisplayName("인프라 배분 필드는 #433과 같은 이유로 null이다")
+    void getMonthlyCost_infraFieldsAreNull() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("2.0"), 1L, 4L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.allPriced()).isFalse();
+        assertThat(response.unpricedEvents()).isEqualTo(1L);
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isNull();
+        assertThat(response.userMonthTechnicalCogsUsd()).isNull();
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -95,9 +95,13 @@ class AdminUserCostServiceTest {
         when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
                 .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
 
+        // 서비스 호출 전후로 "지금" 월을 각각 캡처한다 — 서비스 내부와 이 어설션이 YearMonth.now()를
+        // 별도로 호출하므로, 월 경계(자정)에 걸리면 두 호출이 다른 달을 반환해 거짓 실패가 날 수 있다.
+        YearMonth before = YearMonth.now(AppConstants.ZONE);
         UserMonthlyCostResponse response = service.getMonthlyCost(userId, null);
+        YearMonth after = YearMonth.now(AppConstants.ZONE);
 
-        assertThat(response.month()).isEqualTo(YearMonth.now(AppConstants.ZONE).toString());
+        assertThat(response.month()).isIn(before.toString(), after.toString());
     }
 
     @Test


### PR DESCRIPTION
## 요약
`GET /v1/admin/users/{userId}/cost-monthly` — 유저별 월간 누적 AI 비용을 조회하는 API를 추가합니다. #433의 세션 단위 집계를 유저·월 단위로 바꾼 것으로, 신규 계측 없이 기존 `ai_cost_events`에 쿼리만 추가합니다.

## 관련 이슈
- Closes #434

## 변경 사항
- `UserMonthlyCostResponse` DTO 신설 — `month`, `direct_variable_cost_usd`, `unpriced_events`, `all_priced`, `allocated_fixed_infra_usd_estimate`(null), `user_month_technical_cogs_usd`(null)
- `AdminUserCostService` 신설 — 유저 존재 확인(`USER_NOT_FOUND`) + `AiCostEventRepository.aggregateByUserIdAndCreatedAtBetween()` 소비, `month`(yyyy-MM) 파라미터 파싱(생략 시 이번 달, Asia/Seoul 기준)
- `AdminUserController` 신규 — `GET /v1/admin/users/{userId}/cost-monthly?month=yyyy-MM`

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (신규 엔드포인트)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test
```
### 확인 내용
- `AdminUserCostServiceTest` 5건 신규 — 유저없음(404), 잘못된 month 포맷(400), 명시 month의 정확한 범위 계산 검증, month 생략 시 기본값(이번 달), 인프라 필드 null
- 전체 스위트 그린

## 중점 리뷰 포인트
- `user_month_technical_cogs_usd`라는 필드명 — 앱스토어 수수료·부가세·환불·CS 비용이 빠진 "기술 원가 일부"임을 이름으로 명시(전체 수익성 지표로 오독 방지, 개선안 문서 §2.4 리뷰 반영)
- 월 경계 계산에 `AppConstants.ZONE`(Asia/Seoul) 사용 — UTC 자정 기준으로 계산하면 한국 시간 기준 월과 어긋난다
- #433과 동일하게 인프라 배분 필드는 `null` — AWS Cost Explorer 연동은 별도 이슈

## 배포 / 롤백
- Rollout: 코드 배포만, 스키마 변경 없음
- Rollback: 이 커밋만 되돌리면 됨, 데이터 영향 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `feat/#433-session-cost-api`입니다 — `AdminSessionController`처럼 #433이 건드린 코드 근처(`com.mio.admin.*`)를 같이 다뤄 순서대로(#431→#433→#434) 쌓아뒀습니다. 앞 브랜치들이 순서대로 머지되면 이 PR의 base도 그때그때 develop 쪽으로 옮기겠습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint to retrieve a user’s monthly AI cost.
  * Supports a specified month or defaults to the current month.
  * Responses include direct variable costs, unpriced event counts, pricing completeness, and infrastructure cost estimates.

* **Bug Fixes**
  * Added validation for unknown users and invalid month formats with clear error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->