### PR TITLE
feat: 배분 모델(옵션 A vs 옵션 B) 민감도 관찰 그림자 계산을 추가한다

### DIFF
--- a/src/main/java/com/mio/ai/cost/AllocationSensitivityCalculator.java
+++ b/src/main/java/com/mio/ai/cost/AllocationSensitivityCalculator.java
@@ -1,0 +1,118 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * 옵션 A(시간비례) vs 옵션 B(요청수비례) 배분 모델 민감도 계산 (이슈 #438, 개선안 문서 §5).
+ *
+ * <p>그 달 전체 세션에 대한 합계·평균으로 A/B를 비교하면 항상 0%가 나온다 — 두 배분 방식 모두
+ * 같은 월간총청구액을 비례배분할 뿐이라, 전체 세션 합/평균은 배분 기준과 무관하게 항상 월간
+ * 총청구액(또는 총청구액/세션수)으로 수렴하는 수학적 항등이기 때문이다. 실제로 두 방식이 갈리는
+ * 지점은 세션 개별 단위 — 그래서 세션마다 A_i·B_i를 먼저 계산하고, 그 세션별 민감도
+ * ({@code |A_i-B_i|/B_i}) 의 평균을 최종 지표로 쓴다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AllocationSensitivityCalculator {
+
+    private static final int SCALE = 10;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+    private static final BigDecimal WARN_THRESHOLD_PCT = BigDecimal.valueOf(30);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final InfraCostAllocationSensitivityRepository repository;
+
+    public void computeAndSave(YearMonth month, BigDecimal totalCostUsd) {
+        if (totalCostUsd == null || totalCostUsd.signum() <= 0) {
+            log.info("[AllocationSensitivityCalculator] {}: 월간 총청구액이 0 이하라 계산 스킵", month);
+            return;
+        }
+
+        List<SessionDriver> drivers = fetchEndedSessionDrivers(month);
+        long totalDurationSeconds = drivers.stream().mapToLong(SessionDriver::durationSeconds).sum();
+        long totalMessages = drivers.stream().mapToLong(SessionDriver::messageCount).sum();
+        if (totalDurationSeconds <= 0 || totalMessages <= 0) {
+            log.info("[AllocationSensitivityCalculator] {}: 총세션-초 또는 총메시지수가 0이라 계산 스킵", month);
+            return;
+        }
+
+        BigDecimal sumA = BigDecimal.ZERO;
+        BigDecimal sumB = BigDecimal.ZERO;
+        BigDecimal sumSensitivityPct = BigDecimal.ZERO;
+        int qualifyingCount = 0;
+
+        for (SessionDriver driver : drivers) {
+            if (driver.durationSeconds() <= 0 || driver.messageCount() <= 0) {
+                continue;
+            }
+            BigDecimal a = totalCostUsd
+                    .multiply(BigDecimal.valueOf(driver.durationSeconds()))
+                    .divide(BigDecimal.valueOf(totalDurationSeconds), SCALE, RoundingMode.HALF_UP);
+            BigDecimal b = totalCostUsd
+                    .multiply(BigDecimal.valueOf(driver.messageCount()))
+                    .divide(BigDecimal.valueOf(totalMessages), SCALE, RoundingMode.HALF_UP);
+            BigDecimal sensitivityPct = a.subtract(b).abs()
+                    .divide(b, SCALE, RoundingMode.HALF_UP)
+                    .multiply(HUNDRED);
+
+            sumA = sumA.add(a);
+            sumB = sumB.add(b);
+            sumSensitivityPct = sumSensitivityPct.add(sensitivityPct);
+            qualifyingCount++;
+        }
+
+        if (qualifyingCount == 0) {
+            log.info("[AllocationSensitivityCalculator] {}: duration·message_count가 둘 다 0보다 큰 세션이 없어 계산 스킵", month);
+            return;
+        }
+
+        BigDecimal count = BigDecimal.valueOf(qualifyingCount);
+        BigDecimal avgA = sumA.divide(count, SCALE, RoundingMode.HALF_UP);
+        BigDecimal avgB = sumB.divide(count, SCALE, RoundingMode.HALF_UP);
+        BigDecimal avgSensitivityPct = sumSensitivityPct.divide(count, SCALE, RoundingMode.HALF_UP);
+
+        repository.save(InfraCostAllocationSensitivity.builder()
+                .billingPeriodStart(month.atDay(1))
+                .optionAUsd(avgA)
+                .optionBUsd(avgB)
+                .allocationSensitivityPct(avgSensitivityPct)
+                .snapshotAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build());
+
+        if (avgSensitivityPct.compareTo(WARN_THRESHOLD_PCT) > 0) {
+            log.warn("[AllocationSensitivityCalculator] {}: 배분 민감도 평균 {}%가 임계값({}%) 초과 — "
+                            + "배분 기준 재검토 근거로 참고(정확도 보증 아님)",
+                    month, avgSensitivityPct, WARN_THRESHOLD_PCT);
+        } else {
+            log.info("[AllocationSensitivityCalculator] {}: 배분 민감도 평균 {}% (세션 {}건 기준)",
+                    month, avgSensitivityPct, qualifyingCount);
+        }
+    }
+
+    private List<SessionDriver> fetchEndedSessionDrivers(YearMonth month) {
+        OffsetDateTime from = month.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = month.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        return jdbcTemplate.query("""
+                SELECT EXTRACT(EPOCH FROM (ended_at - started_at))::bigint AS duration_seconds, message_count
+                FROM sessions
+                WHERE status = 'ended' AND started_at >= ? AND started_at < ?
+                """,
+                (rs, rowNum) -> new SessionDriver(rs.getLong("duration_seconds"), rs.getLong("message_count")),
+                from, to);
+    }
+
+    private record SessionDriver(long durationSeconds, long messageCount) {
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivity.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivity.java
@@ -1,0 +1,68 @@
+package com.mio.ai.cost;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 배분 모델(옵션 A 시간비례 vs 옵션 B 요청수비례) 민감도 관찰 기록 (이슈 #438, 개선안 문서 §5).
+ *
+ * <p>둘 중 어느 쪽도 정답(ground truth)이 아니다 — {@code allocationSensitivityPct}는 "어느 쪽이
+ * 정확한지"가 아니라 "배분 기준을 바꾸면 세션별 인프라비용이 얼마나 갈리는지"를 관찰하는 값이다.
+ * 운영 중인 세션·유저 cost API({@link InfraCostAllocator})는 항상 옵션 A만 쓰고, 이 레코드는
+ * 참고용 그림자 계산일 뿐이다.
+ */
+@Entity
+@Table(name = "infra_cost_allocation_sensitivity")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InfraCostAllocationSensitivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "billing_period_start", nullable = false)
+    private LocalDate billingPeriodStart;
+
+    @Column(name = "option_a_usd", nullable = false)
+    private BigDecimal optionAUsd;
+
+    @Column(name = "option_b_usd", nullable = false)
+    private BigDecimal optionBUsd;
+
+    @Column(name = "allocation_sensitivity_pct", nullable = false)
+    private BigDecimal allocationSensitivityPct;
+
+    @Column(name = "snapshot_at", nullable = false)
+    private OffsetDateTime snapshotAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private InfraCostAllocationSensitivity(LocalDate billingPeriodStart, BigDecimal optionAUsd,
+                                            BigDecimal optionBUsd, BigDecimal allocationSensitivityPct,
+                                            OffsetDateTime snapshotAt) {
+        this.billingPeriodStart = billingPeriodStart;
+        this.optionAUsd = optionAUsd;
+        this.optionBUsd = optionBUsd;
+        this.allocationSensitivityPct = allocationSensitivityPct;
+        this.snapshotAt = snapshotAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivityRepository.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivityRepository.java
@@ -1,0 +1,9 @@
+package com.mio.ai.cost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InfraCostAllocationSensitivityRepository
+        extends JpaRepository<InfraCostAllocationSensitivity, UUID> {
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
@@ -33,6 +33,10 @@ import java.util.List;
  *
  * <p>실패해도 기존 캐시는 그대로 두고 다음 배치에서 재시도한다 — {@code WeeklyReflectionJob} 계열
  * 배치와 같은 원칙으로 개별 실패가 앱 전체를 막지 않는다.
+ *
+ * <p>스냅샷 저장 직후, 같은 배치 실행 시점에 {@link AllocationSensitivityCalculator}로 옵션 B
+ * 배분 민감도도 함께 계산한다(이슈 #438) — 이 계산은 별도 try/catch로 격리해, 실패해도 이미
+ * 성공한 스냅샷 캐싱까지 실패로 보이지 않게 한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -48,6 +52,7 @@ public class InfraCostSyncJob {
 
     private final CloudWatchClient cloudWatchClient;
     private final InfraCostSnapshotRepository repository;
+    private final AllocationSensitivityCalculator allocationSensitivityCalculator;
 
     @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
     public void sync() {
@@ -91,6 +96,13 @@ public class InfraCostSyncJob {
 
             log.info("[InfraCostSyncJob] 캐싱 완료 period={}~{} totalCostUsd={} dataPointAt={}",
                     periodStart, periodEnd, totalCostUsd, latest.timestamp());
+
+            try {
+                allocationSensitivityCalculator.computeAndSave(month, totalCostUsd);
+            } catch (Exception e) {
+                // 스냅샷 캐싱은 이미 성공했으니, 민감도 계산 실패로 위 성공까지 실패로 보이면 안 된다(이슈 #438).
+                log.warn("[InfraCostSyncJob] 배분 민감도 계산 실패, 스냅샷 캐싱에는 영향 없음: {}", e.getMessage());
+            }
         } catch (Exception e) {
             log.warn("[InfraCostSyncJob] CloudWatch 동기화 실패, 기존 캐시 유지: {}", e.getMessage());
         }

--- a/src/main/resources/db/migration/V58__create_infra_cost_allocation_sensitivity.sql
+++ b/src/main/resources/db/migration/V58__create_infra_cost_allocation_sensitivity.sql
@@ -1,0 +1,20 @@
+-- 이슈 #438 — 배분 모델 민감도 분석(옵션 A 시간비례 vs 옵션 B 요청수비례).
+-- 정확도 검증이 아니다 — A/B 둘 다 임의의 배분 모형이라 어느 쪽도 정답(ground truth)이 아니다.
+-- option_a_usd/option_b_usd/allocation_sensitivity_pct는 그 달 세션별 민감도(|A_i-B_i|/B_i)의
+-- 평균치다. 전체 세션 합계·평균으로 집계하면 두 배분 방식 모두 같은 월간총청구액으로 수렴해
+-- 항상 0%가 나오므로(비례배분의 수학적 항등), 반드시 세션 단위로 먼저 계산한 뒤 평균낸다.
+
+CREATE TABLE infra_cost_allocation_sensitivity (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_period_start        DATE NOT NULL,
+    option_a_usd                NUMERIC(20, 10) NOT NULL,
+    option_b_usd                NUMERIC(20, 10) NOT NULL,
+    allocation_sensitivity_pct  NUMERIC(20, 10) NOT NULL,
+    snapshot_at                 TIMESTAMPTZ NOT NULL,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_infra_cost_allocation_sensitivity_period_snapshot_at
+    ON infra_cost_allocation_sensitivity (billing_period_start, snapshot_at DESC);
+
+COMMENT ON TABLE infra_cost_allocation_sensitivity IS '옵션 A(시간비례) vs 옵션 B(요청수비례) 배분 모델 민감도 관찰용. 운영 응답(옵션 A)에는 영향 없음 — 그림자 계산.';

--- a/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 배분 모델 민감도(옵션 A vs 옵션 B) 계산을 실제 DB로 검증한다 (이슈 #438).
+ *
+ * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
+ * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class AllocationSensitivityCalculatorIntegrationTest {
+
+    @Autowired
+    private AllocationSensitivityCalculator calculator;
+
+    @Autowired
+    private InfraCostAllocationSensitivityRepository sensitivityRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> insertedUserIds = new ArrayList<>();
+    private final List<UUID> insertedSessionIds = new ArrayList<>();
+    private final List<UUID> insertedSensitivityIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        insertedSessionIds.forEach(id -> jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", id));
+        insertedUserIds.forEach(id -> jdbcTemplate.update("DELETE FROM users WHERE id = ?", id));
+        insertedSensitivityIds.forEach(id -> sensitivityRepository.deleteById(id));
+    }
+
+    @Test
+    @DisplayName("세션별 민감도(|A_i-B_i|/B_i)의 평균을 저장한다 — 전체 합계로 계산하면 항상 0%가 되는 것과 달리 실제로 갈린다")
+    void computeAndSave_averagesPerSessionSensitivity() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        // 총세션-초 100, 총메시지 100 — 세션 A: duration 비중(0.4) > 메시지 비중(0.25) → 시간비례가 더 큼
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+        // 세션 B: duration 비중(0.6) < 메시지 비중(0.75) → 요청수비례가 더 큼
+        insertEndedSession(user, "2026-08-11T10:00:00+09:00", 60, 75);
+
+        calculator.computeAndSave(august, new BigDecimal("100"));
+
+        List<InfraCostAllocationSensitivity> saved = sensitivityRepository.findAll();
+        insertedSensitivityIds.addAll(saved.stream().map(InfraCostAllocationSensitivity::getId).toList());
+        assertThat(saved).hasSize(1);
+
+        InfraCostAllocationSensitivity result = saved.get(0);
+        // A_A=40,B_A=25(민감도60%) / A_B=60,B_B=75(민감도20%) → 평균 40%
+        assertThat(result.getAllocationSensitivityPct()).isEqualByComparingTo(new BigDecimal("40.0000000000"));
+        // sumA=100,sumB=100, count=2 → 둘 다 평균 50 (전체 합계 자체는 배분기준과 무관하게 같다는 걸 보여줌)
+        assertThat(result.getOptionAUsd()).isEqualByComparingTo(new BigDecimal("50.0000000000"));
+        assertThat(result.getOptionBUsd()).isEqualByComparingTo(new BigDecimal("50.0000000000"));
+        assertThat(result.getBillingPeriodStart()).isEqualTo(august.atDay(1));
+    }
+
+    @Test
+    @DisplayName("메시지가 0건인 세션은 개별 평균 계산에서 제외된다(0으로 나누기 방지)")
+    void computeAndSave_excludesZeroMessageSessionFromAverage_butKeepsItInTotals() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+        insertEndedSession(user, "2026-08-11T10:00:00+09:00", 60, 75);
+        // 메시지 0건 세션(duration 100s) — 총세션-초 분모(200)에는 더해지지만 개별 민감도 평균에서는
+        // 빠져야 함(0으로 나누기 회피). 총세션-초가 200으로 바뀌므로 기대값도 그에 맞춰 다시 계산함:
+        // A_A=100*40/200=20, B_A=25 → 민감도 20% / A_B=100*60/200=30, B_B=75 → 민감도 60% → 평균 40%
+        insertEndedSession(user, "2026-08-12T10:00:00+09:00", 100, 0);
+
+        calculator.computeAndSave(august, new BigDecimal("100"));
+
+        List<InfraCostAllocationSensitivity> saved = sensitivityRepository.findAll();
+        insertedSensitivityIds.addAll(saved.stream().map(InfraCostAllocationSensitivity::getId).toList());
+        assertThat(saved).hasSize(1);
+        // qualifying 세션은 여전히 2건(A,B)뿐이지만, 0건 세션의 duration이 분모에 들어가 값 자체는 바뀐다
+        assertThat(saved.get(0).getAllocationSensitivityPct()).isEqualByComparingTo(new BigDecimal("40.0000000000"));
+    }
+
+    @Test
+    @DisplayName("월간 총청구액이 0 이하면 계산을 스킵한다")
+    void computeAndSave_zeroCost_skips() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+
+        calculator.computeAndSave(august, BigDecimal.ZERO);
+
+        assertThat(sensitivityRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그 달 세션이 아예 없으면 계산을 스킵한다")
+    void computeAndSave_noSessions_skips() {
+        calculator.computeAndSave(YearMonth.of(2026, 8), new BigDecimal("100"));
+
+        assertThat(sensitivityRepository.findAll()).isEmpty();
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "allocation-sensitivity-it-" + userId);
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private void insertEndedSession(UUID userId, String startedAt, int durationSeconds, int messageCount) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at, message_count) " +
+                        "VALUES (?, ?, 'mio', 'ended', ?::timestamptz, ?::timestamptz + (? || ' seconds')::interval, ?)",
+                sessionId, userId, startedAt, startedAt, durationSeconds, messageCount);
+        insertedSessionIds.add(sessionId);
+    }
+}

--- a/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.cost;
 
+import com.mio.common.AppConstants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -11,11 +12,14 @@ import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRespo
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.YearMonth;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -25,7 +29,10 @@ class InfraCostSyncJobTest {
 
     private final CloudWatchClient cloudWatchClient = mock(CloudWatchClient.class);
     private final InfraCostSnapshotRepository repository = mock(InfraCostSnapshotRepository.class);
-    private final InfraCostSyncJob job = new InfraCostSyncJob(cloudWatchClient, repository);
+    private final AllocationSensitivityCalculator allocationSensitivityCalculator =
+            mock(AllocationSensitivityCalculator.class);
+    private final InfraCostSyncJob job =
+            new InfraCostSyncJob(cloudWatchClient, repository, allocationSensitivityCalculator);
 
     @Test
     @DisplayName("정상 응답이면 최신 데이터포인트 값을 스냅샷으로 저장한다")
@@ -44,6 +51,39 @@ class InfraCostSyncJobTest {
         assertThat(saved.getTotalCostUsd()).isEqualByComparingTo(new BigDecimal("7.89"));
         assertThat(saved.isEstimated()).isTrue();
         assertThat(saved.getAllocationMethodVersion()).isEqualTo(InfraCostSyncJob.ALLOCATION_METHOD_VERSION);
+    }
+
+    @Test
+    @DisplayName("스냅샷 저장 성공 후 같은 배치 실행에서 배분 민감도 계산도 호출한다")
+    void sync_success_alsoTriggersAllocationSensitivityCalculation() {
+        Datapoint datapoint = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(datapoint).build());
+
+        // job.sync() 안에서 YearMonth.now()를 다시 부르므로, 실행 전후로 캡처해 월 경계(자정) 레이스를
+        // 피한다 — AdminUserCostServiceTest에서 CodeRabbit이 지적했던 것과 같은 패턴(커밋 7b0c6d3).
+        YearMonth before = YearMonth.now(AppConstants.ZONE);
+        job.sync();
+        YearMonth after = YearMonth.now(AppConstants.ZONE);
+
+        ArgumentCaptor<YearMonth> monthCaptor = ArgumentCaptor.forClass(YearMonth.class);
+        verify(allocationSensitivityCalculator)
+                .computeAndSave(monthCaptor.capture(), eq(new BigDecimal("7.89")));
+        assertThat(monthCaptor.getValue()).isIn(before, after);
+    }
+
+    @Test
+    @DisplayName("배분 민감도 계산이 실패해도 이미 성공한 스냅샷 저장에는 영향이 없다")
+    void sync_allocationSensitivityFailure_doesNotAffectSnapshotSave() {
+        Datapoint datapoint = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(datapoint).build());
+        doThrow(new RuntimeException("boom")).when(allocationSensitivityCalculator)
+                .computeAndSave(any(YearMonth.class), any(BigDecimal.class));
+
+        assertThatCode(job::sync).doesNotThrowAnyException();
+
+        verify(repository).save(any(InfraCostSnapshot.class));
     }
 
     @Test


### PR DESCRIPTION
## 요약
옵션 A(시간비례)와 옵션 B(요청수비례) 두 배분 모형을 매월 같이 계산해, 배분 기준을 바꾸면 세션별 인프라비용이 얼마나 민감하게 달라지는지 관찰하는 그림자(shadow) 계산을 추가합니다. **정확도 검증이 아닙니다** — A와 B 둘 다 임의의 배분 모형이라 어느 쪽도 정답(ground truth)이 아닙니다(개선안 문서 §5).

## 관련 이슈
- Closes #438

## 설계에서 확인한 것 — 왜 "세션별 민감도의 평균"인가
이슈 원안의 `allocation_sensitivity_pct = |A - B| / B × 100`을 그 달 전체 세션의 **합계나 평균**으로 계산하면 수학적으로 **항상 0%**가 나옵니다. 옵션 A든 옵션 B든 같은 월간총청구액을 세션들에 비례배분하는 방식이라, 전체 합/평균은 배분 기준과 무관하게 항상 "월간총청구액"(또는 "총청구액/세션수")으로 수렴하는 항등이기 때문입니다.

실제로 A와 B가 갈리는 지점은 **세션 개별 단위**입니다(예: 오래 붙어있었지만 메시지는 적은 세션은 A에서 더 크게, 메시지는 많지만 짧은 세션은 B에서 더 크게 잡힘). 그래서 세션마다 `A_i`, `B_i`를 먼저 계산해 `|A_i-B_i|/B_i`(%)를 구한 뒤, 그 달 세션들의 이 값을 **평균**낸 것을 최종 지표로 씁니다. `option_a_usd`/`option_b_usd`도 이 세션별 계산의 평균(참고용)입니다.

## 변경 사항
- `InfraCostAllocationSensitivity` 엔티티 + 마이그레이션(V58) — `billing_period_start`, `option_a_usd`, `option_b_usd`, `allocation_sensitivity_pct`, `snapshot_at`
- `AllocationSensitivityCalculator` — 그 달 종료된 세션들의 `(duration_seconds, message_count)`를 조회해 옵션 A/B의 총 분모(총세션-초/총메시지수)는 `InfraCostAllocator`와 동일한 기준(모든 종료 세션)으로 계산하되, 세션별 민감도 평균은 `duration>0 AND message_count>0`인 세션만 대상으로 함(0으로 나누기 방지)
- `InfraCostSyncJob`에 연결 — 스냅샷 저장 성공 **직후, 같은 배치 실행 시점**에서 계산(이슈 기술 접근 방향과 일치). 별도 `try/catch`로 격리해 이 계산이 실패해도 이미 성공한 스냅샷 캐싱에는 영향 없음
- 임계값(30%) 초과 시 로그 경고만 남김 — SNS 알람 아님, 운영 중인 세션·유저 cost API 응답에는 영향 없음(항상 옵션 A만 노출)

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다. (내부 관찰용 테이블일 뿐, 노출 API 없음)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (V58, `infra_cost_allocation_sensitivity` 신규 테이블)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. (기존 `InfraCostSyncJob` 배치에 계산 단계 추가)
- [x] 로깅 / 모니터링 포인트가 변경됩니다. (민감도 30% 초과 시 경고 로그)
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test --tests "com.mio.ai.cost.*"
./gradlew test
```
### 확인 내용
- `AllocationSensitivityCalculatorIntegrationTest`(실제 DB) — 세션별 민감도 평균 계산(전체 합계로 계산하면 항상 0%가 되는 것과 실제로 다름을 수치로 검증), 메시지 0건 세션이 개별 평균에서는 제외되지만 총세션-초 분모에는 여전히 반영되는지, 월간 총청구액 0 이하·그 달 세션 없음 케이스에서 스킵(레코드 미저장)하는지 4건
- `InfraCostSyncJobTest`에 배치 연동 테스트 2건 추가 — 스냅샷 저장 성공 시 민감도 계산도 같이 호출되는지, 민감도 계산이 실패해도 스냅샷 저장 자체는 영향받지 않는지
- 전체 스위트: 1073개 중 1071개 통과. 나머지 2개(`MioApplicationTests`)는 #437(PR #439)에서도 보고했던 로컬 개발 DB의 flyway 체크섬 드리프트(V18/V56/V57) — 이번 브랜치가 새로 유발한 게 아니고, V58은 체크섬 불일치 없이 정상 적용됨. 새 DB(CI)에서는 문제없음

## 중점 리뷰 포인트 (PR 올리기 전 자체 리뷰에서 확인한 것)
- **월 경계 레이스 컨디션 방지** — `InfraCostSyncJobTest`의 신규 테스트가 `job.sync()` 실행 전후로 `YearMonth.now()`를 각각 캡처해서 자정 근처 실행 시 거짓 실패가 나지 않게 함(`AdminUserCostServiceTest`에서 CodeRabbit이 지적했던 것과 같은 패턴, 커밋 `7b0c6d3` 사례를 미리 적용)
- **0으로 나누기 방어** — `totalCostUsd<=0`, `totalDurationSeconds<=0`, `totalMessages<=0`, 개별 세션 `duration<=0`/`messageCount<=0` 네 군데 가드 확인
- **실패 격리** — 민감도 계산 실패가 이미 성공한 스냅샷 캐싱의 로그·상태에 영향을 주지 않도록 별도 try/catch로 감쌈(스냅샷 save 이후, log.info 이후에 배치)
- **분모 일관성** — 세션별 A_i/B_i 계산에 쓰는 총세션-초/총메시지수 분모가 `InfraCostAllocator`의 운영 배분 로직과 같은 집합(그 달의 모든 `status='ended'` 세션)을 기준으로 하는지 확인 — 세션별 평균 대상 필터(duration>0 AND message_count>0)와 분모 집합을 다르게 둬야 항등식 문제를 피할 수 있다는 게 이번 설계의 핵심이라 특히 신경 씀

## 배포 / 롤백
- Rollout: Flyway 마이그레이션(V58) 자동 적용. 기존 `InfraCostSyncJob` 배치에 계산 단계가 추가되지만 실패해도 스냅샷 캐싱에 영향 없음 — 무해하게 롤아웃됨
- Rollback: 코드만 이전 커밋으로 되돌리면 됨. `infra_cost_allocation_sensitivity` 테이블은 그대로 둬도 무해(참조하는 다른 로직 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `feat/#437-cost-explorer-integration`입니다 — #431→#433→#434→#437 스택 위에 이어서 진행했습니다(이슈 #438이 #437의 배치·캐싱 인프라를 재사용). 앞 PR들이 순서대로 머지되면 base를 옮기겠습니다.
