### PR TITLE
[FEAT] AI 운영 지연·비용·실패율 대시보드와 경보 (P0-9)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,6 +67,7 @@ dependencies {
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+    testImplementation("io.micrometer:micrometer-registry-prometheus")
     testImplementation("it.ozimov:embedded-redis:0.7.3") {
         exclude(group = "org.slf4j", module = "slf4j-simple")
     }

--- a/docker-compose.observability.yml
+++ b/docker-compose.observability.yml
@@ -1,0 +1,65 @@
+services:
+  prometheus:
+    image: prom/prometheus:v3.13.1
+    profiles: ["observability"]
+    restart: unless-stopped
+    mem_limit: 192m
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=15d
+    volumes:
+      - ./ops/observability/prometheus:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "127.0.0.1:9091:9090"
+    depends_on:
+      - alertmanager
+
+  alertmanager:
+    image: prom/alertmanager:v0.33.1
+    profiles: ["observability"]
+    restart: unless-stopped
+    mem_limit: 64m
+    command:
+      - --config.file=/etc/alertmanager/alertmanager.yml
+      - --storage.path=/alertmanager
+    volumes:
+      - ./ops/observability/alertmanager:/etc/alertmanager:ro
+      - alertmanager_data:/alertmanager
+    secrets:
+      - alertmanager_slack_webhook
+    ports:
+      - "127.0.0.1:9093:9093"
+
+  grafana:
+    image: grafana/grafana:13.0.2
+    profiles: ["observability"]
+    restart: unless-stopped
+    mem_limit: 192m
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD__FILE: /run/secrets/grafana_admin_password
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_PLUGINS_PREINSTALL_DISABLED: "true"
+    volumes:
+      - ./ops/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./ops/observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    secrets:
+      - grafana_admin_password
+    ports:
+      - "127.0.0.1:3000:3000"
+    depends_on:
+      - prometheus
+
+secrets:
+  alertmanager_slack_webhook:
+    file: ${ALERTMANAGER_SLACK_WEBHOOK_FILE:-./secrets/alertmanager-slack-webhook}
+  grafana_admin_password:
+    file: ${GRAFANA_ADMIN_PASSWORD_FILE:-./secrets/grafana-admin-password}
+
+volumes:
+  prometheus_data:
+  alertmanager_data:
+  grafana_data:

--- a/ops/observability/alertmanager/alertmanager.yml
+++ b/ops/observability/alertmanager/alertmanager.yml
@@ -1,0 +1,17 @@
+global:
+  resolve_timeout: 5m
+  slack_api_url_file: /run/secrets/alertmanager_slack_webhook
+
+route:
+  receiver: mio-ai-slack
+  group_by: ["alertname", "severity"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 4h
+
+receivers:
+  - name: mio-ai-slack
+    slack_configs:
+      - send_resolved: true
+        title: "[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ .Annotations.description }}\n{{ end }}"

--- a/ops/observability/grafana/dashboards/mio-ai-overview.json
+++ b/ops/observability/grafana/dashboards/mio-ai-overview.json
@@ -1,0 +1,118 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "graphTooltip": 1,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Safety — crisis and guarded decisions",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "sum(rate(mio_crisis_records_total[5m]))", "legendFormat": "crisis records/s"},
+        {"refId": "B", "expr": "sum by (risk) (rate(mio_ai_policy_decisions_total{risk=~\"high|hard_crisis\"}[5m]))", "legendFormat": "{{risk}}/s"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Turn p95",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "targets": [
+        {"refId": "A", "expr": "histogram_quantile(0.95, sum by (le, delivery_mode) (rate(mio_ai_turn_duration_seconds_bucket[10m])))", "legendFormat": "{{delivery_mode}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "TTFT and first substantive p95",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 0},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "targets": [
+        {"refId": "A", "expr": "histogram_quantile(0.95, sum by (le) (rate(mio_ai_turn_llm_ttft_seconds_bucket[10m])))", "legendFormat": "LLM TTFT"},
+        {"refId": "B", "expr": "histogram_quantile(0.95, sum by (le) (rate(mio_ai_turn_first_substantive_seconds_bucket[10m])))", "legendFormat": "first substantive"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Cost and token rate",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "sum by (component) (rate(mio_llm_cost_usd_total[5m]))", "legendFormat": "USD/s {{component}}"},
+        {"refId": "B", "expr": "sum by (component, type) (rate(mio_llm_tokens_total[5m]))", "legendFormat": "tokens/s {{component}} {{type}}"},
+        {"refId": "C", "expr": "sum(increase(mio_llm_cost_unpriced_total[15m]))", "legendFormat": "unpriced events"},
+        {"refId": "D", "expr": "sum by (component) (increase(mio_llm_cost_usd_total[24h]))", "legendFormat": "24h USD {{component}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Judge failures",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "sum by (outcome) (rate(mio_judge_input_total[5m]))", "legendFormat": "input {{outcome}}"},
+        {"refId": "B", "expr": "sum by (outcome) (rate(mio_judge_output_total[5m]))", "legendFormat": "output {{outcome}}"},
+        {"refId": "C", "expr": "sum by (source, outcome) (rate(mio_retrieval_outcome_total[5m]))", "legendFormat": "retrieval {{source}} {{outcome}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Contract and delivery outcomes",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 8},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "sum by (response_act, result) (rate(mio_ai_contract_results_total[5m]))", "legendFormat": "{{response_act}} {{result}}"},
+        {"refId": "B", "expr": "sum by (outcome) (rate(mio_ai_turn_outcomes_total[5m]))", "legendFormat": "turn {{outcome}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Stuck work and deletion backlog",
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 16},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "sum by (outcome) (increase(mio_turns_swept_total[15m]))", "legendFormat": "turn sweep {{outcome}}"},
+        {"refId": "B", "expr": "max(mio_deletion_backlog)", "legendFormat": "deletion backlog"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Summary pipeline status",
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 16},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": [
+          {
+            "matcher": {"id": "byFrameRefID", "options": "A"},
+            "properties": [{"id": "unit", "value": "s"}]
+          }
+        ]
+      },
+      "targets": [
+        {"refId": "A", "expr": "histogram_quantile(0.95, sum by (le, stage) (rate(mio_summary_stage_duration_seconds_bucket{outcome=\"done\"}[10m])))", "legendFormat": "p95 {{stage}}"},
+        {"refId": "B", "expr": "sum by (component, outcome) (increase(mio_summary_component_total[15m]))", "legendFormat": "{{component}} {{outcome}}"}
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Held-back output distribution",
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 16},
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "targets": [
+        {"refId": "A", "expr": "histogram_quantile(0.95, sum by (le, delivery_mode) (rate(mio_ai_turn_held_back_chars_bucket[10m])))", "legendFormat": "{{delivery_mode}}"}
+      ]
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["mio", "ai", "p0-9"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "Mio AI Operational Overview",
+  "uid": "mio-ai-overview",
+  "version": 1
+}

--- a/ops/observability/grafana/provisioning/alerting/empty.yml
+++ b/ops/observability/grafana/provisioning/alerting/empty.yml
@@ -1,0 +1,1 @@
+apiVersion: 1

--- a/ops/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/ops/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: Mio AI
+    orgId: 1
+    folder: Mio
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards

--- a/ops/observability/grafana/provisioning/datasources/prometheus.yml
+++ b/ops/observability/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/ops/observability/grafana/provisioning/plugins/empty.yml
+++ b/ops/observability/grafana/provisioning/plugins/empty.yml
@@ -1,0 +1,2 @@
+apiVersion: 1
+apps: []

--- a/ops/observability/prometheus/alerts.yml
+++ b/ops/observability/prometheus/alerts.yml
@@ -57,3 +57,39 @@ groups:
         annotations:
           summary: "고착 턴 회수 작업 실패"
           description: "generating 상태 턴의 회수 쿼리 또는 커밋이 실패했습니다."
+
+      - alert: MioCrisisRecordFailed
+        expr: sum(increase(mio_crisis_records_total{outcome="failed"}[15m])) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "위기 이벤트 영속화 실패"
+          description: "위기 안내 이후 기록 재시도가 소진됐습니다. safety latch와 DB 상태를 확인하십시오."
+
+      - alert: MioRetrievalFailureRatioHigh
+        expr: sum(increase(mio_retrieval_outcome_total{outcome="failed"}[10m])) / clamp_min(sum(increase(mio_retrieval_outcome_total[10m])), 1) > 0.10 and sum(increase(mio_retrieval_outcome_total[10m])) >= 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "기억 retrieval 실패율이 10% 초과"
+          description: "최근 10분간 20회 이상 retrieval에서 실패율이 10%를 넘었습니다. source별 실패를 확인하십시오."
+
+      - alert: MioContractViolationRatioHigh
+        expr: sum(increase(mio_ai_contract_results_total{result="violated"}[15m])) / clamp_min(sum(increase(mio_ai_contract_results_total[15m])), 1) > 0.20 and sum(increase(mio_ai_contract_results_total[15m])) >= 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "응답 계약 위반율이 20% 초과"
+          description: "최근 15분간 계약 검사 20건 이상에서 위반율이 20%를 넘었습니다. response_act별 분포를 확인하십시오."
+
+      - alert: MioSummaryPipelineFailure
+        expr: sum(increase(mio_summary_stage_duration_seconds_count{outcome="failed"}[15m])) > 0 or sum(increase(mio_summary_component_total{outcome=~"write_failed|stuck_failed"}[15m])) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "요약 파이프라인 단계 또는 파생 작업 실패"
+          description: "요약 단계 실패, component 상태 기록 실패, 또는 pending 작업 고착 종결이 발생했습니다."

--- a/ops/observability/prometheus/alerts.yml
+++ b/ops/observability/prometheus/alerts.yml
@@ -1,0 +1,59 @@
+groups:
+  - name: mio-ai-operational
+    interval: 30s
+    rules:
+      - alert: MioAiFirstSubstantiveP95High
+        expr: histogram_quantile(0.95, sum by (le) (rate(mio_ai_turn_first_substantive_seconds_bucket[10m]))) > 5
+        for: 15m
+        labels:
+          severity: warning
+          threshold_status: provisional
+        annotations:
+          summary: "AI 첫 실질 응답 p95가 임시 운영 기준을 초과"
+          description: "7일 운영 기준선을 확보한 뒤 5초 임계값을 재조정해야 합니다."
+
+      - alert: MioAiTurnP95High
+        expr: histogram_quantile(0.95, sum by (le) (rate(mio_ai_turn_duration_seconds_bucket[10m]))) > 15
+        for: 15m
+        labels:
+          severity: warning
+          threshold_status: provisional
+        annotations:
+          summary: "AI 턴 전체 p95가 임시 운영 기준을 초과"
+          description: "턴 전체 p95가 15초를 15분 동안 초과했습니다."
+
+      - alert: MioAiJudgeFailureRatioHigh
+        expr: (sum(rate(mio_judge_input_total{outcome="failed"}[10m])) + sum(rate(mio_judge_output_total{outcome="failed"}[10m]))) / clamp_min(sum(rate(mio_judge_input_total[10m])) + sum(rate(mio_judge_output_total[10m])), 0.001) > 0.05 and (sum(increase(mio_judge_input_total[10m])) + sum(increase(mio_judge_output_total[10m]))) >= 20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "AI Judge 실패율이 5% 초과"
+          description: "최근 10분간 20회 이상 판정에서 Input/Output Judge 합산 실패율이 5%를 넘었습니다."
+
+      - alert: MioAiUnpricedCostEvent
+        expr: increase(mio_llm_cost_unpriced_total[15m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "단가 미등록 LLM 비용 이벤트 발생"
+          description: "모델 registry와 가격 설정을 확인하십시오. 비용 0이 아니라 미상 상태입니다."
+
+      - alert: MioAiTurnFailureBurst
+        expr: sum(increase(mio_ai_turn_outcomes_total{outcome="error"}[10m])) >= 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "AI 턴 실패가 연속 발생"
+          description: "10분 안에 AI 턴 실패가 3건 이상 기록됐습니다."
+
+      - alert: MioAiStuckTurnSweepFailed
+        expr: increase(mio_turns_swept_total{outcome="failed"}[15m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "고착 턴 회수 작업 실패"
+          description: "generating 상태 턴의 회수 쿼리 또는 커밋이 실패했습니다."

--- a/ops/observability/prometheus/prometheus.yml
+++ b/ops/observability/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 30s
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+scrape_configs:
+  - job_name: mio-ai
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["app:9090"]
+        labels:
+          environment: production

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -18,7 +18,9 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -51,6 +53,24 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private static final String MODE_COMPLETE_TEXT = "complete_text";
     private static final String MODE_COMPLETE_JSON = "complete_json";
     private static final String MODE_EMBED = "embed";
+
+    /** metric label에 허용하는 코드 소유 역할. 요청 문자열을 그대로 label로 쓰지 않는다. */
+    private static final Set<String> METERED_COMPONENTS = Set.of(
+            "CBT_CLASSIFIER",
+            "CHECKIN_RESPONSE",
+            "CHECKPOINT_SUMMARY",
+            "EXTRACTOR",
+            "INPUT_JUDGE",
+            "MAIN_GENERATION",
+            "ONTOLOGY_EXTRACTOR",
+            "OUTPUT_JUDGE",
+            "REPORT_NARRATIVE",
+            "RETRIEVAL_QUERY_EMBEDDING",
+            "SESSION_SUMMARY",
+            "SUMMARY_RENDER",
+            "SUMMARY_STORAGE_EMBEDDING",
+            "TODO_PERSONALIZER",
+            "WEEKLY_REFLECTION");
 
     private final String apiKey;
     private final HttpClient httpClient;
@@ -461,18 +481,23 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
      */
     private void recordUsage(String mode, LlmUsage usage, String component, UUID userId, UUID sessionId) {
         String model = usage.model();
+        String componentTag = meteredComponent(component);
         if (!usage.resolved()) {
             // "사용량을 못 받았다" 를 별도 값으로 남긴다. 토큰 0 으로 세면 조용히 과소 계상된다.
-            meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode, "outcome", "missing")
+            meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode,
+                            "component", componentTag, "outcome", "missing")
                     .increment();
             return;
         }
 
-        meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode, "outcome", "resolved")
+        meterRegistry.counter(USAGE_METRIC, "model", model, "mode", mode,
+                        "component", componentTag, "outcome", "resolved")
                 .increment();
-        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode, "type", "prompt")
+        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode,
+                        "component", componentTag, "type", "prompt")
                 .increment(usage.promptTokens());
-        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode, "type", "completion")
+        meterRegistry.counter(TOKENS_METRIC, "model", model, "mode", mode,
+                        "component", componentTag, "type", "completion")
                 .increment(usage.completionTokens());
 
         BigDecimal cost = costCalculator.costUsd(usage);
