### PR TITLE
ci: integration 브랜치 검증 게이트 활성화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'integration/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'integration/**']
 
 jobs:
   build:

--- a/.github/workflows/crisis-eval.yml
+++ b/.github/workflows/crisis-eval.yml
@@ -1,0 +1,119 @@
+name: Crisis Eval (full path)
+
+# 위기 탐지 전체 경로 평가 — P0-1 릴리스 게이트.
+# workflow_dispatch는 기본 브랜치에 파일이 있어야 등록되므로 이 dispatcher는 develop에 둔다.
+# 평가 코드는 고정된 1.1 통합 브랜치에서만 checkout해 임의 PR 코드에 API 시크릿을 노출하지 않는다.
+
+on:
+  workflow_dispatch:
+    inputs:
+      archive:
+        description: '결과를 docs/eval/runs 경로 규칙으로 남길지 (아티팩트 업로드는 항상 함)'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  crisis-eval:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    env:
+      EVAL_ARCHIVE_DIR: ${{ inputs.archive && 'docs/eval/runs' || 'build/eval/runs' }}
+    timeout-minutes: 30
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: mio
+          POSTGRES_USER: mio
+          POSTGRES_PASSWORD: mio
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Validate evaluation secret
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY repository secret is required for the P0-1 full-path evaluation"
+            exit 1
+          fi
+
+      - name: Checkout trusted integration branch
+        uses: actions/checkout@v4
+        with:
+          ref: integration/1.1.0
+          persist-credentials: false
+
+      - name: Record revision
+        run: |
+          echo "평가 리비전: $(git rev-parse HEAD)" >> "$GITHUB_STEP_SUMMARY"
+          git status --porcelain | head -20
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Run crisis full-path evaluation
+        run: |
+          ./gradlew test -PllmTests \
+            -PevalArchiveDir="$EVAL_ARCHIVE_DIR" \
+            --tests "com.mio.ai.qa.CrisisDetectionFullPathQaTest" \
+            --tests "com.mio.ai.qa.CrisisDetectionCorpusQaTest"
+        env:
+          SPRING_PROFILES_ACTIVE: local
+          DB_URL: jdbc:postgresql://localhost:5432/mio
+          DB_USERNAME: mio
+          DB_PASSWORD: mio
+          REDIS_HOST: localhost
+          REDIS_PORT: 6379
+          REDIS_PASSWORD: ""
+          JWT_SECRET: ci-test-secret-key-minimum-256bits-long-for-hs256-algorithm-padding
+          JWT_ACCESS_TOKEN_EXPIRE_MS: 900000
+          JWT_REFRESH_TOKEN_EXPIRE_MS: 2592000000
+          APP_ENCRYPTION_KEY: Y2l0ZXN0a2V5MzJieXRlc2xvbmdrZXlmb3JhZXM=
+          APP_BELIEF_IDENTITY_HMAC_KEY: ci-test-belief-identity-hmac-key-at-least-32-bytes
+          APPLE_APP_ID: com.example.mio
+          APPLE_JWKS_URL: https://appleid.apple.com/auth/keys
+          KAKAO_APP_ID: 0
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+      - name: Upload eval archive
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crisis-eval-runs
+          path: ${{ env.EVAL_ARCHIVE_DIR }}/
+          retention-days: 90
+
+      - name: Upload test report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crisis-eval-test-report
+          path: build/reports/tests/
+          retention-days: 30

--- a/src/test/java/com/mio/config/CiWorkflowContractTest.java
+++ b/src/test/java/com/mio/config/CiWorkflowContractTest.java
@@ -1,0 +1,45 @@
+package com.mio.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CiWorkflowContractTest {
+
+    private static final Path WORKFLOW_DIR = Path.of(".github", "workflows");
+
+    @Test
+    @DisplayName("통합 브랜치 push와 PR은 기본 build CI 대상이다")
+    void ciIncludesIntegrationBranches() throws IOException {
+        String workflow = Files.readString(WORKFLOW_DIR.resolve("ci.yml"));
+
+        Pattern push = Pattern.compile(
+                "(?ms)^\\s*push:\\s*\\R\\s*branches:\\s*\\[[^]]*integration/\\*\\*[^]]*]");
+        Pattern pullRequest = Pattern.compile(
+                "(?ms)^\\s*pull_request:\\s*\\R\\s*branches:\\s*\\[[^]]*integration/\\*\\*[^]]*]");
+
+        assertThat(workflow).containsPattern(push).containsPattern(pullRequest);
+    }
+
+    @Test
+    @DisplayName("위기 평가는 기본 브랜치에 등록되지만 고정 integration ref만 checkout한다")
+    void crisisEvalDispatcherPinsTrustedIntegrationRef() throws IOException {
+        Path workflowPath = WORKFLOW_DIR.resolve("crisis-eval.yml");
+        assertThat(workflowPath).exists();
+
+        String workflow = Files.readString(workflowPath);
+        assertThat(workflow)
+                .contains("workflow_dispatch:")
+                .contains("ref: integration/1.1.0")
+                .contains("persist-credentials: false")
+                .contains("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}")
+                .contains("Validate evaluation secret")
+                .doesNotContain("ref: ${{ inputs.");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 기본 CI가 `integration/**` push와 PR을 검증하도록 확장
- 기본 브랜치에 P0-1 위기 평가 dispatcher 등록
- 평가 코드는 신뢰된 `integration/1.1.0` ref만 checkout
- `OPENAI_API_KEY` 누락 시 명시적으로 실패하고 평가 결과를 아티팩트로 보존
- 워크플로 계약 테스트 추가

## 검증
- `./gradlew clean build` (전용 PostgreSQL DB)
- 모든 workflow YAML parse

Closes #446