### PR TITLE
feat: AWS CloudWatch Billing 지표로 인프라 비용 배치 캐싱을 연동한다

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
     implementation("me.paulschwarz:spring-dotenv:4.0.0")
     // Firebase Admin SDK — Android FCM push
     implementation("com.google.firebase:firebase-admin:9.4.1")
+    // AWS CloudWatch — 인프라 비용 배치 캐싱(이슈 #437). AWS/Billing EstimatedCharges 지표를 읽는다 —
+    // Cost Explorer(ce:GetCostAndUsage, 건당 $0.01)보다 이쪽이 무료라 이걸로 전환함(리뷰 반영).
+    // 크리덴셜은 EC2 인스턴스 역할 기본 체인.
+    implementation("software.amazon.awssdk:cloudwatch:2.28.11")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/com/mio/admin/dto/SessionCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionCostResponse.java
@@ -8,9 +8,10 @@ import java.util.UUID;
 /**
  * 세션당 비용 조회 응답 (이슈 #433).
  *
- * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 AWS Cost Explorer 연동이
- * 아직 없어 {@code null}이다 — 0으로 채우면 "인프라 비용이 없다"로 오독되므로, 모르는 값은
- * 비워서 API 응답 자체가 미지원임을 드러낸다("모르는 것을 0으로 감추지 않는다" 원칙).
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 인프라 비용 배치
+ * ({@code InfraCostSyncJob})가 해당 월을 아직 캐싱하지 않았으면 {@code null}이다 — 0으로 채우면
+ * "인프라 비용이 없다"로 오독되므로, 모르는 값은 비워서 API 응답 자체가 미지원임을 드러낸다
+ * ("모르는 것을 0으로 감추지 않는다" 원칙).
  */
 public record SessionCostResponse(
         @JsonProperty("session_id") UUID sessionId,

--- a/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
@@ -9,8 +9,8 @@ import java.util.UUID;
  * 유저별 월간 누적 비용 조회 응답 (이슈 #434).
  *
  * <p>{@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는
- * AWS Cost Explorer 연동이 아직 없어 {@code null}이다 — #433과 같은 원칙, 0으로 채우면
- * "인프라 비용이 없다"로 오독된다.
+ * 인프라 비용 배치({@code InfraCostSyncJob})가 해당 월을 아직 캐싱하지 않았으면 {@code null}이다
+ * — #433과 같은 원칙, 0으로 채우면 "인프라 비용이 없다"로 오독된다.
  *
  * <p>{@code user_month_technical_cogs_usd}라는 이름에 "technical"을 붙인 이유: 앱스토어·결제
  * 수수료, 부가세·환율, 무료 사용량·환불, CS 비용이 빠진 <b>기술 원가 일부</b>라는 걸 명시하기

--- a/src/main/java/com/mio/admin/service/AdminSessionCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionCostService.java
@@ -3,21 +3,27 @@ package com.mio.admin.service;
 import com.mio.admin.dto.SessionCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
 import com.mio.session.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.YearMonth;
 import java.util.UUID;
 
 /**
- * 운영자용 세션당 비용 조회 (이슈 #433, #431의 후속).
+ * 운영자용 세션당 비용 조회 (이슈 #433, #437 — #431의 후속).
  *
- * <p>AI 비용({@code ai_cost_events} 합산)만 반영한다. 비-AI 인프라 비용 배분(AWS Cost Explorer
- * 연동, 옵션 A 시간 비례)은 별도 이슈에서 채운다 — 그 전까지 {@code allocated_fixed_infra_usd_estimate}/
- * {@code total_usd}는 {@code null}로 비워 "인프라 비용 미지원"을 명시적으로 드러낸다.
+ * <p>AI 비용({@code ai_cost_events} 합산) + 비-AI 인프라 비용 배분(옵션 A 시간 비례, 이슈 #437)을
+ * 합쳐 반환한다. 인프라 배치({@code InfraCostSyncJob})가 그 세션이 속한 달을 아직 한 번도 캐싱하지
+ * 않았으면 {@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 여전히 {@code null}이다 —
+ * 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 채워져도 과거 조회 결과와 구분이 안 된다.
  */
 @Service
 @RequiredArgsConstructor
@@ -26,23 +32,32 @@ public class AdminSessionCostService {
 
     private final SessionRepository sessionRepository;
     private final AiCostEventRepository aiCostEventRepository;
+    private final InfraCostAllocator infraCostAllocator;
 
     public SessionCostResponse getCost(UUID sessionId) {
-        var session = sessionRepository.findById(sessionId)
+        Session session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
 
         AiCostAggregate aggregate = aiCostEventRepository.aggregateBySessionId(sessionId);
 
-        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — 0이 아니라 null로 비운다.
-        // 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 연동해도 과거 조회 결과와 구분이 안 된다.
+        BigDecimal allocatedInfraUsd = null;
+        long durationSeconds = session.durationSeconds();
+        if (durationSeconds > 0) {
+            YearMonth sessionMonth = YearMonth.from(session.getStartedAt().atZoneSameInstant(AppConstants.ZONE));
+            allocatedInfraUsd = infraCostAllocator.allocateForSession(sessionMonth, durationSeconds);
+        }
+        BigDecimal totalUsd = allocatedInfraUsd != null
+                ? aggregate.totalCostUsd().add(allocatedInfraUsd)
+                : null;
+
         return new SessionCostResponse(
                 sessionId,
                 session.getUser().getId(),
                 aggregate.totalCostUsd(),
                 aggregate.unpricedCount(),
                 aggregate.allPriced(),
-                null,
-                null
+                allocatedInfraUsd,
+                totalUsd
         );
     }
 }

--- a/src/main/java/com/mio/admin/service/AdminUserCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminUserCostService.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.UserMonthlyCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -11,17 +12,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
 /**
- * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #433의 연장).
+ * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #437 — #433의 연장).
  *
  * <p>세션 단위였던 #433의 집계를 유저·월 단위로만 바꾼 것 — 신규 계측 없이
  * {@code AiCostEventRepository.aggregateByUserIdAndCreatedAtBetween()}만 추가로 소비한다.
- * 인프라 비용 배분은 #433과 동일하게 이번 스코프에서 뺐다.
+ * 인프라 비용 배분(옵션 A 시간 비례)은 이슈 #437에서 채웠다 — 해당 월 캐시가 아직 없으면
+ * {@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는 여전히
+ * {@code null}이다(#433과 같은 이유).
  */
 @Service
 @RequiredArgsConstructor
@@ -30,6 +34,7 @@ public class AdminUserCostService {
 
     private final UserRepository userRepository;
     private final AiCostEventRepository aiCostEventRepository;
+    private final InfraCostAllocator infraCostAllocator;
 
     public UserMonthlyCostResponse getMonthlyCost(UUID userId, String month) {
         if (!userRepository.existsById(userId)) {
@@ -41,16 +46,19 @@ public class AdminUserCostService {
         OffsetDateTime to = yearMonth.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
 
         AiCostAggregate aggregate = aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(userId, from, to);
+        BigDecimal allocatedInfraUsd = infraCostAllocator.allocateForUserMonth(userId, yearMonth);
+        BigDecimal technicalCogsUsd = allocatedInfraUsd != null
+                ? aggregate.totalCostUsd().add(allocatedInfraUsd)
+                : null;
 
-        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — #433과 같은 이유로 0이 아니라 null.
         return new UserMonthlyCostResponse(
                 userId,
                 yearMonth.toString(),
                 aggregate.totalCostUsd(),
                 aggregate.unpricedCount(),
                 aggregate.allPriced(),
-                null,
-                null
+                allocatedInfraUsd,
+                technicalCogsUsd
         );
     }
 

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocator.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocator.java
@@ -1,0 +1,99 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.UUID;
+
+/**
+ * 옵션 A(시간 비례) 인프라 비용 배분 (이슈 #437, 개선안 문서 §2.2).
+ *
+ * <p>{@code (해당 월 총청구액 / 해당 월 총세션-초) × 세션(또는 유저) duration_seconds}.
+ * 캐싱된 {@link InfraCostSnapshot}이 아직 없거나(배치 미실행) 그 달 세션-초 합이 0이면
+ * 배분할 수 없다 — 0으로 채우지 않고 {@code null}을 반환해 "배분 불가"와 "배분값 0"을 구분한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class InfraCostAllocator {
+
+    private static final int SCALE = 10;
+
+    private final InfraCostSnapshotRepository snapshotRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    /** @return 세션 1건에 배분된 인프라비용(USD). 배분 불가하면 {@code null} */
+    public BigDecimal allocateForSession(YearMonth month, long sessionDurationSeconds) {
+        if (sessionDurationSeconds <= 0) {
+            return null;
+        }
+        InfraCostSnapshot snapshot = latestSnapshot(month);
+        if (snapshot == null) {
+            return null;
+        }
+        long totalSeconds = totalSessionSecondsInMonth(month);
+        if (totalSeconds <= 0) {
+            return null;
+        }
+        return allocate(snapshot.getTotalCostUsd(), sessionDurationSeconds, totalSeconds);
+    }
+
+    /** @return 유저의 그 달 세션 전체에 배분된 인프라비용 합(USD). 배분 불가하면 {@code null} */
+    public BigDecimal allocateForUserMonth(UUID userId, YearMonth month) {
+        InfraCostSnapshot snapshot = latestSnapshot(month);
+        if (snapshot == null) {
+            return null;
+        }
+        long totalSeconds = totalSessionSecondsInMonth(month);
+        if (totalSeconds <= 0) {
+            return null;
+        }
+        long userSeconds = userSessionSecondsInMonth(userId, month);
+        if (userSeconds <= 0) {
+            return null;
+        }
+        return allocate(snapshot.getTotalCostUsd(), userSeconds, totalSeconds);
+    }
+
+    private BigDecimal allocate(BigDecimal totalCostUsd, long portionSeconds, long totalSeconds) {
+        return totalCostUsd
+                .multiply(BigDecimal.valueOf(portionSeconds))
+                .divide(BigDecimal.valueOf(totalSeconds), SCALE, RoundingMode.HALF_UP);
+    }
+
+    private InfraCostSnapshot latestSnapshot(YearMonth month) {
+        return snapshotRepository.findTopByBillingPeriodStartOrderBySnapshotAtDesc(month.atDay(1))
+                .orElse(null);
+    }
+
+    private long totalSessionSecondsInMonth(YearMonth month) {
+        OffsetDateTime from = monthStart(month);
+        OffsetDateTime to = monthStart(month.plusMonths(1));
+        Long seconds = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint
+                FROM sessions
+                WHERE status = 'ended' AND started_at >= ? AND started_at < ?
+                """, Long.class, from, to);
+        return seconds != null ? seconds : 0L;
+    }
+
+    private long userSessionSecondsInMonth(UUID userId, YearMonth month) {
+        OffsetDateTime from = monthStart(month);
+        OffsetDateTime to = monthStart(month.plusMonths(1));
+        Long seconds = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint
+                FROM sessions
+                WHERE status = 'ended' AND user_id = ? AND started_at >= ? AND started_at < ?
+                """, Long.class, userId, from, to);
+        return seconds != null ? seconds : 0L;
+    }
+
+    private OffsetDateTime monthStart(YearMonth month) {
+        return month.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSnapshot.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSnapshot.java
@@ -1,0 +1,71 @@
+package com.mio.ai.cost;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * AWS CloudWatch {@code AWS/Billing EstimatedCharges} 월간 총청구액 배치 캐시 (이슈 #437).
+ *
+ * <p>{@code cloudwatch:GetMetricStatistics}는 세션 조회 시점 실시간 호출이 아니라 일 1회 배치로만
+ * 부른다 — 지표 자체가 대략 6시간 간격으로만 갱신된다. {@code isEstimated}는 지표 이름 그대로
+ * AWS 스스로도 "추정치"라 부르는 값이라는 걸 그대로 보존한다.
+ */
+@Entity
+@Table(name = "infra_cost_snapshots")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InfraCostSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "billing_period_start", nullable = false)
+    private LocalDate billingPeriodStart;
+
+    @Column(name = "billing_period_end", nullable = false)
+    private LocalDate billingPeriodEnd;
+
+    @Column(name = "total_cost_usd", nullable = false)
+    private BigDecimal totalCostUsd;
+
+    @Column(name = "is_estimated", nullable = false)
+    private boolean estimated;
+
+    @Column(name = "snapshot_at", nullable = false)
+    private OffsetDateTime snapshotAt;
+
+    @Column(name = "allocation_method_version", nullable = false)
+    private String allocationMethodVersion;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private InfraCostSnapshot(LocalDate billingPeriodStart, LocalDate billingPeriodEnd,
+                              BigDecimal totalCostUsd, boolean estimated, OffsetDateTime snapshotAt,
+                              String allocationMethodVersion) {
+        this.billingPeriodStart = billingPeriodStart;
+        this.billingPeriodEnd = billingPeriodEnd;
+        this.totalCostUsd = totalCostUsd;
+        this.estimated = estimated;
+        this.snapshotAt = snapshotAt;
+        this.allocationMethodVersion = allocationMethodVersion;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSnapshotRepository.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSnapshotRepository.java
@@ -1,0 +1,12 @@
+package com.mio.ai.cost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InfraCostSnapshotRepository extends JpaRepository<InfraCostSnapshot, UUID> {
+
+    Optional<InfraCostSnapshot> findTopByBillingPeriodStartOrderBySnapshotAtDesc(LocalDate billingPeriodStart);
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
@@ -1,0 +1,98 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Statistic;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * AWS {@code AWS/Billing EstimatedCharges} 지표를 일 1회 배치로 캐싱한다 (이슈 #437).
+ *
+ * <p>처음엔 Cost Explorer({@code ce:GetCostAndUsage})로 구현했으나, 그쪽은 호출 1건당 $0.01가
+ * 과금된다 — 하루 1번 배치라도 월 $0.30. {@code cloudwatch:GetMetricStatistics}는 이 호출량에서
+ * 사실상 무료라 이쪽으로 전환했다(리뷰 반영). {@code EstimatedCharges}는 AWS 스스로도 "추정치"라고
+ * 부르는 값이라 이 원장의 {@code isEstimated=true} 원칙과도 맞는다 — 계정 결제 주기에 맞춰
+ * 월초 0으로 리셋되고 그 달 누적으로 올라가는 값이라 별도 기간 조회 없이 최신 값만 읽으면 된다.
+ *
+ * <p>실패해도 기존 캐시는 그대로 두고 다음 배치에서 재시도한다 — {@code WeeklyReflectionJob} 계열
+ * 배치와 같은 원칙으로 개별 실패가 앱 전체를 막지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InfraCostSyncJob {
+
+    public static final String ALLOCATION_METHOD_VERSION = "v1-time-proportional";
+    private static final String NAMESPACE = "AWS/Billing";
+    private static final String METRIC_NAME = "EstimatedCharges";
+    // AWS/Billing 지표는 대략 6시간 간격으로 게시된다 — 최근 24시간을 조회하면 최소 1개는 걸린다.
+    private static final Duration LOOKBACK = Duration.ofHours(24);
+    private static final int PERIOD_SECONDS = 21_600;
+
+    private final CloudWatchClient cloudWatchClient;
+    private final InfraCostSnapshotRepository repository;
+
+    @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
+    public void sync() {
+        try {
+            Instant now = Instant.now();
+            GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+                    .namespace(NAMESPACE)
+                    .metricName(METRIC_NAME)
+                    .dimensions(Dimension.builder().name("Currency").value("USD").build())
+                    .startTime(now.minus(LOOKBACK))
+                    .endTime(now)
+                    .period(PERIOD_SECONDS)
+                    .statistics(Statistic.MAXIMUM)
+                    .build();
+
+            GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
+            List<Datapoint> datapoints = response.datapoints();
+            if (datapoints.isEmpty()) {
+                log.warn("[InfraCostSyncJob] AWS/Billing EstimatedCharges 지표에 최근 {}시간 데이터가 없음",
+                        LOOKBACK.toHours());
+                return;
+            }
+
+            Datapoint latest = datapoints.stream()
+                    .max(Comparator.comparing(Datapoint::timestamp))
+                    .orElseThrow();
+            BigDecimal totalCostUsd = BigDecimal.valueOf(latest.maximum());
+
+            YearMonth month = YearMonth.now(AppConstants.ZONE);
+            LocalDate periodStart = month.atDay(1);
+            LocalDate periodEnd = month.plusMonths(1).atDay(1);
+
+            repository.save(InfraCostSnapshot.builder()
+                    .billingPeriodStart(periodStart)
+                    .billingPeriodEnd(periodEnd)
+                    .totalCostUsd(totalCostUsd)
+                    .estimated(true) // EstimatedCharges는 AWS 스스로도 추정치라고 부르는 값이다.
+                    .snapshotAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .allocationMethodVersion(ALLOCATION_METHOD_VERSION)
+                    .build());
+
+            log.info("[InfraCostSyncJob] 캐싱 완료 period={}~{} totalCostUsd={} dataPointAt={}",
+                    periodStart, periodEnd, totalCostUsd, latest.timestamp());
+        } catch (Exception e) {
+            log.warn("[InfraCostSyncJob] CloudWatch 동기화 실패, 기존 캐시 유지: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/mio/config/AwsConfig.java
+++ b/src/main/java/com/mio/config/AwsConfig.java
@@ -1,0 +1,28 @@
+package com.mio.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+
+/**
+ * AWS CloudWatch 클라이언트 (이슈 #437).
+ *
+ * <p>인프라 비용 배치 캐싱({@code InfraCostSyncJob})이 {@code AWS/Billing} 네임스페이스의
+ * {@code EstimatedCharges} 지표를 읽는 데 쓴다. 처음엔 Cost Explorer({@code ce:GetCostAndUsage})로
+ * 구현했으나, 그쪽은 호출 1건당 $0.01가 과금돼(하루 1번 배치라도 월 $0.30) CloudWatch 지표 조회
+ * (사실상 무료)로 전환했다 — 리뷰 반영. {@code AWS/Billing} 지표는 리전에 상관없이
+ * <b>us-east-1에만 게시</b>된다 — 앱 자체 리전(ap-northeast-2)과 무관한 AWS 고정 사양이다.
+ * 크리덴셜은 지정하지 않고 기본 체인을 쓴다 — EC2 인스턴스 역할(`mio-ec2-cloudwatch-role`,
+ * `cloudwatch:GetMetricStatistics` 인라인 정책 부여됨)을 그대로 탄다.
+ */
+@Configuration
+public class AwsConfig {
+
+    @Bean
+    public CloudWatchClient cloudWatchBillingClient() {
+        return CloudWatchClient.builder()
+                .region(Region.US_EAST_1)
+                .build();
+    }
+}

--- a/src/main/resources/db/migration/V57__create_infra_cost_snapshots.sql
+++ b/src/main/resources/db/migration/V57__create_infra_cost_snapshots.sql
@@ -1,0 +1,21 @@
+-- 이슈 #437 — AWS CloudWatch(AWS/Billing EstimatedCharges) 인프라 비용 배치 캐싱.
+-- 지표 자체가 대략 6시간 간격으로만 갱신돼 세션 조회 시점 실시간 호출이 아니라 배치(일 1회)로
+-- 캐싱한다. is_estimated/snapshot_at는 EstimatedCharges가 확정치가 아니라 지표 이름 그대로
+-- "추정치"라는 걸 API 응답에서도 드러내기 위함이다.
+
+CREATE TABLE infra_cost_snapshots (
+    id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_period_start       DATE NOT NULL,
+    billing_period_end         DATE NOT NULL,
+    total_cost_usd             NUMERIC(20, 10) NOT NULL,
+    is_estimated               BOOLEAN NOT NULL,
+    snapshot_at                TIMESTAMPTZ NOT NULL,
+    allocation_method_version  TEXT NOT NULL,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 특정 월의 최신 스냅샷 조회: WHERE billing_period_start = ? ORDER BY snapshot_at DESC LIMIT 1
+CREATE INDEX idx_infra_cost_snapshots_period_snapshot_at
+    ON infra_cost_snapshots (billing_period_start, snapshot_at DESC);
+
+COMMENT ON TABLE infra_cost_snapshots IS 'AWS CloudWatch(AWS/Billing) 월간 총청구액 배치 캐시. 옵션 A(시간 비례) 인프라비용 배분의 입력값.';

--- a/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.SessionCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
@@ -16,19 +17,23 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-/** 이슈 #433 — AI 비용만 먼저 노출하고, 인프라 배분은 null로 비워 미지원을 드러내는지 검증. */
+/** 이슈 #433/#437 — AI 비용 + 인프라 배분(캐시 있으면), 캐시 없으면 인프라·합계는 null. */
 @ExtendWith(MockitoExtension.class)
 class AdminSessionCostServiceTest {
 
     @Mock private SessionRepository sessionRepository;
     @Mock private AiCostEventRepository aiCostEventRepository;
+    @Mock private InfraCostAllocator infraCostAllocator;
 
     private AdminSessionCostService service;
 
@@ -37,7 +42,7 @@ class AdminSessionCostServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository);
+        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository, infraCostAllocator);
     }
 
     @Test
@@ -68,7 +73,7 @@ class AdminSessionCostServiceTest {
         assertThat(response.unpricedEvents()).isZero();
         assertThat(response.allPriced()).isTrue();
         assertThat(response.allocatedFixedInfraUsdEstimate())
-                .as("AWS Cost Explorer 연동 전까지는 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
+                .as("인프라 비용 배치 캐시가 없으면 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
                 .isNull();
         assertThat(response.totalUsd()).isNull();
     }
@@ -86,5 +91,39 @@ class AdminSessionCostServiceTest {
 
         assertThat(response.allPriced()).isFalse();
         assertThat(response.unpricedEvents()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("인프라 배분 캐시가 있으면 총액을 AI비용+인프라비용으로 채운다")
+    void getCost_infraAllocationAvailable_fillsTotal() {
+        User user = User.builder().id(userId).build();
+        OffsetDateTime startedAt = OffsetDateTime.parse("2026-08-10T10:00:00+09:00");
+        OffsetDateTime endedAt = OffsetDateTime.parse("2026-08-10T10:05:00+09:00");
+        Session session = Session.builder()
+                .id(sessionId).user(user).startedAt(startedAt).endedAt(endedAt).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.013"), 0L, 2L));
+        when(infraCostAllocator.allocateForSession(eq(YearMonth.of(2026, 8)), eq(300L)))
+                .thenReturn(new BigDecimal("0.555"));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isEqualByComparingTo(new BigDecimal("0.555"));
+        assertThat(response.totalUsd()).isEqualByComparingTo(new BigDecimal("0.568"));
+    }
+
+    @Test
+    @DisplayName("세션 길이가 0(진행 중이거나 미종료)이면 인프라 배분을 시도하지 않는다")
+    void getCost_zeroDuration_skipsInfraAllocation() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
+
+        service.getCost(sessionId);
+
+        org.mockito.Mockito.verifyNoInteractions(infraCostAllocator);
     }
 }

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.UserMonthlyCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -26,12 +27,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-/** 이슈 #434 — #433과 같은 원칙(인프라 배분 null)으로 유저·월 단위 집계만 바뀐 것 검증. */
+/** 이슈 #434/#437 — #433과 같은 원칙(캐시 없으면 인프라 배분 null)으로 유저·월 단위 집계. */
 @ExtendWith(MockitoExtension.class)
 class AdminUserCostServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private AiCostEventRepository aiCostEventRepository;
+    @Mock private InfraCostAllocator infraCostAllocator;
 
     private AdminUserCostService service;
 
@@ -39,7 +41,7 @@ class AdminUserCostServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminUserCostService(userRepository, aiCostEventRepository);
+        service = new AdminUserCostService(userRepository, aiCostEventRepository, infraCostAllocator);
     }
 
     @Test
@@ -105,11 +107,13 @@ class AdminUserCostServiceTest {
     }
 
     @Test
-    @DisplayName("인프라 배분 필드는 #433과 같은 이유로 null이다")
-    void getMonthlyCost_infraFieldsAreNull() {
+    @DisplayName("인프라 배분 캐시가 없으면 필드는 여전히 null이다")
+    void getMonthlyCost_noInfraCache_fieldsAreNull() {
         when(userRepository.existsById(userId)).thenReturn(true);
         when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
                 .thenReturn(new AiCostAggregate(new BigDecimal("2.0"), 1L, 4L));
+        when(infraCostAllocator.allocateForUserMonth(eq(userId), eq(YearMonth.of(2026, 8))))
+                .thenReturn(null);
 
         UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
 
@@ -117,5 +121,20 @@ class AdminUserCostServiceTest {
         assertThat(response.unpricedEvents()).isEqualTo(1L);
         assertThat(response.allocatedFixedInfraUsdEstimate()).isNull();
         assertThat(response.userMonthTechnicalCogsUsd()).isNull();
+    }
+
+    @Test
+    @DisplayName("인프라 배분 캐시가 있으면 기술원가 합계를 채운다")
+    void getMonthlyCost_infraAllocationAvailable_fillsTechnicalCogs() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("1.5"), 0L, 3L));
+        when(infraCostAllocator.allocateForUserMonth(eq(userId), eq(YearMonth.of(2026, 8))))
+                .thenReturn(new BigDecimal("0.7"));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isEqualByComparingTo(new BigDecimal("0.7"));
+        assertThat(response.userMonthTechnicalCogsUsd()).isEqualByComparingTo(new BigDecimal("2.2"));
     }
 }

--- a/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 옵션 A(시간 비례) 배분 계산을 실제 DB로 검증한다 (이슈 #437).
+ *
+ * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
+ * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class InfraCostAllocatorIntegrationTest {
+
+    @Autowired
+    private InfraCostAllocator allocator;
+
+    @Autowired
+    private InfraCostSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> insertedUserIds = new ArrayList<>();
+    private final List<UUID> insertedSessionIds = new ArrayList<>();
+    private final List<UUID> insertedSnapshotIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        insertedSessionIds.forEach(id -> jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", id));
+        insertedUserIds.forEach(id -> jdbcTemplate.update("DELETE FROM users WHERE id = ?", id));
+        insertedSnapshotIds.forEach(id -> snapshotRepository.deleteById(id));
+    }
+
+    @Test
+    @DisplayName("캐시가 없으면 배분하지 않는다")
+    void allocateForSession_noSnapshot_returnsNull() {
+        assertThat(allocator.allocateForSession(YearMonth.of(2026, 8), 300L)).isNull();
+    }
+
+    @Test
+    @DisplayName("월 총청구액을 그 달 총세션-초 대비 세션 duration 비율로 배분한다")
+    void allocateForSession_withSnapshotAndSessions_allocatesProportionally() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID user1 = insertUser();
+        UUID user2 = insertUser();
+        // 이번 세션 300초 + 다른 세션 700초 = 그 달 총 1000초
+        insertEndedSession(user1, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertEndedSession(user2, "2026-08-11T10:00:00+09:00", "2026-08-11T10:11:40+09:00"); // 700s
+
+        // 18.5 * 300 / 1000 = 5.55
+        BigDecimal allocated = allocator.allocateForSession(august, 300L);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("5.55"));
+    }
+
+    @Test
+    @DisplayName("유저의 그 달 세션 전체(합산 시간) 기준으로 배분한다")
+    void allocateForUserMonth_sumsUserSessionsInMonth() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID targetUser = insertUser();
+        UUID otherUser = insertUser();
+        // targetUser: 300s + 200s = 500s, otherUser: 500s → 그 달 총 1000초
+        insertEndedSession(targetUser, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertEndedSession(targetUser, "2026-08-12T10:00:00+09:00", "2026-08-12T10:03:20+09:00"); // 200s
+        insertEndedSession(otherUser, "2026-08-11T10:00:00+09:00", "2026-08-11T10:08:20+09:00"); // 500s
+
+        // 18.5 * 500 / 1000 = 9.25
+        BigDecimal allocated = allocator.allocateForUserMonth(targetUser, august);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("9.25"));
+    }
+
+    @Test
+    @DisplayName("진행 중(미종료)인 세션은 총세션-초 계산에서 제외된다")
+    void allocateForSession_excludesUnendedSessions() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID user1 = insertUser();
+        insertEndedSession(user1, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertActiveSession(user1, "2026-08-11T10:00:00+09:00"); // 미종료 — 집계 제외돼야 함
+
+        // 미종료 세션이 섞여도 총세션-초는 300초만 잡혀야 한다: 18.5 * 300 / 300 = 18.5
+        BigDecimal allocated = allocator.allocateForSession(august, 300L);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("18.5"));
+    }
+
+    private void saveSnapshot(YearMonth month, BigDecimal totalCostUsd) {
+        InfraCostSnapshot snapshot = snapshotRepository.save(InfraCostSnapshot.builder()
+                .billingPeriodStart(month.atDay(1))
+                .billingPeriodEnd(month.plusMonths(1).atDay(1))
+                .totalCostUsd(totalCostUsd)
+                .estimated(true)
+                .snapshotAt(OffsetDateTime.now())
+                .allocationMethodVersion(InfraCostSyncJob.ALLOCATION_METHOD_VERSION)
+                .build());
+        insertedSnapshotIds.add(snapshot.getId());
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "infra-cost-it-" + userId);
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private void insertEndedSession(UUID userId, String startedAt, String endedAt) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at) " +
+                        "VALUES (?, ?, 'mio', 'ended', ?::timestamptz, ?::timestamptz)",
+                sessionId, userId, startedAt, endedAt);
+        insertedSessionIds.add(sessionId);
+    }
+
+    private void insertActiveSession(UUID userId, String startedAt) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at) " +
+                        "VALUES (?, ?, 'mio', 'active', ?::timestamptz)",
+                sessionId, userId, startedAt);
+        insertedSessionIds.add(sessionId);
+    }
+}

--- a/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
@@ -1,0 +1,70 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InfraCostSyncJobTest {
+
+    private final CloudWatchClient cloudWatchClient = mock(CloudWatchClient.class);
+    private final InfraCostSnapshotRepository repository = mock(InfraCostSnapshotRepository.class);
+    private final InfraCostSyncJob job = new InfraCostSyncJob(cloudWatchClient, repository);
+
+    @Test
+    @DisplayName("정상 응답이면 최신 데이터포인트 값을 스냅샷으로 저장한다")
+    void sync_success_savesLatestDatapoint() {
+        Datapoint older = Datapoint.builder().timestamp(Instant.parse("2026-08-15T02:38:00Z")).maximum(7.56).build();
+        Datapoint latest = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(older, latest).build());
+
+        job.sync();
+
+        ArgumentCaptor<InfraCostSnapshot> captor = ArgumentCaptor.forClass(InfraCostSnapshot.class);
+        verify(repository).save(captor.capture());
+        InfraCostSnapshot saved = captor.getValue();
+        // 두 데이터포인트 중 타임스탬프가 더 최근인 쪽(7.89)을 써야 한다 — 값이 더 큰 쪽이 아니라.
+        assertThat(saved.getTotalCostUsd()).isEqualByComparingTo(new BigDecimal("7.89"));
+        assertThat(saved.isEstimated()).isTrue();
+        assertThat(saved.getAllocationMethodVersion()).isEqualTo(InfraCostSyncJob.ALLOCATION_METHOD_VERSION);
+    }
+
+    @Test
+    @DisplayName("CloudWatch 호출이 실패해도 예외를 전파하지 않고 저장을 건너뛴다")
+    void sync_apiFailure_doesNotThrowOrSave() {
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenThrow(CloudWatchException.builder().message("access denied").build());
+
+        assertThatCode(job::sync).doesNotThrowAnyException();
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    @DisplayName("최근 24시간 내 데이터포인트가 없으면 저장을 건너뛴다")
+    void sync_noRecentDatapoints_skipsSave() {
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(List.of()).build());
+
+        job.sync();
+
+        verifyNoInteractions(repository);
+    }
+}


### PR DESCRIPTION
## 요약
AWS CloudWatch(`AWS/Billing EstimatedCharges` 지표)를 일 1회 배치로 연동해, #433/#434에서 `null`로 비워뒀던 인프라 비용 배분 필드(`allocated_fixed_infra_usd_estimate`/`total_usd`/`user_month_technical_cogs_usd`)를 옵션 A(시간 비례)로 채웁니다. IAM 권한(`cloudwatch:GetMetricStatistics`)은 `mio-ec2-cloudwatch-role`에 이미 부여 완료했습니다.

처음엔 Cost Explorer(`ce:GetCostAndUsage`)로 구현했으나, 호출 1건당 $0.01 과금(일 1회 배치라도 월 $0.30)이 확인돼 리뷰 반영 후 CloudWatch Billing 지표(이 호출량에서 사실상 무료, 이 계정은 Billing Alerts가 이미 활성화돼 있어 바로 사용 가능)로 전환했습니다. 자세한 비교는 Issue #437 본문 참고.

## 관련 이슈
- Closes #437

## 변경 사항
- `software.amazon.awssdk:cloudwatch` 의존성 추가
- `InfraCostSnapshot` 엔티티 + 마이그레이션(V57) — `billing_period_start/end`, `total_cost_usd`, `is_estimated`, `snapshot_at`, `allocation_method_version`
- `AwsConfig` — `CloudWatchClient` 빈(**us-east-1 리전 고정** — `AWS/Billing` 지표 게시 리전 사양, 앱 리전과 무관), 크리덴셜은 EC2 인스턴스 역할 기본 체인
- `InfraCostSyncJob` — 매일 00:30(Asia/Seoul) 배치로 최근 24시간 내 최신 `EstimatedCharges` 데이터포인트를 캐싱. 실패해도 기존 캐시 유지, 다음 배치에서 재시도
- `InfraCostAllocator` — 옵션 A 배분 계산(`(월간 총청구액 / 월간 총세션-초) × 대상 duration`), 캐시가 없거나 그 달 세션-초 합이 0이면 `null` 반환(0으로 채우지 않음)
- `AdminSessionCostService`/`AdminUserCostService`에 `InfraCostAllocator` 연결 — 인프라 배분이 가능하면 `total_usd`/`user_month_technical_cogs_usd`를 실제로 채움

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (기존 null 필드가 실제 값으로 채워짐 — 필드 자체는 #433/#434에서 이미 존재, breaking change 아님)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (V57, `infra_cost_snapshots` 신규 테이블)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다. (IAM 권한은 이미 부여 완료, 코드 배포만 필요)
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. (신규 일 1회 AWS CloudWatch Billing 배치)
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test --tests "com.mio.ai.cost.*" --tests "com.mio.admin.service.*"
./gradlew test
```
### 확인 내용
- `InfraCostAllocatorIntegrationTest`(실제 DB) — 캐시 없을 때 null, 세션당 시간비례 배분, 유저 월간 합산 배분, 미종료 세션이 총세션-초 계산에서 제외되는지 4건
- `InfraCostSyncJobTest`(mock CloudWatchClient) — 여러 데이터포인트 중 타임스탬프가 최신인 값을 저장(값이 큰 쪽이 아니라), API 실패 시 예외 미전파·저장 스킵, 빈 결과 스킵 3건
- `AdminSessionCostServiceTest`/`AdminUserCostServiceTest`에 인프라 배분 있음/없음 케이스 추가
- 전체 스위트: 1067개 중 1065개 통과. 나머지 2개(`MioApplicationTests`)는 로컬 개발 DB의 flyway `schema_history` 체크섬 드리프트 때문에 실패 — V57은 방금 커밋 전 자체 리뷰에서 주석을 수정해 체크섬이 바뀌었고, V18/V56은 이 브랜치와 무관하게 로컬 DB에 이미 있던 드리프트. 코드 정합성 문제가 아니라 새 DB(CI)에서는 문제없이 적용됨 — 로컬 DB 상태이므로 별도로 건드리지 않았습니다.

## 중점 리뷰 포인트 (PR 올리기 전 자체 리뷰에서 확인한 것)
- **CloudWatch 전환 후 문서 잔재 정리** — `InfraCostSnapshot`/DTO(`SessionCostResponse`/`UserMonthlyCostResponse`)/V57 마이그레이션/테스트 어설션 메시지에 남아있던 "AWS Cost Explorer" 문구가 CloudWatch로 전환된 뒤에도 그대로 남아있어 자체 리뷰에서 전부 정리함(구현 로직은 이미 CloudWatch였는데 주석만 예전 그대로였던 것)
- **타임스탬프 UTC 명시** — `InfraCostSnapshot.createdAt`/`InfraCostSyncJob`의 `snapshotAt`을 `ZoneOffset.UTC`로 명시 — `AiCostEvent`가 항상 UTC를 명시하는 기존 컨벤션과 일치(#432 리뷰에서 나온 비동기 타임스탬프 이슈와 같은 계열, 이번엔 미리 잡음)
- **SUM+NULL 처리** — `InfraCostAllocator`의 세션-초 집계 SQL이 `COALESCE(SUM(...), 0)`을 쓰는지 확인함(#432에서 지적됐던 "빈 결과셋에서 NULL 언박싱 NPE" 패턴 재발 방지)
- **월간 총청구액이 0이거나 그 달 세션이 아예 없을 때** — 나눗셈 방지 가드(`totalSeconds <= 0` 체크) 있음, `null` 반환으로 처리
- **여러 데이터포인트 중 어느 걸 쓰는지** — CloudWatch가 24시간 조회창에서 여러 6시간 간격 데이터포인트를 돌려줄 수 있어, 값이 가장 큰 게 아니라 타임스탬프가 가장 최신인 데이터포인트를 쓰도록 함(월중 비용은 단조증가하지만, MAXIMUM 통계라도 "최신"과 "최댓값"을 혼동하면 안 돼 테스트로 명시적으로 검증)

## 배포 / 롤백
- Rollout: Flyway 마이그레이션(V57) 자동 적용. 배치는 매일 00:30 KST 첫 실행 전까지는 기존과 동일하게 인프라 필드가 null — 점진적으로 채워짐
- Rollback: 코드만 이전 커밋으로 되돌리면 됨. `infra_cost_snapshots` 테이블은 그대로 둬도 무해(참조하는 다른 로직 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `feat/#434-user-monthly-cost-api`입니다 — #431→#433→#434 스택 위에 이어서 진행했습니다. 앞 PR들이 순서대로 머지되면 base를 옮기겠습니다.
