### PR TITLE
feat: 메모리 조회·정정·동의 철회 API를 추가한다 (P0-6)

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -92,7 +92,8 @@ public class EmbeddingWorker {
                     embedding_attempts = embedding_attempts + 1
                 WHERE id IN (
                     SELECT id FROM session_summaries
-                    WHERE embedding_attempts < ?
+                    WHERE memory_status = 'active'
+                      AND embedding_attempts < ?
                       AND (
                         embedding_status = 'pending'
                         OR (embedding_status = 'processing'

--- a/src/main/java/com/mio/ai/memory/consolidation/MemoryConsentChecker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/MemoryConsentChecker.java
@@ -1,0 +1,39 @@
+package com.mio.ai.memory.consolidation;
+
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * 메모리 수집·활용 동의 조회 (이슈 #453).
+ *
+ * <p>장기 기억을 만드는 모든 경로(SessionConsolidator·WeeklyReflectionJob 등)가 같은
+ * 판정을 공유한다. 선호 행이 없는 사용자는 기본 동의 상태다
+ * (user_memory_preferences.memory_retention_agreed 기본값과 동일).
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MemoryConsentChecker {
+
+    private final UserMemoryPreferenceRepository preferenceRepository;
+
+    /**
+     * 조회 실패 시 <b>적재하지 않는다</b>(fail-closed) — 철회한 사용자의 기억을 만드는
+     * 쪽이 기억 한 번을 건너뛰는 쪽보다 나쁜 실패다.
+     */
+    public boolean isRetentionAllowed(UUID userId) {
+        try {
+            return preferenceRepository.findByUserId(userId)
+                    .map(UserMemoryPreference::isMemoryRetentionAgreed)
+                    .orElse(true);
+        } catch (Exception e) {
+            log.error("MemoryConsentChecker: consent lookup failed, treating as withdrawn userId={}", userId, e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.domain.CbtPattern;
 import com.mio.ai.domain.EmotionalState;
 import com.mio.ai.domain.MemoryEmbedding;
-import com.mio.ai.domain.UserMemoryPreference;
-import com.mio.ai.repository.UserMemoryPreferenceRepository;
 import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.ontology.OntologyValidator;
@@ -23,6 +21,7 @@ import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
+import io.micrometer.core.instrument.MeterRegistry;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -105,7 +104,8 @@ public class SessionConsolidator {
     private final SummaryComponentStatusWriter componentStatusWriter;
     private final CrisisEpisodePromoter crisisEpisodePromoter;
     private final SummaryStageMetrics stageMetrics;
-    private final UserMemoryPreferenceRepository memoryPreferenceRepository;
+    private final MemoryConsentChecker memoryConsentChecker;
+    private final MeterRegistry meterRegistry;
     // 메모리 보강을 별도 트랜잭션(REQUIRES_NEW)으로 호출하기 위한 self 프록시.
     // self-invocation으로는 프록시 어드바이스(@Transactional)가 적용되지 않으므로 ObjectProvider로 우회.
     private final ObjectProvider<SessionConsolidator> self;
@@ -134,11 +134,13 @@ public class SessionConsolidator {
         // 컴포넌트 상태 모델(#426)의 skipped 는 session_summaries 행에 붙는 파생 작업
         // 상태라서 여기서는 쓸 수 없다 — 동의 철회는 요약 행 자체를 만들지 않는다.
         // 세션 수준 SummaryStatus 에는 skipped 가 없고, failed 는 "요약이 오지 않는다" 는
-        // 기존 terminal(메시지 0건 세션과 동일) 이므로 그대로 쓴다.
-        if (!isMemoryRetentionAllowed(event.userId())) {
+        // 기존 terminal(메시지 0건 세션과 동일) 이므로 그대로 쓴다. 대신 동의 기인 스킵을
+        // 실제 실패와 구분할 수 있게 별도 카운터로 남긴다 — 없으면 failed 비율 분석이
+        // 철회 사용자 수에 오염된다.
+        if (!memoryConsentChecker.isRetentionAllowed(event.userId())) {
             log.info("SessionConsolidator: memory consent withdrawn, skipping consolidation sessionId={}",
                     event.sessionId());
-            summaryStatusWriter.markFailed(event.sessionId());
+            markConsentSkip(event.sessionId(), "gate");
             return;
         }
 
@@ -256,17 +258,15 @@ public class SessionConsolidator {
         todo.stop("done");
     }
 
-    /** 선호 행이 없는 사용자는 기본 동의 상태다 (user_memory_preferences 기본값과 동일). */
-    private boolean isMemoryRetentionAllowed(UUID userId) {
-        try {
-            return memoryPreferenceRepository.findByUserId(userId)
-                    .map(UserMemoryPreference::isMemoryRetentionAgreed)
-                    .orElse(true);
-        } catch (Exception e) {
-            // 조회 실패 시 적재하지 않는다 — 철회한 사용자의 기억을 만드는 쪽이 더 나쁜 실패다.
-            log.error("SessionConsolidator: consent lookup failed, skipping consolidation userId={}", userId, e);
-            return false;
-        }
+    /**
+     * 동의 기인 스킵을 종결한다: failed 확정 + 전용 카운터.
+     *
+     * <p>카운터(mio.summary.consent.skip)가 없으면 summary_status=failed 비율 분석이
+     * 철회 사용자 수에 오염된다 — 운영은 실패율에서 이 값을 빼고 본다.
+     */
+    private void markConsentSkip(UUID sessionId, String stage) {
+        meterRegistry.counter("mio.summary.consent.skip", "stage", stage).increment();
+        summaryStatusWriter.markFailed(sessionId);
     }
 
     /**
@@ -341,6 +341,18 @@ public class SessionConsolidator {
                         .toList());
         boolean cbtIntervened = "cbt_success".equalsIgnoreCase(extracted.episodeType())
                 || "cbt_partial".equalsIgnoreCase(extracted.episodeType());
+
+        // 동의 재확인 (이슈 #453 리뷰, TOCTOU). onSessionEnded 진입 게이트 통과 후 이 지점까지
+        // 수 초의 LLM 호출이 끼어든다 — 그 사이 사용자가 동의를 철회하면, 철회의 일괄
+        // 비활성화(UPDATE ... WHERE memory_status='active')는 아직 커밋되지 않은 이 행을
+        // 보지 못하고, 이 행은 active 로 커밋되어 영구히 회수 가능해진다. 영속화 직전에
+        // 같은 트랜잭션 안에서 다시 확인하고, 철회됐으면 아무것도 저장하지 않는다.
+        if (!memoryConsentChecker.isRetentionAllowed(userId)) {
+            log.info("SessionConsolidator: consent withdrawn during consolidation, aborting persist sessionId={}",
+                    sessionId);
+            meterRegistry.counter("mio.summary.consent.skip", "stage", "persist_recheck").increment();
+            return null;
+        }
 
         upsertSessionSummary(session, user, characterId, summaryText, ciphertext, dekId,
                 dominantEmotion, extracted.triggerTags(), extracted.episodeType(),

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.domain.CbtPattern;
 import com.mio.ai.domain.EmotionalState;
 import com.mio.ai.domain.MemoryEmbedding;
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
 import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.ontology.OntologyValidator;
@@ -101,6 +103,7 @@ public class SessionConsolidator {
     private final UserSummaryWriter userSummaryWriter;
     private final SummaryStatusWriter summaryStatusWriter;
     private final CrisisEpisodePromoter crisisEpisodePromoter;
+    private final UserMemoryPreferenceRepository memoryPreferenceRepository;
     // 메모리 보강을 별도 트랜잭션(REQUIRES_NEW)으로 호출하기 위한 self 프록시.
     // self-invocation으로는 프록시 어드바이스(@Transactional)가 적용되지 않으므로 ObjectProvider로 우회.
     private final ObjectProvider<SessionConsolidator> self;
@@ -121,6 +124,17 @@ public class SessionConsolidator {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void onSessionEnded(SessionEndedEvent event) {
         log.info("SessionConsolidator: processing sessionId={}", event.sessionId());
+
+        // 메모리 동의 철회 게이트 (이슈 #453). LLM 을 부르기 전에 막아야 한다 —
+        // 요약을 만들고 버리는 것은 게이트가 아니라, 대화 원문이 이미 외부로 나간 뒤다.
+        // 상태를 failed 로 확정해 요약 조회가 pending 에 고착되지 않게 한다 (이슈 #356).
+        if (!isMemoryRetentionAllowed(event.userId())) {
+            log.info("SessionConsolidator: memory consent withdrawn, skipping consolidation sessionId={}",
+                    event.sessionId());
+            summaryStatusWriter.markFailed(event.sessionId());
+            return;
+        }
+
         EnrichmentInput enrichInput;
         try {
             // 1단계: 세션 요약을 독립 트랜잭션(REQUIRES_NEW)에서 영속화한다.
@@ -202,6 +216,19 @@ public class SessionConsolidator {
             return;
         }
         summaryStatusWriter.markDone(event.sessionId());
+    }
+
+    /** 선호 행이 없는 사용자는 기본 동의 상태다 (user_memory_preferences 기본값과 동일). */
+    private boolean isMemoryRetentionAllowed(UUID userId) {
+        try {
+            return memoryPreferenceRepository.findByUserId(userId)
+                    .map(UserMemoryPreference::isMemoryRetentionAgreed)
+                    .orElse(true);
+        } catch (Exception e) {
+            // 조회 실패 시 적재하지 않는다 — 철회한 사용자의 기억을 만드는 쪽이 더 나쁜 실패다.
+            log.error("SessionConsolidator: consent lookup failed, skipping consolidation userId={}", userId, e);
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
@@ -55,6 +55,7 @@ public class WeeklyReflectionJob {
     private final LlmClient llmClient;
     private final UserSelfModelRepository selfModelRepository;
     private final ObjectMapper objectMapper;
+    private final MemoryConsentChecker memoryConsentChecker;
 
     @Scheduled(cron = "0 0 0 * * SUN", zone = "Asia/Seoul")
     public void run() {
@@ -76,6 +77,14 @@ public class WeeklyReflectionJob {
     }
 
     private void processUser(UUID userId, LocalDate weekStart, LocalDate weekEnd) {
+        // 메모리 동의 철회 게이트 (이슈 #453). 대상 선정은 sessions 만 보므로 철회한
+        // 사용자도 들어온다 — 여기서 막지 않으면 그 사용자의 집계가 외부 LLM 으로 나가고
+        // user_self_model·weekly_reports 에 새 파생 장기 상태가 쌓인다. 집계 전에 끊는다.
+        if (!memoryConsentChecker.isRetentionAllowed(userId)) {
+            log.info("[WeeklyReflectionJob] memory consent withdrawn, skipping userId={}", userId);
+            return;
+        }
+
         // 집계 (읽기 전용, 트랜잭션 불필요)
         Map<String, Double> effectiveMap = aggregateEffectiveInterventions(userId, weekStart);
         List<String> recurringTriggers = aggregateRecurringTriggers(userId, weekStart);
@@ -133,14 +142,21 @@ public class WeeklyReflectionJob {
         return result;
     }
 
-    private List<String> aggregateRecurringTriggers(UUID userId, LocalDate weekStart) {
+    // package-private: memory_status 필터 회귀를 실 DB 로 검증하려면 집계만 따로 불러야 한다.
+    List<String> aggregateRecurringTriggers(UUID userId, LocalDate weekStart) {
         try {
+            // memory_status 필터는 검색기 4곳과 같은 이유로 여기에도 필요하다 (이슈 #453 리뷰).
+            // 주간 회고는 로그가 아니라 weekly_reports.narrative 로 사용자에게 그대로 노출되는
+            // 산출물이라, 사용자가 정정·비활성화한 요약의 트리거 태그가 여기로 새면
+            // "서버가 나를 어떻게 기억하는지 통제한다"는 약속이 깨진다. processUser 의 동의
+            // 게이트는 전체 철회만 막으므로 개별 기억 단위는 이 조건이 담당한다.
             return jdbcTemplate.query("""
                     SELECT t AS trigger, COUNT(*) AS cnt
                     FROM session_summaries ss,
                          UNNEST(ss.trigger_tags) t
                     WHERE ss.user_id = ?
                       AND (ss.created_at AT TIME ZONE 'Asia/Seoul')::date >= ?
+                      AND ss.memory_status = 'active'
                     GROUP BY t ORDER BY cnt DESC LIMIT 5
                     """,
                     (rs, i) -> rs.getString("trigger"),

--- a/src/main/java/com/mio/ai/memory/retrieval/LexicalRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/LexicalRetriever.java
@@ -30,6 +30,7 @@ public class LexicalRetriever {
                                plainto_tsquery('simple', ?)) AS score
                 FROM session_summaries ss
                 WHERE ss.user_id = ?
+                  AND ss.memory_status = 'active'
                   AND to_tsvector('simple', ss.summary_text)
                       @@ plainto_tsquery('simple', ?)
                 ORDER BY score DESC

--- a/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/StructuredRetriever.java
@@ -116,6 +116,7 @@ public class StructuredRetriever {
                                    1.0 AS score
                             FROM session_summaries ss
                             WHERE ss.user_id = ?
+                              AND ss.memory_status = 'active'
                               AND ss.trigger_tags && ?
                             ORDER BY ss.created_at DESC
                             LIMIT 3
@@ -158,6 +159,8 @@ public class StructuredRetriever {
                             FROM thoughts t
                             JOIN session_summaries ss ON ss.session_id = t.session_id
                             WHERE t.user_id = ?
+                              AND t.memory_status = 'active'
+                              AND ss.memory_status = 'active'
                               AND t.distortion_code = ANY (?)
                             GROUP BY ss.id, ss.summary_text
                             ORDER BY MAX(t.created_at) DESC

--- a/src/main/java/com/mio/ai/memory/retrieval/VectorRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/VectorRetriever.java
@@ -21,6 +21,15 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class VectorRetriever {
 
+    /**
+     * KNN over-fetch 배수 (이슈 #453 리뷰).
+     *
+     * <p>{@code memory_status} 필터는 ivfflat KNN 이 고른 후보에 사후 적용된다. 비활성
+     * 기억이 많은 사용자는 상위 k 후보가 필터에서 대부분 걸러져 회수량이 k 에 못 미칠 수
+     * 있다 — 후보를 k×4 로 넉넉히 뽑은 뒤 필터하고 k 로 자른다.
+     */
+    private static final int KNN_OVERFETCH_FACTOR = 4;
+
     private final JdbcTemplate jdbcTemplate;
 
     public List<RetrievedItem> retrieveEpisodes(UUID userId, float[] queryEmbedding, int k) {
@@ -29,15 +38,21 @@ public class VectorRetriever {
         String vectorLiteral = toVectorLiteral(queryEmbedding);
         return jdbcTemplate.query(
                 """
-                SELECT id::text,
-                       summary_text AS content,
-                       1 - (episode_emb <=> ?::vector) AS score
-                FROM session_summaries
-                WHERE user_id = ?
-                  AND episode_emb IS NOT NULL
-                  AND embedding_status = 'done'
-                  AND memory_status = 'active'
-                ORDER BY episode_emb <=> ?::vector
+                SELECT id, content, score
+                FROM (
+                    SELECT id::text AS id,
+                           summary_text AS content,
+                           1 - (episode_emb <=> ?::vector) AS score,
+                           memory_status
+                    FROM session_summaries
+                    WHERE user_id = ?
+                      AND episode_emb IS NOT NULL
+                      AND embedding_status = 'done'
+                    ORDER BY episode_emb <=> ?::vector
+                    LIMIT ?
+                ) candidates
+                WHERE memory_status = 'active'
+                ORDER BY score DESC
                 LIMIT ?
                 """,
                 (rs, rowNum) -> new RetrievedItem(
@@ -48,7 +63,7 @@ public class VectorRetriever {
                         rs.getDouble("score"),
                         rowNum + 1
                 ),
-                vectorLiteral, userId, vectorLiteral, k
+                vectorLiteral, userId, vectorLiteral, k * KNN_OVERFETCH_FACTOR, k
         );
     }
 

--- a/src/main/java/com/mio/ai/memory/retrieval/VectorRetriever.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/VectorRetriever.java
@@ -36,6 +36,7 @@ public class VectorRetriever {
                 WHERE user_id = ?
                   AND episode_emb IS NOT NULL
                   AND embedding_status = 'done'
+                  AND memory_status = 'active'
                 ORDER BY episode_emb <=> ?::vector
                 LIMIT ?
                 """,

--- a/src/main/java/com/mio/common/error/ErrorCode.java
+++ b/src/main/java/com/mio/common/error/ErrorCode.java
@@ -79,6 +79,12 @@ public enum ErrorCode {
     CRISIS_EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "존재하지 않는 위기 이벤트입니다."),
     CRISIS_EVENT_ALREADY_REVIEWED(HttpStatus.CONFLICT, "CONFLICT", "이미 검토된 위기 이벤트입니다."),
 
+    // Memory Control (이슈 #453)
+    MEMORY_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMORY_NOT_FOUND", "기억을 찾을 수 없습니다."),
+    INVALID_MEMORY_ACTION(HttpStatus.BAD_REQUEST, "INVALID_MEMORY_ACTION", "유효하지 않은 메모리 조작입니다."),
+    MEMORY_CORRECTION_TEXT_REQUIRED(HttpStatus.BAD_REQUEST, "MEMORY_CORRECTION_TEXT_REQUIRED",
+            "정정 내용을 입력해야 합니다."),
+
     // Rate Limit
     RATE_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "RATE_LIMITED", "요청 한도를 초과했습니다."),
 

--- a/src/main/java/com/mio/memorycontrol/controller/MemoryControlController.java
+++ b/src/main/java/com/mio/memorycontrol/controller/MemoryControlController.java
@@ -6,6 +6,7 @@ import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
 import com.mio.memorycontrol.dto.MemoryListResponse;
 import com.mio.memorycontrol.dto.MemoryUpdateRequest;
 import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.memorycontrol.service.MemoryControlRateLimiter;
 import com.mio.memorycontrol.service.MemoryControlService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,14 +33,17 @@ import java.util.UUID;
 public class MemoryControlController {
 
     private final MemoryControlService memoryControlService;
+    private final MemoryControlRateLimiter rateLimiter;
 
     @GetMapping("/v1/users/me/memories")
     public ResponseEntity<ApiResponse<MemoryListResponse>> listMemories(
             Principal principal,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
+        UUID userId = PrincipalUtils.resolveUserId(principal);
+        rateLimiter.checkList(userId);
         return ResponseEntity.ok(ApiResponse.ok(
-                memoryControlService.listMemories(PrincipalUtils.resolveUserId(principal), page, size)));
+                memoryControlService.listMemories(userId, page, size)));
     }
 
     @PatchMapping("/v1/users/me/memories/{memoryId}")
@@ -47,13 +51,17 @@ public class MemoryControlController {
             @PathVariable UUID memoryId,
             @Valid @RequestBody MemoryUpdateRequest request,
             Principal principal) {
+        UUID userId = PrincipalUtils.resolveUserId(principal);
+        rateLimiter.checkUpdate(userId);
         return ResponseEntity.ok(ApiResponse.ok(
-                memoryControlService.updateMemory(PrincipalUtils.resolveUserId(principal), memoryId, request)));
+                memoryControlService.updateMemory(userId, memoryId, request)));
     }
 
     @PostMapping("/v1/users/me/memory-consent/withdraw")
     public ResponseEntity<ApiResponse<MemoryConsentWithdrawResponse>> withdrawConsent(Principal principal) {
+        UUID userId = PrincipalUtils.resolveUserId(principal);
+        rateLimiter.checkWithdraw(userId);
         return ResponseEntity.ok(ApiResponse.ok(
-                memoryControlService.withdrawConsent(PrincipalUtils.resolveUserId(principal))));
+                memoryControlService.withdrawConsent(userId)));
     }
 }

--- a/src/main/java/com/mio/memorycontrol/controller/MemoryControlController.java
+++ b/src/main/java/com/mio/memorycontrol/controller/MemoryControlController.java
@@ -1,0 +1,59 @@
+package com.mio.memorycontrol.controller;
+
+import com.mio.common.PrincipalUtils;
+import com.mio.common.response.ApiResponse;
+import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
+import com.mio.memorycontrol.dto.MemoryListResponse;
+import com.mio.memorycontrol.dto.MemoryUpdateRequest;
+import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.memorycontrol.service.MemoryControlService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
+import java.util.UUID;
+
+/**
+ * 사용자 장기 기억 통제 API (이슈 #453, 로드맵 §12 P0-6).
+ *
+ * <p>사용자는 서버가 자신에 대해 기억하는 것(세션 요약·추출된 사고·신념)을 조회하고,
+ * 잘못된 기억을 정정하거나 비활성화하고, 메모리 수집·활용 동의를 철회할 수 있다.
+ */
+@RestController
+@RequiredArgsConstructor
+public class MemoryControlController {
+
+    private final MemoryControlService memoryControlService;
+
+    @GetMapping("/v1/users/me/memories")
+    public ResponseEntity<ApiResponse<MemoryListResponse>> listMemories(
+            Principal principal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                memoryControlService.listMemories(PrincipalUtils.resolveUserId(principal), page, size)));
+    }
+
+    @PatchMapping("/v1/users/me/memories/{memoryId}")
+    public ResponseEntity<ApiResponse<MemoryUpdateResponse>> updateMemory(
+            @PathVariable UUID memoryId,
+            @Valid @RequestBody MemoryUpdateRequest request,
+            Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                memoryControlService.updateMemory(PrincipalUtils.resolveUserId(principal), memoryId, request)));
+    }
+
+    @PostMapping("/v1/users/me/memory-consent/withdraw")
+    public ResponseEntity<ApiResponse<MemoryConsentWithdrawResponse>> withdrawConsent(Principal principal) {
+        return ResponseEntity.ok(ApiResponse.ok(
+                memoryControlService.withdrawConsent(PrincipalUtils.resolveUserId(principal))));
+    }
+}

--- a/src/main/java/com/mio/memorycontrol/domain/MemoryCorrection.java
+++ b/src/main/java/com/mio/memorycontrol/domain/MemoryCorrection.java
@@ -1,0 +1,68 @@
+package com.mio.memorycontrol.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 사용자 제공 기억 정정 이력 (이슈 #453).
+ *
+ * <p>정정문은 사용자 발화와 같은 민감도로 취급해 AES-256 암호화로만 저장한다.
+ * 원본 기억 행은 삭제하지 않고 {@code memory_status='corrected'} 로 남는다.
+ */
+@Entity
+@Table(name = "user_memory_corrections")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemoryCorrection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    /** summary / episode / belief */
+    @Column(name = "memory_type", nullable = false)
+    private String memoryType;
+
+    @Column(name = "memory_id", nullable = false)
+    private UUID memoryId;
+
+    @Column(name = "corrected_text_ciphertext", nullable = false)
+    private byte[] correctedTextCiphertext;
+
+    @Column(name = "corrected_text_dek_id", nullable = false)
+    private String correctedTextDekId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private MemoryCorrection(UUID userId, String memoryType, UUID memoryId,
+                             byte[] correctedTextCiphertext, String correctedTextDekId) {
+        this.userId = userId;
+        this.memoryType = memoryType;
+        this.memoryId = memoryId;
+        this.correctedTextCiphertext = correctedTextCiphertext;
+        this.correctedTextDekId = correctedTextDekId;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/memorycontrol/dto/MemoryConsentWithdrawResponse.java
+++ b/src/main/java/com/mio/memorycontrol/dto/MemoryConsentWithdrawResponse.java
@@ -1,0 +1,16 @@
+package com.mio.memorycontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+
+/**
+ * 메모리 동의 철회 결과 (이슈 #453).
+ *
+ * @param withdrawnAt   최초 철회 시각 — 재호출해도 바뀌지 않는다(멱등)
+ * @param disabledCount 이번 호출로 비활성화된 기존 기억 수
+ */
+public record MemoryConsentWithdrawResponse(
+        @JsonProperty("withdrawn_at") OffsetDateTime withdrawnAt,
+        @JsonProperty("disabled_count") long disabledCount
+) {}

--- a/src/main/java/com/mio/memorycontrol/dto/MemoryItemResponse.java
+++ b/src/main/java/com/mio/memorycontrol/dto/MemoryItemResponse.java
@@ -1,0 +1,28 @@
+package com.mio.memorycontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 사용자 장기 기억 한 건 (이슈 #453, 로드맵 §12 P0-6).
+ *
+ * <p>{@code content} 는 소유자 본인 조회이므로 복호화해 반환한다. 복호화에 실패한 항목은
+ * 목록에서 빼지 않고 {@code content=null} 로 남긴다 — "서버가 나에 대해 무엇을 기억하는가"
+ * 를 보여주는 API 가 항목 자체를 숨기면 통제권이 성립하지 않는다.
+ *
+ * @param type   summary(세션 요약) | episode(추출된 사고) | belief(신념)
+ * @param source 출처 테이블 수준의 provenance
+ * @param status active | corrected | disabled (belief 는 dormant/revised/retired 도 가능)
+ */
+public record MemoryItemResponse(
+        UUID id,
+        String type,
+        String content,
+        @JsonProperty("corrected_text") String correctedText,
+        String status,
+        String source,
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("created_at") OffsetDateTime createdAt
+) {}

--- a/src/main/java/com/mio/memorycontrol/dto/MemoryListResponse.java
+++ b/src/main/java/com/mio/memorycontrol/dto/MemoryListResponse.java
@@ -1,0 +1,13 @@
+package com.mio.memorycontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/** 사용자 장기 기억 목록 (이슈 #453). */
+public record MemoryListResponse(
+        List<MemoryItemResponse> items,
+        int page,
+        int size,
+        @JsonProperty("total_elements") long totalElements
+) {}

--- a/src/main/java/com/mio/memorycontrol/dto/MemoryUpdateRequest.java
+++ b/src/main/java/com/mio/memorycontrol/dto/MemoryUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.mio.memorycontrol.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 기억 정정·비활성화 요청 (이슈 #453).
+ *
+ * @param action        correct(정정) | disable(비활성화) — 허용값 검증은 서비스에서 한다
+ * @param correctedText action=correct 일 때 필수인 사용자 제공 수정문
+ */
+public record MemoryUpdateRequest(
+        @NotBlank(message = "action은 필수입니다.") String action,
+        @JsonProperty("corrected_text")
+        @Size(max = 1000, message = "정정 내용은 1000자 이내여야 합니다.") String correctedText
+) {}

--- a/src/main/java/com/mio/memorycontrol/dto/MemoryUpdateResponse.java
+++ b/src/main/java/com/mio/memorycontrol/dto/MemoryUpdateResponse.java
@@ -1,0 +1,10 @@
+package com.mio.memorycontrol.dto;
+
+import java.util.UUID;
+
+/** 기억 정정·비활성화 결과 (이슈 #453). */
+public record MemoryUpdateResponse(
+        UUID id,
+        String type,
+        String status
+) {}

--- a/src/main/java/com/mio/memorycontrol/repository/MemoryCorrectionRepository.java
+++ b/src/main/java/com/mio/memorycontrol/repository/MemoryCorrectionRepository.java
@@ -1,0 +1,15 @@
+package com.mio.memorycontrol.repository;
+
+import com.mio.memorycontrol.domain.MemoryCorrection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+public interface MemoryCorrectionRepository extends JpaRepository<MemoryCorrection, UUID> {
+
+    /** 최신 정정이 먼저 오도록 정렬 — 목록 조합 시 기억별 첫 항목이 최신 정정문이다. */
+    List<MemoryCorrection> findByUserIdAndMemoryIdInOrderByCreatedAtDesc(
+            UUID userId, Collection<UUID> memoryIds);
+}

--- a/src/main/java/com/mio/memorycontrol/service/MemoryControlRateLimiter.java
+++ b/src/main/java/com/mio/memorycontrol/service/MemoryControlRateLimiter.java
@@ -1,0 +1,62 @@
+package com.mio.memorycontrol.service;
+
+import com.mio.common.error.RateLimitExceededException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 메모리 통제 엔드포인트의 사용자별 호출 제한 (이슈 #453, PR #441 의
+ * {@link com.mio.user.service.DataDeletionStatusRateLimiter} 전례를 따른다).
+ *
+ * <p>조회는 UNION 3종 + 복호화를 수행하고, 정정·철회는 감사 로그와 대량 UPDATE 를
+ * 남긴다 — 무제한 호출을 허용하면 사용자 하나가 DB·감사 테이블을 부풀릴 수 있다.
+ * 쓰기 계열은 정상 UX 에서 드문 행위이므로 더 엄격하게 잡는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class MemoryControlRateLimiter {
+
+    private static final long WINDOW_SECONDS = 60L;
+    private static final String KEY_PREFIX = "memory-control:ratelimit:";
+
+    private static final int LIST_PER_MINUTE = 30;
+    private static final int UPDATE_PER_MINUTE = 10;
+    private static final int WITHDRAW_PER_MINUTE = 3;
+
+    private final StringRedisTemplate redisTemplate;
+
+    public void checkList(UUID userId) {
+        check("list", userId, LIST_PER_MINUTE);
+    }
+
+    public void checkUpdate(UUID userId) {
+        check("update", userId, UPDATE_PER_MINUTE);
+    }
+
+    public void checkWithdraw(UUID userId) {
+        check("withdraw", userId, WITHDRAW_PER_MINUTE);
+    }
+
+    private void check(String operation, UUID userId, int maxPerMinute) {
+        String key = KEY_PREFIX + operation + ":" + userId;
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count == null) {
+            return;
+        }
+        if (count == 1) {
+            redisTemplate.expire(key, WINDOW_SECONDS, TimeUnit.SECONDS);
+        }
+        if (count > maxPerMinute) {
+            throw new RateLimitExceededException(retryAfterSeconds(key));
+        }
+    }
+
+    private long retryAfterSeconds(String key) {
+        Long ttl = redisTemplate.getExpire(key, TimeUnit.SECONDS);
+        return ttl == null || ttl < 0 ? WINDOW_SECONDS : ttl;
+    }
+}

--- a/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
+++ b/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
@@ -1,28 +1,280 @@
 package com.mio.memorycontrol.service;
 
+import com.mio.common.audit.AuditLogService;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.memorycontrol.domain.MemoryCorrection;
 import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
+import com.mio.memorycontrol.dto.MemoryItemResponse;
 import com.mio.memorycontrol.dto.MemoryListResponse;
 import com.mio.memorycontrol.dto.MemoryUpdateRequest;
 import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.memorycontrol.repository.MemoryCorrectionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 /**
  * 사용자 장기 기억 통제 — 조회·정정·비활성화·동의 철회 (이슈 #453, 로드맵 §12 P0-6).
+ *
+ * <p>정정·비활성화는 행을 지우지 않는 soft-disable 이다. 검색기 3종(Vector/Lexical/Structured)이
+ * active 상태만 회수하므로, 상태 전이만으로 다음 턴 프롬프트 주입에서 즉시 빠진다.
+ * 임베딩 재색인은 비동기 후속 작업(TODO — 이슈 #453 본문 참조)이다.
+ *
+ * <p>상태값은 DB CHECK 제약 대상이라 쓰기 전에 애플리케이션에서 화이트리스트로 검증한다 —
+ * 미검증 값이 CHECK 에 걸리면 트랜잭션 전체가 롤백된다(이슈 #219 계열 사고).
  */
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class MemoryControlService {
 
+    static final String TYPE_SUMMARY = "summary";
+    static final String TYPE_EPISODE = "episode";
+    static final String TYPE_BELIEF = "belief";
+
+    private static final String STATUS_ACTIVE = "active";
+    private static final String STATUS_CORRECTED = "corrected";
+    private static final String STATUS_DISABLED = "disabled";
+    /** DB CHECK 허용값과 동일한 쓰기 화이트리스트 (이슈 #219 재발 방지). */
+    private static final Set<String> WRITABLE_STATUSES = Set.of(STATUS_CORRECTED, STATUS_DISABLED);
+
+    private static final String ACTION_CORRECT = "correct";
+    private static final String ACTION_DISABLE = "disable";
+
+    private static final int MAX_PAGE_SIZE = 100;
+
+    private static final Map<String, String> SOURCE_BY_TYPE = Map.of(
+            TYPE_SUMMARY, "session_summary",
+            TYPE_EPISODE, "extracted_thought",
+            TYPE_BELIEF, "user_belief");
+
+    private static final String LIST_BODY = """
+            FROM (
+                SELECT ss.id, '%s' AS type,
+                       COALESCE(ss.user_summary_text, ss.summary_text) AS content_plain,
+                       NULL::bytea AS content_ciphertext,
+                       ss.memory_status AS status, ss.session_id, ss.created_at
+                FROM session_summaries ss WHERE ss.user_id = ?
+                UNION ALL
+                SELECT t.id, '%s', NULL, t.thought_text_ciphertext,
+                       t.memory_status, t.session_id, t.created_at
+                FROM thoughts t WHERE t.user_id = ?
+                UNION ALL
+                SELECT b.id, '%s', NULL, b.belief_text_ciphertext,
+                       b.status, NULL::uuid, b.created_at
+                FROM user_beliefs b WHERE b.user_id = ?
+            ) m
+            """.formatted(TYPE_SUMMARY, TYPE_EPISODE, TYPE_BELIEF);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final MessageEncryptor messageEncryptor;
+    private final MemoryCorrectionRepository correctionRepository;
+    private final AuditLogService auditLogService;
+
+    // ── 조회 ─────────────────────────────────────────────────────
+
+    @Transactional(readOnly = true)
     public MemoryListResponse listMemories(UUID userId, int page, int size) {
-        throw new UnsupportedOperationException("not implemented yet — issue #453");
+        validatePaging(page, size);
+
+        Long total = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) " + LIST_BODY, Long.class, userId, userId, userId);
+        List<MemoryItemResponse> rows = jdbcTemplate.query(
+                "SELECT * " + LIST_BODY + " ORDER BY created_at DESC, id LIMIT ? OFFSET ?",
+                this::mapRow, userId, userId, userId, size, (long) page * size);
+
+        List<MemoryItemResponse> items = attachCorrections(userId, rows);
+        auditLogService.record(userId, "memory_view", "memory_list", userId.toString(),
+                Map.of("page", page, "size", size, "returned", items.size()));
+        return new MemoryListResponse(items, page, size, total == null ? 0 : total);
     }
 
+    private void validatePaging(int page, int size) {
+        if (page < 0 || size < 1 || size > MAX_PAGE_SIZE) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT,
+                    "page는 0 이상, size는 1~" + MAX_PAGE_SIZE + " 이어야 합니다.");
+        }
+    }
+
+    private MemoryItemResponse mapRow(ResultSet rs, int rowNum) throws SQLException {
+        UUID id = rs.getObject("id", UUID.class);
+        String type = rs.getString("type");
+        String content = rs.getString("content_plain");
+        if (content == null) {
+            content = decryptOrNull(rs.getBytes("content_ciphertext"), id);
+        }
+        return new MemoryItemResponse(
+                id, type, content, null,
+                rs.getString("status"),
+                SOURCE_BY_TYPE.getOrDefault(type, type),
+                rs.getObject("session_id", UUID.class),
+                rs.getObject("created_at", OffsetDateTime.class));
+    }
+
+    /**
+     * 소유자 본인 조회이므로 복호화해 반환한다. 실패한 항목은 목록에서 숨기지 않고
+     * 본문만 비운다 — 무엇이 저장돼 있는지 자체가 통제의 대상이다.
+     */
+    private String decryptOrNull(byte[] ciphertext, UUID memoryId) {
+        if (ciphertext == null) return null;
+        try {
+            return new String(messageEncryptor.decrypt(ciphertext), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.warn("MemoryControlService: decrypt failed for memoryId={}", memoryId);
+            return null;
+        }
+    }
+
+    private List<MemoryItemResponse> attachCorrections(UUID userId, List<MemoryItemResponse> rows) {
+        if (rows.isEmpty()) return rows;
+        List<UUID> ids = rows.stream().map(MemoryItemResponse::id).toList();
+        Map<UUID, String> latestByMemory = new HashMap<>();
+        for (MemoryCorrection correction :
+                correctionRepository.findByUserIdAndMemoryIdInOrderByCreatedAtDesc(userId, ids)) {
+            latestByMemory.putIfAbsent(correction.getMemoryId(),
+                    decryptOrNull(correction.getCorrectedTextCiphertext(), correction.getMemoryId()));
+        }
+        return rows.stream()
+                .map(item -> latestByMemory.containsKey(item.id())
+                        ? new MemoryItemResponse(item.id(), item.type(), item.content(),
+                                latestByMemory.get(item.id()), item.status(), item.source(),
+                                item.sessionId(), item.createdAt())
+                        : item)
+                .toList();
+    }
+
+    // ── 정정·비활성화 ─────────────────────────────────────────────
+
+    @Transactional
     public MemoryUpdateResponse updateMemory(UUID userId, UUID memoryId, MemoryUpdateRequest request) {
-        throw new UnsupportedOperationException("not implemented yet — issue #453");
+        String action = request.action();
+        if (!ACTION_CORRECT.equals(action) && !ACTION_DISABLE.equals(action)) {
+            throw new BusinessException(ErrorCode.INVALID_MEMORY_ACTION);
+        }
+        String type = locateMemoryType(userId, memoryId);
+
+        String newStatus;
+        if (ACTION_CORRECT.equals(action)) {
+            saveCorrection(userId, memoryId, type, request.correctedText());
+            newStatus = STATUS_CORRECTED;
+        } else {
+            newStatus = STATUS_DISABLED;
+        }
+        transitionStatus(userId, memoryId, type, newStatus);
+
+        auditLogService.record(userId, "memory_" + action, "memory_" + type, memoryId.toString(),
+                Map.of("type", type, "new_status", newStatus));
+        return new MemoryUpdateResponse(memoryId, type, newStatus);
     }
 
+    /** 소유권 검증을 겸한다 — 남의 기억은 존재 자체를 알려주지 않고 NOT_FOUND 로 답한다. */
+    private String locateMemoryType(UUID userId, UUID memoryId) {
+        if (exists("SELECT COUNT(*) FROM session_summaries WHERE id = ? AND user_id = ?", memoryId, userId)) {
+            return TYPE_SUMMARY;
+        }
+        if (exists("SELECT COUNT(*) FROM thoughts WHERE id = ? AND user_id = ?", memoryId, userId)) {
+            return TYPE_EPISODE;
+        }
+        if (exists("SELECT COUNT(*) FROM user_beliefs WHERE id = ? AND user_id = ?", memoryId, userId)) {
+            return TYPE_BELIEF;
+        }
+        throw new BusinessException(ErrorCode.MEMORY_NOT_FOUND);
+    }
+
+    private boolean exists(String sql, Object... args) {
+        Integer count = jdbcTemplate.queryForObject(sql, Integer.class, args);
+        return count != null && count > 0;
+    }
+
+    private void saveCorrection(UUID userId, UUID memoryId, String type, String correctedText) {
+        if (correctedText == null || correctedText.isBlank()) {
+            throw new BusinessException(ErrorCode.MEMORY_CORRECTION_TEXT_REQUIRED);
+        }
+        correctionRepository.save(MemoryCorrection.builder()
+                .userId(userId)
+                .memoryType(type)
+                .memoryId(memoryId)
+                .correctedTextCiphertext(
+                        messageEncryptor.encrypt(correctedText.trim().getBytes(StandardCharsets.UTF_8)))
+                .correctedTextDekId(messageEncryptor.dekId())
+                .build());
+    }
+
+    private void transitionStatus(UUID userId, UUID memoryId, String type, String newStatus) {
+        requireWritableStatus(newStatus);
+        String sql = switch (type) {
+            case TYPE_SUMMARY -> "UPDATE session_summaries SET memory_status = ? WHERE id = ? AND user_id = ?";
+            case TYPE_EPISODE -> "UPDATE thoughts SET memory_status = ? WHERE id = ? AND user_id = ?";
+            case TYPE_BELIEF -> "UPDATE user_beliefs SET status = ? WHERE id = ? AND user_id = ?";
+            default -> throw new BusinessException(ErrorCode.MEMORY_NOT_FOUND);
+        };
+        int updated = jdbcTemplate.update(sql, newStatus, memoryId, userId);
+        if (updated == 0) {
+            throw new BusinessException(ErrorCode.MEMORY_NOT_FOUND);
+        }
+    }
+
+    private void requireWritableStatus(String status) {
+        if (!WRITABLE_STATUSES.contains(status)) {
+            throw new BusinessException(ErrorCode.INVALID_MEMORY_ACTION,
+                    "허용되지 않은 기억 상태 전이입니다: " + status);
+        }
+    }
+
+    // ── 동의 철회 ─────────────────────────────────────────────────
+
+    /**
+     * 동의를 철회하고 기존 장기 기억을 전부 비활성화한다. 멱등 — 최초 철회 시각은 유지된다.
+     * 신규 적재 중단은 {@code SessionConsolidator} 가 {@code memory_retention_agreed} 를 보고
+     * 세션 종료 시점에 게이트한다.
+     */
+    @Transactional
     public MemoryConsentWithdrawResponse withdrawConsent(UUID userId) {
-        throw new UnsupportedOperationException("not implemented yet — issue #453");
+        jdbcTemplate.update(
+                """
+                INSERT INTO user_memory_preferences (user_id, memory_retention_agreed, memory_consent_withdrawn_at)
+                VALUES (?, false, ?)
+                ON CONFLICT (user_id) DO UPDATE
+                SET memory_retention_agreed = false,
+                    memory_consent_withdrawn_at =
+                        COALESCE(user_memory_preferences.memory_consent_withdrawn_at,
+                                 EXCLUDED.memory_consent_withdrawn_at),
+                    updated_at = now()
+                """,
+                userId, OffsetDateTime.now(ZoneOffset.UTC));
+
+        requireWritableStatus(STATUS_DISABLED);
+        long disabled = 0;
+        disabled += jdbcTemplate.update(
+                "UPDATE session_summaries SET memory_status = ? WHERE user_id = ? AND memory_status = ?",
+                STATUS_DISABLED, userId, STATUS_ACTIVE);
+        disabled += jdbcTemplate.update(
+                "UPDATE thoughts SET memory_status = ? WHERE user_id = ? AND memory_status = ?",
+                STATUS_DISABLED, userId, STATUS_ACTIVE);
+        disabled += jdbcTemplate.update(
+                "UPDATE user_beliefs SET status = ? WHERE user_id = ? AND status = ?",
+                STATUS_DISABLED, userId, STATUS_ACTIVE);
+
+        OffsetDateTime withdrawnAt = jdbcTemplate.queryForObject(
+                "SELECT memory_consent_withdrawn_at FROM user_memory_preferences WHERE user_id = ?",
+                OffsetDateTime.class, userId);
+        auditLogService.record(userId, "memory_consent_withdraw", "memory_consent", userId.toString(),
+                Map.of("disabled_count", disabled));
+        return new MemoryConsentWithdrawResponse(withdrawnAt, disabled);
     }
 }

--- a/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
+++ b/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
@@ -92,16 +92,29 @@ public class MemoryControlService {
     public MemoryListResponse listMemories(UUID userId, int page, int size) {
         validatePaging(page, size);
 
-        Long total = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) " + LIST_BODY, Long.class, userId, userId, userId);
+        // UNION 을 두 번 돌리지 않는다 — 총 건수는 페이지 쿼리의 윈도우 집계로 함께 읽는다.
+        long[] totalHolder = {0};
         List<MemoryItemResponse> rows = jdbcTemplate.query(
-                "SELECT * " + LIST_BODY + " ORDER BY created_at DESC, id LIMIT ? OFFSET ?",
-                this::mapRow, userId, userId, userId, size, (long) page * size);
+                "SELECT *, COUNT(*) OVER () AS total_count " + LIST_BODY
+                        + " ORDER BY created_at DESC, id LIMIT ? OFFSET ?",
+                (rs, rowNum) -> {
+                    totalHolder[0] = rs.getLong("total_count");
+                    return mapRow(rs, rowNum);
+                },
+                userId, userId, userId, size, (long) page * size);
+        // 범위 밖 페이지는 행이 없어 윈도우 값을 못 읽는다 — 그때만 카운트를 따로 조회한다.
+        long total = rows.isEmpty() ? countMemories(userId) : totalHolder[0];
 
         List<MemoryItemResponse> items = attachCorrections(userId, rows);
         auditLogService.record(userId, "memory_view", "memory_list", userId.toString(),
                 Map.of("page", page, "size", size, "returned", items.size()));
-        return new MemoryListResponse(items, page, size, total == null ? 0 : total);
+        return new MemoryListResponse(items, page, size, total);
+    }
+
+    private long countMemories(UUID userId) {
+        Long total = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) " + LIST_BODY, Long.class, userId, userId, userId);
+        return total == null ? 0 : total;
     }
 
     private void validatePaging(int page, int size) {
@@ -245,7 +258,8 @@ public class MemoryControlService {
      */
     @Transactional
     public MemoryConsentWithdrawResponse withdrawConsent(UUID userId) {
-        jdbcTemplate.update(
+        // RETURNING 으로 최초 철회 시각을 upsert 와 한 문장에서 읽는다 (별도 SELECT 불필요).
+        OffsetDateTime withdrawnAt = jdbcTemplate.queryForObject(
                 """
                 INSERT INTO user_memory_preferences (user_id, memory_retention_agreed, memory_consent_withdrawn_at)
                 VALUES (?, false, ?)
@@ -255,10 +269,13 @@ public class MemoryControlService {
                         COALESCE(user_memory_preferences.memory_consent_withdrawn_at,
                                  EXCLUDED.memory_consent_withdrawn_at),
                     updated_at = now()
+                RETURNING memory_consent_withdrawn_at
                 """,
-                userId, OffsetDateTime.now(ZoneOffset.UTC));
+                OffsetDateTime.class, userId, OffsetDateTime.now(ZoneOffset.UTC));
 
-        requireWritableStatus(STATUS_DISABLED);
+        // 아래 UPDATE 의 'disabled' 리터럴은 WRITABLE_STATUSES 화이트리스트에 포함된
+        // 컴파일 타임 상수라 별도 런타임 검증이 무의미하다 (transitionStatus 와 달리
+        // 호출자 입력이 섞이지 않는 경로).
         long disabled = 0;
         disabled += jdbcTemplate.update(
                 "UPDATE session_summaries SET memory_status = ? WHERE user_id = ? AND memory_status = ?",
@@ -270,9 +287,6 @@ public class MemoryControlService {
                 "UPDATE user_beliefs SET status = ? WHERE user_id = ? AND status = ?",
                 STATUS_DISABLED, userId, STATUS_ACTIVE);
 
-        OffsetDateTime withdrawnAt = jdbcTemplate.queryForObject(
-                "SELECT memory_consent_withdrawn_at FROM user_memory_preferences WHERE user_id = ?",
-                OffsetDateTime.class, userId);
         auditLogService.record(userId, "memory_consent_withdraw", "memory_consent", userId.toString(),
                 Map.of("disabled_count", disabled));
         return new MemoryConsentWithdrawResponse(withdrawnAt, disabled);

--- a/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
+++ b/src/main/java/com/mio/memorycontrol/service/MemoryControlService.java
@@ -1,0 +1,28 @@
+package com.mio.memorycontrol.service;
+
+import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
+import com.mio.memorycontrol.dto.MemoryListResponse;
+import com.mio.memorycontrol.dto.MemoryUpdateRequest;
+import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * 사용자 장기 기억 통제 — 조회·정정·비활성화·동의 철회 (이슈 #453, 로드맵 §12 P0-6).
+ */
+@Service
+public class MemoryControlService {
+
+    public MemoryListResponse listMemories(UUID userId, int page, int size) {
+        throw new UnsupportedOperationException("not implemented yet — issue #453");
+    }
+
+    public MemoryUpdateResponse updateMemory(UUID userId, UUID memoryId, MemoryUpdateRequest request) {
+        throw new UnsupportedOperationException("not implemented yet — issue #453");
+    }
+
+    public MemoryConsentWithdrawResponse withdrawConsent(UUID userId) {
+        throw new UnsupportedOperationException("not implemented yet — issue #453");
+    }
+}

--- a/src/main/resources/db/migration/V70__add_memory_control_status.sql
+++ b/src/main/resources/db/migration/V70__add_memory_control_status.sql
@@ -1,0 +1,36 @@
+-- 이슈 #453 (로드맵 §12 P0-6): 메모리 조회·정정·동의 철회
+--
+-- 장기 기억 3종(session_summaries·thoughts·user_beliefs)에 soft-disable 상태를 도입한다.
+-- 검색기(Vector/Lexical/Structured)는 active 상태만 회수하고, 정정·비활성·철회된 기억은
+-- 행을 지우지 않은 채 검색·프롬프트 주입에서 제외된다. 임베딩 재색인은 비동기 후속 작업.
+
+-- ── 1. session_summaries.memory_status ───────────────────────────
+ALTER TABLE session_summaries
+    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active'
+        CONSTRAINT chk_session_summaries_memory_status
+        CHECK (memory_status IN ('active', 'corrected', 'disabled'));
+
+CREATE INDEX idx_session_summaries_user_memory_status
+    ON session_summaries(user_id, memory_status);
+
+-- ── 2. thoughts.memory_status ────────────────────────────────────
+ALTER TABLE thoughts
+    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active'
+        CONSTRAINT chk_thoughts_memory_status
+        CHECK (memory_status IN ('active', 'corrected', 'disabled'));
+
+CREATE INDEX idx_thoughts_user_memory_status
+    ON thoughts(user_id, memory_status);
+
+-- ── 3. user_beliefs.status 허용값 확장 ────────────────────────────
+-- 기존 상태 모델(active/dormant/revised/retired)에 사용자 통제 상태를 추가한다.
+ALTER TABLE user_beliefs
+    DROP CONSTRAINT user_beliefs_status_check;
+ALTER TABLE user_beliefs
+    ADD CONSTRAINT user_beliefs_status_check
+        CHECK (status IN ('active', 'dormant', 'revised', 'retired', 'corrected', 'disabled'));
+
+-- ── 4. 동의 철회 시각 ─────────────────────────────────────────────
+-- memory_retention_agreed 는 현재 상태, withdrawn_at 은 최초 철회 시각(멱등 보장 근거).
+ALTER TABLE user_memory_preferences
+    ADD COLUMN memory_consent_withdrawn_at TIMESTAMPTZ;

--- a/src/main/resources/db/migration/V70__add_memory_control_status.sql
+++ b/src/main/resources/db/migration/V70__add_memory_control_status.sql
@@ -1,34 +1,40 @@
--- 이슈 #453 (로드맵 §12 P0-6): 메모리 조회·정정·동의 철회
+-- 이슈 #453 (로드맵 §12 P0-6): 메모리 조회·정정·동의 철회 — 상태 컬럼 (1/3)
 --
 -- 장기 기억 3종(session_summaries·thoughts·user_beliefs)에 soft-disable 상태를 도입한다.
 -- 검색기(Vector/Lexical/Structured)는 active 상태만 회수하고, 정정·비활성·철회된 기억은
 -- 행을 지우지 않은 채 검색·프롬프트 주입에서 제외된다. 임베딩 재색인은 비동기 후속 작업.
+--
+-- 이 파일은 V60~V62(이슈 #426)와 같은 잠금 안전 3단계 패턴의 1단계로, 메타데이터 전용
+-- ALTER 만 수행한다. session_summaries·thoughts 는 쓰기가 잦은 테이블이라 ACCESS EXCLUSIVE
+-- 잠금을 잡는 시간이 곧 장애 시간이다.
+--  * PG16 에서 상수 DEFAULT 를 가진 ADD COLUMN 은 테이블 재작성 없이 끝난다.
+--  * CHECK 제약은 NOT VALID 로 추가해 기존 행 전수 검사를 뒤(V72)로 미룬다.
+--  * 인덱스 생성은 V73 에서 CONCURRENTLY 로 분리한다.
 
 -- ── 1. session_summaries.memory_status ───────────────────────────
 ALTER TABLE session_summaries
-    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active'
-        CONSTRAINT chk_session_summaries_memory_status
-        CHECK (memory_status IN ('active', 'corrected', 'disabled'));
-
-CREATE INDEX idx_session_summaries_user_memory_status
-    ON session_summaries(user_id, memory_status);
+    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active',
+    ADD CONSTRAINT chk_session_summaries_memory_status
+        CHECK (memory_status IN ('active', 'corrected', 'disabled')) NOT VALID;
 
 -- ── 2. thoughts.memory_status ────────────────────────────────────
 ALTER TABLE thoughts
-    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active'
-        CONSTRAINT chk_thoughts_memory_status
-        CHECK (memory_status IN ('active', 'corrected', 'disabled'));
-
-CREATE INDEX idx_thoughts_user_memory_status
-    ON thoughts(user_id, memory_status);
+    ADD COLUMN memory_status TEXT NOT NULL DEFAULT 'active',
+    ADD CONSTRAINT chk_thoughts_memory_status
+        CHECK (memory_status IN ('active', 'corrected', 'disabled')) NOT VALID;
 
 -- ── 3. user_beliefs.status 허용값 확장 ────────────────────────────
 -- 기존 상태 모델(active/dormant/revised/retired)에 사용자 통제 상태를 추가한다.
+-- 확장 제약을 NOT VALID 로 먼저 추가한 뒤 기존 제약을 제거한다 — 두 문장 모두
+-- 메타데이터 전용이고, 어느 시점에도 status 컬럼이 무제약 상태가 되지 않는다.
+-- 검증은 V72 에서 한다.
+ALTER TABLE user_beliefs
+    ADD CONSTRAINT ck_user_beliefs_status
+        CHECK (status IN ('active', 'dormant', 'revised', 'retired', 'corrected', 'disabled'))
+        NOT VALID;
+
 ALTER TABLE user_beliefs
     DROP CONSTRAINT user_beliefs_status_check;
-ALTER TABLE user_beliefs
-    ADD CONSTRAINT user_beliefs_status_check
-        CHECK (status IN ('active', 'dormant', 'revised', 'retired', 'corrected', 'disabled'));
 
 -- ── 4. 동의 철회 시각 ─────────────────────────────────────────────
 -- memory_retention_agreed 는 현재 상태, withdrawn_at 은 최초 철회 시각(멱등 보장 근거).

--- a/src/main/resources/db/migration/V71__add_user_memory_corrections.sql
+++ b/src/main/resources/db/migration/V71__add_user_memory_corrections.sql
@@ -1,0 +1,20 @@
+-- 이슈 #453: 사용자 제공 정정 이력
+--
+-- 정정문은 사용자 발화와 같은 민감도로 다룬다 — AES-256 암호화 저장.
+-- 원본 기억 행은 남고(memory_status='corrected'), 정정문은 여기 별도 이력으로 쌓인다.
+
+CREATE TABLE user_memory_corrections (
+    id                         UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id                    UUID        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    memory_type                TEXT        NOT NULL
+        CHECK (memory_type IN ('summary', 'episode', 'belief')),
+    memory_id                  UUID        NOT NULL,
+    corrected_text_ciphertext  BYTEA       NOT NULL,
+    corrected_text_dek_id      TEXT        NOT NULL,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_user_memory_corrections_user
+    ON user_memory_corrections(user_id, created_at DESC);
+CREATE INDEX idx_user_memory_corrections_memory
+    ON user_memory_corrections(memory_id, created_at DESC);

--- a/src/main/resources/db/migration/V71__add_user_memory_corrections.sql
+++ b/src/main/resources/db/migration/V71__add_user_memory_corrections.sql
@@ -16,5 +16,7 @@ CREATE TABLE user_memory_corrections (
 
 CREATE INDEX idx_user_memory_corrections_user
     ON user_memory_corrections(user_id, created_at DESC);
+-- findByUserIdAndMemoryIdInOrderByCreatedAtDesc (memory_id IN + user_id 필터) 를 서빙한다.
+-- 신규 빈 테이블이라 CONCURRENTLY 불필요 (V73 과 달리 잠금 위험 없음).
 CREATE INDEX idx_user_memory_corrections_memory
-    ON user_memory_corrections(memory_id, created_at DESC);
+    ON user_memory_corrections(memory_id, user_id, created_at DESC);

--- a/src/main/resources/db/migration/V72__validate_memory_control_constraints.sql
+++ b/src/main/resources/db/migration/V72__validate_memory_control_constraints.sql
@@ -1,0 +1,14 @@
+-- 이슈 #453: 메모리 상태 CHECK 검증 (2/3)
+--
+-- V70 이 NOT VALID 로 추가한 CHECK 제약을 검증한다. VALIDATE 는 SHARE UPDATE EXCLUSIVE 만
+-- 잡으므로 쓰기를 막지 않는다 (V61 과 동일 패턴, 이슈 #426).
+-- 모든 기존 행은 V70 의 DEFAULT 'active' 또는 기존 허용값이므로 검증은 스캔만 한다.
+
+ALTER TABLE session_summaries
+    VALIDATE CONSTRAINT chk_session_summaries_memory_status;
+
+ALTER TABLE thoughts
+    VALIDATE CONSTRAINT chk_thoughts_memory_status;
+
+ALTER TABLE user_beliefs
+    VALIDATE CONSTRAINT ck_user_beliefs_status;

--- a/src/main/resources/db/migration/V73__create_memory_status_indexes.sql
+++ b/src/main/resources/db/migration/V73__create_memory_status_indexes.sql
@@ -1,0 +1,13 @@
+-- 이슈 #453: 메모리 상태 인덱스 (3/3)
+--
+-- 인덱스 생성을 CONCURRENTLY 로 분리한다 (V62 와 동일 패턴, 이슈 #426).
+-- CREATE INDEX CONCURRENTLY 는 트랜잭션 안에서 실행할 수 없으므로 이 스크립트는
+-- V73__...sql.conf 의 executeInTransaction=false 와 함께 Flyway 트랜잭션 밖에서 돈다.
+-- 실패 시 INVALID 인덱스가 남을 수 있어 IF NOT EXISTS 로 재실행을 안전하게 둔다.
+
+-- 검색기·동의 철회의 사용자 단위 상태 필터를 서빙한다.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_session_summaries_user_memory_status
+    ON session_summaries (user_id, memory_status);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_thoughts_user_memory_status
+    ON thoughts (user_id, memory_status);

--- a/src/main/resources/db/migration/V73__create_memory_status_indexes.sql.conf
+++ b/src/main/resources/db/migration/V73__create_memory_status_indexes.sql.conf
@@ -1,0 +1,1 @@
+executeInTransaction=false

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -63,7 +63,7 @@ class SessionConsolidatorTest {
     private SessionSummaryRenderer sessionSummaryRenderer;
     private UserSummaryWriter userSummaryWriter;
     private CrisisEpisodePromoter crisisEpisodePromoter;
-    private com.mio.ai.repository.UserMemoryPreferenceRepository memoryPreferenceRepository;
+    private MemoryConsentChecker memoryConsentChecker;
     private ObjectProvider<SessionConsolidator> self;
     private SimpleMeterRegistry meterRegistry;
     private SessionSummaryRepository sessionSummaryRepository;
@@ -93,7 +93,9 @@ class SessionConsolidatorTest {
         sessionSummaryRenderer = mock(SessionSummaryRenderer.class);
         userSummaryWriter = mock(UserSummaryWriter.class);
         crisisEpisodePromoter = mock(CrisisEpisodePromoter.class);
-        memoryPreferenceRepository = mock(com.mio.ai.repository.UserMemoryPreferenceRepository.class);
+        memoryConsentChecker = mock(MemoryConsentChecker.class);
+        // 기본은 동의 유지 — 게이트 테스트에서만 철회로 뒤집는다.
+        when(memoryConsentChecker.isRetentionAllowed(any())).thenReturn(true);
         meterRegistry = new SimpleMeterRegistry();
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
@@ -125,7 +127,8 @@ class SessionConsolidatorTest {
                 componentStatusWriter,
                 crisisEpisodePromoter,
                 new SummaryStageMetrics(meterRegistry),
-                memoryPreferenceRepository,
+                memoryConsentChecker,
+                meterRegistry,
                 selfProvider
         );
     }
@@ -182,11 +185,7 @@ class SessionConsolidatorTest {
         SessionConsolidator consolidator = newConsolidator();
         UUID userId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
-        when(memoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(
-                com.mio.ai.domain.UserMemoryPreference.builder()
-                        .userId(userId)
-                        .memoryRetentionAgreed(false)
-                        .build()));
+        when(memoryConsentChecker.isRetentionAllowed(userId)).thenReturn(false);
 
         consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 0));
 
@@ -198,6 +197,9 @@ class SessionConsolidatorTest {
         verifyNoInteractions(crisisEpisodePromoter);
         verifyNoInteractions(todoRecommendationService);
         verifyNoInteractions(componentStatusWriter);
+        // 동의 기인 스킵은 실제 실패와 구분되는 전용 카운터로 남는다
+        assertThat(meterRegistry.counter("mio.summary.consent.skip", "stage", "gate").count())
+                .isEqualTo(1.0);
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -53,6 +53,7 @@ class SessionConsolidatorTest {
     private SessionSummaryRenderer sessionSummaryRenderer;
     private UserSummaryWriter userSummaryWriter;
     private CrisisEpisodePromoter crisisEpisodePromoter;
+    private com.mio.ai.repository.UserMemoryPreferenceRepository memoryPreferenceRepository;
     private ObjectProvider<SessionConsolidator> self;
 
     private SessionConsolidator newConsolidator() {
@@ -68,6 +69,7 @@ class SessionConsolidatorTest {
         sessionSummaryRenderer = mock(SessionSummaryRenderer.class);
         userSummaryWriter = mock(UserSummaryWriter.class);
         crisisEpisodePromoter = mock(CrisisEpisodePromoter.class);
+        memoryPreferenceRepository = mock(com.mio.ai.repository.UserMemoryPreferenceRepository.class);
         when(messageEncryptor.encrypt(any())).thenReturn(new byte[]{1});
         when(messageEncryptor.dekId()).thenReturn("app-key-v1");
         when(beliefIdentityHasher.hash(any(), anyString(), anyShort())).thenReturn(new byte[]{9});
@@ -96,6 +98,7 @@ class SessionConsolidatorTest {
                 userSummaryWriter,
                 summaryStatusWriter,
                 crisisEpisodePromoter,
+                memoryPreferenceRepository,
                 selfProvider
         );
     }
@@ -136,6 +139,27 @@ class SessionConsolidatorTest {
 
         // 승격 호출이 통째로 빠져도 나머지 단언은 통과한다 — 배선 자체를 고정한다 (이슈 #256).
         verify(crisisEpisodePromoter).promoteIfCrisis(userId, sessionId, "regular");
+    }
+
+    @Test
+    @DisplayName("메모리 동의를 철회한 사용자는 컨솔리데이션이 시작 전에 차단된다 (이슈 #453)")
+    void onSessionEnded_skipsConsolidationWhenConsentWithdrawn() {
+        SessionConsolidator consolidator = newConsolidator();
+        UUID userId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        when(memoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(
+                com.mio.ai.domain.UserMemoryPreference.builder()
+                        .userId(userId)
+                        .memoryRetentionAgreed(false)
+                        .build()));
+
+        consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 0));
+
+        verify(summaryStatusWriter).markFailed(sessionId);
+        // LLM 요약·보강·위기 승격·Todo 생성 어느 것도 시작되지 않아야 한다
+        verifyNoInteractions(self);
+        verifyNoInteractions(crisisEpisodePromoter);
+        verifyNoInteractions(todoRecommendationService);
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/consolidation/WeeklyReflectionMemoryStatusIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/WeeklyReflectionMemoryStatusIntegrationTest.java
@@ -1,0 +1,88 @@
+package com.mio.ai.memory.consolidation;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 주간 회고의 트리거 집계가 정정·비활성화된 기억을 회수하지 않는지 검증한다 (이슈 #453).
+ *
+ * <p>주간 회고는 내부 로그가 아니라 {@code weekly_reports.narrative} 로 사용자에게 그대로
+ * 노출되는 산출물이다. 검색기 4곳에는 {@code memory_status} 필터가 들어갔지만 이 집계 경로가
+ * 빠지면, 사용자가 껐다고 생각한 요약의 트리거 태그가 주간 인사이트로 되살아난다.
+ * {@code processUser} 의 동의 게이트는 <b>전체 철회</b>만 막으므로 개별 기억 단위 통제는
+ * 이 쿼리의 필터가 유일한 방어선이다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class WeeklyReflectionMemoryStatusIntegrationTest {
+
+    private static final String ACTIVE_TRIGGER = "work_stress";
+    private static final String DISABLED_TRIGGER = "family_conflict";
+    private static final String CORRECTED_TRIGGER = "sleep_deprivation";
+
+    @Autowired private WeeklyReflectionJob weeklyReflectionJob;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private UUID userId;
+    private LocalDate weekStart;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        weekStart = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(6);
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "weekly-memstatus-" + userId);
+
+        insertSummary(ACTIVE_TRIGGER, "active");
+        insertSummary(DISABLED_TRIGGER, "disabled");
+        insertSummary(CORRECTED_TRIGGER, "corrected");
+    }
+
+    @Test
+    @DisplayName("주간 트리거 집계는 active 기억만 회수한다 — disabled·corrected 는 0건")
+    void aggregateRecurringTriggers_excludesDisabledAndCorrectedMemories() {
+        List<String> triggers = weeklyReflectionJob.aggregateRecurringTriggers(userId, weekStart);
+
+        assertThat(triggers).containsExactly(ACTIVE_TRIGGER);
+        assertThat(triggers).doesNotContain(DISABLED_TRIGGER, CORRECTED_TRIGGER);
+    }
+
+    @Test
+    @DisplayName("모든 기억을 비활성화하면 주간 트리거 집계는 비어 있다")
+    void aggregateRecurringTriggers_returnsEmptyWhenAllMemoriesDisabled() {
+        jdbcTemplate.update(
+                "UPDATE session_summaries SET memory_status = 'disabled' WHERE user_id = ?", userId);
+
+        assertThat(weeklyReflectionJob.aggregateRecurringTriggers(userId, weekStart)).isEmpty();
+    }
+
+    private void insertSummary(String triggerTag, String memoryStatus) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, ended_at) "
+                        + "VALUES (?, ?, 'mio', 'ended', now())",
+                sessionId, userId);
+        jdbcTemplate.update(
+                """
+                INSERT INTO session_summaries
+                    (id, user_id, session_id, character_id, summary_text, embedding_status,
+                     trigger_tags, memory_status, created_at)
+                VALUES (?, ?, ?, 'mio', ?, 'done', ARRAY[?]::text[], ?, now() - interval '1 hour')
+                """,
+                UUID.randomUUID(), userId, sessionId, "요약 " + triggerTag, triggerTag, memoryStatus);
+    }
+}

--- a/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
@@ -1,0 +1,140 @@
+package com.mio.memorycontrol.consent;
+
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.LlmUsage;
+import com.mio.ai.llm.OpenAiLlmClient;
+import com.mio.ai.memory.consolidation.ExtractorLlmClient;
+import com.mio.ai.memory.consolidation.ExtractorResult;
+import com.mio.ai.memory.consolidation.SessionConsolidator;
+import com.mio.ai.memory.consolidation.SessionEndedEvent;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.memorycontrol.service.MemoryControlService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+/**
+ * 동의 철회 후 신규 장기 기억 적재 중단 검증 (이슈 #453 완료 조건).
+ *
+ * <p>철회한 사용자의 세션이 끝나도 컨솔리데이션이 요약·사고·신념을 <b>한 건도</b> 만들지
+ * 않아야 하고, LLM 호출 자체가 일어나지 않아야 한다. LLM 을 부른 뒤에 버리는 것은 게이트가
+ * 아니다 — 사용자의 대화 원문이 이미 외부로 나간 뒤다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class MemoryConsentGateIntegrationTest {
+
+    private static final long WAIT_TIMEOUT_MS = 15_000;
+
+    @Autowired private SessionConsolidator sessionConsolidator;
+    @Autowired private MemoryControlService memoryControlService;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private MessageEncryptor messageEncryptor;
+
+    // OpenAiLlmClient 는 LlmClient·EmbeddingClient 겸용 구현체다. 인터페이스가 아니라
+    // 구현체를 mock 해야 EmbeddingWorker 처럼 구현체 타입을 직접 주입받는 빈이 함께 만족된다.
+    @MockBean private OpenAiLlmClient llmClient;
+    @MockBean private ExtractorLlmClient extractorLlmClient;
+
+    private UUID userId;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "consent-it-" + userId);
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, ended_at) VALUES (?, ?, 'mio', 'ended', now())",
+                sessionId, userId);
+        jdbcTemplate.update(
+                """
+                INSERT INTO messages (id, session_id, user_id, role, content_ciphertext, content_dek_id)
+                VALUES (?, ?, ?, 'user', ?, ?)
+                """,
+                UUID.randomUUID(), sessionId, userId,
+                messageEncryptor.encrypt("오늘 발표를 망친 것 같아".getBytes(StandardCharsets.UTF_8)),
+                messageEncryptor.dekId());
+
+        when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
+            Consumer<String> chunkHandler = invocation.getArgument(1);
+            chunkHandler.accept("발표에 대한 걱정을 나눈 세션 요약.");
+            return new LlmStreamResult(10, LlmUsage.unresolved("test"), false);
+        });
+        when(extractorLlmClient.extract(anyString(), any(), any()))
+                .thenReturn(new ExtractorResult(List.of(), null, List.of(), "regular", null));
+    }
+
+    @Test
+    @DisplayName("동의를 유지한 사용자는 세션 종료 후 요약이 적재된다 (게이트 오탐 방지 대조군)")
+    void consentedUser_stillGetsConsolidation() {
+        sessionConsolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 0));
+
+        waitUntilSummaryStatusLeavesPending();
+        Integer summaries = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM session_summaries WHERE user_id = ?", Integer.class, userId);
+        assertThat(summaries).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("동의 철회 후에는 신규 장기 기억이 한 건도 생성되지 않고 LLM 호출도 없다")
+    void withdrawnUser_getsNoNewLongTermMemory() {
+        memoryControlService.withdrawConsent(userId);
+
+        sessionConsolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 0));
+
+        waitUntilSummaryStatusLeavesPending();
+        assertThat(countFor("session_summaries")).isZero();
+        assertThat(countFor("thoughts")).isZero();
+        assertThat(countFor("user_beliefs")).isZero();
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT summary_status FROM sessions WHERE id = ?", String.class, sessionId))
+                .isEqualTo("failed");
+        verifyNoInteractions(llmClient);
+        verifyNoInteractions(extractorLlmClient);
+    }
+
+    private int countFor(String table) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM " + table + " WHERE user_id = ?", Integer.class, userId);
+        return count == null ? 0 : count;
+    }
+
+    /** onSessionEnded 는 @Async 다 — summary_status 가 pending 을 벗어날 때까지 폴링한다. */
+    private void waitUntilSummaryStatusLeavesPending() {
+        long deadline = System.currentTimeMillis() + WAIT_TIMEOUT_MS;
+        while (System.currentTimeMillis() < deadline) {
+            String status = jdbcTemplate.queryForObject(
+                    "SELECT summary_status FROM sessions WHERE id = ?", String.class, sessionId);
+            if (status != null && !"pending".equals(status)) {
+                return;
+            }
+            try {
+                Thread.sleep(200);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError("interrupted while waiting for consolidation", e);
+            }
+        }
+        throw new AssertionError("consolidation did not finish within " + WAIT_TIMEOUT_MS + "ms");
+    }
+}

--- a/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
@@ -77,8 +77,7 @@ class MemoryConsentGateIntegrationTest {
                 messageEncryptor.dekId());
 
         when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
-            Consumer<String> chunkHandler = invocation.getArgument(1);
-            chunkHandler.accept("발표에 대한 걱정을 나눈 세션 요약.");
+            emitChunk(invocation, "발표에 대한 걱정을 나눈 세션 요약.");
             return new LlmStreamResult(10, LlmUsage.unresolved("test"), false);
         });
         when(extractorLlmClient.extract(anyString(), any(), any()))
@@ -125,8 +124,7 @@ class MemoryConsentGateIntegrationTest {
             Thread withdrawer = new Thread(() -> memoryControlService.withdrawConsent(userId));
             withdrawer.start();
             withdrawer.join();
-            Consumer<String> chunkHandler = invocation.getArgument(1);
-            chunkHandler.accept("발표에 대한 걱정을 나눈 세션 요약.");
+            emitChunk(invocation, "발표에 대한 걱정을 나눈 세션 요약.");
             return new LlmStreamResult(10, LlmUsage.unresolved("test"), false);
         });
 
@@ -172,6 +170,20 @@ class MemoryConsentGateIntegrationTest {
         assertThat(selfModelCount(consentedUserId)).isEqualTo(1);
     }
 
+    /**
+     * 스트리밍 청크를 흘려보낸다.
+     *
+     * <p>{@code any()} 스텁은 요약 생성 외에 청크 핸들러 없이 {@code stream} 을 부르는 경로
+     * (렌더링·개인화)까지 함께 잡는다. 핸들러가 없으면 흘릴 곳이 없을 뿐 스텁이 깨질 일은
+     * 아니므로 조용히 건너뛴다.
+     */
+    private void emitChunk(org.mockito.invocation.InvocationOnMock invocation, String chunk) {
+        Consumer<String> chunkHandler = invocation.getArgument(1);
+        if (chunkHandler != null) {
+            chunkHandler.accept(chunk);
+        }
+    }
+
     /** 지난주 활동 흔적: 종료 세션 + 지배 감정 — 주간 회고 대상 선정과 집계에 걸리게 한다. */
     private void seedWeeklyActivity(UUID targetUserId) {
         UUID weeklySession = UUID.randomUUID();
@@ -184,7 +196,7 @@ class MemoryConsentGateIntegrationTest {
         jdbcTemplate.update(
                 """
                 INSERT INTO emotional_states (user_id, source_event_id, primary_emotion, intensity, source)
-                VALUES (?, ?, 'anxiety', 60, 'chat')
+                VALUES (?, ?, 'anxious', 60, 'chat')
                 """,
                 targetUserId, weeklySession);
     }

--- a/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
@@ -43,6 +43,7 @@ class MemoryConsentGateIntegrationTest {
     private static final long WAIT_TIMEOUT_MS = 15_000;
 
     @Autowired private SessionConsolidator sessionConsolidator;
+    @Autowired private com.mio.ai.memory.consolidation.WeeklyReflectionJob weeklyReflectionJob;
     @Autowired private MemoryControlService memoryControlService;
     @Autowired private JdbcTemplate jdbcTemplate;
     @Autowired private MessageEncryptor messageEncryptor;
@@ -111,6 +112,87 @@ class MemoryConsentGateIntegrationTest {
                 .isEqualTo("failed");
         verifyNoInteractions(llmClient);
         verifyNoInteractions(extractorLlmClient);
+    }
+
+    @Test
+    @DisplayName("게이트 통과 후 LLM 처리 중에 철회해도 영속화 직전 재확인이 적재를 막는다 (TOCTOU)")
+    void withdrawalDuringConsolidation_abortsPersist() {
+        // 세션 종료 → 진입 게이트는 동의 상태로 통과. LLM 스트리밍이 도는 사이(별도 스레드,
+        // 별도 트랜잭션으로 커밋) 사용자가 동의를 철회한다. 철회의 일괄 비활성화는 아직
+        // 커밋되지 않은 요약 행을 볼 수 없으므로, 영속화 직전 재확인이 없다면 이 요약은
+        // active 로 남아 영구히 회수 가능해진다.
+        when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
+            Thread withdrawer = new Thread(() -> memoryControlService.withdrawConsent(userId));
+            withdrawer.start();
+            withdrawer.join();
+            Consumer<String> chunkHandler = invocation.getArgument(1);
+            chunkHandler.accept("발표에 대한 걱정을 나눈 세션 요약.");
+            return new LlmStreamResult(10, LlmUsage.unresolved("test"), false);
+        });
+
+        sessionConsolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 0));
+
+        waitUntilSummaryStatusLeavesPending();
+        assertThat(countFor("session_summaries")).isZero();
+        assertThat(countFor("thoughts")).isZero();
+        assertThat(countFor("user_beliefs")).isZero();
+        Integer activeSummaries = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM session_summaries WHERE user_id = ? AND memory_status = 'active'",
+                Integer.class, userId);
+        assertThat(activeSummaries).isZero();
+    }
+
+    @Test
+    @DisplayName("주간 회고는 철회 사용자를 LLM 호출·파생 저장 없이 건너뛰고, 동의 사용자는 처리한다")
+    void weeklyReflection_skipsWithdrawnUserEntirely() {
+        seedWeeklyActivity(userId);
+        UUID consentedUserId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                consentedUserId, "consent-weekly-" + consentedUserId);
+        seedWeeklyActivity(consentedUserId);
+
+        memoryControlService.withdrawConsent(userId);
+        when(llmClient.completeText(any())).thenReturn("주간 회고 텍스트");
+
+        weeklyReflectionJob.run();
+
+        // 철회 사용자: 외부 LLM 으로 어떤 집계도 나가지 않고, 파생 장기 상태도 쌓이지 않는다
+        org.mockito.ArgumentCaptor<com.mio.ai.llm.LlmRequest> captor =
+                org.mockito.ArgumentCaptor.forClass(com.mio.ai.llm.LlmRequest.class);
+        org.mockito.Mockito.verify(llmClient, org.mockito.Mockito.atLeast(0))
+                .completeText(captor.capture());
+        assertThat(captor.getAllValues())
+                .noneMatch(request -> userId.equals(request.userId()));
+        assertThat(selfModelCount(userId)).isZero();
+
+        // 동의 사용자(대조군): LLM 호출과 self-model 갱신이 일어난다
+        assertThat(captor.getAllValues())
+                .anyMatch(request -> consentedUserId.equals(request.userId()));
+        assertThat(selfModelCount(consentedUserId)).isEqualTo(1);
+    }
+
+    /** 지난주 활동 흔적: 종료 세션 + 지배 감정 — 주간 회고 대상 선정과 집계에 걸리게 한다. */
+    private void seedWeeklyActivity(UUID targetUserId) {
+        UUID weeklySession = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at)
+                VALUES (?, ?, 'mio', 'ended', now() - interval '2 days', now() - interval '2 days')
+                """,
+                weeklySession, targetUserId);
+        jdbcTemplate.update(
+                """
+                INSERT INTO emotional_states (user_id, source_event_id, primary_emotion, intensity, source)
+                VALUES (?, ?, 'anxiety', 60, 'chat')
+                """,
+                targetUserId, weeklySession);
+    }
+
+    private int selfModelCount(UUID targetUserId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM user_self_model WHERE user_id = ?", Integer.class, targetUserId);
+        return count == null ? 0 : count;
     }
 
     private int countFor(String table) {

--- a/src/test/java/com/mio/memorycontrol/controller/MemoryControlControllerTest.java
+++ b/src/test/java/com/mio/memorycontrol/controller/MemoryControlControllerTest.java
@@ -7,6 +7,7 @@ import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
 import com.mio.memorycontrol.dto.MemoryItemResponse;
 import com.mio.memorycontrol.dto.MemoryListResponse;
 import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.memorycontrol.service.MemoryControlRateLimiter;
 import com.mio.memorycontrol.service.MemoryControlService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,7 @@ class MemoryControlControllerTest {
 
     @Autowired private MockMvc mockMvc;
     @MockBean private MemoryControlService memoryControlService;
+    @MockBean private MemoryControlRateLimiter rateLimiter;
 
     private final UUID userId = UUID.randomUUID();
     private final Principal principal = userId::toString;
@@ -97,6 +99,20 @@ class MemoryControlControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"action\": \"\"}"))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("호출 한도를 넘으면 서비스에 닿기 전에 429와 Retry-After 로 차단한다")
+    void listMemories_rateLimited_returns429BeforeService() throws Exception {
+        org.mockito.Mockito.doThrow(new com.mio.common.error.RateLimitExceededException(37))
+                .when(rateLimiter).checkList(userId);
+
+        mockMvc.perform(get("/v1/users/me/memories").principal(principal))
+                .andExpect(status().isTooManyRequests())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers
+                        .header().string("Retry-After", "37"));
+
+        org.mockito.Mockito.verifyNoInteractions(memoryControlService);
     }
 
     @Test

--- a/src/test/java/com/mio/memorycontrol/controller/MemoryControlControllerTest.java
+++ b/src/test/java/com/mio/memorycontrol/controller/MemoryControlControllerTest.java
@@ -1,0 +1,114 @@
+package com.mio.memorycontrol.controller;
+
+import com.mio.auth.filter.JwtAuthenticationFilter;
+import com.mio.common.error.GlobalExceptionHandler;
+import com.mio.config.SecurityConfig;
+import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
+import com.mio.memorycontrol.dto.MemoryItemResponse;
+import com.mio.memorycontrol.dto.MemoryListResponse;
+import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.memorycontrol.service.MemoryControlService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.security.Principal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(
+        value = MemoryControlController.class,
+        excludeAutoConfiguration = {SecurityAutoConfiguration.class, SecurityFilterAutoConfiguration.class},
+        excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = JwtAuthenticationFilter.class),
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)
+        }
+)
+@Import(GlobalExceptionHandler.class)
+class MemoryControlControllerTest {
+
+    @Autowired private MockMvc mockMvc;
+    @MockBean private MemoryControlService memoryControlService;
+
+    private final UUID userId = UUID.randomUUID();
+    private final Principal principal = userId::toString;
+
+    @Test
+    @DisplayName("GET /v1/users/me/memories — 기억 목록을 snake_case 로 반환한다")
+    void listMemories_returnsItems() throws Exception {
+        UUID memoryId = UUID.randomUUID();
+        when(memoryControlService.listMemories(eq(userId), eq(0), eq(20)))
+                .thenReturn(new MemoryListResponse(
+                        List.of(new MemoryItemResponse(memoryId, "summary", "요약 내용", null,
+                                "active", "session_summary", UUID.randomUUID(),
+                                OffsetDateTime.parse("2026-08-15T12:00:00Z"))),
+                        0, 20, 1));
+
+        mockMvc.perform(get("/v1/users/me/memories").principal(principal))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.total_elements").value(1))
+                .andExpect(jsonPath("$.data.items[0].id").value(memoryId.toString()))
+                .andExpect(jsonPath("$.data.items[0].type").value("summary"))
+                .andExpect(jsonPath("$.data.items[0].created_at").exists());
+    }
+
+    @Test
+    @DisplayName("PATCH /v1/users/me/memories/{id} — 정정 요청을 서비스로 전달한다")
+    void updateMemory_delegatesToService() throws Exception {
+        UUID memoryId = UUID.randomUUID();
+        when(memoryControlService.updateMemory(eq(userId), eq(memoryId), any()))
+                .thenReturn(new MemoryUpdateResponse(memoryId, "summary", "corrected"));
+
+        mockMvc.perform(patch("/v1/users/me/memories/{id}", memoryId)
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"action": "correct", "corrected_text": "사실은 잘 끝났다"}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.status").value("corrected"));
+    }
+
+    @Test
+    @DisplayName("PATCH — action 이 비면 400 검증 오류로 거부한다")
+    void updateMemory_rejectsBlankAction() throws Exception {
+        mockMvc.perform(patch("/v1/users/me/memories/{id}", UUID.randomUUID())
+                        .principal(principal)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"action\": \"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("POST /v1/users/me/memory-consent/withdraw — 철회 결과를 반환한다")
+    void withdrawConsent_returnsResult() throws Exception {
+        when(memoryControlService.withdrawConsent(userId))
+                .thenReturn(new MemoryConsentWithdrawResponse(
+                        OffsetDateTime.parse("2026-08-16T00:00:00Z"), 3));
+
+        mockMvc.perform(post("/v1/users/me/memory-consent/withdraw").principal(principal))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.withdrawn_at").exists())
+                .andExpect(jsonPath("$.data.disabled_count").value(3));
+    }
+}

--- a/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
@@ -1,0 +1,345 @@
+package com.mio.memorycontrol.service;
+
+import com.mio.ai.memory.composer.ContextComposer;
+import com.mio.ai.memory.retrieval.LexicalRetriever;
+import com.mio.ai.memory.retrieval.RetrievedItem;
+import com.mio.ai.memory.retrieval.StructuredRetriever;
+import com.mio.ai.memory.retrieval.VectorRetriever;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.memorycontrol.dto.MemoryConsentWithdrawResponse;
+import com.mio.memorycontrol.dto.MemoryItemResponse;
+import com.mio.memorycontrol.dto.MemoryListResponse;
+import com.mio.memorycontrol.dto.MemoryUpdateRequest;
+import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 메모리 조회·정정·동의 철회의 완료 조건 검증 (이슈 #453, 로드맵 §12 P0-6).
+ *
+ * <p>핵심 완료 조건: 정정·비활성화한 기억이 벡터·어휘·구조 검색 <b>어디서도</b> 회수되지
+ * 않아야 하고(회수율 0), 동의 철회 후 기존 기억이 전부 비활성화돼야 한다. 검색기가 하나라도
+ * 필터를 빼먹으면 사용자가 지운 기억이 다음 턴 프롬프트에 되살아난다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class MemoryControlIntegrationTest {
+
+    private static final String SUMMARY_TEXT = "프로젝트 발표를 망쳤다고 걱정함. 파국화 패턴이 관찰됨.";
+    private static final String THOUGHT_TEXT = "나는 항상 실패한다";
+    private static final String BELIEF_TEXT = "나는 부족한 사람이다";
+    private static final String TRIGGER_TAG = "work_stress";
+    private static final String DISTORTION_CODE = "catastrophizing";
+
+    @Autowired private MemoryControlService memoryControlService;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private MessageEncryptor messageEncryptor;
+    @Autowired private VectorRetriever vectorRetriever;
+    @Autowired private LexicalRetriever lexicalRetriever;
+    @Autowired private StructuredRetriever structuredRetriever;
+    @Autowired private ContextComposer contextComposer;
+
+    private UUID userId;
+    private UUID sessionId;
+    private UUID summaryId;
+    private UUID thoughtId;
+    private UUID beliefId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        sessionId = UUID.randomUUID();
+        summaryId = UUID.randomUUID();
+        thoughtId = UUID.randomUUID();
+        beliefId = UUID.randomUUID();
+
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "memctl-it-" + userId);
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, ended_at) VALUES (?, ?, 'mio', 'ended', now())",
+                sessionId, userId);
+        jdbcTemplate.update(
+                """
+                INSERT INTO session_summaries
+                    (id, user_id, session_id, character_id, summary_text, embedding_status,
+                     trigger_tags, episode_emb, created_at)
+                VALUES (?, ?, ?, 'mio', ?, 'done',
+                        ARRAY[?]::text[], array_fill(0.1::real, ARRAY[1536])::vector, now() - interval '2 hours')
+                """,
+                summaryId, userId, sessionId, SUMMARY_TEXT, TRIGGER_TAG);
+        jdbcTemplate.update(
+                """
+                INSERT INTO thoughts
+                    (id, user_id, session_id, thought_text_ciphertext, thought_text_dek_id,
+                     distortion_code, confidence, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, 0.9, now() - interval '1 hour')
+                """,
+                thoughtId, userId, sessionId, encrypt(THOUGHT_TEXT), messageEncryptor.dekId(), DISTORTION_CODE);
+        jdbcTemplate.update(
+                """
+                INSERT INTO user_beliefs
+                    (id, user_id, belief_text_ciphertext, belief_text_dek_id, belief_kind, polarity,
+                     confidence, status, created_at)
+                VALUES (?, ?, ?, ?, 'core_self', 'negative', 0.9, 'active', now())
+                """,
+                beliefId, userId, encrypt(BELIEF_TEXT), messageEncryptor.dekId());
+    }
+
+    // ── 조회 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("사용자는 요약·에피소드·신념을 출처·생성일과 함께 복호화된 본문으로 조회한다")
+    void listMemories_returnsAllTypesWithDecryptedContentAndProvenance() {
+        MemoryListResponse response = memoryControlService.listMemories(userId, 0, 20);
+
+        assertThat(response.totalElements()).isEqualTo(3);
+        assertThat(response.items()).hasSize(3);
+        assertThat(response.items()).extracting(MemoryItemResponse::type)
+                .containsExactlyInAnyOrder("summary", "episode", "belief");
+        assertThat(response.items()).allSatisfy(item -> {
+            assertThat(item.status()).isEqualTo("active");
+            assertThat(item.createdAt()).isNotNull();
+            assertThat(item.source()).isNotBlank();
+        });
+
+        MemoryItemResponse summary = itemOf(response, "summary");
+        MemoryItemResponse episode = itemOf(response, "episode");
+        MemoryItemResponse belief = itemOf(response, "belief");
+        assertThat(summary.content()).isEqualTo(SUMMARY_TEXT);
+        assertThat(summary.sessionId()).isEqualTo(sessionId);
+        assertThat(episode.content()).isEqualTo(THOUGHT_TEXT);
+        assertThat(belief.content()).isEqualTo(BELIEF_TEXT);
+
+        // 생성일 내림차순 — 가장 최근 기억이 먼저 보인다
+        assertThat(response.items().getFirst().type()).isEqualTo("belief");
+
+        Integer viewAudit = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM audit_logs WHERE user_id = ? AND action = 'memory_view'",
+                Integer.class, userId);
+        assertThat(viewAudit).isPositive();
+    }
+
+    @Test
+    @DisplayName("페이지네이션 — size만큼 자르고 전체 건수를 함께 준다")
+    void listMemories_paginates() {
+        MemoryListResponse first = memoryControlService.listMemories(userId, 0, 2);
+        MemoryListResponse second = memoryControlService.listMemories(userId, 1, 2);
+
+        assertThat(first.items()).hasSize(2);
+        assertThat(second.items()).hasSize(1);
+        assertThat(first.totalElements()).isEqualTo(3);
+        assertThat(second.totalElements()).isEqualTo(3);
+    }
+
+    // ── 정정 ─────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("정정한 요약은 벡터·어휘·트리거·왜곡그래프 검색 어디서도 회수되지 않는다")
+    void correctedSummary_isExcludedFromAllRetrievalSources() {
+        MemoryUpdateResponse updated = memoryControlService.updateMemory(userId, summaryId,
+                new MemoryUpdateRequest("correct", "발표는 사실 무사히 끝났다"));
+
+        assertThat(updated.status()).isEqualTo("corrected");
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT memory_status FROM session_summaries WHERE id = ?", String.class, summaryId))
+                .isEqualTo("corrected");
+
+        assertThat(vectorRetriever.retrieveEpisodes(userId, uniformEmbedding(), 5)).isEmpty();
+        assertThat(lexicalRetriever.retrieveByKeywords(userId, "프로젝트", 5)).isEmpty();
+        assertThat(structuredRetriever.retrieveTriggers(userId, List.of(TRIGGER_TAG))).isEmpty();
+        assertThat(structuredRetriever.retrieveRelatedDistortionEpisodes(
+                userId, Set.of(DISTORTION_CODE))).isEmpty();
+
+        // 정정 원문은 암호화되어 이력으로 남는다
+        byte[] ciphertext = jdbcTemplate.queryForObject(
+                "SELECT corrected_text_ciphertext FROM user_memory_corrections WHERE memory_id = ?",
+                byte[].class, summaryId);
+        assertThat(new String(messageEncryptor.decrypt(ciphertext), StandardCharsets.UTF_8))
+                .isEqualTo("발표는 사실 무사히 끝났다");
+
+        // 다음 턴 조회에서 정정문이 함께 보인다
+        MemoryItemResponse summary = itemOf(memoryControlService.listMemories(userId, 0, 20), "summary");
+        assertThat(summary.correctedText()).isEqualTo("발표는 사실 무사히 끝났다");
+
+        assertAudit("memory_correct", summaryId.toString());
+    }
+
+    @Test
+    @DisplayName("정정·비활성 기억은 프롬프트 컨텍스트 조합에 주입되지 않는다")
+    void correctedMemory_isNotComposedIntoPromptContext() {
+        memoryControlService.updateMemory(userId, summaryId,
+                new MemoryUpdateRequest("correct", "발표는 사실 무사히 끝났다"));
+        memoryControlService.updateMemory(userId, beliefId, new MemoryUpdateRequest("disable", null));
+
+        List<RetrievedItem> all = new ArrayList<>();
+        all.addAll(vectorRetriever.retrieveEpisodes(userId, uniformEmbedding(), 5));
+        all.addAll(vectorRetriever.retrieveBeliefs(userId, null, 5));
+        all.addAll(lexicalRetriever.retrieveByKeywords(userId, "프로젝트", 5));
+        all.addAll(structuredRetriever.retrieveProfile(userId));
+        all.addAll(structuredRetriever.retrieveTriggers(userId, List.of(TRIGGER_TAG)));
+        all.addAll(structuredRetriever.retrieveRelatedDistortionEpisodes(userId, Set.of(DISTORTION_CODE)));
+        all.addAll(structuredRetriever.retrieveBeliefNeighbors(userId, Set.of(beliefId.toString())));
+
+        String context = contextComposer.compose(all, "restricted", false);
+        assertThat(context).doesNotContain(SUMMARY_TEXT);
+        assertThat(context).doesNotContain("core_self");
+    }
+
+    // ── 비활성화 ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("비활성화한 신념은 프로필·신념 검색에서 회수되지 않는다")
+    void disabledBelief_isExcludedFromBeliefRetrieval() {
+        MemoryUpdateResponse updated = memoryControlService.updateMemory(
+                userId, beliefId, new MemoryUpdateRequest("disable", null));
+
+        assertThat(updated.status()).isEqualTo("disabled");
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT status FROM user_beliefs WHERE id = ?", String.class, beliefId))
+                .isEqualTo("disabled");
+
+        assertThat(vectorRetriever.retrieveBeliefs(userId, null, 5)).isEmpty();
+        assertThat(structuredRetriever.retrieveProfile(userId)).isEmpty();
+        assertThat(structuredRetriever.retrieveBeliefNeighbors(userId, Set.of(beliefId.toString()))).isEmpty();
+
+        assertAudit("memory_disable", beliefId.toString());
+    }
+
+    @Test
+    @DisplayName("비활성화한 에피소드는 왜곡 그래프 검색에서 회수되지 않는다")
+    void disabledEpisode_isExcludedFromDistortionGraphRetrieval() {
+        memoryControlService.updateMemory(userId, thoughtId, new MemoryUpdateRequest("disable", null));
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT memory_status FROM thoughts WHERE id = ?", String.class, thoughtId))
+                .isEqualTo("disabled");
+        assertThat(structuredRetriever.retrieveRelatedDistortionEpisodes(
+                userId, Set.of(DISTORTION_CODE))).isEmpty();
+    }
+
+    // ── 입력 검증·소유권 ─────────────────────────────────────────
+
+    @Test
+    @DisplayName("남의 기억·없는 기억·잘못된 action은 거부한다")
+    void updateMemory_rejectsInvalidInput() {
+        assertThatThrownBy(() -> memoryControlService.updateMemory(
+                userId, UUID.randomUUID(), new MemoryUpdateRequest("disable", null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MEMORY_NOT_FOUND);
+
+        UUID otherUser = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                otherUser, "memctl-other-" + otherUser);
+        assertThatThrownBy(() -> memoryControlService.updateMemory(
+                otherUser, summaryId, new MemoryUpdateRequest("disable", null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MEMORY_NOT_FOUND);
+
+        assertThatThrownBy(() -> memoryControlService.updateMemory(
+                userId, summaryId, new MemoryUpdateRequest("erase", null)))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_MEMORY_ACTION);
+
+        assertThatThrownBy(() -> memoryControlService.updateMemory(
+                userId, summaryId, new MemoryUpdateRequest("correct", "  ")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.MEMORY_CORRECTION_TEXT_REQUIRED);
+    }
+
+    // ── 동의 철회 ─────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("동의 철회는 기존 기억을 전부 비활성화하고 검색 회수율을 0으로 만든다")
+    void withdrawConsent_disablesAllExistingMemories() {
+        MemoryConsentWithdrawResponse response = memoryControlService.withdrawConsent(userId);
+
+        assertThat(response.withdrawnAt()).isNotNull();
+        assertThat(response.disabledCount()).isEqualTo(3);
+
+        Boolean agreed = jdbcTemplate.queryForObject(
+                "SELECT memory_retention_agreed FROM user_memory_preferences WHERE user_id = ?",
+                Boolean.class, userId);
+        assertThat(agreed).isFalse();
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT memory_status FROM session_summaries WHERE id = ?", String.class, summaryId))
+                .isEqualTo("disabled");
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT memory_status FROM thoughts WHERE id = ?", String.class, thoughtId))
+                .isEqualTo("disabled");
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT status FROM user_beliefs WHERE id = ?", String.class, beliefId))
+                .isEqualTo("disabled");
+
+        assertThat(vectorRetriever.retrieveEpisodes(userId, uniformEmbedding(), 5)).isEmpty();
+        assertThat(vectorRetriever.retrieveBeliefs(userId, null, 5)).isEmpty();
+        assertThat(lexicalRetriever.retrieveByKeywords(userId, "프로젝트", 5)).isEmpty();
+        assertThat(structuredRetriever.retrieveProfile(userId)).isEmpty();
+        assertThat(structuredRetriever.retrieveTriggers(userId, List.of(TRIGGER_TAG))).isEmpty();
+
+        // 철회 후에도 사용자는 자신의 기억 목록을 볼 수 있다 (상태만 disabled)
+        MemoryListResponse list = memoryControlService.listMemories(userId, 0, 20);
+        assertThat(list.items()).hasSize(3);
+        assertThat(list.items()).allSatisfy(item -> assertThat(item.status()).isEqualTo("disabled"));
+
+        assertAudit("memory_consent_withdraw", userId.toString());
+    }
+
+    @Test
+    @DisplayName("동의 철회는 멱등이다 — 재호출해도 최초 철회 시각이 유지된다")
+    void withdrawConsent_isIdempotent() {
+        MemoryConsentWithdrawResponse first = memoryControlService.withdrawConsent(userId);
+        MemoryConsentWithdrawResponse second = memoryControlService.withdrawConsent(userId);
+
+        assertThat(second.withdrawnAt()).isEqualTo(first.withdrawnAt());
+        assertThat(second.disabledCount()).isZero();
+    }
+
+    // ── helpers ──────────────────────────────────────────────────
+
+    private byte[] encrypt(String text) {
+        return messageEncryptor.encrypt(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private float[] uniformEmbedding() {
+        float[] embedding = new float[1536];
+        java.util.Arrays.fill(embedding, 0.1f);
+        return embedding;
+    }
+
+    private MemoryItemResponse itemOf(MemoryListResponse response, String type) {
+        return response.items().stream()
+                .filter(item -> item.type().equals(type))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("type not found: " + type));
+    }
+
+    private void assertAudit(String action, String resourceId) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM audit_logs WHERE user_id = ? AND action = ? AND resource_id = ?",
+                Integer.class, userId, action, resourceId);
+        assertThat(count).isPositive();
+    }
+}

--- a/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
@@ -146,6 +146,98 @@ class MemoryControlIntegrationTest {
         assertThat(second.items()).hasSize(1);
         assertThat(first.totalElements()).isEqualTo(3);
         assertThat(second.totalElements()).isEqualTo(3);
+
+        // 범위 밖 페이지도 총 건수를 잃지 않는다 (COUNT(*) OVER() 폴백 경로)
+        MemoryListResponse beyond = memoryControlService.listMemories(userId, 5, 2);
+        assertThat(beyond.items()).isEmpty();
+        assertThat(beyond.totalElements()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("created_at 동률 행은 id 타이브레이커로 페이지 간 중복·누락 없이 나뉜다")
+    void listMemories_tieBreaksByIdAcrossPages() {
+        // 기존 3건과 겹치지 않는 정확히 같은 시각의 에피소드 4건
+        for (int i = 0; i < 4; i++) {
+            jdbcTemplate.update(
+                    """
+                    INSERT INTO thoughts
+                        (id, user_id, session_id, thought_text_ciphertext, thought_text_dek_id,
+                         distortion_code, confidence, created_at)
+                    VALUES (?, ?, ?, ?, ?, ?, 0.5, TIMESTAMPTZ '2026-08-10 12:00:00+00')
+                    """,
+                    UUID.randomUUID(), userId, sessionId, encrypt("동시각 사고 " + i),
+                    messageEncryptor.dekId(), DISTORTION_CODE);
+        }
+
+        java.util.List<UUID> collected = new ArrayList<>();
+        for (int page = 0; page < 4; page++) {
+            memoryControlService.listMemories(userId, page, 2).items()
+                    .forEach(item -> collected.add(item.id()));
+        }
+
+        assertThat(collected).hasSize(7);
+        assertThat(collected).doesNotHaveDuplicates();
+    }
+
+    @Test
+    @DisplayName("페이지 인자 경계를 벗어나면 거부한다 (page<0, size=0, size>100)")
+    void listMemories_rejectsOutOfRangePaging() {
+        for (int[] paging : new int[][]{{-1, 20}, {0, 0}, {0, 101}}) {
+            assertThatThrownBy(() -> memoryControlService.listMemories(userId, paging[0], paging[1]))
+                    .isInstanceOf(BusinessException.class)
+                    .extracting(e -> ((BusinessException) e).getErrorCode())
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Test
+    @DisplayName("복호화에 실패한 항목은 본문만 비운 채 목록에 남는다")
+    void listMemories_keepsRowWithNullContentOnDecryptFailure() {
+        UUID corruptId = UUID.randomUUID();
+        jdbcTemplate.update(
+                """
+                INSERT INTO thoughts
+                    (id, user_id, session_id, thought_text_ciphertext, thought_text_dek_id,
+                     distortion_code, confidence)
+                VALUES (?, ?, ?, ?, ?, ?, 0.5)
+                """,
+                corruptId, userId, sessionId, new byte[]{1, 2, 3}, messageEncryptor.dekId(),
+                DISTORTION_CODE);
+
+        MemoryListResponse response = memoryControlService.listMemories(userId, 0, 20);
+
+        MemoryItemResponse corrupt = response.items().stream()
+                .filter(item -> item.id().equals(corruptId))
+                .findFirst().orElseThrow();
+        assertThat(corrupt.content()).isNull();
+        assertThat(corrupt.status()).isEqualTo("active");
+        assertThat(response.totalElements()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("비활성 기억이 벡터 상위 후보를 채워도 over-fetch 로 활성 기억을 회수한다")
+    void vectorRetrieval_overFetchesPastDisabledCandidates() {
+        // 활성 요약 1건(기존) + 비활성 요약 5건 — 전부 동일 임베딩이라 KNN 순위가 무의미하게 섞인다
+        for (int i = 0; i < 5; i++) {
+            UUID extraSession = UUID.randomUUID();
+            jdbcTemplate.update(
+                    "INSERT INTO sessions (id, user_id, character_id, status, ended_at) VALUES (?, ?, 'mio', 'ended', now())",
+                    extraSession, userId);
+            jdbcTemplate.update(
+                    """
+                    INSERT INTO session_summaries
+                        (id, user_id, session_id, character_id, summary_text, embedding_status,
+                         episode_emb, memory_status)
+                    VALUES (?, ?, ?, 'mio', ?, 'done',
+                            array_fill(0.1::real, ARRAY[1536])::vector, 'disabled')
+                    """,
+                    UUID.randomUUID(), userId, extraSession, "비활성 요약 " + i);
+        }
+
+        var retrieved = vectorRetriever.retrieveEpisodes(userId, uniformEmbedding(), 3);
+
+        assertThat(retrieved).hasSize(1);
+        assertThat(retrieved.getFirst().content()).isEqualTo(SUMMARY_TEXT);
     }
 
     // ── 정정 ─────────────────────────────────────────────────────

--- a/src/test/java/com/mio/memorycontrol/service/MemoryControlRateLimiterTest.java
+++ b/src/test/java/com/mio/memorycontrol/service/MemoryControlRateLimiterTest.java
@@ -1,0 +1,103 @@
+package com.mio.memorycontrol.service;
+
+import com.mio.common.error.RateLimitExceededException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 메모리 통제 엔드포인트 호출 제한 (이슈 #453, PR #441 전례).
+ */
+@ExtendWith(MockitoExtension.class)
+class MemoryControlRateLimiterTest {
+
+    @Mock private StringRedisTemplate redisTemplate;
+    @Mock private ValueOperations<String, String> valueOperations;
+
+    private MemoryControlRateLimiter rateLimiter;
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        rateLimiter = new MemoryControlRateLimiter(redisTemplate);
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
+
+    @Test
+    @DisplayName("첫 조회 호출은 통과하고 60초 사용자별 윈도우 키를 만든다")
+    void firstListRequest_setsPerUserWindow() {
+        when(valueOperations.increment(anyString())).thenReturn(1L);
+
+        assertThatCode(() -> rateLimiter.checkList(userId)).doesNotThrowAnyException();
+
+        ArgumentCaptor<String> key = ArgumentCaptor.forClass(String.class);
+        verify(valueOperations).increment(key.capture());
+        assertThat(key.getValue())
+                .startsWith("memory-control:ratelimit:list:")
+                .contains(userId.toString());
+        verify(redisTemplate).expire(key.getValue(), 60L, TimeUnit.SECONDS);
+    }
+
+    @Test
+    @DisplayName("조회는 분당 30회를 넘으면 Retry-After 와 함께 차단한다")
+    void listOverLimit_throwsWithRetryAfter() {
+        when(valueOperations.increment(anyString())).thenReturn(31L);
+        when(redisTemplate.getExpire(anyString(), org.mockito.ArgumentMatchers.eq(TimeUnit.SECONDS)))
+                .thenReturn(42L);
+
+        assertThatThrownBy(() -> rateLimiter.checkList(userId))
+                .isInstanceOf(RateLimitExceededException.class)
+                .extracting(e -> ((RateLimitExceededException) e).getRetryAfterSeconds())
+                .isEqualTo(42L);
+    }
+
+    @Test
+    @DisplayName("정정·비활성화는 분당 10회까지만 허용한다")
+    void updateOverLimit_throws() {
+        when(valueOperations.increment(anyString())).thenReturn(11L);
+        when(redisTemplate.getExpire(anyString(), org.mockito.ArgumentMatchers.eq(TimeUnit.SECONDS)))
+                .thenReturn(10L);
+
+        assertThatThrownBy(() -> rateLimiter.checkUpdate(userId))
+                .isInstanceOf(RateLimitExceededException.class);
+    }
+
+    @Test
+    @DisplayName("동의 철회는 가장 엄격하게 분당 3회까지만 허용한다")
+    void withdrawOverLimit_throws() {
+        when(valueOperations.increment(anyString())).thenReturn(4L);
+        when(redisTemplate.getExpire(anyString(), org.mockito.ArgumentMatchers.eq(TimeUnit.SECONDS)))
+                .thenReturn(10L);
+
+        assertThatThrownBy(() -> rateLimiter.checkWithdraw(userId))
+                .isInstanceOf(RateLimitExceededException.class);
+    }
+
+    @Test
+    @DisplayName("한도 내 호출은 윈도우를 재설정하지 않는다")
+    void withinLimit_doesNotResetWindow() {
+        when(valueOperations.increment(anyString())).thenReturn(2L);
+
+        assertThatCode(() -> rateLimiter.checkWithdraw(userId)).doesNotThrowAnyException();
+
+        verify(redisTemplate, org.mockito.Mockito.never())
+                .expire(anyString(), org.mockito.ArgumentMatchers.eq(60L),
+                        org.mockito.ArgumentMatchers.eq(TimeUnit.SECONDS));
+    }
+}


### PR DESCRIPTION
## 요약
사용자가 서버가 자신에 대해 기억하는 것(세션 요약·추출된 사고·신념)을 조회·정정하고 메모리 동의를 철회할 수 있게 한다. P0-6(메모리 통제 UX/API 완결)에서 삭제 트랙(#373 → PR #441) 이후 남아 있던 조회·정정·동의 철회 트랙이다 (로드맵 §12 P0-6, §8.4).

## 관련 이슈
- Closes #453

## 변경 사항
- `GET /v1/users/me/memories` — 장기 기억 3종(session_summaries·thoughts·user_beliefs)을 출처(provenance)·생성일·상태와 함께 페이지 조회. 암호화 본문은 소유자 본인 조회이므로 복호화해 반환하고, 복호화 실패 항목은 숨기지 않고 본문만 비운다.
- `PATCH /v1/users/me/memories/{id}` — `action=correct`(사용자 제공 정정, 암호화 이력 `user_memory_corrections` 보존) 또는 `action=disable`(soft-disable). 상태값은 DB CHECK 제약 대상이라 쓰기 전에 애플리케이션 화이트리스트로 검증한다 (이슈 #219 계열 사고 재발 방지). 남의 기억은 존재를 알려주지 않고 `MEMORY_NOT_FOUND`.
- `POST /v1/users/me/memory-consent/withdraw` — `memory_retention_agreed=false` 전환 + 기존 active 기억 전량 disabled. 최초 철회 시각을 보존해 멱등.
- 검색 게이트 — VectorRetriever(episode)·LexicalRetriever·StructuredRetriever(trigger·distortion graph)가 `memory_status='active'` 만 회수하도록 필터 추가 (belief 계열은 기존 `status='active'` 필터 재사용). 정정·비활성 기억은 다음 턴 프롬프트 조합(ContextComposer)에서 즉시 제외된다.
- SessionConsolidator — 세션 종료 시 LLM 호출 **전에** 동의 게이트. 철회 사용자의 대화 원문이 요약 목적으로 외부 LLM 에 나가지 않고, `summary_status=failed` 로 확정해 pending 고착(이슈 #356)을 막는다. EmbeddingWorker 도 active 요약만 임베딩한다.
- terminal audit — 조회(`memory_view`)·정정(`memory_correct`)·비활성화(`memory_disable`)·철회(`memory_consent_withdraw`)를 `audit_logs` 에 기록 (기억 원문 미포함).
- Flyway `V70__add_memory_control_status.sql`(session_summaries·thoughts `memory_status`, user_beliefs status CHECK 확장, 동의 철회 시각), `V71__add_user_memory_corrections.sql`(정정 이력 테이블). V60~V64 는 PR #445/#452 예약 구간이라 V70+ 를 사용했다.

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. (SessionConsolidator 동의 게이트, EmbeddingWorker claim 필터)
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test
# 로컬 mio DB 는 V42/V45 재번호 이력 어긋남이 있어 임시 DB 로 실행:
# SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/mio_memctl ./gradlew test
```

### 확인 내용
- 전체 1,257건 통과 (failures 0, errors 0). 실 LLM 태그(`llm-integration`) 테스트는 기본 제외.
- `MemoryControlIntegrationTest` (9건) — 3종 기억 복호화 조회·페이지네이션, 정정·비활성 후 벡터·어휘·트리거·왜곡그래프·프로필·신념 검색 회수율 0, ContextComposer 조합 결과에 미주입, 소유권·action·정정문 검증, 철회 멱등성·전량 비활성화·audit 기록.
- `MemoryConsentGateIntegrationTest` (2건) — 동의 유지 대조군은 요약이 적재되고, 철회 사용자는 session_summaries/thoughts/user_beliefs 가 0건 + LLM 무호출(`verifyNoInteractions`)임을 실제 컨솔리데이션 경로로 검증.
- `MemoryControlControllerTest` (4건) — snake_case 응답 계약, `@Valid` 검증, 서비스 위임.
- `SessionConsolidatorTest` — 철회 사용자의 컨솔리데이션이 시작 전에 차단됨을 단위 수준으로 고정.

## 중점 리뷰 포인트
- 검색 제외 필터가 RetrievalPlan 전 소스를 빠짐없이 커버하는지 (session_summaries 4개 쿼리 + belief 계열 기존 필터). emotional_states·behavior_tasks 등 파생 통계 소스는 "장기 기억" 범위 밖으로 보고 이번 트랙에서 제외했다.
- 동의 게이트 위치 — LLM 호출 전 차단이 맞는지, 조회 실패 시 fail-closed(적재 중단) 정책이 적절한지.
- `user_beliefs.status` CHECK 확장(corrected/disabled 추가)이 기존 상태 모델(dormant/revised/retired)과 충돌하지 않는지.
- 마이그레이션 버전(V70/V71) — V60~V64 예약 구간과의 순서 조율.

## 배포 / 롤백
- Rollout: 마이그레이션 V70/V71 은 additive(컬럼 추가·CHECK 확장·신규 테이블)라 무중단 적용 가능. 기존 행은 전부 `memory_status='active'` 기본값.
- Rollback: 애플리케이션 롤백만으로 안전 (이전 코드는 새 컬럼을 참조하지 않음). 스키마 되돌림이 필요하면 `memory_status` 컬럼·`user_memory_corrections` 테이블 drop + user_beliefs CHECK 원복.
- 후속(TODO, 이슈로 분리 예정): 비활성 기억의 기존 임베딩(memory_embeddings·episode_emb) 비동기 정리, Daily/WeeklyReflectionJob 등 파생 요약 경로의 동의 게이트 확장, API 명세서 문서 반영.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
