### PR TITLE
ci: 1.1 통합 브랜치에 검증 게이트 동기화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, 'integration/**']
   pull_request:
-    branches: [main, develop]
+    branches: [main, develop, 'integration/**']
 
 jobs:
   build:

--- a/.github/workflows/crisis-eval.yml
+++ b/.github/workflows/crisis-eval.yml
@@ -17,6 +17,8 @@ name: Crisis Eval (full path)
 # 언제 돌리는가.
 #   main 머지 전, 그리고 SafetyL1·InputJudge 프롬프트·PolicyEngine·OutputPreFilter·
 #   OutputJudge 를 바꾼 PR 에서. 평가 코드는 1.1 통합 브랜치에서만 실행한다.
+# workflow_dispatch는 기본 브랜치에 파일이 있어야 등록되므로 이 dispatcher는 develop에 둔다.
+# 평가 코드는 고정된 1.1 통합 브랜치에서만 checkout해 임의 PR 코드에 API 시크릿을 노출하지 않는다.
 
 on:
   workflow_dispatch:
@@ -63,7 +65,16 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Checkout
+      - name: Validate evaluation secret
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          if [ -z "$OPENAI_API_KEY" ]; then
+            echo "::error::OPENAI_API_KEY repository secret is required for the P0-1 full-path evaluation"
+            exit 1
+          fi
+
+      - name: Checkout trusted integration branch
         uses: actions/checkout@v4
         with:
           # 저장소 시크릿을 임의 브랜치 코드에 노출하지 않는다.

--- a/src/test/java/com/mio/config/CiWorkflowContractTest.java
+++ b/src/test/java/com/mio/config/CiWorkflowContractTest.java
@@ -1,0 +1,45 @@
+package com.mio.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CiWorkflowContractTest {
+
+    private static final Path WORKFLOW_DIR = Path.of(".github", "workflows");
+
+    @Test
+    @DisplayName("통합 브랜치 push와 PR은 기본 build CI 대상이다")
+    void ciIncludesIntegrationBranches() throws IOException {
+        String workflow = Files.readString(WORKFLOW_DIR.resolve("ci.yml"));
+
+        Pattern push = Pattern.compile(
+                "(?ms)^\\s*push:\\s*\\R\\s*branches:\\s*\\[[^]]*integration/\\*\\*[^]]*]");
+        Pattern pullRequest = Pattern.compile(
+                "(?ms)^\\s*pull_request:\\s*\\R\\s*branches:\\s*\\[[^]]*integration/\\*\\*[^]]*]");
+
+        assertThat(workflow).containsPattern(push).containsPattern(pullRequest);
+    }
+
+    @Test
+    @DisplayName("위기 평가는 기본 브랜치에 등록되지만 고정 integration ref만 checkout한다")
+    void crisisEvalDispatcherPinsTrustedIntegrationRef() throws IOException {
+        Path workflowPath = WORKFLOW_DIR.resolve("crisis-eval.yml");
+        assertThat(workflowPath).exists();
+
+        String workflow = Files.readString(workflowPath);
+        assertThat(workflow)
+                .contains("workflow_dispatch:")
+                .contains("ref: integration/1.1.0")
+                .contains("persist-credentials: false")
+                .contains("OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}")
+                .contains("Validate evaluation secret")
+                .doesNotContain("ref: ${{ inputs.");
+    }
+}


### PR DESCRIPTION
## 변경 사항
- `develop`에 등록된 `integration/**` 기본 CI 필터를 1.1 통합 브랜치에도 동기화
- 기존 위기 평가 워크플로에 `OPENAI_API_KEY` 사전 검증 추가
- 고정된 `integration/1.1.0` checkout 및 최소 권한 유지
- 워크플로 계약 테스트 추가

## 검증
- workflow YAML 전체 parse
- `CiWorkflowContractTest` 통과

Relates to #446