@@ -480,14 +505,26 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         // 지연만큼 실제 사용 시각과 어긋나고, 자정 근처 호출이 월간 집계에서 다음 달로 샐 수 있다.
         OffsetDateTime occurredAt = OffsetDateTime.now(ZoneOffset.UTC);
         if (cost == null) {
-            meterRegistry.counter(UNPRICED_METRIC, "model", model, "mode", mode).increment();
+            meterRegistry.counter(UNPRICED_METRIC, "model", model, "mode", mode,
+                    "component", componentTag).increment();
             // 단가 미등록이라 비용은 모르지만, 토큰량 자체는 ai_cost_events에 남긴다(cost_usd=null).
             recordCostEvent(userId, sessionId, component, model, mode, usage, null, occurredAt);
             return;
         }
-        meterRegistry.counter(COST_METRIC, "model", model, "mode", mode)
+        meterRegistry.counter(COST_METRIC, "model", model, "mode", mode,
+                        "component", componentTag)
                 .increment(cost.doubleValue());
         recordCostEvent(userId, sessionId, component, model, mode, usage, cost, occurredAt);
+    }
+
+    private String meteredComponent(String component) {
+        if (component == null || component.isBlank()) {
+            return "unattributed";
+        }
+        String normalized = component.toUpperCase(Locale.ROOT);
+        return METERED_COMPONENTS.contains(normalized)
+                ? normalized.toLowerCase(Locale.ROOT)
+                : "other";
     }
 
     /**

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -99,7 +99,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     @Override
     public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
         long startMs = System.currentTimeMillis();
-        AtomicLong ttft = new AtomicLong(0);
+        // 콘텐츠가 끝내 오지 않은 정상 종료와 0ms 안에 도착한 첫 토큰을 구분한다.
+        AtomicLong ttft = new AtomicLong(-1);
         AtomicReference<LlmUsage> usage = new AtomicReference<>();
         AtomicBoolean truncated = new AtomicBoolean(false);
         // 이 호출의 종료(outcome + usage)를 이미 기록했는지. 아래 catch 는 우리가 던진 예외와
@@ -148,7 +149,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     attempt++;
                     // 재시도는 앞선 시도의 결과를 버린다. 리셋하지 않으면 실패한 시도의
                     // 사용량이 남아 최종 결과에 섞이거나 중복 집계된다.
-                    ttft.set(0);
+                    ttft.set(-1);
                     usage.set(null);
                     truncated.set(false);
                     continue;
@@ -180,7 +181,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                                 }
                                 String content = extractDeltaContent(chunk);
                                 if (content != null && !content.isEmpty()) {
-                                    if (ttft.get() == 0) {
+                                    if (ttft.get() < 0) {
                                         ttft.set(System.currentTimeMillis() - startMs);
                                     }
                                     chunkHandler.accept(content);
@@ -215,8 +216,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         LlmUsage resolved = resolveUsage(usage, request.model());
         recordUsage(MODE_STREAM, resolved, request);
 
-        long ttftMs = ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
-        return new LlmStreamResult(ttftMs, resolved, truncated.get());
+        return new LlmStreamResult(ttft.get(), resolved, truncated.get());
     }
 
     private long streamRetryDelayMs(HttpResponse<?> response, int attempt) {

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -234,7 +234,7 @@ public class AiDecisionLogger {
         //   first_rendered_token_ms    — 사용자가 무언가를 보기까지
         // 검토된 safe prefix 를 서버가 먼저 보내는 기능이 없는 동안 뒤의 두 값은 같다.
         // 필드를 미리 두어 그 기능이 들어올 때 값이 갈라지는 것을 볼 수 있게 한다.
-        trace.put("llm_ttft_ms", ttftMs);
+        trace.put("llm_ttft_ms", ttftMs >= 0 ? ttftMs : null);
         trace.put("first_substantive_token_ms",
                 firstSubstantiveTokenMs >= 0 ? firstSubstantiveTokenMs : null);
         trace.put("first_rendered_token_ms",

--- a/src/main/java/com/mio/ai/orchestrator/AiTurnMetrics.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiTurnMetrics.java
@@ -1,0 +1,144 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.plan.ResponseContractResult;
+import com.mio.ai.policy.PolicyDecision;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * AI 턴의 운영 결과를 Prometheus에서 집계 가능한 저카디널리티 지표로 기록한다.
+ *
+ * <p>정책 trace에는 세션별 원인이 필요하지만 metric label에는 사용자·세션·메시지·결정 ID를
+ * 절대 넣지 않는다. 아래 태그는 enum 또는 서버가 통제하는 닫힌 값 집합뿐이다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AiTurnMetrics {
+
+    private static final String TURN_DURATION = "mio.ai.turn.duration";
+    private static final String LLM_TTFT = "mio.ai.turn.llm.ttft";
+    private static final String FIRST_SUBSTANTIVE = "mio.ai.turn.first.substantive";
+    private static final String HELD_BACK_CHARS = "mio.ai.turn.held.back.chars";
+    private static final String TURN_OUTCOMES = "mio.ai.turn.outcomes";
+    private static final String POLICY_DECISIONS = "mio.ai.policy.decisions";
+    private static final String CONTRACT_RESULTS = "mio.ai.contract.results";
+
+    private static final Set<String> ALLOWED_OUTCOMES = Set.of(
+            "stop", "crisis_flow", "security_refusal", "replaced_by_guard",
+            "error", "replayed", "other");
+
+    private final MeterRegistry meterRegistry;
+
+    public void recordCompleted(
+            PolicyDecision decision,
+            ResponseContractResult contractResult,
+            long totalPipelineMs,
+            long llmTtftMs,
+            long firstSubstantiveTokenMs,
+            int heldBackChars,
+            String finishedReason) {
+
+        String outcome = boundedOutcome(finishedReason);
+        String deliveryMode = enumTag(decision.deliveryMode());
+        String responseAct = enumTag(decision.responsePlan().responseAct());
+
+        recordTurnDuration(totalPipelineMs, outcome, deliveryMode);
+        meterRegistry.counter(TURN_OUTCOMES, "outcome", outcome).increment();
+        meterRegistry.counter(
+                POLICY_DECISIONS,
+                "risk", enumTag(decision.riskLevel()),
+                "response_act", responseAct,
+                "generation_freedom", enumTag(decision.responsePlan().generationFreedom()),
+                "delivery_mode", deliveryMode).increment();
+        meterRegistry.counter(
+                CONTRACT_RESULTS,
+                "response_act", responseAct,
+                "result", contractResultTag(contractResult)).increment();
+
+        if (llmTtftMs >= 0) {
+            latencyTimer(
+                    LLM_TTFT,
+                    "LLM stream first token latency",
+                    "response_act", responseAct,
+                    "delivery_mode", deliveryMode)
+                    .record(Duration.ofMillis(llmTtftMs));
+        }
+        if (firstSubstantiveTokenMs >= 0) {
+            latencyTimer(
+                    FIRST_SUBSTANTIVE,
+                    "First approved substantive content latency",
+                    "delivery_mode", deliveryMode)
+                    .record(Duration.ofMillis(firstSubstantiveTokenMs));
+        }
+
+        DistributionSummary.builder(HELD_BACK_CHARS)
+                .description("Generated characters withheld from user delivery")
+                .publishPercentileHistogram()
+                .serviceLevelObjectives(1, 16, 64, 128, 256, 512, 1_024)
+                .tags("delivery_mode", deliveryMode, "outcome", outcome)
+                .register(meterRegistry)
+                .record(Math.max(heldBackChars, 0));
+    }
+
+    public void recordFailed(long totalPipelineMs) {
+        recordTurnDuration(totalPipelineMs, "error", "unknown");
+        meterRegistry.counter(TURN_OUTCOMES, "outcome", "error").increment();
+    }
+
+    public void recordReplay(long totalPipelineMs) {
+        recordTurnDuration(totalPipelineMs, "replayed", "replay");
+        meterRegistry.counter(TURN_OUTCOMES, "outcome", "replayed").increment();
+    }
+
+    private void recordTurnDuration(long millis, String outcome, String deliveryMode) {
+        latencyTimer(
+                TURN_DURATION,
+                "AI conversation turn end-to-end latency",
+                "outcome", outcome,
+                "delivery_mode", deliveryMode)
+                .record(Duration.ofMillis(Math.max(millis, 0)));
+    }
+
+    private Timer latencyTimer(String name, String description, String... tags) {
+        return Timer.builder(name)
+                .description(description)
+                .publishPercentileHistogram()
+                .minimumExpectedValue(Duration.ofMillis(1))
+                .maximumExpectedValue(Duration.ofSeconds(60))
+                .serviceLevelObjectives(
+                        Duration.ofMillis(50),
+                        Duration.ofMillis(100),
+                        Duration.ofMillis(250),
+                        Duration.ofMillis(500),
+                        Duration.ofSeconds(1),
+                        Duration.ofSeconds(2),
+                        Duration.ofSeconds(5),
+                        Duration.ofSeconds(10),
+                        Duration.ofSeconds(20),
+                        Duration.ofSeconds(30))
+                .tags(tags)
+                .register(meterRegistry);
+    }
+
+    private String boundedOutcome(String value) {
+        String normalized = value != null ? value.toLowerCase(Locale.ROOT) : "other";
+        return ALLOWED_OUTCOMES.contains(normalized) ? normalized : "other";
+    }
+
+    private String contractResultTag(ResponseContractResult result) {
+        return (result != null ? result : ResponseContractResult.notApplicable())
+                .logValue()
+                .toLowerCase(Locale.ROOT);
+    }
+
+    private String enumTag(Enum<?> value) {
+        return value != null ? value.name().toLowerCase(Locale.ROOT) : "unknown";
+    }
+}

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -86,6 +86,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Service
@@ -123,6 +124,7 @@ public class ConversationOrchestrator {
     private final WorkingMemory workingMemory;
     private final ContextPreWarmer contextPreWarmer;
     private final AiDecisionLogger decisionLogger;
+    private final AiTurnMetrics aiTurnMetrics;
     private final CbtReconstructionService cbtReconstructionService;
     private final SessionMessagePersistenceService messagePersistenceService;
     private final ConversationCheckpointService checkpointService;
@@ -166,6 +168,7 @@ public class ConversationOrchestrator {
             // 같은 Idempotency-Key 로 이미 완료된 턴이 있으면 저장된 응답을 재생한다.
             // LLM 을 다시 호출하지 않으므로 재시도가 비용을 늘리지 않는다 (이슈 P0-A).
             if (replayCompletedTurn(sessionId, idempotencyKey, outboundMsgId, emitter)) {
+                aiTurnMetrics.recordReplay(System.currentTimeMillis() - startMs);
                 emitter.complete();
                 return;
             }
@@ -254,7 +257,7 @@ public class ConversationOrchestrator {
 
             // 7. Execute based on decision
             String assistantContent;
-            long llmTtftMs = 0;
+            long llmTtftMs = -1;
             // LLM 을 호출하지 않은 턴(보안 거절·위기·폴백)에서는 null 로 남는다.
             // 호출하지 않았다는 사실 자체가 기록돼야 하므로 빈 사용량으로 채우지 않는다.
             LlmUsage llmUsage = null;
@@ -265,7 +268,7 @@ public class ConversationOrchestrator {
             OutputPreFilterResult preFilterResult = OutputPreFilterResult.pass();
             // 전달 계측 (이슈 #306). 첫 생성 토큰 지연(llmTtftMs)과 구분해서 남긴다 —
             // 하나로 재면 서버가 먼저 보내는 문구만으로도 수치가 좋아진다.
-            long firstSubstantiveTokenMs = -1;
+            AtomicLong firstSubstantiveTokenMs = new AtomicLong(-1);
             int heldBackChars = 0;
             OutputJudgeResult judgeActionResult = null;
             // 계약 검사 결과 (이슈 #303). 계획되지 않은 턴은 "통과"가 아니라 "대상 아님"이고,
@@ -277,6 +280,7 @@ public class ConversationOrchestrator {
             if (decision.action() == DecisionAction.SECURITY_REFUSAL) {
                 assistantContent = securityRefusalTemplate.get();
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
+                markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                         userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                         "security_refusal", false);
@@ -298,6 +302,9 @@ public class ConversationOrchestrator {
                 CrisisFlowService.CrisisHandleResult crisisResult =
                         crisisFlowService.handle(l1Result, appliedCrisisTrigger, userMessage,
                                 user, session, emitter, outboundMsgId, userSignal.emotionScore());
+                if (crisisResult != null && crisisResult.delivered()) {
+                    markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
+                }
                 recordCrisisOutcome(crisisResult, finishedReasonRef, crisisSeverityRef);
 
             } else if (decision.action() == DecisionAction.GENERATE) {
@@ -336,7 +343,8 @@ public class ConversationOrchestrator {
                             assistantContent = resolveOutputJudgeAction(
                                     judgeActionResult, assistantContent, userMessage, l1Result, user, session, emitter,
                                     outboundMsgId, userSignal.emotionScore(),
-                                    finishedReasonRef, crisisSeverityRef, turn, turnPersisted);
+                                    finishedReasonRef, crisisSeverityRef, turn, turnPersisted,
+                                    firstSubstantiveTokenMs, startMs);
                             if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
                                 crisisFlowTriggered = true;
                                 appliedCrisisTrigger = CrisisTrigger.OUTPUT_GUARD;
@@ -345,6 +353,7 @@ public class ConversationOrchestrator {
                     }
                     if (judgeActionResult == null || judgeActionResult.action() != OutputJudgeAction.CRISIS_FLOW) {
                         sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
+                        markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
                         sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                 userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                 "stop", true);
@@ -393,7 +402,10 @@ public class ConversationOrchestrator {
                                         outputJudgeExecutor));
                                 return false;
                             },
-                            unit -> sendEvent(emitter, new SseEventDto.DeltaEvent(unit, outboundMsgId)));
+                            unit -> {
+                                sendEvent(emitter, new SseEventDto.DeltaEvent(unit, outboundMsgId));
+                                markFirstSubstantive(firstSubstantiveTokenMs, startMs, unit);
+                            });
 
                     LlmStreamResult streamResult = llmClient.stream(llmRequest, withHeartbeat(turn, chunk -> {
                         contentBuilder.append(chunk);
@@ -408,7 +420,6 @@ public class ConversationOrchestrator {
                     } catch (Exception e) {
                         throw new RuntimeException(e);
                     }
-                    firstSubstantiveTokenMs = holdback.firstSubstantiveTokenMs();
                     heldBackChars = holdback.heldBackChars(contentBuilder.toString());
                     llmTtftMs = streamResult.ttftMs();
                     llmUsage = streamResult.usage();
@@ -475,6 +486,9 @@ public class ConversationOrchestrator {
                             CrisisFlowService.CrisisHandleResult crisisResult =
                                     crisisFlowService.handle(l1Result, CrisisTrigger.OUTPUT_GUARD, userMessage,
                                             user, session, emitter, outboundMsgId, userSignal.emotionScore());
+                            if (crisisResult != null && crisisResult.delivered()) {
+                                markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
+                            }
                             recordCrisisOutcome(crisisResult, finishedReasonRef, crisisSeverityRef);
                         } else {
                             String replacedContent = switch (judgeActionResult.action()) {
@@ -488,6 +502,7 @@ public class ConversationOrchestrator {
                             if (replacedContent != null) {
                                 assistantContent = replacedContent;
                                 sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(assistantContent, outboundMsgId));
+                                markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
                                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                         userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "replaced_by_guard", false);
@@ -498,6 +513,7 @@ public class ConversationOrchestrator {
                                         ? capturedSnapshotRef.get() : assistantContent;
                                 assistantContent = reviewedContent;
                                 sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(reviewedContent, outboundMsgId));
+                                markFirstSubstantive(firstSubstantiveTokenMs, startMs, reviewedContent);
                                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                         userMessage, reviewedContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "stop", true);
@@ -519,6 +535,7 @@ public class ConversationOrchestrator {
                         contentBuilder.append(chunk);
                         try {
                             sendEvent(emitter, new SseEventDto.DeltaEvent(chunk, outboundMsgId));
+                            markFirstSubstantive(firstSubstantiveTokenMs, startMs, chunk);
                         } catch (IOException e) {
                             throw new RuntimeException(e);
                         }
@@ -535,6 +552,7 @@ public class ConversationOrchestrator {
                 log.warn("Unhandled decision action: {} for session={}", decision.action(), sessionId);
                 assistantContent = "지금 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.";
                 sendEvent(emitter, new SseEventDto.DeltaEvent(assistantContent, outboundMsgId));
+                markFirstSubstantive(firstSubstantiveTokenMs, startMs, assistantContent);
                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                         userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                         "error", false);
@@ -554,17 +572,26 @@ public class ConversationOrchestrator {
 
             // 10. Log decision
             long totalMs = System.currentTimeMillis() - startMs;
+            aiTurnMetrics.recordCompleted(
+                    decision,
+                    contractResult,
+                    totalMs,
+                    llmTtftMs,
+                    firstSubstantiveTokenMs.get(),
+                    heldBackChars,
+                    resolveFinishedReason(finishedReasonRef));
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
                     inputJudgeCalled, preFilterResult, judgeActionResult,
                     profile.source(), safetyProfileCacheHit, memoryCacheFallbackUsed,
                     profile.degraded(), appliedCrisisTrigger, llmUsage, contractResult,
-                    firstSubstantiveTokenMs, heldBackChars, liveMemoryResult);
+                    firstSubstantiveTokenMs.get(), heldBackChars, liveMemoryResult);
 
             emitter.complete();
 
         } catch (Exception e) {
             log.error("Conversation orchestration failed for session {}", sessionId, e);
+            aiTurnMetrics.recordFailed(System.currentTimeMillis() - startMs);
             // 1) 결말을 먼저 저장한다. 이게 없으면 턴이 generating 에 영원히 머물러 재시도 시
             //    "진행 중"으로 오인된다 (이슈 P0-A). 연결 상태와 무관하게 항상 수행한다.
             if (turn != null) {
@@ -639,6 +666,18 @@ public class ConversationOrchestrator {
         }
         messagePersistenceService.completeTurn(turn.getId(), turn.getLeaseToken(),
                 assistantContent, crisisFlowTriggered, finishedReason, crisisSeverity);
+    }
+
+    /** 실제 SSE 전송이 성공한 첫 비어 있지 않은 콘텐츠만 사용자 체감 지연으로 기록한다. */
+    private void markFirstSubstantive(AtomicLong firstSubstantiveTokenMs,
+                                      long pipelineStartedAtMs,
+                                      String content) {
+        if (content == null || content.isBlank()) {
+            return;
+        }
+        firstSubstantiveTokenMs.compareAndSet(
+                -1,
+                Math.max(0, System.currentTimeMillis() - pipelineStartedAtMs));
     }
 
     /** 실패로 끝난 턴에서 사용자에게 내보내는 문구. */
@@ -782,7 +821,9 @@ public class ConversationOrchestrator {
             AtomicReference<String> finishedReasonRef,
             AtomicReference<Integer> crisisSeverityRef,
             MessageTurn turn,
-            AtomicBoolean turnPersisted) throws IOException {
+            AtomicBoolean turnPersisted,
+            AtomicLong firstSubstantiveTokenMs,
+            long pipelineStartedAtMs) throws IOException {
 
         return switch (result.action()) {
             case SEND -> originalContent;
@@ -798,6 +839,12 @@ public class ConversationOrchestrator {
                 CrisisFlowService.CrisisHandleResult cr =
                         crisisFlowService.handle(l1Result, CrisisTrigger.OUTPUT_GUARD, originalUserMessage,
                                 user, session, emitter, outboundMsgId, emotionScore);
+                if (cr != null && cr.delivered()) {
+                    markFirstSubstantive(
+                            firstSubstantiveTokenMs,
+                            pipelineStartedAtMs,
+                            preview.fixedResponse());
+                }
                 recordCrisisOutcome(cr, finishedReasonRef, crisisSeverityRef);
                 yield cr != null ? cr.fixedResponse() : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             }

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -81,10 +81,14 @@ class OpenAiLlmClientTest {
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(response);
 
-        client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
+        LlmStreamResult result =
+                client(httpClient).stream(LlmRequest.of(MODEL, "system", "user"), chunk -> { });
 
         assertThat(requestBody(capturedRequest(httpClient)))
                 .contains("\"stream_options\":{\"include_usage\":true}");
+        assertThat(result.ttftMs())
+                .as("콘텐츠 없는 DONE-only 스트림은 종료 시간을 TTFT로 가장하면 안 된다")
+                .isEqualTo(-1);
     }
 
     @Test
@@ -281,6 +285,9 @@ class OpenAiLlmClientTest {
         assertThat(result.usage().promptTokens())
                 .as("버려진 시도의 사용량이 남으면 비용이 부풀려 계상된다")
                 .isEqualTo(11);
+        assertThat(result.ttftMs())
+                .as("재시도 후에도 콘텐츠가 없으면 TTFT sentinel을 유지해야 한다")
+                .isEqualTo(-1);
         assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(11.0);
         assertThat(counter("mio.llm.retries", "reason", "rate_limited"))
                 .as("재시도로 삼켜진 스로틀링은 결과가 success 라 별도 지표가 없으면 흔적이 없다")

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -18,6 +18,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Flow;
 import java.util.stream.Stream;
@@ -112,6 +113,50 @@ class OpenAiLlmClientTest {
         // 0.15*100/1e6 + 0.60*40/1e6 = 0.000015 + 0.000024
         assertThat(counter("mio.llm.cost.usd", "mode", "stream")).isEqualTo(0.000039);
         assertThat(counter("mio.llm.usage", "outcome", "resolved")).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("LLM 토큰과 비용을 고정된 역할 component별로 집계한다")
+    void stream_recordsUsageByBoundedComponent() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":40}}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        LlmRequest request = LlmRequest.of(MODEL, "system", "user")
+                .withAttribution("MAIN_GENERATION", UUID.randomUUID(), UUID.randomUUID());
+        client(httpClient).stream(request, chunk -> { });
+
+        assertThat(meterRegistry.find("mio.llm.cost.usd")
+                .tag("component", "main_generation").counter().count()).isEqualTo(0.000039);
+        assertThat(meterRegistry.find("mio.llm.tokens")
+                .tags("component", "main_generation", "type", "prompt")
+                .counter().count()).isEqualTo(100.0);
+    }
+
+    @Test
+    @DisplayName("등록되지 않은 component 문자열은 metric label로 직접 사용하지 않는다")
+    void stream_mapsUnknownComponentToOther() throws Exception {
+        HttpClient httpClient = mock(HttpClient.class);
+        HttpResponse<Stream<String>> response = streamingResponse(List.of(
+                "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":10,\"completion_tokens\":5}}",
+                "data: [DONE]"));
+        when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(response);
+
+        LlmRequest request = LlmRequest.of(MODEL, "system", "user")
+                .withAttribution("session-05619207-f2d2-43ea-bc87-a7c59ac8afa3",
+                        UUID.randomUUID(), UUID.randomUUID());
+        client(httpClient).stream(request, chunk -> { });
+
+        assertThat(meterRegistry.find("mio.llm.cost.usd")
+                .tag("component", "other").counter().count()).isPositive();
+        assertThat(meterRegistry.getMeters())
+                .flatMap(meter -> meter.getId().getTags())
+                .extracting(tag -> tag.getValue())
+                .noneMatch(value -> value.contains("05619207"));
     }
 
     @Test
@@ -346,7 +391,7 @@ class OpenAiLlmClientTest {
 
         client(httpClient).embed("안녕하세요", "EMBEDDING", null, null);
 
-        assertThat(counter("mio.llm.tokens", "mode", "embed")).isEqualTo(24.0);
+        assertThat(counter("mio.llm.tokens", "type", "prompt")).isEqualTo(24.0);
         // 24 * 0.02 / 1e6 = 4.8e-7 — 6자리로 끊으면 0 이 되던 값이다.
         assertThat(counter("mio.llm.cost.usd", "mode", "embed")).isEqualTo(4.8e-7);
     }

--- a/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
@@ -1,0 +1,148 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.plan.GenerationFreedom;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.ai.plan.ResponseContractResult;
+import com.mio.ai.plan.ResponsePlan;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.JudgeStatus;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.security.SecurityLevel;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AiTurnMetricsTest {
+
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final AiTurnMetrics metrics = new AiTurnMetrics(registry);
+
+    @Test
+    @DisplayName("턴 전체·LLM TTFT·첫 실질 노출 지연을 histogram으로 기록한다")
+    void recordsLatencyHistograms() {
+        PolicyDecision decision = constrainedDecision();
+
+        metrics.recordCompleted(
+                decision,
+                ResponseContractResult.pass(),
+                1_800,
+                240,
+                520,
+                37,
+                "stop");
+
+        Timer total = registry.find("mio.ai.turn.duration")
+                .tags("outcome", "stop", "delivery_mode", "cautious_speculative")
+                .timer();
+        Timer ttft = registry.find("mio.ai.turn.llm.ttft")
+                .tags("response_act", "emotion_check", "delivery_mode", "cautious_speculative")
+                .timer();
+        Timer firstSubstantive = registry.find("mio.ai.turn.first.substantive")
+                .tags("delivery_mode", "cautious_speculative")
+                .timer();
+        DistributionSummary heldBack = registry.find("mio.ai.turn.held.back.chars")
+                .tags("delivery_mode", "cautious_speculative", "outcome", "stop")
+                .summary();
+
+        assertThat(total).isNotNull();
+        assertThat(total.count()).isEqualTo(1);
+        assertThat(total.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(1_800);
+        assertThat(ttft).isNotNull();
+        assertThat(ttft.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(240);
+        assertThat(firstSubstantive).isNotNull();
+        assertThat(firstSubstantive.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(520);
+        assertThat(heldBack).isNotNull();
+        assertThat(heldBack.totalAmount()).isEqualTo(37);
+    }
+
+    @Test
+    @DisplayName("정책·계약·턴 결과를 서로 분리된 저카디널리티 counter로 기록한다")
+    void recordsBoundedDecisionAndOutcomeCounters() {
+        PolicyDecision decision = constrainedDecision();
+
+        metrics.recordCompleted(
+                decision,
+                ResponseContractResult.violated(List.of("question_limit")),
+                900,
+                100,
+                300,
+                12,
+                "crisis_flow");
+        metrics.recordFailed(75);
+        metrics.recordReplay(20);
+
+        assertThat(registry.find("mio.ai.policy.decisions")
+                .tags(
+                        "risk", "medium",
+                        "response_act", "emotion_check",
+                        "generation_freedom", "constrained",
+                        "delivery_mode", "cautious_speculative")
+                .counter().count()).isEqualTo(1);
+        assertThat(registry.find("mio.ai.contract.results")
+                .tags("response_act", "emotion_check", "result", "violated")
+                .counter().count()).isEqualTo(1);
+        assertThat(registry.find("mio.ai.turn.outcomes")
+                .tag("outcome", "crisis_flow").counter().count()).isEqualTo(1);
+        assertThat(registry.find("mio.ai.turn.outcomes")
+                .tag("outcome", "error").counter().count()).isEqualTo(1);
+        assertThat(registry.find("mio.ai.turn.outcomes")
+                .tag("outcome", "replayed").counter().count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("호출자가 넘긴 임의 문자열은 metric label로 직접 사용하지 않는다")
+    void mapsUnknownTerminalReasonToOther() {
+        metrics.recordCompleted(
+                constrainedDecision(),
+                ResponseContractResult.pass(),
+                100,
+                -1,
+                -1,
+                0,
+                "session-05619207-f2d2-43ea-bc87-a7c59ac8afa3");
+
+        assertThat(registry.find("mio.ai.turn.outcomes")
+                .tag("outcome", "other").counter().count()).isEqualTo(1);
+        List<String> tagValues = registry.getMeters().stream()
+                .flatMap(meter -> meter.getId().getTags().stream())
+                .map(tag -> tag.getValue())
+                .toList();
+        assertThat(tagValues)
+                .noneMatch(value -> value.contains("05619207"));
+    }
+
+    private PolicyDecision constrainedDecision() {
+        PolicyDecision decision = new PolicyDecision(
+                "pd_metrics",
+                DecisionAction.GENERATE,
+                GenerationMode.SUPPORTIVE,
+                DeliveryMode.CAUTIOUS_SPECULATIVE,
+                SecurityLevel.CLEAN,
+                true,
+                true,
+                true,
+                InterventionHints.empty(),
+                "test-policy",
+                RiskLevel.MEDIUM,
+                null,
+                JudgeStatus.SUCCEEDED
+        );
+        return decision.withResponsePlan(new ResponsePlan(
+                ResponseAct.EMOTION_CHECK,
+                GenerationFreedom.CONSTRAINED,
+                1,
+                4,
+                ResponsePlan.BASE_FORBIDDEN));
+    }
+}

--- a/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
@@ -15,6 +15,8 @@ import com.mio.ai.security.SecurityLevel;
 import io.micrometer.core.instrument.DistributionSummary;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -120,6 +122,32 @@ class AiTurnMetricsTest {
                 .toList();
         assertThat(tagValues)
                 .noneMatch(value -> value.contains("05619207"));
+    }
+
+    @Test
+    @DisplayName("Prometheus export 이름이 대시보드와 경보가 참조하는 bucket 계약과 일치한다")
+    void exportsExpectedPrometheusHistogramNames() {
+        PrometheusMeterRegistry prometheus =
+                new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        AiTurnMetrics prometheusMetrics = new AiTurnMetrics(prometheus);
+
+        prometheusMetrics.recordCompleted(
+                constrainedDecision(),
+                ResponseContractResult.pass(),
+                1_800,
+                240,
+                520,
+                37,
+                "stop");
+
+        assertThat(prometheus.scrape())
+                .contains("mio_ai_turn_duration_seconds_bucket")
+                .contains("mio_ai_turn_llm_ttft_seconds_bucket")
+                .contains("mio_ai_turn_first_substantive_seconds_bucket")
+                .contains("mio_ai_turn_held_back_chars_bucket")
+                .contains("mio_ai_policy_decisions_total")
+                .contains("mio_ai_contract_results_total")
+                .contains("mio_ai_turn_outcomes_total");
     }
 
     private PolicyDecision constrainedDecision() {

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -11,6 +11,7 @@ import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.llm.LlmUsage;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -53,6 +54,9 @@ class ConversationOrchestratorContractIntegrationTest {
 
     @Autowired
     private ObjectMapper objectMapper;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
 
     /**
      * 인터페이스가 아니라 구현 타입을 목으로 둔다. {@code EmbeddingWorker} 가 구체 타입
@@ -172,6 +176,30 @@ class ConversationOrchestratorContractIntegrationTest {
                 .isIn("PASS", "VIOLATED");
     }
 
+    @Test
+    @DisplayName("실제 오케스트레이터 경로가 턴 지연·정책·계약 metric을 기록한다")
+    void operationalMetricsAreWiredToTheProductPath() {
+        double turnsBefore = counterTotal("mio.ai.turn.outcomes");
+        long latencyBefore = timerCount("mio.ai.turn.duration");
+
+        streamReplies("그런 일이 있었군요. 어떤 점이 가장 힘드셨나요?");
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        assertThat(counterTotal("mio.ai.turn.outcomes")).isEqualTo(turnsBefore + 1);
+        assertThat(timerCount("mio.ai.turn.duration")).isEqualTo(latencyBefore + 1);
+        assertThat(meterRegistry.find("mio.ai.policy.decisions")
+                .tags(
+                        "risk", "medium",
+                        "response_act", "emotion_check",
+                        "generation_freedom", "constrained",
+                        "delivery_mode", "cautious_speculative")
+                .counter()).isNotNull();
+        assertThat(meterRegistry.find("mio.ai.contract.results")
+                .tags("response_act", "emotion_check")
+                .counters()).isNotEmpty();
+    }
+
     /**
      * 조기 중단 경로에서도 계약 위반이 판정 사유로 전달된다 (이 이슈의 본체).
      *
@@ -234,5 +262,17 @@ class ConversationOrchestratorContractIntegrationTest {
             }
         }
         throw new AssertionError("결정 로그가 기록되지 않았다 — trace 배선이 끊겼다는 뜻이다");
+    }
+
+    private double counterTotal(String name) {
+        return meterRegistry.find(name).counters().stream()
+                .mapToDouble(counter -> counter.count())
+                .sum();
+    }
+
+    private long timerCount(String name) {
+        return meterRegistry.find(name).timers().stream()
+                .mapToLong(timer -> timer.count())
+                .sum();
     }
 }

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -200,6 +200,19 @@ class ConversationOrchestratorContractIntegrationTest {
                 .counters()).isNotEmpty();
     }
 
+    @Test
+    @DisplayName("콘텐츠 없는 스트림의 unavailable TTFT를 지연 histogram에 넣지 않는다")
+    void unavailableTtftIsNotRecordedAsLatency() {
+        long ttftBefore = timerCount("mio.ai.turn.llm.ttft");
+        when(llmClient.stream(any(), any()))
+                .thenReturn(new LlmStreamResult(-1L, LlmUsage.unresolved("gpt-4o"), false));
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        assertThat(timerCount("mio.ai.turn.llm.ttft")).isEqualTo(ttftBefore);
+    }
+
     /**
      * 조기 중단 경로에서도 계약 위반이 판정 사유로 전달된다 (이 이슈의 본체).
      *

--- a/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
+++ b/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
@@ -38,7 +38,14 @@ class ObservabilityContractTest {
 
         String composeText = text("docker-compose.observability.yml");
         assertThat(composeText).doesNotContain("9090:9090");
-        assertThat(composeText).contains("alertmanager_slack_webhook");
+        assertThat(composeText)
+                .contains("alertmanager_slack_webhook")
+                .contains("GF_PLUGINS_PREINSTALL_DISABLED: \"true\"");
+        assertThat(ROOT.resolve("ops/observability/grafana/provisioning/alerting")).isDirectory();
+        assertThat(ROOT.resolve("ops/observability/grafana/provisioning/plugins")).isDirectory();
+        assertThat(ROOT.resolve("ops/observability/grafana/provisioning/alerting/.gitkeep"))
+                .as("Grafana는 provisioning 디렉터리의 알 수 없는 확장자를 경고한다")
+                .doesNotExist();
     }
 
     @Test
@@ -103,10 +110,27 @@ class ObservabilityContractTest {
                 .contains("Judge failures")
                 .contains("Contract")
                 .contains("Stuck work")
+                .contains("Summary pipeline")
                 .contains("histogram_quantile(0.95")
                 .contains("mio_ai_turn_duration_seconds_bucket")
                 .contains("mio_ai_turn_llm_ttft_seconds_bucket")
-                .contains("mio_ai_turn_first_substantive_seconds_bucket");
+                .contains("mio_ai_turn_first_substantive_seconds_bucket")
+                .contains("mio_summary_stage_duration_seconds_bucket")
+                .contains("mio_summary_component_total")
+                .contains("increase(mio_llm_cost_usd_total[24h])");
+    }
+
+    @Test
+    @DisplayName("요약 지연의 초 단위가 상태 이벤트 건수에 잘못 적용되지 않는다")
+    void summaryPanelUsesSecondsOnlyForLatencySeries() throws IOException {
+        JsonNode dashboard = JSON.readTree(text(
+                "ops/observability/grafana/dashboards/mio-ai-overview.json"));
+        JsonNode summaryPanel = findPanel(dashboard, "Summary pipeline status");
+
+        assertThat(summaryPanel).isNotNull();
+        assertThat(summaryPanel.path("fieldConfig").path("defaults").has("unit")).isFalse();
+        assertThat(summaryPanel.path("fieldConfig").path("overrides").toString())
+                .contains("byFrameRefID", "\"options\":\"A\"", "\"value\":\"s\"");
     }
 
     @Test
@@ -140,5 +164,14 @@ class ObservabilityContractTest {
         Path path = ROOT.resolve(relative);
         assertThat(path).as("필수 운영 artifact가 없다: " + relative).exists();
         return Files.readString(path);
+    }
+
+    private JsonNode findPanel(JsonNode dashboard, String title) {
+        for (JsonNode panel : dashboard.path("panels")) {
+            if (title.equals(panel.path("title").asText())) {
+                return panel;
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
+++ b/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
@@ -1,0 +1,144 @@
+package com.mio.ai.qa;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ObservabilityContractTest {
+
+    private static final Path ROOT = Path.of(System.getProperty("user.dir"));
+    private static final ObjectMapper JSON = new ObjectMapper();
+    private static final Yaml YAML = new Yaml();
+
+    @Test
+    @DisplayName("관측성 스택은 명시적 profile에서만 기동하고 관리 포트를 외부에 열지 않는다")
+    void observabilityStackIsOptInAndPrivate() throws IOException {
+        Map<String, Object> compose = yaml("docker-compose.observability.yml");
+        Map<String, Object> services = map(compose.get("services"));
+
+        assertThat(services).containsOnlyKeys("prometheus", "alertmanager", "grafana");
+        for (String name : services.keySet()) {
+            Map<String, Object> service = map(services.get(name));
+            assertThat(list(service.get("profiles")))
+                    .as(name + "은 기본 production compose와 함께 자동 기동되면 안 된다")
+                    .contains("observability");
+            assertThat(list(service.get("ports")))
+                    .allMatch(port -> port.toString().startsWith("127.0.0.1:"));
+        }
+
+        String composeText = text("docker-compose.observability.yml");
+        assertThat(composeText).doesNotContain("9090:9090");
+        assertThat(composeText).contains("alertmanager_slack_webhook");
+    }
+
+    @Test
+    @DisplayName("Prometheus는 앱 관리망을 scrape하고 규칙을 Alertmanager로 전달한다")
+    void prometheusScrapesPrivateManagementPortAndRoutesAlerts() throws IOException {
+        Map<String, Object> prometheus = yaml("ops/observability/prometheus/prometheus.yml");
+
+        assertThat(text("ops/observability/prometheus/prometheus.yml"))
+                .contains("app:9090")
+                .contains("/actuator/prometheus")
+                .contains("alertmanager:9093")
+                .contains("alerts.yml");
+        assertThat(prometheus).containsKeys("scrape_configs", "rule_files", "alerting");
+    }
+
+    @Test
+    @DisplayName("경보 규칙은 실제 metric과 p95 histogram을 사용하고 임상 SLO를 가장하지 않는다")
+    void alertRulesUseMeasuredMetrics() throws IOException {
+        Map<String, Object> alerts = yaml("ops/observability/prometheus/alerts.yml");
+        String alertText = text("ops/observability/prometheus/alerts.yml");
+
+        assertThat(alerts).containsKey("groups");
+        assertThat(alertText)
+                .contains("mio_ai_turn_duration_seconds_bucket")
+                .contains("mio_ai_turn_first_substantive_seconds_bucket")
+                .contains("mio_judge_input_total")
+                .contains("mio_judge_output_total")
+                .contains("mio_llm_cost_unpriced_total")
+                .contains("severity: warning")
+                .doesNotContain("clinical", "임상", "REPLACE_ME");
+    }
+
+    @Test
+    @DisplayName("Alertmanager는 webhook 비밀을 파일로만 읽고 저장소에 URL을 넣지 않는다")
+    void alertmanagerReadsWebhookFromSecretFile() throws IOException {
+        String config = text("ops/observability/alertmanager/alertmanager.yml");
+
+        assertThat(config)
+                .contains("slack_api_url_file: /run/secrets/alertmanager_slack_webhook")
+                .contains("send_resolved: true")
+                .doesNotContain("hooks.slack.com", "REPLACE_ME");
+        assertThat(yaml("ops/observability/alertmanager/alertmanager.yml"))
+                .containsKeys("global", "route", "receivers");
+    }
+
+    @Test
+    @DisplayName("Grafana 최소 대시보드는 안전·지연·비용·실패·계약·고착을 한 화면에 제공한다")
+    void dashboardContainsOperationalEvidencePanels() throws IOException {
+        JsonNode dashboard = JSON.readTree(text(
+                "ops/observability/grafana/dashboards/mio-ai-overview.json"));
+        JsonNode panels = dashboard.path("panels");
+
+        assertThat(panels.isArray()).isTrue();
+        assertThat(panels.size()).isGreaterThanOrEqualTo(7);
+
+        String dashboardText = dashboard.toString();
+        assertThat(dashboardText)
+                .contains("Safety")
+                .contains("Turn p95")
+                .contains("TTFT")
+                .contains("Cost")
+                .contains("Judge failures")
+                .contains("Contract")
+                .contains("Stuck work")
+                .contains("histogram_quantile(0.95")
+                .contains("mio_ai_turn_duration_seconds_bucket")
+                .contains("mio_ai_turn_llm_ttft_seconds_bucket")
+                .contains("mio_ai_turn_first_substantive_seconds_bucket");
+    }
+
+    @Test
+    @DisplayName("운영 설정과 PromQL에 고카디널리티 식별자 label을 두지 않는다")
+    void metricConfigurationHasNoHighCardinalityLabels() throws IOException {
+        String all = String.join("\n",
+                text("ops/observability/prometheus/prometheus.yml"),
+                text("ops/observability/prometheus/alerts.yml"),
+                text("ops/observability/grafana/dashboards/mio-ai-overview.json"));
+
+        assertThat(all.toLowerCase())
+                .doesNotContain("user_id", "session_id", "message_id", "trace_id", "decision_id");
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> yaml(String relative) throws IOException {
+        return YAML.load(text(relative));
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> map(Object value) {
+        return (Map<String, Object>) value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<Object> list(Object value) {
+        return (List<Object>) value;
+    }
+
+    private String text(String relative) throws IOException {
+        Path path = ROOT.resolve(relative);
+        assertThat(path).as("필수 운영 artifact가 없다: " + relative).exists();
+        return Files.readString(path);
+    }
+}

--- a/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
+++ b/src/test/java/com/mio/ai/qa/ObservabilityContractTest.java
@@ -74,6 +74,11 @@ class ObservabilityContractTest {
                 .contains("mio_judge_input_total")
                 .contains("mio_judge_output_total")
                 .contains("mio_llm_cost_unpriced_total")
+                .contains("MioCrisisRecordFailed", "mio_crisis_records_total")
+                .contains("MioRetrievalFailureRatioHigh", "mio_retrieval_outcome_total")
+                .contains("MioContractViolationRatioHigh", "mio_ai_contract_results_total")
+                .contains("MioSummaryPipelineFailure", "mio_summary_stage_duration_seconds_count")
+                .contains("mio_summary_component_total")
                 .contains("severity: warning")
                 .doesNotContain("clinical", "임상", "REPLACE_ME");
     }


### PR DESCRIPTION
## 목적

P0-9 운영 관측 기준을 실제 제품 경로와 opt-in 관측 스택으로 구현합니다.

## 변경

- 턴 전체 지연, LLM TTFT, 첫 실질 응답, holdback 분포를 histogram으로 기록
- 정책 결정, 응답 계약, 턴 종료 결과를 저카디널리티 counter로 기록
- LLM 비용·토큰 지표에 서버 통제 component 태그 추가
- Prometheus 3.13.1 LTS, Alertmanager 0.33.1, Grafana 13.0.2 구성 추가
- 안전, p95 지연, 24시간 구성요소별 비용, Judge·retrieval 실패, 계약, 고착, 요약 파이프라인 대시보드 추가
- 6개 운영 경보와 파일 기반 Slack/Grafana 비밀 주입 추가
- Grafana 기본 플러그인 자동 설치 비활성화

사용자별 비용은 고카디널리티 metric label로 만들지 않고 기존 관리자 월별 비용 API로 조회합니다. 요약 파이프라인 패널은 PR #445의 bounded metric이 합쳐지면 즉시 데이터가 채워집니다.

## 검증

- TDD RED/GREEN
- 대상 단위 테스트 및 실제 ConversationOrchestrator 통합 경로 통과
- 전체 ./gradlew clean build 통과
- promtool config/rules 검증 통과
- amtool Alertmanager 설정 검증 통과
- 실제 Prometheus, Alertmanager, Grafana 컨테이너 기동 통과
- Grafana dashboard uid mio-ai-overview 프로비저닝 확인
- Prometheus 6개 alert rule health ok 확인
- production compose와 observability overlay 통합 config 확인
- 비밀값 및 user/session/message/trace/decision 식별자 label 없음 확인

## 범위 밖

- 로드맵/API 명세 문서 Git 커밋 없음
- 릴리스/태그 생성 없음
- 외부 전문가 자문은 P0 완료 기준에서 제외

Closes #450


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in observability stack with Prometheus, Alertmanager, and Grafana.
  * Added dashboards for AI performance, latency, costs, failures, delivery outcomes, and operational health.
  * Added alerts for elevated latency, failures, unpriced costs, and stuck-turn processing.
  * Added metrics for turn outcomes, policy decisions, response contracts, token usage, and response timing.
  * Added Slack notifications for active and resolved alerts.

* **Bug Fixes**
  * Improved metric labeling and prevented unknown identifiers from creating excessive metric dimensions.
  * Corrected handling of unavailable first-token timing values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->