### PR TITLE
feat: 검토된 safe prefix 를 먼저 전달한다 (P0-4)

### DIFF
--- a/src/main/java/com/mio/ai/delivery/SafePrefixCatalog.java
+++ b/src/main/java/com/mio/ai/delivery/SafePrefixCatalog.java
@@ -99,6 +99,10 @@ public class SafePrefixCatalog {
         }
         // 판정을 받지 못한 턴(Judge 실패·L0 미해결)은 보수 경로다. 위험 등급을 모르는 상태에서
         // 감정 인정 문장을 먼저 확정하지 않는다.
+        //
+        // {@code SKIPPED} 는 막지 않는다 — 판정 미수행은 판정 실패가 아니다. Judge 를 부르지
+        // 않은 턴은 룰 레이어가 부를 이유를 찾지 못한 턴이고, 그 결과 위험 등급은 아래 허용
+        // 목록으로 그대로 확인된다. 실패({@code FAILED})만이 "알 수 없음"이다.
         if (decision.judgeStatus() == JudgeStatus.FAILED
                 || decision.moderationStatus() != ModerationStatus.RESOLVED) {
             return Optional.empty();

--- a/src/main/java/com/mio/ai/delivery/SafePrefixCatalog.java
+++ b/src/main/java/com/mio/ai/delivery/SafePrefixCatalog.java
@@ -1,0 +1,125 @@
+package com.mio.ai.delivery;
+
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.moderation.ModerationStatus;
+import com.mio.ai.plan.GenerationFreedom;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.ai.plan.ResponsePlan;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.JudgeStatus;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.security.SecurityLevel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * 서버가 먼저 보내는 <b>검토된 첫 문장</b>의 목록과 적용 조건 (P0-4, 로드맵 §5.6).
+ *
+ * <p>승인 단위 holdback(이슈 #306)은 검증 전 노출을 0으로 만들었지만 첫 문장이 완성될 때까지
+ * 기다리므로 <b>지연을 늘렸다.</b> 로드맵이 적은 해법은 지연을 되돌리는 것이 아니라 지연되는
+ * 대상을 바꾸는 것이다 — 안전한 첫 반응은 서버가 만들어 먼저 보내고, 뒤의 질문만 계약 검사를
+ * 통과한 뒤 연다.
+ *
+ * <p><b>이 문구가 안전한 이유는 검사에 통과해서가 아니라 모델이 쓰지 않았기 때문이다.</b>
+ * 서버가 사전에 검토한 고정 문구이므로 생성 토큰과 같은 경로로 취급하지 않는다. 반대로,
+ * 여기 있는 문구를 모델이 채우게 하는 순간 이 클래스의 전제가 무너진다.
+ *
+ * <p>적용 조건은 <b>허용 목록</b>이다. 조건에 이름이 없는 턴은 prefix 를 받지 않는다.
+ * 금지 목록으로 쓰면 새 경로가 추가될 때마다 기본값이 "붙인다"가 되어, 위기·보안 거절처럼
+ * 서버 문구가 이미 나가는 경로에 문장이 하나 더 얹힌다.
+ */
+@Component
+@Slf4j
+public class SafePrefixCatalog {
+
+    /** 서버가 미리 전달하는 문장 수. 계약의 문장 상한에서 이만큼을 뺀다. */
+    public static final int RESERVED_SENTENCES = 1;
+
+    /**
+     * 응답 행위별 검토된 첫 문장.
+     *
+     * <p>문구 제약(로드맵 §5.6·§5.7): 진단명 없음, 사용자 상태 단정 없음, 의존 강화 표현 없음,
+     * 결과 보장 없음, 질문 없음. 질문은 계약이 정한 유일한 질문이라 모델 쪽에 남겨야 한다 —
+     * 여기서 하나를 쓰면 사용자는 답할 질문을 두 개 받는다.
+     *
+     * <p>표현은 이미 검토된 카피에서 가져왔다. {@code emotion_def.acknowledgment_phrases}
+     * (V21 시드)의 감정 인정 문구를 감정 코드에 의존하지 않도록 완화한 형태다 — 이 시점에는
+     * 어떤 감정인지 확정되지 않았으므로 감정을 지목하면 단정이 된다.
+     */
+    private static final Map<ResponseAct, String> PREFIXES = Map.of(
+            // 시드의 "그 마음이 많이 무거우시겠어요" 를 추정 어미로 낮춘 것.
+            ResponseAct.EMOTION_CHECK, "지금 마음이 많이 무거우실 것 같아요.",
+            // 맥락 확인 턴은 감정을 지목할 근거가 더 약하다. 말해준 사실만 인정한다.
+            ResponseAct.CLARIFY_CONTEXT, "그 이야기를 꺼내주셔서 고마워요."
+    );
+
+    /**
+     * prefix 를 붙일 수 있는 위험 등급.
+     *
+     * <p>{@code HIGH} 는 제외한다. 그 턴은 출력 가드가 위기로 승격할 확률이 가장 높은 구간이고,
+     * 승격 시 전달되는 것은 {@code delta.replace} 가 아니라 crisis 이벤트라서 <b>이미 렌더된
+     * 서버 문장이 핫라인 위에 그대로 남는다.</b> 지연 몇백 밀리초를 얻으려고 위기 화면 구성을
+     * 바꾸지 않는다.
+     */
+    private static final Set<RiskLevel> ALLOWED_RISK =
+            EnumSet.of(RiskLevel.CLEAR_LOW, RiskLevel.LOW, RiskLevel.MEDIUM);
+
+    /**
+     * 이 턴에 먼저 보낼 검토된 문장. 조건을 만족하지 않으면 비어 있다.
+     *
+     * <p>선택 실패가 턴을 실패시키면 안 된다 — prefix 는 지연 개선이지 응답의 일부가 아니다.
+     * 그래서 어떤 예외도 "붙이지 않음"으로 흡수한다.
+     */
+    public Optional<String> select(PolicyDecision decision) {
+        try {
+            return selectInternal(decision);
+        } catch (RuntimeException e) {
+            log.warn("Safe prefix selection failed — continuing without prefix", e);
+            return Optional.empty();
+        }
+    }
+
+    private Optional<String> selectInternal(PolicyDecision decision) {
+        if (decision == null || decision.action() != DecisionAction.GENERATE) {
+            // 위기 고정 플로우·보안 거절·폴백은 서버 문구가 이미 나간다. 앞에 문장을 더 얹으면
+            // 검토된 고정 응답의 형태가 바뀐다.
+            return Optional.empty();
+        }
+        // 승인 단위 holdback 이 걸린 턴만 대상이다. 그 대기 시간을 메우는 것이 목적이고,
+        // 즉시 스트리밍(SPECULATIVE)에는 메울 대기가 없다. BUFFER 는 판정 실패·HIGH 전용
+        // 경로라 아래 조건에서 어차피 걸리지만, 전달 방식으로도 명시해 둔다.
+        if (decision.deliveryMode() != DeliveryMode.CAUTIOUS_SPECULATIVE) {
+            return Optional.empty();
+        }
+        // 판정을 받지 못한 턴(Judge 실패·L0 미해결)은 보수 경로다. 위험 등급을 모르는 상태에서
+        // 감정 인정 문장을 먼저 확정하지 않는다.
+        if (decision.judgeStatus() == JudgeStatus.FAILED
+                || decision.moderationStatus() != ModerationStatus.RESOLVED) {
+            return Optional.empty();
+        }
+        // 조작 시도가 의심되는 턴에 서버 문구를 먼저 주면, 그 문구 자체가 프롬프트 반응처럼
+        // 보인다. 보안 등급이 깨끗한 턴만 대상이다.
+        if (decision.securityLevel() != SecurityLevel.CLEAN
+                || !ALLOWED_RISK.contains(decision.riskLevel())) {
+            return Optional.empty();
+        }
+        ResponsePlan plan = decision.responsePlan();
+        if (plan == null || plan.generationFreedom() != GenerationFreedom.CONSTRAINED) {
+            // 계약이 걸리지 않은 턴은 모델이 무엇을 쓸지 서버가 모른다. 그 앞에 감정 인정을
+            // 붙이면 이어지는 문장과 어긋날 수 있다.
+            return Optional.empty();
+        }
+        return Optional.ofNullable(PREFIXES.get(plan.responseAct()));
+    }
+
+    /** 검토 대상 문구 전체 — 문구 제약 회귀 테스트가 읽는다. */
+    public Map<ResponseAct, String> reviewedCopy() {
+        return PREFIXES;
+    }
+}

--- a/src/main/java/com/mio/ai/delivery/SafePrefixDelivery.java
+++ b/src/main/java/com/mio/ai/delivery/SafePrefixDelivery.java
@@ -1,0 +1,112 @@
+package com.mio.ai.delivery;
+
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.session.dto.SseEventDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * 검토된 첫 문장의 전달 절차 (P0-4, 로드맵 §5.6).
+ *
+ * <p>{@link SafePrefixCatalog} 가 <b>무엇을 보낼지</b>를 정하고, 이 클래스가 <b>언제·어떻게
+ * 보내고 지우는지</b>를 담당한다. {@code ConversationOrchestrator} 에 두면 이미 상한을 넘긴
+ * 파일이 더 커지고, 전달 규칙이 턴 흐름 코드 사이에 흩어진다 — 이슈 #306 이
+ * {@link HoldbackDelivery} 를 분리한 것과 같은 이유다.
+ *
+ * <p>SSE 전송 자체는 하지 않는다. 호출부가 {@link EventSender} 로 넘긴다 — 여기서 emitter 를
+ * 직접 다루면 전달 규칙과 전송 구현이 다시 묶인다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SafePrefixDelivery {
+
+    private final SafePrefixCatalog catalog;
+
+    /** 이벤트 하나를 실제로 내보낸다. 실패는 예외로 알린다. */
+    @FunctionalInterface
+    public interface EventSender {
+        void send(SseEventDto event) throws Exception;
+    }
+
+    /**
+     * 이 턴에 검토된 첫 문장을 보낸다.
+     *
+     * <p>선택과 전송 실패를 모두 삼킨다 — prefix 는 지연 개선 수단이지 응답의 필수 부분이
+     * 아니므로, 여기서 예외를 올리면 원래 성공했을 턴이 prefix 때문에 실패한다.
+     *
+     * @return 실제로 전달된 문구. 대상이 아니거나 전송에 실패했으면 {@code null}
+     */
+    public String deliverFor(PolicyDecision decision, EventSender sender, String outboundMsgId,
+                             AtomicLong firstRenderedTokenMs, long pipelineStartedAtMs) {
+        String prefix = catalog.select(decision).orElse(null);
+        if (prefix == null || prefix.isBlank()) {
+            return null;
+        }
+        try {
+            sender.send(new SseEventDto.DeltaEvent(prefix, outboundMsgId));
+            firstRenderedTokenMs.compareAndSet(
+                    -1, Math.max(0, System.currentTimeMillis() - pipelineStartedAtMs));
+            return prefix;
+        } catch (Exception e) {
+            log.warn("Safe prefix not delivered — continuing without it: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * 위기 안내를 보내기 전에 이미 렌더된 서버 문구를 지운다 (안전 리뷰 HIGH).
+     *
+     * <p>{@code CAUTIOUS_SPECULATIVE} 의 OutputJudge 는 사전 위험 라벨이 아니라 <b>모델이 실제로
+     * 생성한 텍스트</b>를 보고 판정한다. 그래서 prefix 를 받는 MEDIUM·LOW 턴에서도
+     * {@code CRISIS_FLOW} 가 나올 수 있고, 그때 나가는 것은 {@code delta.replace} 가 아니라
+     * crisis 이벤트다 — 지우지 않으면 사용자는 감정 인정 문장 <b>바로 아래</b>에서 핫라인을
+     * 본다. 위험 등급을 좁히는 방식으로는 막을 수 없는 문제다.
+     *
+     * <p>새 이벤트 타입을 만들지 않는다. 판정 교체 분기가 이미 쓰는 "메시지 전체 교체" 의미를
+     * 그대로 쓰되 내용을 비운다 — FE 계약이 바뀌지 않는다.
+     *
+     * <p>전송 실패는 삼킨다. 이 호출 뒤에 위기 안내 전송이 이어지고 그쪽에 실패 처리가 이미
+     * 있다. 여기서 예외를 올리면 위기 안내 자체가 나가지 않는다.
+     */
+    public void clearRendered(String deliveredPrefix, EventSender sender, String outboundMsgId) {
+        if (deliveredPrefix == null || deliveredPrefix.isBlank()) {
+            return;
+        }
+        try {
+            sender.send(new SseEventDto.DeltaReplaceEvent("", outboundMsgId));
+        } catch (Exception e) {
+            log.warn("Safe prefix not cleared before crisis event: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * 서버가 먼저 보낸 문장을 응답 본문 앞에 잇는다.
+     *
+     * <p>사용자가 읽은 것과 저장·재생되는 것이 같아야 한다. 이어 붙일 때 양쪽 공백을 정리해
+     * 문구가 이미 공백으로 끝나거나 본문이 공백으로 시작해도 이중 공백이 생기지 않게 한다.
+     */
+    public String withPrefix(String deliveredPrefix, String content) {
+        if (deliveredPrefix == null || deliveredPrefix.isBlank()) {
+            return content;
+        }
+        if (content == null || content.isBlank()) {
+            return deliveredPrefix.strip();
+        }
+        return deliveredPrefix.strip() + " " + content.strip();
+    }
+
+    /**
+     * 사용자가 무언가를 보기까지 걸린 시간.
+     *
+     * <p>safe prefix 가 나간 턴은 그 전송 시각이고, 없으면 첫 승인 콘텐츠 시각과 같다. 둘을
+     * 하나로 재면 서버가 먼저 보내는 문구만으로 수치가 좋아져 "지연 개선"과 "지연 은폐"를
+     * 구분할 수 없다 (이슈 #306, 14번 리뷰 지적 E).
+     */
+    public long firstRenderedMs(long renderedMs, long firstSubstantiveMs) {
+        return renderedMs >= 0 ? renderedMs : firstSubstantiveMs;
+    }
+}

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -64,6 +64,8 @@ public class AiDecisionLogger {
             LlmUsage llmUsage,
             ResponseContractResult contractResult,
             long firstSubstantiveTokenMs,
+            long firstRenderedTokenMs,
+            boolean safePrefixApplied,
             int heldBackChars,
             MemoryContextResult memoryContextResult) {
 
@@ -74,7 +76,8 @@ public class AiDecisionLogger {
                     inputJudgeCalled, preFilterResult, outputJudgeResult,
                     l1ThresholdSource, safetyProfileCacheHit, memoryCacheHit,
                     safetyProfileDegraded, appliedCrisisTrigger, llmUsage, contractResult,
-                    firstSubstantiveTokenMs, heldBackChars, memoryContextResult);
+                    firstSubstantiveTokenMs, firstRenderedTokenMs, safePrefixApplied,
+                    heldBackChars, memoryContextResult);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -126,7 +129,7 @@ public class AiDecisionLogger {
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered, inputJudgeCalled,
                 preFilterResult, outputJudgeResult, l1ThresholdSource, safetyProfileCacheHit,
                 memoryCacheHit, safetyProfileDegraded, appliedCrisisTrigger, llmUsage,
-                ResponseContractResult.notApplicable(), -1, 0, null);
+                ResponseContractResult.notApplicable(), -1, -1, false, 0, null);
     }
 
     /** Phase 1 호환 오버로드 */
@@ -145,7 +148,7 @@ public class AiDecisionLogger {
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered,
                 false, OutputPreFilterResult.pass(), null,
                 "default", false, false, false, decision.crisisTrigger(), null,
-                ResponseContractResult.notApplicable(), -1, 0, null);
+                ResponseContractResult.notApplicable(), -1, -1, false, 0, null);
     }
 
     private Map<String, Object> buildTrace(
@@ -166,6 +169,8 @@ public class AiDecisionLogger {
             LlmUsage llmUsage,
             ResponseContractResult contractResult,
             long firstSubstantiveTokenMs,
+            long firstRenderedTokenMs,
+            boolean safePrefixApplied,
             int heldBackChars,
             MemoryContextResult memoryContextResult) {
 
@@ -232,13 +237,16 @@ public class AiDecisionLogger {
         //   llm_ttft_ms                — 첫 생성 토큰
         //   first_substantive_token_ms — 승인되어 실제로 전달된 첫 콘텐츠
         //   first_rendered_token_ms    — 사용자가 무언가를 보기까지
-        // 검토된 safe prefix 를 서버가 먼저 보내는 기능이 없는 동안 뒤의 두 값은 같다.
-        // 필드를 미리 두어 그 기능이 들어올 때 값이 갈라지는 것을 볼 수 있게 한다.
+        // 검토된 safe prefix 가 나간 턴에서만 뒤의 두 값이 갈라진다 (P0-4). prefix 가 없는
+        // 턴에서 값이 갈라지면 배선이 틀렸다는 뜻이다 — 사용자가 먼저 볼 것이 없기 때문이다.
         trace.put("llm_ttft_ms", ttftMs >= 0 ? ttftMs : null);
         trace.put("first_substantive_token_ms",
                 firstSubstantiveTokenMs >= 0 ? firstSubstantiveTokenMs : null);
         trace.put("first_rendered_token_ms",
-                firstSubstantiveTokenMs >= 0 ? firstSubstantiveTokenMs : null);
+                firstRenderedTokenMs >= 0 ? firstRenderedTokenMs : null);
+        // 이 턴에 서버가 검토된 첫 문장을 먼저 보냈는지. 두 지연 값의 차이를 해석하려면
+        // 차이의 원인이 함께 있어야 한다.
+        trace.put("safe_prefix_applied", safePrefixApplied);
         // 생성됐지만 위반으로 전달되지 않은 문자 수. 전달 정책의 비용과 효과를 함께 보여준다.
         trace.put("delivery_held_back_chars", heldBackChars);
         trace.put("llm_usage_resolved", llmUsage != null ? llmUsage.resolved() : null);

--- a/src/main/java/com/mio/ai/orchestrator/AiTurnMetrics.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiTurnMetrics.java
@@ -25,6 +25,7 @@ public class AiTurnMetrics {
     private static final String TURN_DURATION = "mio.ai.turn.duration";
     private static final String LLM_TTFT = "mio.ai.turn.llm.ttft";
     private static final String FIRST_SUBSTANTIVE = "mio.ai.turn.first.substantive";
+    private static final String FIRST_RENDERED = "mio.ai.turn.first.rendered";
     private static final String HELD_BACK_CHARS = "mio.ai.turn.held.back.chars";
     private static final String TURN_OUTCOMES = "mio.ai.turn.outcomes";
     private static final String POLICY_DECISIONS = "mio.ai.policy.decisions";
@@ -42,6 +43,7 @@ public class AiTurnMetrics {
             long totalPipelineMs,
             long llmTtftMs,
             long firstSubstantiveTokenMs,
+            long firstRenderedTokenMs,
             int heldBackChars,
             String finishedReason) {
 
@@ -76,6 +78,16 @@ public class AiTurnMetrics {
                     "First approved substantive content latency",
                     "delivery_mode", deliveryMode)
                     .record(Duration.ofMillis(firstSubstantiveTokenMs));
+        }
+        // 사용자가 무언가를 보기까지 (P0-4). 승인된 첫 모델 콘텐츠와 따로 잰다 — 하나로 재면
+        // 서버가 먼저 보내는 문구만으로 수치가 좋아져 지연 개선과 지연 은폐가 섞인다.
+        if (firstRenderedTokenMs >= 0) {
+            latencyTimer(
+                    FIRST_RENDERED,
+                    "First user-visible content latency (server safe prefix included)",
+                    "response_act", responseAct,
+                    "delivery_mode", deliveryMode)
+                    .record(Duration.ofMillis(firstRenderedTokenMs));
         }
 
         DistributionSummary.builder(HELD_BACK_CHARS)

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -38,6 +38,7 @@ import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.delivery.ApprovedUnitBuffer;
 import com.mio.ai.delivery.HoldbackDelivery;
 import com.mio.ai.delivery.SafePrefixCatalog;
+import com.mio.ai.delivery.SafePrefixDelivery;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.plan.ResponseContractResult;
 import com.mio.ai.plan.ResponseContractValidator;
@@ -110,7 +111,7 @@ public class ConversationOrchestrator {
     private final SafetyProfileBuilder safetyProfileBuilder;
     private final InputJudge inputJudge;
     private final ResponsePlanner responsePlanner;
-    private final SafePrefixCatalog safePrefixCatalog;
+    private final SafePrefixDelivery safePrefixDelivery;
     private final ResponseContractValidator responseContractValidator;
     private final CbtMetadataClassifier cbtMetadataClassifier;
     private final OutputPreFilter outputPreFilter;
@@ -294,11 +295,21 @@ public class ConversationOrchestrator {
             // 정책 결정을 바꾸지 않고 "무엇을 할지"만 덧붙인다 — 계획은 위험 등급을 낮출 수 없다.
             decision = decision.withResponsePlan(responsePlanner.plan(decision));
 
-            // 6c. 검토된 safe prefix 선택 (P0-4, 로드맵 §5.6). 서버가 사전에 검토한 고정 문구라
-            // 모델 출력과 같은 검사 경로를 타지 않는다 — 안전한 이유가 "검사를 통과해서"가
-            // 아니라 "모델이 쓰지 않아서"다. 붙는 턴은 계약의 문장 상한을 하나 줄인다.
-            String safePrefix = safePrefixCatalog.select(decision).orElse(null);
-            if (safePrefix != null) {
+            // 사용자가 무언가를 보기까지 (P0-4). 아래 첫 승인 콘텐츠 지연과는 safe prefix 가
+            // 나간 턴에서만 갈라진다 — prefix 가 없으면 처음 보이는 것이 곧 첫 승인 콘텐츠다.
+            AtomicLong firstRenderedTokenMs = new AtomicLong(-1);
+
+            // 6c. 검토된 safe prefix 를 생성보다 먼저 전달한다 (P0-4, 로드맵 §5.6). 서버가 사전에
+            // 검토한 고정 문구라 모델 출력과 같은 검사 경로를 타지 않는다 — 안전한 이유가
+            // "검사를 통과해서"가 아니라 "모델이 쓰지 않아서"다.
+            //
+            // 문장 상한은 **전달에 성공한 뒤에만** 줄인다. 선택 시점에 줄이면 전송이 실패한 턴
+            // (연결 끊김 등)에서 사용자는 보상 문장 없이 한 문장 짧은 응답을 받는다. 프롬프트
+            // 지시와 계약 상한이 같은 조건을 보도록 이 한 값에서 갈라져 나간다.
+            String deliveredPrefix = safePrefixDelivery.deliverFor(
+                    decision, event -> sendEvent(emitter, event), outboundMsgId,
+                    firstRenderedTokenMs, startMs);
+            if (deliveredPrefix != null) {
                 decision = decision.withResponsePlan(
                         decision.responsePlan().reservingSentences(SafePrefixCatalog.RESERVED_SENTENCES));
             }
@@ -328,9 +339,6 @@ public class ConversationOrchestrator {
             // 전달 계측 (이슈 #306). 첫 생성 토큰 지연(llmTtftMs)과 구분해서 남긴다 —
             // 하나로 재면 서버가 먼저 보내는 문구만으로도 수치가 좋아진다.
             AtomicLong firstSubstantiveTokenMs = new AtomicLong(-1);
-            // 사용자가 무언가를 보기까지 (P0-4). safe prefix 가 나간 턴에서만 위 값과 갈라진다 —
-            // prefix 가 없으면 처음 보이는 것이 곧 첫 승인 콘텐츠이므로 두 값은 같아야 한다.
-            AtomicLong firstRenderedTokenMs = new AtomicLong(-1);
             int heldBackChars = 0;
             OutputJudgeResult judgeActionResult = null;
             // 계약 검사 결과 (이슈 #303). 계획되지 않은 턴은 "통과"가 아니라 "대상 아님"이고,
@@ -373,19 +381,12 @@ public class ConversationOrchestrator {
                 recordCrisisOutcome(crisisResult, finishedReasonRef, crisisSeverityRef);
 
             } else if (decision.action() == DecisionAction.GENERATE) {
-                // 검토된 첫 문장을 생성보다 먼저 보낸다 (P0-4). 여기가 가장 이른 지점이다 —
-                // 프롬프트 조립·LLM 호출 앞에 두어야 승인 단위를 기다리는 시간이 실제로 메워진다.
-                // 전송에 실패해도 턴은 계속된다. 다만 나가지 않은 문장을 저장하지 않도록
-                // 전달 여부를 따로 들고 간다.
-                boolean safePrefixDelivered = deliverSafePrefix(
-                        safePrefix, emitter, outboundMsgId, firstRenderedTokenMs, startMs);
-
                 // OutputGuard 실행 여부는 deliveryMode로 제어 (requireOutputGuard 필드는 감사 로그용)
                 // GENERATE: build prompt with GenerationMode instruction
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints(), memoryContext,
-                        session.getCharacterId(), checkpointSummary, responsePlan, safePrefixDelivered);
-                String deliveredPrefix = safePrefixDelivered ? safePrefix : null;
+                        session.getCharacterId(), checkpointSummary, responsePlan,
+                        deliveredPrefix != null);
                 List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
@@ -417,7 +418,7 @@ public class ConversationOrchestrator {
                                     judgeActionResult, assistantContent, userMessage, l1Result, user, session, emitter,
                                     outboundMsgId, userSignal.emotionScore(),
                                     finishedReasonRef, crisisSeverityRef, turn, turnPersisted,
-                                    firstSubstantiveTokenMs, startMs);
+                                    firstSubstantiveTokenMs, startMs, deliveredPrefix);
                             if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
                                 crisisFlowTriggered = true;
                                 crisisContextRef.set(true);
@@ -559,6 +560,12 @@ public class ConversationOrchestrator {
                             persistTurnOutcome(turn, turnPersisted, assistantContent, true,
                                     "crisis_flow", preview.severity());
 
+                            // 이미 렌더된 서버 문구를 지우고 위기 안내를 보낸다. 이 분기는 조기
+                            // 중단 경로와 스트림 종료 후 경로가 함께 들어온다 — 둘 다 여기서
+                            // 지워진다.
+                            safePrefixDelivery.clearRendered(
+                                    deliveredPrefix, event -> sendEvent(emitter, event), outboundMsgId);
+
                             CrisisFlowService.CrisisHandleResult crisisResult =
                                     crisisFlowService.handleWithFixedResponse(
                                             l1Result, CrisisTrigger.OUTPUT_GUARD, userMessage,
@@ -592,7 +599,7 @@ public class ConversationOrchestrator {
                                 // 문장도 이 메시지의 일부이므로 함께 실어야 화면에서 사라지지
                                 // 않는다. 판정이 교체한 응답(위 분기)과는 다르다 — 그쪽은
                                 // 앞선 텍스트를 남기지 않는 것이 목적이다.
-                                String reviewedContent = withSafePrefix(deliveredPrefix,
+                                String reviewedContent = safePrefixDelivery.withPrefix(deliveredPrefix,
                                         capturedSnapshotRef.get() != null
                                                 ? capturedSnapshotRef.get() : assistantContent);
                                 assistantContent = reviewedContent;
@@ -602,7 +609,7 @@ public class ConversationOrchestrator {
                                         userMessage, reviewedContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "stop", true);
                             } else {
-                                assistantContent = withSafePrefix(deliveredPrefix, assistantContent);
+                                assistantContent = safePrefixDelivery.withPrefix(deliveredPrefix, assistantContent);
                                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                         userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "stop", true);
@@ -611,7 +618,7 @@ public class ConversationOrchestrator {
                     } else {
                         // 서버가 먼저 보낸 문장도 이 턴의 응답이다. 저장하지 않으면 재생·요약·
                         // 워킹 메모리가 사용자가 실제로 읽은 것과 달라진다.
-                        assistantContent = withSafePrefix(deliveredPrefix, assistantContent);
+                        assistantContent = safePrefixDelivery.withPrefix(deliveredPrefix, assistantContent);
                         sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                 userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                 "stop", true);
@@ -660,7 +667,8 @@ public class ConversationOrchestrator {
 
             // 10. Log decision
             long totalMs = System.currentTimeMillis() - startMs;
-            long firstRenderedMs = resolveFirstRenderedMs(firstRenderedTokenMs, firstSubstantiveTokenMs);
+            long firstRenderedMs = safePrefixDelivery.firstRenderedMs(
+                    firstRenderedTokenMs.get(), firstSubstantiveTokenMs.get());
             aiTurnMetrics.recordCompleted(
                     decision,
                     contractResult,
@@ -759,55 +767,6 @@ public class ConversationOrchestrator {
         }
         messagePersistenceService.completeTurn(turn.getId(), turn.getLeaseToken(),
                 assistantContent, crisisFlowTriggered, finishedReason, crisisSeverity);
-    }
-
-    /**
-     * 검토된 첫 문장을 생성 전에 보낸다 (P0-4, 로드맵 §5.6).
-     *
-     * <p>실패는 삼킨다. prefix 는 지연 개선 수단이지 응답의 필수 부분이 아니므로, 여기서
-     * 예외를 올리면 원래 성공했을 턴이 prefix 때문에 실패한다. 전송하지 못한 문장을 응답에
-     * 넣지 않도록 {@code false} 를 돌려준다.
-     *
-     * @return 실제로 전달됐는지
-     */
-    private boolean deliverSafePrefix(String safePrefix, SseEmitter emitter, String outboundMsgId,
-                                      AtomicLong firstRenderedTokenMs, long pipelineStartedAtMs) {
-        if (safePrefix == null || safePrefix.isBlank()) {
-            return false;
-        }
-        try {
-            sendEvent(emitter, new SseEventDto.DeltaEvent(safePrefix, outboundMsgId));
-            firstRenderedTokenMs.compareAndSet(
-                    -1, Math.max(0, System.currentTimeMillis() - pipelineStartedAtMs));
-            return true;
-        } catch (Exception e) {
-            log.warn("Safe prefix not delivered — continuing without it: {}", e.getMessage());
-            return false;
-        }
-    }
-
-    /** 서버가 먼저 보낸 문장을 응답 본문 앞에 잇는다. prefix 가 없으면 원문 그대로다. */
-    private String withSafePrefix(String deliveredPrefix, String content) {
-        if (deliveredPrefix == null || deliveredPrefix.isBlank()) {
-            return content;
-        }
-        if (content == null || content.isBlank()) {
-            return deliveredPrefix;
-        }
-        return deliveredPrefix + " " + content;
-    }
-
-    /**
-     * 사용자가 무언가를 보기까지 걸린 시간.
-     *
-     * <p>safe prefix 가 나간 턴은 그 전송 시각이고, 없으면 첫 승인 콘텐츠 시각과 같다. 둘을
-     * 하나로 재면 서버가 먼저 보내는 문구만으로 수치가 좋아져 "지연 개선"과 "지연 은폐"를
-     * 구분할 수 없다 (이슈 #306, 14번 리뷰 지적 E).
-     */
-    private long resolveFirstRenderedMs(AtomicLong firstRenderedTokenMs,
-                                        AtomicLong firstSubstantiveTokenMs) {
-        long rendered = firstRenderedTokenMs.get();
-        return rendered >= 0 ? rendered : firstSubstantiveTokenMs.get();
     }
 
     /** 실제 SSE 전송이 성공한 첫 비어 있지 않은 콘텐츠만 사용자 체감 지연으로 기록한다. */
@@ -995,7 +954,8 @@ public class ConversationOrchestrator {
             MessageTurn turn,
             AtomicBoolean turnPersisted,
             AtomicLong firstSubstantiveTokenMs,
-            long pipelineStartedAtMs) throws IOException {
+            long pipelineStartedAtMs,
+            String deliveredPrefix) throws IOException {
 
         return switch (result.action()) {
             case SEND -> originalContent;
@@ -1008,6 +968,12 @@ public class ConversationOrchestrator {
                         session.getId(), user.getId());
                 persistTurnOutcome(turn, turnPersisted, preview.fixedResponse(), true,
                         "crisis_flow", preview.severity());
+
+                // 이 경로의 전달 방식(BUFFER)은 현재 prefix 대상이 아니지만, 위기 안내 앞을
+                // 지우는 책임은 위기를 보내는 모든 지점에 있어야 한다. 대상 조건이 넓어질 때
+                // 이 분기만 조용히 빠지는 것이 정확히 이 리뷰가 잡은 실패 형태다.
+                safePrefixDelivery.clearRendered(
+                        deliveredPrefix, event -> sendEvent(emitter, event), outboundMsgId);
 
                 CrisisFlowService.CrisisHandleResult cr =
                         crisisFlowService.handleWithFixedResponse(

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -37,6 +37,7 @@ import com.mio.ai.profile.SafetyProfileBuilder.ProfileResult;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.delivery.ApprovedUnitBuffer;
 import com.mio.ai.delivery.HoldbackDelivery;
+import com.mio.ai.delivery.SafePrefixCatalog;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.plan.ResponseContractResult;
 import com.mio.ai.plan.ResponseContractValidator;
@@ -109,6 +110,7 @@ public class ConversationOrchestrator {
     private final SafetyProfileBuilder safetyProfileBuilder;
     private final InputJudge inputJudge;
     private final ResponsePlanner responsePlanner;
+    private final SafePrefixCatalog safePrefixCatalog;
     private final ResponseContractValidator responseContractValidator;
     private final CbtMetadataClassifier cbtMetadataClassifier;
     private final OutputPreFilter outputPreFilter;
@@ -291,6 +293,15 @@ public class ConversationOrchestrator {
             // 6b. 응답 계약 확정 (이슈 #303). 결정론적이며 LLM 을 호출하지 않는다.
             // 정책 결정을 바꾸지 않고 "무엇을 할지"만 덧붙인다 — 계획은 위험 등급을 낮출 수 없다.
             decision = decision.withResponsePlan(responsePlanner.plan(decision));
+
+            // 6c. 검토된 safe prefix 선택 (P0-4, 로드맵 §5.6). 서버가 사전에 검토한 고정 문구라
+            // 모델 출력과 같은 검사 경로를 타지 않는다 — 안전한 이유가 "검사를 통과해서"가
+            // 아니라 "모델이 쓰지 않아서"다. 붙는 턴은 계약의 문장 상한을 하나 줄인다.
+            String safePrefix = safePrefixCatalog.select(decision).orElse(null);
+            if (safePrefix != null) {
+                decision = decision.withResponsePlan(
+                        decision.responsePlan().reservingSentences(SafePrefixCatalog.RESERVED_SENTENCES));
+            }
             ResponsePlan responsePlan = decision.responsePlan();
 
             // 현재 컨텍스트가 확정된 뒤, 안전한 생성 턴의 다음 턴 맥락만 비동기 활성화한다.
@@ -317,6 +328,9 @@ public class ConversationOrchestrator {
             // 전달 계측 (이슈 #306). 첫 생성 토큰 지연(llmTtftMs)과 구분해서 남긴다 —
             // 하나로 재면 서버가 먼저 보내는 문구만으로도 수치가 좋아진다.
             AtomicLong firstSubstantiveTokenMs = new AtomicLong(-1);
+            // 사용자가 무언가를 보기까지 (P0-4). safe prefix 가 나간 턴에서만 위 값과 갈라진다 —
+            // prefix 가 없으면 처음 보이는 것이 곧 첫 승인 콘텐츠이므로 두 값은 같아야 한다.
+            AtomicLong firstRenderedTokenMs = new AtomicLong(-1);
             int heldBackChars = 0;
             OutputJudgeResult judgeActionResult = null;
             // 계약 검사 결과 (이슈 #303). 계획되지 않은 턴은 "통과"가 아니라 "대상 아님"이고,
@@ -359,11 +373,19 @@ public class ConversationOrchestrator {
                 recordCrisisOutcome(crisisResult, finishedReasonRef, crisisSeverityRef);
 
             } else if (decision.action() == DecisionAction.GENERATE) {
+                // 검토된 첫 문장을 생성보다 먼저 보낸다 (P0-4). 여기가 가장 이른 지점이다 —
+                // 프롬프트 조립·LLM 호출 앞에 두어야 승인 단위를 기다리는 시간이 실제로 메워진다.
+                // 전송에 실패해도 턴은 계속된다. 다만 나가지 않은 문장을 저장하지 않도록
+                // 전달 여부를 따로 들고 간다.
+                boolean safePrefixDelivered = deliverSafePrefix(
+                        safePrefix, emitter, outboundMsgId, firstRenderedTokenMs, startMs);
+
                 // OutputGuard 실행 여부는 deliveryMode로 제어 (requireOutputGuard 필드는 감사 로그용)
                 // GENERATE: build prompt with GenerationMode instruction
                 String systemPrompt = promptBuilder.buildSystemPrompt(
                         decision.generationMode(), decision.interventionHints(), memoryContext,
-                        session.getCharacterId(), checkpointSummary, responsePlan);
+                        session.getCharacterId(), checkpointSummary, responsePlan, safePrefixDelivered);
+                String deliveredPrefix = safePrefixDelivered ? safePrefix : null;
                 List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
@@ -565,8 +587,14 @@ public class ConversationOrchestrator {
                             } else if (stopSendingDeltas.get()) {
                                 // Stopped mid-stream but content is safe — restore only the reviewed snapshot,
                                 // not trailing tokens that arrived after the early stop
-                                String reviewedContent = capturedSnapshotRef.get() != null
-                                        ? capturedSnapshotRef.get() : assistantContent;
+                                //
+                                // delta.replace 는 메시지 전체를 갈아끼운다. 서버가 먼저 보낸
+                                // 문장도 이 메시지의 일부이므로 함께 실어야 화면에서 사라지지
+                                // 않는다. 판정이 교체한 응답(위 분기)과는 다르다 — 그쪽은
+                                // 앞선 텍스트를 남기지 않는 것이 목적이다.
+                                String reviewedContent = withSafePrefix(deliveredPrefix,
+                                        capturedSnapshotRef.get() != null
+                                                ? capturedSnapshotRef.get() : assistantContent);
                                 assistantContent = reviewedContent;
                                 sendEvent(emitter, new SseEventDto.DeltaReplaceEvent(reviewedContent, outboundMsgId));
                                 markFirstSubstantive(firstSubstantiveTokenMs, startMs, reviewedContent);
@@ -574,12 +602,16 @@ public class ConversationOrchestrator {
                                         userMessage, reviewedContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "stop", true);
                             } else {
+                                assistantContent = withSafePrefix(deliveredPrefix, assistantContent);
                                 sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                         userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                         "stop", true);
                             }
                         }
                     } else {
+                        // 서버가 먼저 보낸 문장도 이 턴의 응답이다. 저장하지 않으면 재생·요약·
+                        // 워킹 메모리가 사용자가 실제로 읽은 것과 달라진다.
+                        assistantContent = withSafePrefix(deliveredPrefix, assistantContent);
                         sendDoneEvent(emitter, finishedReasonRef, turn, crisisSeverityRef, turnPersisted, userId, sessionId, outboundMsgId, userSignal.emotionScore(), false,
                                 userMessage, assistantContent, userSignal, sessionDelta, recentWorkingMessages,
                                 "stop", true);
@@ -628,12 +660,14 @@ public class ConversationOrchestrator {
 
             // 10. Log decision
             long totalMs = System.currentTimeMillis() - startMs;
+            long firstRenderedMs = resolveFirstRenderedMs(firstRenderedTokenMs, firstSubstantiveTokenMs);
             aiTurnMetrics.recordCompleted(
                     decision,
                     contractResult,
                     totalMs,
                     llmTtftMs,
                     firstSubstantiveTokenMs.get(),
+                    firstRenderedMs,
                     heldBackChars,
                     resolveFinishedReason(finishedReasonRef));
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
@@ -641,7 +675,8 @@ public class ConversationOrchestrator {
                     inputJudgeCalled, preFilterResult, judgeActionResult,
                     profile.source(), safetyProfileCacheHit, memoryCacheFallbackUsed,
                     profile.degraded(), appliedCrisisTrigger, llmUsage, contractResult,
-                    firstSubstantiveTokenMs.get(), heldBackChars, liveMemoryResult);
+                    firstSubstantiveTokenMs.get(), firstRenderedMs,
+                    firstRenderedTokenMs.get() >= 0, heldBackChars, liveMemoryResult);
 
             emitter.complete();
 
@@ -724,6 +759,55 @@ public class ConversationOrchestrator {
         }
         messagePersistenceService.completeTurn(turn.getId(), turn.getLeaseToken(),
                 assistantContent, crisisFlowTriggered, finishedReason, crisisSeverity);
+    }
+
+    /**
+     * 검토된 첫 문장을 생성 전에 보낸다 (P0-4, 로드맵 §5.6).
+     *
+     * <p>실패는 삼킨다. prefix 는 지연 개선 수단이지 응답의 필수 부분이 아니므로, 여기서
+     * 예외를 올리면 원래 성공했을 턴이 prefix 때문에 실패한다. 전송하지 못한 문장을 응답에
+     * 넣지 않도록 {@code false} 를 돌려준다.
+     *
+     * @return 실제로 전달됐는지
+     */
+    private boolean deliverSafePrefix(String safePrefix, SseEmitter emitter, String outboundMsgId,
+                                      AtomicLong firstRenderedTokenMs, long pipelineStartedAtMs) {
+        if (safePrefix == null || safePrefix.isBlank()) {
+            return false;
+        }
+        try {
+            sendEvent(emitter, new SseEventDto.DeltaEvent(safePrefix, outboundMsgId));
+            firstRenderedTokenMs.compareAndSet(
+                    -1, Math.max(0, System.currentTimeMillis() - pipelineStartedAtMs));
+            return true;
+        } catch (Exception e) {
+            log.warn("Safe prefix not delivered — continuing without it: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /** 서버가 먼저 보낸 문장을 응답 본문 앞에 잇는다. prefix 가 없으면 원문 그대로다. */
+    private String withSafePrefix(String deliveredPrefix, String content) {
+        if (deliveredPrefix == null || deliveredPrefix.isBlank()) {
+            return content;
+        }
+        if (content == null || content.isBlank()) {
+            return deliveredPrefix;
+        }
+        return deliveredPrefix + " " + content;
+    }
+
+    /**
+     * 사용자가 무언가를 보기까지 걸린 시간.
+     *
+     * <p>safe prefix 가 나간 턴은 그 전송 시각이고, 없으면 첫 승인 콘텐츠 시각과 같다. 둘을
+     * 하나로 재면 서버가 먼저 보내는 문구만으로 수치가 좋아져 "지연 개선"과 "지연 은폐"를
+     * 구분할 수 없다 (이슈 #306, 14번 리뷰 지적 E).
+     */
+    private long resolveFirstRenderedMs(AtomicLong firstRenderedTokenMs,
+                                        AtomicLong firstSubstantiveTokenMs) {
+        long rendered = firstRenderedTokenMs.get();
+        return rendered >= 0 ? rendered : firstSubstantiveTokenMs.get();
     }
 
     /** 실제 SSE 전송이 성공한 첫 비어 있지 않은 콘텐츠만 사용자 체감 지연으로 기록한다. */

--- a/src/main/java/com/mio/ai/plan/ResponsePlan.java
+++ b/src/main/java/com/mio/ai/plan/ResponsePlan.java
@@ -48,6 +48,22 @@ public record ResponsePlan(
         return new ResponsePlan(responseAct, GenerationFreedom.TEMPLATE_ONLY, 0, 0, BASE_FORBIDDEN);
     }
 
+    /**
+     * 서버가 문장 일부를 먼저 전달한 계획 (P0-4, 로드맵 §5.6).
+     *
+     * <p>safe prefix 는 사용자에게 보이는 응답의 일부다. 상한을 그대로 두면 사용자가 읽는
+     * 문장 수가 계약보다 하나 많아진다 — 계약이 정한 것은 "모델이 쓴 문장 수"가 아니라
+     * "이 턴에 나가는 문장 수"이기 때문이다. 상한은 줄이기만 한다. 계획은 위험 등급도,
+     * 그에 따른 제약도 완화할 수 없다.
+     */
+    public ResponsePlan reservingSentences(int reserved) {
+        if (reserved <= 0 || maxSentences == Integer.MAX_VALUE) {
+            return this;
+        }
+        return new ResponsePlan(responseAct, generationFreedom, maxQuestions,
+                Math.max(1, maxSentences - reserved), forbiddenElements);
+    }
+
     /** 계약 검사를 적용할 수 있는 계획인지. */
     public boolean isContractEnforced() {
         return generationFreedom == GenerationFreedom.CONSTRAINED

--- a/src/main/java/com/mio/ai/prompt/PromptBuilder.java
+++ b/src/main/java/com/mio/ai/prompt/PromptBuilder.java
@@ -42,8 +42,25 @@ public class PromptBuilder {
     public String buildSystemPrompt(GenerationMode mode, InterventionHints hints,
                                     String memoryContext, String characterId, String checkpointSummary,
                                     ResponsePlan plan) {
+        return buildSystemPrompt(mode, hints, memoryContext, characterId, checkpointSummary, plan, false);
+    }
+
+    /**
+     * 서버가 첫 문장을 이미 보낸 턴을 프롬프트에 알린다 (P0-4, 로드맵 §5.6).
+     *
+     * <p>모델은 감정을 먼저 인정하도록 지시받는다. 서버가 그 문장을 이미 보냈는데 알리지
+     * 않으면 사용자는 같은 인정을 두 번 읽는다 — 눈에 보이는 제품 퇴행이다.
+     *
+     * <p><b>문구 자체는 프롬프트에 넣지 않는다.</b> 넣으면 모델이 그대로 따라 쓰는 것이 가장
+     * 흔한 실패가 된다. 필요한 정보는 "이미 전달됐다"는 사실뿐이고, 그것만 주면 반복이
+     * 생길 수 있는 표면이 좁아진다. 전달 단계에서 잘라내는 방식은 택하지 않았다 — 모델 출력을
+     * 서버가 편집하면 사용자가 읽은 텍스트와 저장·재생되는 텍스트가 갈라진다.
+     */
+    public String buildSystemPrompt(GenerationMode mode, InterventionHints hints,
+                                    String memoryContext, String characterId, String checkpointSummary,
+                                    ResponsePlan plan, boolean safePrefixDelivered) {
         String base = resolveBasePrompt(characterId) + buildModeInstruction(mode)
-                + buildPlanInstruction(plan);
+                + buildPlanInstruction(plan) + buildSafePrefixInstruction(plan, safePrefixDelivered);
         if (hints != null && !hints.suggestedCodes().isEmpty()) {
             base += buildHintsInstruction(hints);
         }
@@ -90,6 +107,14 @@ public class PromptBuilder {
         }
         sb.append(" 진단·단정·결과 보장 표현을 쓰지 마세요.");
         return sb.toString();
+    }
+
+    private String buildSafePrefixInstruction(ResponsePlan plan, boolean safePrefixDelivered) {
+        if (!safePrefixDelivered || plan == null || plan.responseAct() == ResponseAct.UNPLANNED) {
+            return "";
+        }
+        return "\n\n[이미 전달됨] 감정을 인정하는 첫 문장은 서버가 이미 사용자에게 보냈습니다. "
+                + "인사나 감정 인정을 다시 쓰지 말고, 곧바로 이번 턴의 응답 행위부터 시작하세요.";
     }
 
     private String buildHintsInstruction(InterventionHints hints) {

--- a/src/test/java/com/mio/ai/delivery/SafePrefixCatalogTest.java
+++ b/src/test/java/com/mio/ai/delivery/SafePrefixCatalogTest.java
@@ -1,0 +1,171 @@
+package com.mio.ai.delivery;
+
+import com.mio.ai.judge.OutputPreFilter;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.moderation.ModerationStatus;
+import com.mio.ai.plan.GenerationFreedom;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.ai.plan.ResponsePlan;
+import com.mio.ai.plan.ResponseContractValidator;
+import com.mio.ai.plan.ResponsePlanner;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.JudgeStatus;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 서버가 먼저 보내는 검토된 첫 문장의 적용 조건과 문구 제약 (P0-4, 로드맵 §5.6).
+ *
+ * <p>이 클래스가 잘못되면 <b>사용자가 보는 첫 문장이 잘못된 턴에 나간다.</b> 위기·보안 거절
+ * 처럼 서버 고정 문구가 이미 나가는 경로에 문장이 하나 더 얹히는 것이 가장 나쁜 실패다.
+ */
+class SafePrefixCatalogTest {
+
+    private final SafePrefixCatalog catalog = new SafePrefixCatalog();
+    private final ResponsePlanner planner = new ResponsePlanner();
+    private final OutputPreFilter outputPreFilter = new OutputPreFilter();
+    private final ResponseContractValidator contractValidator = new ResponseContractValidator();
+
+    private PolicyDecision decision(DecisionAction action, GenerationMode mode,
+                                    DeliveryMode delivery, RiskLevel risk,
+                                    SecurityLevel security, JudgeStatus judgeStatus,
+                                    ModerationStatus moderationStatus) {
+        PolicyDecision base = new PolicyDecision(
+                "pd_prefix_test", action, mode, delivery, security,
+                action == DecisionAction.GENERATE, true, true,
+                InterventionHints.empty(), "test", risk, null, judgeStatus, moderationStatus,
+                ResponsePlan.unplanned());
+        return base.withResponsePlan(planner.plan(base));
+    }
+
+    private PolicyDecision plannedTurn(GenerationMode mode, RiskLevel risk) {
+        return decision(DecisionAction.GENERATE, mode, DeliveryMode.CAUTIOUS_SPECULATIVE, risk,
+                SecurityLevel.CLEAN, JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+    }
+
+    @Test
+    @DisplayName("MEDIUM 감정 확인 턴은 검토된 첫 문장을 받는다")
+    void emotionCheckTurnGetsAPrefix() {
+        PolicyDecision turn = plannedTurn(GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM);
+
+        assertThat(turn.responsePlan().responseAct()).isEqualTo(ResponseAct.EMOTION_CHECK);
+        assertThat(catalog.select(turn)).contains("지금 마음이 많이 무거우실 것 같아요.");
+    }
+
+    @Test
+    @DisplayName("룰이 승격한 맥락 확인 턴도 검토된 첫 문장을 받는다")
+    void clarifyContextTurnGetsAPrefix() {
+        PolicyDecision turn = plannedTurn(GenerationMode.SUPPORTIVE, RiskLevel.LOW);
+
+        assertThat(turn.responsePlan().responseAct()).isEqualTo(ResponseAct.CLARIFY_CONTEXT);
+        assertThat(catalog.select(turn)).isPresent();
+    }
+
+    @Test
+    @DisplayName("위기 고정 플로우와 보안 거절에는 아무것도 덧붙이지 않는다")
+    void fixedServerCopyPathsNeverGetAPrefix() {
+        PolicyDecision crisis = decision(DecisionAction.CRISIS_FLOW, GenerationMode.CRISIS,
+                DeliveryMode.CRISIS_FLOW, RiskLevel.HARD_CRISIS, SecurityLevel.CLEAN,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+        PolicyDecision refusal = decision(DecisionAction.SECURITY_REFUSAL, GenerationMode.CRISIS,
+                DeliveryMode.SECURITY_REFUSAL, RiskLevel.ATTACK, SecurityLevel.ATTACK,
+                JudgeStatus.SKIPPED, ModerationStatus.RESOLVED);
+        PolicyDecision fallback = decision(DecisionAction.FALLBACK, GenerationMode.CRISIS,
+                DeliveryMode.BUFFER, RiskLevel.MEDIUM, SecurityLevel.CLEAN,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+
+        assertThat(catalog.select(crisis)).isEmpty();
+        assertThat(catalog.select(refusal)).isEmpty();
+        assertThat(catalog.select(fallback)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("HIGH 위험 턴에는 붙이지 않는다 — 위기 승격 시 화면에 남는다")
+    void highRiskTurnsNeverGetAPrefix() {
+        PolicyDecision high = decision(DecisionAction.GENERATE, GenerationMode.GUARDED,
+                DeliveryMode.BUFFER, RiskLevel.HIGH, SecurityLevel.CLEAN,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+
+        assertThat(high.responsePlan().responseAct()).isEqualTo(ResponseAct.EMPATHIC_REFLECTION);
+        assertThat(catalog.select(high)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("판정을 받지 못한 보수 경로에는 붙이지 않는다")
+    void conservativePathsWithoutAVerdictNeverGetAPrefix() {
+        PolicyDecision judgeFailed = decision(DecisionAction.GENERATE, GenerationMode.GUARDED,
+                DeliveryMode.BUFFER, RiskLevel.MEDIUM, SecurityLevel.CLEAN,
+                JudgeStatus.FAILED, ModerationStatus.RESOLVED);
+        PolicyDecision moderationUnresolved = decision(DecisionAction.GENERATE,
+                GenerationMode.SUPPORTIVE, DeliveryMode.CAUTIOUS_SPECULATIVE, RiskLevel.MEDIUM,
+                SecurityLevel.CLEAN, JudgeStatus.SUCCEEDED, ModerationStatus.UNRESOLVED);
+
+        assertThat(catalog.select(judgeFailed)).isEmpty();
+        assertThat(catalog.select(moderationUnresolved)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("조작 의심 턴과 계약 없는 턴에는 붙이지 않는다")
+    void suspiciousAndUnplannedTurnsNeverGetAPrefix() {
+        PolicyDecision suspicious = decision(DecisionAction.GENERATE, GenerationMode.GUARDED,
+                DeliveryMode.CAUTIOUS_SPECULATIVE, RiskLevel.LOW, SecurityLevel.SUSPICIOUS,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+        PolicyDecision unplanned = decision(DecisionAction.GENERATE, GenerationMode.NORMAL,
+                DeliveryMode.CAUTIOUS_SPECULATIVE, RiskLevel.CLEAR_LOW, SecurityLevel.CLEAN,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+
+        assertThat(catalog.select(suspicious)).isEmpty();
+        assertThat(unplanned.responsePlan().responseAct()).isEqualTo(ResponseAct.UNPLANNED);
+        assertThat(catalog.select(unplanned)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("즉시 스트리밍 턴에는 메울 대기가 없으므로 붙이지 않는다")
+    void immediateStreamingTurnsNeverGetAPrefix() {
+        PolicyDecision speculative = decision(DecisionAction.GENERATE, GenerationMode.SUPPORTIVE,
+                DeliveryMode.SPECULATIVE, RiskLevel.LOW, SecurityLevel.CLEAN,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED);
+
+        assertThat(catalog.select(speculative)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("선택이 실패해도 턴은 실패하지 않는다")
+    void selectionFailureFallsBackToNoPrefix() {
+        assertThat(catalog.select(null)).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    @DisplayName("검토된 문구는 질문 없는 한 문장이고 금지 표현을 포함하지 않는다")
+    void reviewedCopyObeysTheCopyConstraints() {
+        assertThat(catalog.reviewedCopy()).isNotEmpty();
+        catalog.reviewedCopy().forEach((act, copy) -> {
+            assertThat(copy).as("%s 문구는 질문을 포함하지 않는다 — 계약이 허용한 질문은 모델 몫이다", act)
+                    .doesNotContain("?").doesNotContain("？");
+            assertThat(copy.split("[.!?。！？]")).as("%s 문구는 한 문장이다", act)
+                    .hasSize(1);
+            // 서버 문구라도 출력 사전 필터 기준을 통과해야 한다. 위기 맥락에서도 가벼운
+            // 응답으로 분류되면 안 된다 — 그 문구가 위기 턴의 첫 화면이 될 수 있다.
+            assertThat(outputPreFilter.checkWithCrisisContext(copy, true).passed())
+                    .as("%s 문구가 출력 사전 필터에 걸린다", act)
+                    .isTrue();
+            // 진단·단정·결과 보장 금지는 모델 출력에만 적용되는 규칙이 아니다. 서버가 쓴
+            // 문장이 같은 기준을 어기면 검토됐다는 말이 의미를 잃는다.
+            assertThat(contractValidator.validate(
+                    new ResponsePlan(act, GenerationFreedom.CONSTRAINED, 0, 1,
+                            ResponsePlan.BASE_FORBIDDEN),
+                    copy).violations())
+                    .as("%s 문구가 계약 금지 표현에 걸린다", act)
+                    .isEmpty();
+        });
+    }
+}

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -470,6 +470,8 @@ class AiDecisionLoggerTest {
                 null,
                 ResponseContractResult.notApplicable(),
                 -1,
+                -1,
+                false,
                 0,
                 memoryResult
         );

--- a/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiTurnMetricsTest.java
@@ -31,7 +31,7 @@ class AiTurnMetricsTest {
     private final AiTurnMetrics metrics = new AiTurnMetrics(registry);
 
     @Test
-    @DisplayName("턴 전체·LLM TTFT·첫 실질 노출 지연을 histogram으로 기록한다")
+    @DisplayName("턴 전체·LLM TTFT·첫 실질 노출·첫 렌더 지연을 histogram으로 기록한다")
     void recordsLatencyHistograms() {
         PolicyDecision decision = constrainedDecision();
 
@@ -41,6 +41,7 @@ class AiTurnMetricsTest {
                 1_800,
                 240,
                 520,
+                180,
                 37,
                 "stop");
 
@@ -53,6 +54,9 @@ class AiTurnMetricsTest {
         Timer firstSubstantive = registry.find("mio.ai.turn.first.substantive")
                 .tags("delivery_mode", "cautious_speculative")
                 .timer();
+        Timer firstRendered = registry.find("mio.ai.turn.first.rendered")
+                .tags("response_act", "emotion_check", "delivery_mode", "cautious_speculative")
+                .timer();
         DistributionSummary heldBack = registry.find("mio.ai.turn.held.back.chars")
                 .tags("delivery_mode", "cautious_speculative", "outcome", "stop")
                 .summary();
@@ -64,6 +68,10 @@ class AiTurnMetricsTest {
         assertThat(ttft.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(240);
         assertThat(firstSubstantive).isNotNull();
         assertThat(firstSubstantive.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(520);
+        // safe prefix 가 나간 턴은 두 지연이 갈라진다 (P0-4). 같은 값으로 기록되면 서버가
+        // 먼저 보낸 문구가 첫 실질 토큰 지연까지 좋아 보이게 만든다.
+        assertThat(firstRendered).isNotNull();
+        assertThat(firstRendered.totalTime(TimeUnit.MILLISECONDS)).isEqualTo(180);
         assertThat(heldBack).isNotNull();
         assertThat(heldBack.totalAmount()).isEqualTo(37);
     }
@@ -78,6 +86,7 @@ class AiTurnMetricsTest {
                 ResponseContractResult.violated(List.of("question_limit")),
                 900,
                 100,
+                300,
                 300,
                 12,
                 "crisis_flow");
@@ -111,6 +120,7 @@ class AiTurnMetricsTest {
                 100,
                 -1,
                 -1,
+                -1,
                 0,
                 "session-05619207-f2d2-43ea-bc87-a7c59ac8afa3");
 
@@ -137,6 +147,7 @@ class AiTurnMetricsTest {
                 1_800,
                 240,
                 520,
+                180,
                 37,
                 "stop");
 
@@ -144,6 +155,7 @@ class AiTurnMetricsTest {
                 .contains("mio_ai_turn_duration_seconds_bucket")
                 .contains("mio_ai_turn_llm_ttft_seconds_bucket")
                 .contains("mio_ai_turn_first_substantive_seconds_bucket")
+                .contains("mio_ai_turn_first_rendered_seconds_bucket")
                 .contains("mio_ai_turn_held_back_chars_bucket")
                 .contains("mio_ai_policy_decisions_total")
                 .contains("mio_ai_contract_results_total")

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -11,6 +11,9 @@ import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.llm.LlmUsage;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
+import com.mio.ai.delivery.SafePrefixCatalog;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.session.service.SessionMessagePersistenceService;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -57,6 +60,12 @@ class ConversationOrchestratorContractIntegrationTest {
 
     @Autowired
     private MeterRegistry meterRegistry;
+
+    @Autowired
+    private SafePrefixCatalog safePrefixCatalog;
+
+    @Autowired
+    private SessionMessagePersistenceService messagePersistenceService;
 
     /**
      * 인터페이스가 아니라 구현 타입을 목으로 둔다. {@code EmbeddingWorker} 가 구체 타입
@@ -239,12 +248,127 @@ class ConversationOrchestratorContractIntegrationTest {
                 .anyMatch(reason -> reason.startsWith("contract:"));
     }
 
+    // ── 검토된 safe prefix (P0-4, 로드맵 §5.6) ────────────────────────────────
+
+    @Test
+    @DisplayName("검토된 첫 문장이 모델 응답보다 먼저 전달된다")
+    void reviewedSafePrefixIsDeliveredBeforeTheGeneratedText() {
+        String reply = "지금 어떤 감정이 가장 크게 느껴지나요?";
+        streamReplies(reply);
+        RecordingEmitter emitter = new RecordingEmitter();
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "prefix-order-key");
+
+        String prefix = safePrefixCatalog.reviewedCopy().get(ResponseAct.EMOTION_CHECK);
+        String stream = emitter.joined();
+        // 사용자가 먼저 읽는 것이 서버 문구여야 한다. 순서가 뒤집히면 이 기능은 지연을
+        // 개선하지 않고 문장만 하나 늘린다.
+        assertThat(stream).contains(prefix);
+        assertThat(stream.indexOf(prefix))
+                .as("검토된 서버 문구가 생성 텍스트보다 먼저 나가야 한다")
+                .isLessThan(stream.indexOf(reply));
+        // 저장하지 않으면 재생·요약·워킹 메모리가 사용자가 읽은 것과 달라진다.
+        assertThat(storedAssistantContent("prefix-order-key"))
+                .as("서버가 보낸 문장도 이 턴의 응답이다")
+                .startsWith(prefix);
+    }
+
+    @Test
+    @DisplayName("prefix 가 붙은 턴은 첫 렌더와 첫 실질 토큰 지연이 갈라진다")
+    void renderedAndSubstantiveLatencyDivergeOnPrefixedTurns() {
+        // 생성이 즉시 끝나면 두 값이 모두 0ms 라 갈라짐을 확인할 수 없다. 실제 스트림에는
+        // 항상 존재하는 첫 토큰 지연을 명시적으로 만든다.
+        streamRepliesAfter(120L, "지금 어떤 감정이 가장 크게 느껴지나요?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        JsonNode trace = awaitTrace();
+        assertThat(trace.path("safe_prefix_applied").asBoolean()).isTrue();
+        assertThat(trace.path("first_rendered_token_ms").asLong())
+                .as("서버 문구는 첫 승인 모델 콘텐츠보다 먼저 나간다")
+                .isLessThan(trace.path("first_substantive_token_ms").asLong());
+    }
+
+    @Test
+    @DisplayName("prefix 가 없는 턴에서는 두 지연이 같다")
+    void renderedAndSubstantiveLatencyStayEqualWithoutAPrefix() {
+        // Judge 판정을 받지 못한 보수 경로 — prefix 를 붙이지 않는 턴이다.
+        when(llmClient.completeJson(any())).thenThrow(new IllegalStateException("judge down"));
+        streamRepliesAfter(120L, "무슨 일이 있었는지 조금 더 들려주실 수 있을까요?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new SseEmitter(30_000L), null);
+
+        JsonNode trace = awaitTrace();
+        assertThat(trace.path("safe_prefix_applied").asBoolean()).isFalse();
+        assertThat(trace.path("first_rendered_token_ms").asLong())
+                .as("먼저 보인 것이 없으면 처음 보이는 것이 곧 첫 승인 콘텐츠다")
+                .isEqualTo(trace.path("first_substantive_token_ms").asLong());
+    }
+
+    /**
+     * 전송된 SSE 이벤트를 그대로 모으는 emitter.
+     *
+     * <p>실제 요청 없이 {@code SseEmitter} 를 쓰면 전송이 무시되므로, 전송 순서를 보려면
+     * 여기서 가로채는 수밖에 없다. {@code super.send} 는 부르지 않는다 — 부를 대상이 없다.
+     */
+    private static final class RecordingEmitter extends SseEmitter {
+        private final List<String> parts = new java.util.ArrayList<>();
+
+        private RecordingEmitter() {
+            super(30_000L);
+        }
+
+        @Override
+        public void send(SseEventBuilder builder) {
+            builder.build().forEach(part -> parts.add(String.valueOf(part.getData())));
+        }
+
+        private String joined() {
+            return String.join("", parts);
+        }
+    }
+
+    /** 암호화 컬럼이라 서비스 경로로 읽는다. */
+    private String storedAssistantContent(String idempotencyKey) {
+        for (int attempt = 0; attempt < 50; attempt++) {
+            String content = messagePersistenceService.findTurn(sessionId, idempotencyKey)
+                    .map(turn -> turn.getAssistantMessageId())
+                    .flatMap(messagePersistenceService::loadAssistantContent)
+                    .orElse(null);
+            if (content != null) {
+                return content;
+            }
+            sleepBriefly();
+        }
+        throw new AssertionError("assistant 메시지가 저장되지 않았다");
+    }
+
+    private void sleepBriefly() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
     /** LLM 이 주어진 텍스트를 한 청크로 흘리도록 한다. */
     private void streamReplies(String reply) {
         when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
             Consumer<String> chunkHandler = invocation.getArgument(1);
             chunkHandler.accept(reply);
             return new LlmStreamResult(10L, LlmUsage.unresolved("gpt-4o"), false);
+        });
+    }
+
+    /** 첫 토큰까지의 지연이 있는 스트림. 실제 생성에는 항상 이 구간이 있다. */
+    private void streamRepliesAfter(long ttftMs, String reply) {
+        when(llmClient.stream(any(), any())).thenAnswer(invocation -> {
+            Thread.sleep(ttftMs);
+            Consumer<String> chunkHandler = invocation.getArgument(1);
+            chunkHandler.accept(reply);
+            return new LlmStreamResult(ttftMs, LlmUsage.unresolved("gpt-4o"), false);
         });
     }
 

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -13,8 +13,10 @@ import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.delivery.SafePrefixCatalog;
 import com.mio.ai.plan.ResponseAct;
+import com.mio.session.domain.MessageTurn;
 import com.mio.session.service.SessionMessagePersistenceService;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +29,8 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -101,6 +105,27 @@ class ConversationOrchestratorContractIntegrationTest {
             """;
 
     /**
+     * 룰이 위험 후보로 올렸지만 Judge 가 내린 턴을 만드는 판정 (이슈 #298).
+     *
+     * <p>{@code CLARIFY_CONTEXT} 계약이 붙고 룰 승격 때문에 전달은 {@code CAUTIOUS_SPECULATIVE}
+     * 가 된다 — prefix 를 받는 두 번째 행위다.
+     */
+    private static final String LOW_RISK_VERDICT = """
+            {
+              "security": {"level": "CLEAN", "attack_types": [], "require_output_security_guard": false},
+              "risk": {
+                "risk_level": "LOW",
+                "risk_types": [],
+                "crisis_attribution": "NONE",
+                "recommended_generation_mode": "NORMAL",
+                "recommended_delivery": "SPECULATIVE",
+                "require_output_safety_guard": false
+              },
+              "confidence": 0.8
+            }
+            """;
+
+    /**
      * SafetyL1 의 위험 키워드를 건드려 룰이 Judge 를 부르게 하는 발화.
      *
      * <p><b>{@code SafetyL1.RISK_KEYWORDS} 의 "사라지고싶다" 에 의존한다.</b> 그 목록은 튜닝
@@ -134,6 +159,12 @@ class ConversationOrchestratorContractIntegrationTest {
 
     @AfterEach
     void tearDown() {
+        // 위기로 끝난 턴은 sessions 를 참조하는 행을 남긴다. 정리하지 않으면 위기 승격
+        // 테스트가 검증에 성공하고도 teardown 에서 FK 위반으로 실패한다.
+        jdbcTemplate.update("DELETE FROM crisis_flow_transitions WHERE session_id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM crisis_flow_states WHERE session_id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM crisis_todo_safety_states WHERE session_id = ?", sessionId);
+        jdbcTemplate.update("DELETE FROM crisis_events WHERE session_id = ?", sessionId);
         jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", sessionId);
         jdbcTemplate.update("DELETE FROM users WHERE id = ?", userId);
     }
@@ -307,6 +338,144 @@ class ConversationOrchestratorContractIntegrationTest {
                 .isEqualTo(trace.path("first_substantive_token_ms").asLong());
     }
 
+    @Test
+    @DisplayName("prefix 전송이 실패하면 문장 예산을 깎지 않는다")
+    void failedPrefixDeliveryKeepsTheOriginalSentenceBudget() {
+        streamReplies("지금 어떤 감정이 가장 크게 느껴지나요?");
+        String prefix = new SafePrefixCatalog().reviewedCopy().get(ResponseAct.EMOTION_CHECK);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new PrefixRejectingEmitter(prefix), null);
+
+        // 나가지 않은 문장을 예산에서 빼면 사용자는 보상 없이 한 문장 짧은 응답을 받는다.
+        // 프롬프트 지시와 계약 상한은 언제나 같은 조건을 봐야 한다.
+        String systemPrompt = capturedSystemPrompt();
+        assertThat(systemPrompt).doesNotContain("[이미 전달됨]");
+        assertThat(systemPrompt)
+                .as("전달되지 않은 prefix 는 문장 예산을 깎지 않는다")
+                .contains("전체 4문장");
+    }
+
+    @Test
+    @DisplayName("prefix 가 전달된 턴만 문장 예산을 하나 줄인다")
+    void deliveredPrefixReducesTheSentenceBudget() {
+        streamReplies("지금 어떤 감정이 가장 크게 느껴지나요?");
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new RecordingEmitter(), null);
+
+        String systemPrompt = capturedSystemPrompt();
+        assertThat(systemPrompt).contains("[이미 전달됨]");
+        assertThat(systemPrompt)
+                .as("사용자가 읽는 총 문장 수는 원래 계약 안에 있어야 한다")
+                .contains("전체 3문장");
+    }
+
+    /** prefix 문구만 전송에 실패하는 emitter — 연결이 끊긴 순간을 재현한다. */
+    private static final class PrefixRejectingEmitter extends SseEmitter {
+        private final String rejected;
+
+        private PrefixRejectingEmitter(String rejected) {
+            super(30_000L);
+            this.rejected = rejected;
+        }
+
+        @Override
+        public void send(SseEventBuilder builder) throws IOException {
+            StringBuilder frame = new StringBuilder();
+            builder.build().forEach(part -> frame.append(String.valueOf(part.getData())));
+            if (frame.indexOf(rejected) >= 0) {
+                throw new IOException("connection closed");
+            }
+        }
+    }
+
+    private String capturedSystemPrompt() {
+        ArgumentCaptor<LlmRequest> request = ArgumentCaptor.forClass(LlmRequest.class);
+        org.mockito.Mockito.verify(llmClient).stream(request.capture(), any());
+        return request.getValue().messages().stream()
+                .filter(message -> "system".equals(message.role()))
+                .map(LlmRequest.Message::content)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("시스템 프롬프트가 없다"));
+    }
+
+    // ── 출력측 위기 승격 (안전 리뷰 HIGH) ──────────────────────────────────────
+    //
+    // CAUTIOUS_SPECULATIVE 의 OutputJudge 는 사전 위험 라벨이 아니라 모델이 실제로 생성한
+    // 텍스트를 보고 판정한다. 그래서 prefix 를 받는 MEDIUM·LOW 턴에서도 CRISIS_FLOW 가
+    // 나올 수 있고, 그때 나가는 것은 delta.replace 가 아니라 crisis 이벤트다. 지우지 않으면
+    // 사용자는 감정 인정 문장 바로 아래에서 핫라인을 본다.
+
+    @Test
+    @DisplayName("조기 중단 후 위기로 승격하면 서버 문구가 핫라인 위에 남지 않는다")
+    void earlyStopCrisisPromotionClearsTheRenderedPrefix() {
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.crisisFlow());
+        // 첫 문장이 사전 필터를 위반해 승인 게이트가 스트림을 멈춘다 — 조기 중단 경로.
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        RecordingEmitter emitter = new RecordingEmitter();
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, null);
+
+        assertPrefixClearedBeforeCrisis(emitter, ResponseAct.EMOTION_CHECK);
+    }
+
+    @Test
+    @DisplayName("스트림 종료 후 위기로 승격해도 서버 문구가 핫라인 위에 남지 않는다")
+    void postStreamCrisisPromotionClearsTheRenderedPrefix() {
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.crisisFlow());
+        // 사전 필터는 통과하되 계약(질문 1개)을 위반해 스트림 종료 후 판정으로 넘어간다.
+        streamReplies("그랬군요. 어떤 기분인가요? 언제부터였나요? 지금은 어떠세요?");
+        RecordingEmitter emitter = new RecordingEmitter();
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, null);
+
+        assertPrefixClearedBeforeCrisis(emitter, ResponseAct.EMOTION_CHECK);
+    }
+
+    @Test
+    @DisplayName("맥락 확인 턴이 위기로 승격해도 서버 문구가 핫라인 위에 남지 않는다")
+    void clarifyContextCrisisPromotionClearsTheRenderedPrefix() {
+        // 룰이 위험 후보로 올렸지만 Judge 가 LOW 로 내린 턴 — CLARIFY_CONTEXT 계약이 붙는다.
+        when(llmClient.completeJson(any())).thenReturn(LOW_RISK_VERDICT);
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.crisisFlow());
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        RecordingEmitter emitter = new RecordingEmitter();
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, null);
+
+        assertPrefixClearedBeforeCrisis(emitter, ResponseAct.CLARIFY_CONTEXT);
+    }
+
+    /**
+     * 위기 승격 턴의 사용자 화면 상태를 검증한다.
+     *
+     * <p>이벤트가 나갔는지가 아니라 <b>화면에 무엇이 남는지</b>로 판정한다. 지우는 이벤트가
+     * 위기 안내 뒤에 가거나 다른 msg_id 로 나가면 이벤트 목록만으로는 통과해 버린다.
+     */
+    private void assertPrefixClearedBeforeCrisis(RecordingEmitter emitter, ResponseAct act) {
+        String prefix = safePrefixCatalog.reviewedCopy().get(act);
+        List<String> names = emitter.eventNames();
+
+        assertThat(emitter.joined())
+                .as("이 턴은 애초에 prefix 를 받아야 한다 — 아니면 테스트가 아무것도 재현하지 않는다")
+                .contains(prefix);
+        assertThat(names)
+                .as("위기로 끝난 턴이어야 한다")
+                .contains("crisis");
+        assertThat(names.indexOf("delta.replace"))
+                .as("지우는 신호가 위기 안내보다 먼저 나가야 한다 — 순서는 clear → crisis → done")
+                .isBetween(0, names.indexOf("crisis"));
+        assertThat(names.get(names.size() - 1)).isEqualTo("done");
+        assertThat(emitter.renderedMessage())
+                .as("핫라인 위에 서버 문구가 남으면 안 된다")
+                .doesNotContain(prefix)
+                .isEmpty();
+    }
+
     /**
      * 전송된 SSE 이벤트를 그대로 모으는 emitter.
      *
@@ -314,7 +483,8 @@ class ConversationOrchestratorContractIntegrationTest {
      * 여기서 가로채는 수밖에 없다. {@code super.send} 는 부르지 않는다 — 부를 대상이 없다.
      */
     private static final class RecordingEmitter extends SseEmitter {
-        private final List<String> parts = new java.util.ArrayList<>();
+        /** 전송 호출 하나가 원소 하나다. 순서를 봐야 하므로 호출을 합치지 않는다. */
+        private final List<String> events = new java.util.ArrayList<>();
 
         private RecordingEmitter() {
             super(30_000L);
@@ -322,35 +492,80 @@ class ConversationOrchestratorContractIntegrationTest {
 
         @Override
         public void send(SseEventBuilder builder) {
-            builder.build().forEach(part -> parts.add(String.valueOf(part.getData())));
+            StringBuilder frame = new StringBuilder();
+            builder.build().forEach(part -> frame.append(String.valueOf(part.getData())));
+            events.add(frame.toString());
         }
 
         private String joined() {
-            return String.join("", parts);
+            return String.join("", events);
+        }
+
+        /** 전송된 이벤트 이름을 순서대로. SSE 프레임의 {@code event:<name>} 줄에서 뽑는다. */
+        private List<String> eventNames() {
+            List<String> names = new java.util.ArrayList<>();
+            for (String event : events) {
+                String name = nameOf(event);
+                if (name != null) {
+                    names.add(name);
+                }
+            }
+            return names;
+        }
+
+        /**
+         * 사용자 화면에 남는 텍스트.
+         *
+         * <p>{@code delta} 는 이어 붙이고 {@code delta.replace} 는 전부 갈아끼운다 — 그것이
+         * 이 PR 이 기대는 "메시지 전체 교체" 의미다. 위기 안내 위에 서버 문구가 남는지는
+         * 이벤트 목록이 아니라 <b>이 화면 상태</b>로 판정해야 한다.
+         */
+        private String renderedMessage() {
+            StringBuilder screen = new StringBuilder();
+            for (String event : events) {
+                String name = nameOf(event);
+                if ("delta".equals(name)) {
+                    screen.append(jsonField(event, "chunk"));
+                } else if ("delta.replace".equals(name)) {
+                    screen.setLength(0);
+                    screen.append(jsonField(event, "safe_response"));
+                }
+            }
+            return screen.toString();
+        }
+
+        private String nameOf(String event) {
+            for (String line : event.split("\n")) {
+                if (line.startsWith("event:")) {
+                    return line.substring("event:".length()).trim();
+                }
+            }
+            return null;
+        }
+
+        private String jsonField(String event, String field) {
+            String needle = "\"" + field + "\":\"";
+            int start = event.indexOf(needle);
+            if (start < 0) {
+                return "";
+            }
+            start += needle.length();
+            int end = event.indexOf('"', start);
+            return end < 0 ? "" : event.substring(start, end);
         }
     }
 
     /** 암호화 컬럼이라 서비스 경로로 읽는다. */
     private String storedAssistantContent(String idempotencyKey) {
-        for (int attempt = 0; attempt < 50; attempt++) {
-            String content = messagePersistenceService.findTurn(sessionId, idempotencyKey)
-                    .map(turn -> turn.getAssistantMessageId())
-                    .flatMap(messagePersistenceService::loadAssistantContent)
-                    .orElse(null);
-            if (content != null) {
-                return content;
-            }
-            sleepBriefly();
-        }
-        throw new AssertionError("assistant 메시지가 저장되지 않았다");
-    }
-
-    private void sleepBriefly() {
-        try {
-            Thread.sleep(100);
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-        }
+        // Awaitility 는 spring-boot-starter-test 가 함께 가져온다. 수동 sleep 루프를 하나 더
+        // 만들지 않는다 — 기존 awaitTrace() 는 이 PR 범위 밖이라 그대로 둔다.
+        return Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(100))
+                .until(() -> messagePersistenceService.findTurn(sessionId, idempotencyKey)
+                        .map(MessageTurn::getAssistantMessageId)
+                        .flatMap(messagePersistenceService::loadAssistantContent)
+                        .orElse(null), java.util.Objects::nonNull);
     }
 
     /** LLM 이 주어진 텍스트를 한 청크로 흘리도록 한다. */

--- a/src/test/java/com/mio/ai/plan/ResponsePlanTest.java
+++ b/src/test/java/com/mio/ai/plan/ResponsePlanTest.java
@@ -1,0 +1,68 @@
+package com.mio.ai.plan;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 서버가 문장 일부를 먼저 전달한 계획의 상한 계산 (P0-4, 로드맵 §5.6).
+ *
+ * <p>운영 경로는 {@code 4 - 1 = 3} 한 가지만 실행한다. 상한이 1인 계획, 예약 0·음수, 계획
+ * 범위 밖 턴은 통합 테스트로는 절대 실행되지 않으므로 여기서 고정한다 — 상한이 0이 되면
+ * 계약 검사가 모든 응답을 위반으로 세고, 그 위반은 Judge 승격으로 이어진다.
+ */
+class ResponsePlanTest {
+
+    private ResponsePlan constrained(int maxSentences) {
+        return new ResponsePlan(ResponseAct.EMOTION_CHECK, GenerationFreedom.CONSTRAINED,
+                1, maxSentences, ResponsePlan.BASE_FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("전달한 문장 수만큼 상한을 줄인다")
+    void reservesTheDeliveredSentence() {
+        assertThat(constrained(4).reservingSentences(1).maxSentences()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("상한이 1인 계획도 0으로 내려가지 않는다")
+    void neverFallsBelowOneSentence() {
+        ResponsePlan reserved = constrained(1).reservingSentences(1);
+
+        // 0이면 모델이 무엇을 쓰든 계약 위반이 된다 — 지킬 수 없는 계약은 계약이 아니다.
+        assertThat(reserved.maxSentences()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("예약이 0이거나 음수면 계획을 바꾸지 않는다")
+    void nonPositiveReservationIsANoOp() {
+        ResponsePlan plan = constrained(4);
+
+        assertThat(plan.reservingSentences(0)).isSameAs(plan);
+        assertThat(plan.reservingSentences(-2)).isSameAs(plan);
+    }
+
+    @Test
+    @DisplayName("계획 범위 밖 턴은 상한을 만들지 않는다")
+    void unplannedTurnKeepsItsUnboundedLimit() {
+        ResponsePlan unplanned = ResponsePlan.unplanned();
+
+        // 상한이 없다는 것과 상한이 큰 것은 다르다. 여기서 1을 빼면 계획하지 않은 턴에
+        // 계약이 생긴 것처럼 보이고, 준수율 통계가 그 턴까지 세기 시작한다.
+        assertThat(unplanned.reservingSentences(1)).isSameAs(unplanned);
+        assertThat(unplanned.reservingSentences(1).maxSentences()).isEqualTo(Integer.MAX_VALUE);
+    }
+
+    @Test
+    @DisplayName("줄인 계획은 행위·자유도·질문 수·금지 요소를 그대로 유지한다")
+    void reservationOnlyChangesTheSentenceLimit() {
+        ResponsePlan original = constrained(4);
+        ResponsePlan reserved = original.reservingSentences(1);
+
+        assertThat(reserved.responseAct()).isEqualTo(original.responseAct());
+        assertThat(reserved.generationFreedom()).isEqualTo(original.generationFreedom());
+        assertThat(reserved.maxQuestions()).isEqualTo(original.maxQuestions());
+        assertThat(reserved.forbiddenElements()).isEqualTo(original.forbiddenElements());
+    }
+}

--- a/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
+++ b/src/test/java/com/mio/ai/prompt/PromptBuilderTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.prompt;
 
+import com.mio.ai.delivery.SafePrefixCatalog;
 import com.mio.ai.plan.GenerationFreedom;
 import com.mio.ai.plan.ResponseAct;
 import com.mio.ai.plan.ResponsePlan;
@@ -117,6 +118,40 @@ class PromptBuilderTest {
 
         assertThat(prompt).contains("미오");
         assertThat(prompt).doesNotContain("[응답 계약]");
+    }
+
+    @Test
+    @DisplayName("서버가 첫 문장을 보낸 턴은 감정 인정을 반복하지 말라고 지시한다")
+    void safe_prefix_turn_tells_the_model_not_to_repeat_the_acknowledgement() {
+        ResponsePlan plan = new ResponsePlan(ResponseAct.EMOTION_CHECK,
+                GenerationFreedom.CONSTRAINED, 1, 3, ResponsePlan.BASE_FORBIDDEN);
+
+        String prompt = builder.buildSystemPrompt(GenerationMode.SUPPORTIVE,
+                InterventionHints.empty(), null, "mio", null, plan, true);
+
+        // 지시하지 않으면 사용자는 같은 인정을 두 번 읽는다 — 눈에 보이는 제품 퇴행이다.
+        assertThat(prompt).contains("[이미 전달됨]");
+        assertThat(prompt).contains("다시 쓰지 말고");
+    }
+
+    @Test
+    @DisplayName("서버 문구 자체는 프롬프트에 넣지 않는다")
+    void the_server_copy_itself_never_reaches_the_prompt() {
+        ResponsePlan plan = new ResponsePlan(ResponseAct.EMOTION_CHECK,
+                GenerationFreedom.CONSTRAINED, 1, 3, ResponsePlan.BASE_FORBIDDEN);
+
+        String prompt = builder.buildSystemPrompt(GenerationMode.SUPPORTIVE,
+                InterventionHints.empty(), null, "mio", null, plan, true);
+
+        // 문구를 넣으면 모델이 그대로 따라 쓰는 것이 가장 흔한 반복 실패가 된다.
+        new SafePrefixCatalog().reviewedCopy().values()
+                .forEach(copy -> assertThat(prompt).doesNotContain(copy));
+    }
+
+    @Test
+    @DisplayName("prefix 를 보내지 않은 턴에는 그 지시가 없다")
+    void turns_without_a_prefix_do_not_get_the_instruction() {
+        assertThat(promptFor(ResponseAct.EMOTION_CHECK)).doesNotContain("[이미 전달됨]");
     }
 
     private String promptFor(ResponseAct act) {

--- a/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
+++ b/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
@@ -79,7 +79,13 @@ class DeliveryExposureQaTest {
      *              얻는다 — 행위를 하네스가 직접 지정하면 계획 규칙이 바뀌어도 조용히 통과한다
      */
     private record Scenario(String name, List<String> chunks, GenerationMode mode, RiskLevel risk,
-                            DeliveryMode delivery) {}
+                            DeliveryMode delivery, boolean crisisPromotion) {
+
+        private Scenario(String name, List<String> chunks, GenerationMode mode, RiskLevel risk,
+                         DeliveryMode delivery) {
+            this(name, chunks, mode, risk, delivery, false);
+        }
+    }
 
     /**
      * 합성 스트림.
@@ -116,12 +122,24 @@ class DeliveryExposureQaTest {
                     GenerationMode.NORMAL, RiskLevel.CLEAR_LOW, DeliveryMode.CAUTIOUS_SPECULATIVE),
             new Scenario("HIGH 위험 응답", List.of(
                     "많이 힘드셨겠어요. ", "지금 안전한 곳에 계신가요?"),
-                    GenerationMode.GUARDED, RiskLevel.HIGH, DeliveryMode.BUFFER)
+                    GenerationMode.GUARDED, RiskLevel.HIGH, DeliveryMode.BUFFER),
+            // prefix 를 받는 턴에서 출력측 위기 승격이 뒤따르는 경우 (안전 리뷰 HIGH).
+            // OutputJudge 는 사전 위험 라벨이 아니라 생성된 텍스트를 보고 판정하므로 MEDIUM
+            // 턴에서도 CRISIS_FLOW 가 나온다. 그때 사용자 화면에 서버 문구가 남으면 감정 인정
+            // 문장 바로 아래에 핫라인이 붙는다.
+            new Scenario("prefix 턴이 위기로 승격", List.of(
+                    "그랬군요. ", "많이 힘드셨겠어요. ", "지금은 어떠세요?"),
+                    GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM, DeliveryMode.CAUTIOUS_SPECULATIVE,
+                    true)
     );
+
+    /** 위기 승격 시 서버가 보내는 고정 안내(축약). 실제 문구는 CrisisFlowService 가 만든다. */
+    private static final String CRISIS_FIXED_COPY = "지금 많이 힘드시겠어요. 도움을 받을 수 있는 곳이 있어요.";
 
     /** 한 시나리오의 측정 결과. */
     private record Measurement(String prefix, long renderedMs, long substantiveMs,
-                               String deliveredContent, int exposedChars, int firstUnitChars) {
+                               String deliveredContent, String finalScreen,
+                               int exposedChars, int firstUnitChars) {
 
         boolean prefixed() {
             return prefix != null;
@@ -177,6 +195,33 @@ class DeliveryExposureQaTest {
             assertThat(String.join("", scenario.chunks()))
                     .as("%s — prefix 가 모델 출력에서 왔다면 서버 문구라고 말할 수 없다",
                             scenario.name())
+                    .doesNotContain(m.prefix());
+        }
+    }
+
+    /**
+     * 위기로 승격한 턴에는 서버 문구가 화면에 남지 않는다 (안전 리뷰 HIGH).
+     *
+     * <p>{@code CAUTIOUS_SPECULATIVE} 의 OutputJudge 는 사전 위험 라벨이 아니라 생성된 텍스트를
+     * 보고 판정한다. prefix 를 받는 MEDIUM·LOW 턴에서도 {@code CRISIS_FLOW} 가 나올 수 있고,
+     * 그때 지우지 않으면 감정 인정 문장 <b>바로 아래</b>에 핫라인이 붙는다.
+     */
+    @Test
+    @DisplayName("위기로 승격한 prefix 턴은 최종 화면에 서버 문구를 남기지 않는다")
+    void crisisPromotionLeavesNoServerCopyOnScreen() throws Exception {
+        List<Scenario> promoted = SCENARIOS.stream().filter(Scenario::crisisPromotion).toList();
+
+        assertThat(promoted)
+                .as("prefix 시나리오에 위기 승격 케이스가 없으면 이 실패 모드를 재지 못한다")
+                .isNotEmpty();
+
+        for (Scenario scenario : promoted) {
+            Measurement m = measure(scenario);
+            assertThat(m.prefixed())
+                    .as("%s — 애초에 prefix 를 받는 턴이어야 의미가 있다", scenario.name())
+                    .isTrue();
+            assertThat(m.finalScreen())
+                    .as("%s — 핫라인 위에 서버 문구가 남으면 안 된다", scenario.name())
                     .doesNotContain(m.prefix());
         }
     }
@@ -286,8 +331,31 @@ class DeliveryExposureQaTest {
                 renderedMs >= 0 ? renderedMs : substantiveMs,
                 substantiveMs,
                 delivered,
+                finalScreenOf(scenario, prefix, delivered),
                 exposed,
                 firstUnitLengthOf(scenario));
+    }
+
+    /**
+     * 턴이 끝났을 때 사용자 화면에 남는 텍스트.
+     *
+     * <p>클라이언트 렌더 모델이다 — {@code delta} 는 이어 붙고 {@code delta.replace} 는 전부
+     * 갈아끼운다. 위기로 승격한 턴은 지우는 신호를 먼저 보낸 뒤 crisis 이벤트가 고정 안내를
+     * 싣는다. 그래서 최종 화면에는 서버 문구가 남지 않는다.
+     *
+     * <p><b>이 계산이 오케스트레이터를 검증하지는 않는다.</b> 실제 배선은
+     * {@code ConversationOrchestratorContractIntegrationTest} 가 SSE 순서로 확인한다. 여기서는
+     * prefix 시나리오 집합에 위기 승격 케이스를 포함시켜, 지연 표가 "사용자가 결국 무엇을
+     * 보는가"까지 함께 보여주도록 한다.
+     */
+    private String finalScreenOf(Scenario scenario, String prefix, String delivered) {
+        if (scenario.crisisPromotion()) {
+            return CRISIS_FIXED_COPY;
+        }
+        if (prefix == null) {
+            return delivered;
+        }
+        return delivered.isEmpty() ? prefix : prefix + " " + delivered;
     }
 
     /** 실제 계획 규칙을 태운 정책 결정. 응답 행위를 하네스가 지정하지 않는다. */
@@ -349,19 +417,22 @@ class DeliveryExposureQaTest {
         out.append("\n══════════════════════════════════════════════════════════════\n");
         out.append("  첫 화면 지연 vs 첫 실질 토큰 지연 (P0-4)\n");
         out.append("══════════════════════════════════════════════════════════════\n");
-        out.append("  %-24s %7s %9s %11s %9s%n"
-                .formatted("시나리오", "prefix", "첫 화면", "첫 실질 토큰", "개선"));
-        measured.forEach((name, m) -> out.append("  %-24s %7s %7dms %9dms %7s%n".formatted(
+        out.append("  %-24s %7s %9s %11s %9s %14s%n"
+                .formatted("시나리오", "prefix", "첫 화면", "첫 실질 토큰", "개선", "최종 화면"));
+        measured.forEach((name, m) -> out.append("  %-24s %7s %7dms %9dms %7s %14s%n".formatted(
                 name,
                 m.prefixed() ? "O" : "-",
                 m.renderedMs(),
                 m.substantiveMs(),
-                m.deltaMs() < 0 ? "미전달" : m.deltaMs() + "ms")));
+                m.deltaMs() < 0 ? "미전달" : m.deltaMs() + "ms",
+                m.prefixed() && !m.finalScreen().contains(m.prefix()) ? "prefix 지워짐" : "유지")));
         out.append("\n  가상 시계 기준. 첫 생성 토큰 %dms + 초당 %.0f자를 가정했고, 승인 단위 판정은\n"
                 .formatted(ASSUMED_TTFT_MS, ASSUMED_CHARS_PER_SECOND));
         out.append("  실제 HoldbackDelivery·OutputPreFilter·SafePrefixCatalog 가 수행한다.\n");
         out.append("  \"미전달\"은 승인된 모델 콘텐츠가 하나도 없었던 턴이다 — 그 턴에서 사용자가\n");
         out.append("  본 것은 서버 문구뿐이고, 나머지는 교체 경로가 처리한다.\n");
+        out.append("  \"prefix 지워짐\"은 위기로 승격해 화면 전체가 고정 안내로 교체된 턴이다 —\n");
+        out.append("  핫라인 위에 감정 인정 문장이 남지 않아야 한다.\n");
         out.append("  실제 값은 운영 trace 의 first_rendered_token_ms / first_substantive_token_ms\n");
         out.append("  로 대체돼야 한다.\n");
         out.append("══════════════════════════════════════════════════════════════\n");

--- a/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
+++ b/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
@@ -2,11 +2,11 @@ package com.mio.ai.qa;
 
 import com.mio.ai.delivery.ApprovedUnitBuffer;
 import com.mio.ai.delivery.HoldbackDelivery;
+import com.mio.ai.delivery.SafePrefixCatalog;
 import com.mio.ai.judge.OutputPreFilter;
 import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.judge.RiskLevel;
 import com.mio.ai.moderation.ModerationStatus;
-import com.mio.ai.plan.ResponseAct;
 import com.mio.ai.plan.ResponsePlan;
 import com.mio.ai.plan.ResponsePlanner;
 import com.mio.ai.policy.DecisionAction;
@@ -39,10 +39,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 계산한다 — 첫 검사가 200자 시점이므로, 그 전에 도착한 문자는 전부 검사 없이 전달됐다.
  *
  * <p>지연은 <b>가상 시계</b>로 잰다. 실제 시계로 재면 CI 부하에 따라 값이 흔들려 회귀와
- * 잡음을 구분할 수 없다. 시계는 가정이지만 측정 대상인 {@link HoldbackDelivery} 는 실제
- * 구현이다 — 하네스가 흉내 내는 것은 시간뿐이다.
+ * 잡음을 구분할 수 없다. 시계는 가정이지만 측정 대상인 {@link HoldbackDelivery}·
+ * {@link SafePrefixCatalog} 는 실제 구현이다 — 하네스가 흉내 내는 것은 시간뿐이다.
  */
-@DisplayName("[QA] 전달 노출·첫 화면 지연 — 승인 단위 holdback")
+@DisplayName("[QA] 전달 노출·첫 화면 지연 — 승인 단위 holdback + safe prefix")
 class DeliveryExposureQaTest {
 
     /** 이전 구현의 사후 검사 간격. 비교 기준으로만 쓴다. */
@@ -67,13 +67,11 @@ class DeliveryExposureQaTest {
      */
     private static final long ASSUMED_TTFT_MS = 600;
 
-
     /** 서버 문구 전송에 드는 시간. 메모리에 있는 문자열 하나를 SSE 로 쓰는 비용이다. */
-    /** safe prefix 대상 응답 행위 — 로드맵 §5.6 이 예로 든 자유도가 낮은 행위. */
-    private static final java.util.Set<ResponseAct> PREFIX_ELIGIBLE_ACTS =
-            java.util.Set.of(ResponseAct.EMOTION_CHECK, ResponseAct.CLARIFY_CONTEXT);
+    private static final long PREFIX_SEND_MS = 0;
 
     private final OutputPreFilter outputPreFilter = new OutputPreFilter();
+    private final SafePrefixCatalog safePrefixCatalog = new SafePrefixCatalog();
     private final ResponsePlanner responsePlanner = new ResponsePlanner();
 
     /**
@@ -122,8 +120,12 @@ class DeliveryExposureQaTest {
     );
 
     /** 한 시나리오의 측정 결과. */
-    private record Measurement(boolean prefixEligible, long renderedMs, long substantiveMs,
+    private record Measurement(String prefix, long renderedMs, long substantiveMs,
                                String deliveredContent, int exposedChars, int firstUnitChars) {
+
+        boolean prefixed() {
+            return prefix != null;
+        }
 
         /** 첫 화면과 첫 실질 콘텐츠의 차이. 아무것도 전달되지 않았으면 잴 수 없다. */
         long deltaMs() {
@@ -154,6 +156,31 @@ class DeliveryExposureQaTest {
                 .allMatch(chars -> chars == 0);
     }
 
+    /**
+     * 서버가 먼저 보내는 문장은 <b>모델 출력이 아니다.</b>
+     *
+     * <p>이 구분이 무너지면 P0-4 는 "검사 전에 내보내도 되는 예외"를 만든 작업이 된다. 위
+     * 노출 0 보장은 전달된 텍스트를 다시 검사해서 재므로, prefix 를 모델 경로로 흘려보내면
+     * 그 테스트가 아니라 이 테스트가 먼저 깨지도록 둔다.
+     */
+    @Test
+    @DisplayName("먼저 전달되는 문장은 서버가 검토한 고정 문구뿐이다")
+    void onlyServerAuthoredCopyIsDeliveredBeforeVerification() throws Exception {
+        for (Scenario scenario : SCENARIOS) {
+            Measurement m = measure(scenario);
+            if (!m.prefixed()) {
+                continue;
+            }
+            assertThat(safePrefixCatalog.reviewedCopy().values())
+                    .as("%s — 검토 목록에 없는 문장이 먼저 나갔다", scenario.name())
+                    .contains(m.prefix());
+            assertThat(String.join("", scenario.chunks()))
+                    .as("%s — prefix 가 모델 출력에서 왔다면 서버 문구라고 말할 수 없다",
+                            scenario.name())
+                    .doesNotContain(m.prefix());
+        }
+    }
+
     @Test
     @DisplayName("safe prefix 가 붙은 턴은 첫 화면 지연이 첫 실질 토큰보다 앞선다")
     void safePrefixMakesRenderedAndSubstantiveLatencyDiverge() throws Exception {
@@ -162,15 +189,15 @@ class DeliveryExposureQaTest {
         printLatencyReport(measured);
 
         List<String> prefixed = measured.entrySet().stream()
-                .filter(entry -> entry.getValue().prefixEligible())
+                .filter(entry -> entry.getValue().prefixed())
                 .map(Map.Entry::getKey)
                 .toList();
         List<String> plain = measured.entrySet().stream()
-                .filter(entry -> !entry.getValue().prefixEligible())
+                .filter(entry -> !entry.getValue().prefixed())
                 .map(Map.Entry::getKey)
                 .toList();
 
-        assertThat(prefixed).as("prefix 대상 시나리오가 하나도 없다 — 계획 규칙이 바뀐 것이다").isNotEmpty();
+        assertThat(prefixed).as("prefix 가 붙는 시나리오가 하나도 없다 — 배선이 끊겼다").isNotEmpty();
         assertThat(plain).as("대조군이 없으면 갈라짐이 배선 때문인지 알 수 없다").isNotEmpty();
 
         for (String name : prefixed) {
@@ -227,8 +254,7 @@ class DeliveryExposureQaTest {
      */
     private Measurement measure(Scenario scenario) throws Exception {
         PolicyDecision decision = decisionFor(scenario);
-        boolean prefixEligible = PREFIX_ELIGIBLE_ACTS.contains(decision.responsePlan().responseAct())
-                && decision.deliveryMode() == DeliveryMode.CAUTIOUS_SPECULATIVE;
+        String prefix = safePrefixCatalog.select(decision).orElse(null);
 
         AtomicLong clockMs = new AtomicLong(0);
         List<String> sent = new ArrayList<>();
@@ -238,8 +264,8 @@ class DeliveryExposureQaTest {
                 sent::add,
                 clockMs::get);
 
-        // 아직 서버가 먼저 보내는 문장이 없다. 사용자가 처음 보는 것은 첫 승인 단위이므로
-        // 첫 화면 지연과 첫 실질 토큰 지연은 같은 값이다 — 그것이 이 커밋이 재현하는 상태다.
+        long renderedMs = prefix != null ? PREFIX_SEND_MS : -1;
+
         // 생성은 prefix 와 무관하게 진행된다 — 서버가 먼저 보내는 것은 전달이지 생성이 아니다.
         clockMs.set(ASSUMED_TTFT_MS);
         String generated = String.join("", scenario.chunks());
@@ -256,8 +282,8 @@ class DeliveryExposureQaTest {
         int exposed = outputPreFilter.check(delivered).passed() ? 0 : delivered.length();
 
         return new Measurement(
-                prefixEligible,
-                substantiveMs,
+                prefix,
+                renderedMs >= 0 ? renderedMs : substantiveMs,
                 substantiveMs,
                 delivered,
                 exposed,
@@ -327,13 +353,13 @@ class DeliveryExposureQaTest {
                 .formatted("시나리오", "prefix", "첫 화면", "첫 실질 토큰", "개선"));
         measured.forEach((name, m) -> out.append("  %-24s %7s %7dms %9dms %7s%n".formatted(
                 name,
-                m.prefixEligible() ? "O" : "-",
+                m.prefixed() ? "O" : "-",
                 m.renderedMs(),
                 m.substantiveMs(),
                 m.deltaMs() < 0 ? "미전달" : m.deltaMs() + "ms")));
         out.append("\n  가상 시계 기준. 첫 생성 토큰 %dms + 초당 %.0f자를 가정했고, 승인 단위 판정은\n"
                 .formatted(ASSUMED_TTFT_MS, ASSUMED_CHARS_PER_SECOND));
-        out.append("  실제 HoldbackDelivery·OutputPreFilter 가 수행한다.\n");
+        out.append("  실제 HoldbackDelivery·OutputPreFilter·SafePrefixCatalog 가 수행한다.\n");
         out.append("  \"미전달\"은 승인된 모델 콘텐츠가 하나도 없었던 턴이다 — 그 턴에서 사용자가\n");
         out.append("  본 것은 서버 문구뿐이고, 나머지는 교체 경로가 처리한다.\n");
         out.append("  실제 값은 운영 trace 의 first_rendered_token_ms / first_substantive_token_ms\n");

--- a/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
+++ b/src/test/java/com/mio/ai/qa/DeliveryExposureQaTest.java
@@ -4,6 +4,18 @@ import com.mio.ai.delivery.ApprovedUnitBuffer;
 import com.mio.ai.delivery.HoldbackDelivery;
 import com.mio.ai.judge.OutputPreFilter;
 import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.moderation.ModerationStatus;
+import com.mio.ai.plan.ResponseAct;
+import com.mio.ai.plan.ResponsePlan;
+import com.mio.ai.plan.ResponsePlanner;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.JudgeStatus;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.security.SecurityLevel;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -11,20 +23,26 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * 검증 전 노출 측정 (이슈 #306, 로드맵 §12 P0-4).
+ * 검증 전 노출과 첫 화면 지연 측정 (이슈 #306 · P0-4, 로드맵 §12).
  *
  * <p>P0-4의 완료 조건은 "위해 노출 증가 없이 지연 개선"이다. 그 판정에 생성 LLM 은 필요
  * 없다 — 전달 컨트롤러에 합성 스트림을 흘리면 <b>검사를 통과하지 않은 채 몇 글자가
- * 전달되는지</b>를 결정론적으로 잴 수 있다. 과금 없이 회귀 게이트로 쓸 수 있어야 한다.
+ * 전달되는지</b>와 <b>사용자가 첫 글자를 보기까지 얼마나 걸리는지</b>를 결정론적으로 잴 수
+ * 있다. 과금 없이 회귀 게이트로 쓸 수 있어야 한다.
  *
  * <p>비교 대상인 기존 방식(200자 간격 사후 검사)의 노출량은 코드를 남기지 않고 정의로
  * 계산한다 — 첫 검사가 200자 시점이므로, 그 전에 도착한 문자는 전부 검사 없이 전달됐다.
+ *
+ * <p>지연은 <b>가상 시계</b>로 잰다. 실제 시계로 재면 CI 부하에 따라 값이 흔들려 회귀와
+ * 잡음을 구분할 수 없다. 시계는 가정이지만 측정 대상인 {@link HoldbackDelivery} 는 실제
+ * 구현이다 — 하네스가 흉내 내는 것은 시간뿐이다.
  */
-@DisplayName("[QA] 전달 노출 — 승인 단위 holdback")
+@DisplayName("[QA] 전달 노출·첫 화면 지연 — 승인 단위 holdback")
 class DeliveryExposureQaTest {
 
     /** 이전 구현의 사후 검사 간격. 비교 기준으로만 쓴다. */
@@ -39,9 +57,31 @@ class DeliveryExposureQaTest {
      */
     private static final double ASSUMED_CHARS_PER_SECOND = 30.0;
 
-    private final OutputPreFilter outputPreFilter = new OutputPreFilter();
+    /**
+     * 첫 생성 토큰까지의 가정 지연.
+     *
+     * <p>safe prefix 가 메우는 구간은 "첫 생성 토큰까지" 와 "첫 승인 단위까지" 를 합한 시간이다.
+     * 앞쪽은 모델·프롬프트·cold start 에 달려 있어 이 하네스가 잴 수 없으므로 값을 가정한다.
+     * 이 값이 크든 작든 <b>prefix 가 만드는 차이의 방향</b>은 바뀌지 않는다 — prefix 는 두
+     * 구간 모두의 앞에 나가기 때문이다.
+     */
+    private static final long ASSUMED_TTFT_MS = 600;
 
-    private record Scenario(String name, List<String> chunks, boolean violating) {}
+
+    /** 서버 문구 전송에 드는 시간. 메모리에 있는 문자열 하나를 SSE 로 쓰는 비용이다. */
+    /** safe prefix 대상 응답 행위 — 로드맵 §5.6 이 예로 든 자유도가 낮은 행위. */
+    private static final java.util.Set<ResponseAct> PREFIX_ELIGIBLE_ACTS =
+            java.util.Set.of(ResponseAct.EMOTION_CHECK, ResponseAct.CLARIFY_CONTEXT);
+
+    private final OutputPreFilter outputPreFilter = new OutputPreFilter();
+    private final ResponsePlanner responsePlanner = new ResponsePlanner();
+
+    /**
+     * @param mode  이 턴의 생성 모드·위험도. 실제 {@code ResponsePlanner} 를 태워 응답 행위를
+     *              얻는다 — 행위를 하네스가 직접 지정하면 계획 규칙이 바뀌어도 조용히 통과한다
+     */
+    private record Scenario(String name, List<String> chunks, GenerationMode mode, RiskLevel risk,
+                            DeliveryMode delivery) {}
 
     /**
      * 합성 스트림.
@@ -52,61 +92,104 @@ class DeliveryExposureQaTest {
     private static final List<Scenario> SCENARIOS = List.of(
             new Scenario("정상 공감 응답", List.of(
                     "많이 지치셨겠어요. ", "그런 날은 누구에게나 있어요. ",
-                    "지금 어떤 기분이 가장 크게 느껴지나요?"), false),
+                    "지금 어떤 기분이 가장 크게 느껴지나요?"),
+                    GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM, DeliveryMode.CAUTIOUS_SPECULATIVE),
             new Scenario("긴 정상 응답", List.of(
                     "오늘 하루가 정말 길게 느껴지셨겠어요. ",
                     "아침부터 계속 신경 쓸 일이 많았다고 하셨죠. ",
                     "그렇게 하루 종일 긴장이 이어지면 몸도 마음도 지치기 마련이에요. ",
                     "잠깐이라도 숨을 고를 틈이 있었는지 궁금해요. ",
-                    "지금은 조금 나아지셨나요?"), false),
+                    "지금은 조금 나아지셨나요?"),
+                    GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM, DeliveryMode.CAUTIOUS_SPECULATIVE),
             new Scenario("첫 문장이 위반", List.of(
-                    "당신은 우울증이에요. ", "하지만 곧 좋아질 거예요. ", "힘내세요."), true),
+                    "당신은 우울증이에요. ", "하지만 곧 좋아질 거예요. ", "힘내세요."),
+                    GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM, DeliveryMode.CAUTIOUS_SPECULATIVE),
             new Scenario("중간 문장이 위반", List.of(
                     "그랬군요. ", "많이 힘드셨겠어요. ",
-                    "당신은 불안장애 증상이 있어요. ", "그래도 괜찮아요."), true),
+                    "당신은 불안장애 증상이 있어요. ", "그래도 괜찮아요."),
+                    GenerationMode.SUPPORTIVE, RiskLevel.LOW, DeliveryMode.CAUTIOUS_SPECULATIVE),
             new Scenario("종결 부호 없는 긴 출력", List.of(
-                    "아주 긴 문장이 종결 부호 없이 계속 이어지는 경우도 있어요 ".repeat(6)), false)
+                    "아주 긴 문장이 종결 부호 없이 계속 이어지는 경우도 있어요 ".repeat(6)),
+                    GenerationMode.SUPPORTIVE, RiskLevel.MEDIUM, DeliveryMode.CAUTIOUS_SPECULATIVE),
+            // prefix 가 붙지 않는 대조군. 붙는 턴만 재면 "두 값이 갈라진다"가 배선 때문인지
+            // 하네스가 항상 그렇게 계산하기 때문인지 구분할 수 없다.
+            new Scenario("계획 밖 일반 대화", List.of(
+                    "그랬군요. ", "오늘은 어떤 하루였는지 더 들려주실래요?"),
+                    GenerationMode.NORMAL, RiskLevel.CLEAR_LOW, DeliveryMode.CAUTIOUS_SPECULATIVE),
+            new Scenario("HIGH 위험 응답", List.of(
+                    "많이 힘드셨겠어요. ", "지금 안전한 곳에 계신가요?"),
+                    GenerationMode.GUARDED, RiskLevel.HIGH, DeliveryMode.BUFFER)
     );
+
+    /** 한 시나리오의 측정 결과. */
+    private record Measurement(boolean prefixEligible, long renderedMs, long substantiveMs,
+                               String deliveredContent, int exposedChars, int firstUnitChars) {
+
+        /** 첫 화면과 첫 실질 콘텐츠의 차이. 아무것도 전달되지 않았으면 잴 수 없다. */
+        long deltaMs() {
+            return substantiveMs < 0 ? -1 : substantiveMs - renderedMs;
+        }
+    }
 
     @Test
     @DisplayName("검사를 통과하지 않은 문자는 사용자에게 전달되지 않는다")
     void noContentIsDeliveredBeforeItPassesTheCheck() throws Exception {
-        Map<String, Integer> holdbackExposure = new LinkedHashMap<>();
-        Map<String, Integer> legacyExposure = new LinkedHashMap<>();
-        Map<String, Integer> firstUnitChars = new LinkedHashMap<>();
+        Map<String, Measurement> measured = measureAll();
         List<String> leaked = new ArrayList<>();
 
-        for (Scenario scenario : SCENARIOS) {
-            List<String> sent = new ArrayList<>();
-            HoldbackDelivery holdback = new HoldbackDelivery(
-                    new ApprovedUnitBuffer(),
-                    candidate -> outputPreFilter.check(candidate).passed(),
-                    sent::add);
-
-            holdback.consume(scenario.chunks());
-
-            String delivered = String.join("", sent);
-            OutputPreFilterResult deliveredCheck = outputPreFilter.check(delivered);
-            if (!delivered.isEmpty() && !deliveredCheck.passed()) {
-                leaked.add("%s → %s".formatted(scenario.name(), deliveredCheck.failReasons()));
+        measured.forEach((name, m) -> {
+            OutputPreFilterResult deliveredCheck = outputPreFilter.check(m.deliveredContent());
+            if (!m.deliveredContent().isEmpty() && !deliveredCheck.passed()) {
+                leaked.add("%s → %s".formatted(name, deliveredCheck.failReasons()));
             }
+        });
 
-            // 노출은 상수가 아니라 결과로 잰다 — 전달된 텍스트를 다시 검사해서 통과하지 않는
-            // 내용이 섞였는지 본다. 값이 아니라 결과로 확인해야 게이트를 우회하는 변경을 잡는다.
-            holdbackExposure.put(scenario.name(),
-                    deliveredCheck.passed() ? 0 : delivered.length());
-            legacyExposure.put(scenario.name(), legacyExposureOf(scenario));
-            firstUnitChars.put(scenario.name(), firstUnitLengthOf(scenario));
-        }
-
-        printReport(holdbackExposure, legacyExposure, firstUnitChars);
+        printExposureReport(measured);
 
         assertThat(leaked)
                 .as("검사를 통과하지 못한 내용이 전달됐다")
                 .isEmpty();
-        assertThat(holdbackExposure.values())
+        assertThat(measured.values().stream().map(Measurement::exposedChars).toList())
                 .as("승인 단위 전달에서 검증 전 노출은 0이어야 한다")
                 .allMatch(chars -> chars == 0);
+    }
+
+    @Test
+    @DisplayName("safe prefix 가 붙은 턴은 첫 화면 지연이 첫 실질 토큰보다 앞선다")
+    void safePrefixMakesRenderedAndSubstantiveLatencyDiverge() throws Exception {
+        Map<String, Measurement> measured = measureAll();
+
+        printLatencyReport(measured);
+
+        List<String> prefixed = measured.entrySet().stream()
+                .filter(entry -> entry.getValue().prefixEligible())
+                .map(Map.Entry::getKey)
+                .toList();
+        List<String> plain = measured.entrySet().stream()
+                .filter(entry -> !entry.getValue().prefixEligible())
+                .map(Map.Entry::getKey)
+                .toList();
+
+        assertThat(prefixed).as("prefix 대상 시나리오가 하나도 없다 — 계획 규칙이 바뀐 것이다").isNotEmpty();
+        assertThat(plain).as("대조군이 없으면 갈라짐이 배선 때문인지 알 수 없다").isNotEmpty();
+
+        for (String name : prefixed) {
+            Measurement m = measured.get(name);
+            assertThat(m.renderedMs())
+                    .as("%s — 서버 문구는 생성보다 먼저 나간다", name)
+                    .isLessThan(ASSUMED_TTFT_MS);
+            if (m.substantiveMs() >= 0) {
+                assertThat(m.deltaMs())
+                        .as("%s — 두 지연이 같으면 prefix 가 사용자에게 도달하지 않았다는 뜻이다", name)
+                        .isPositive();
+            }
+        }
+        for (String name : plain) {
+            Measurement m = measured.get(name);
+            assertThat(m.renderedMs())
+                    .as("%s — prefix 가 없는 턴에서 두 값이 갈라지면 배선이 틀린 것이다", name)
+                    .isEqualTo(m.substantiveMs());
+        }
     }
 
     @Test
@@ -125,6 +208,70 @@ class DeliveryExposureQaTest {
         assertThat(delivered).isEqualTo("그랬군요. 많이 힘드셨겠어요. ");
         assertThat(delivered).doesNotContain("불안장애");
         assertThat(holdback.blocked()).isTrue();
+    }
+
+    private Map<String, Measurement> measureAll() throws Exception {
+        Map<String, Measurement> measured = new LinkedHashMap<>();
+        for (Scenario scenario : SCENARIOS) {
+            measured.put(scenario.name(), measure(scenario));
+        }
+        return measured;
+    }
+
+    /**
+     * 한 시나리오를 가상 시계로 재생한다.
+     *
+     * <p>청크가 아니라 <b>글자 단위</b>로 흘린다. 단위 경계는 청크 경계와 무관하게 결정되므로
+     * (종결 부호가 없으면 길이 상한에서 끊긴다) 청크 단위로 시간을 진행시키면 그 시나리오의
+     * 지연이 실제보다 작게 나온다.
+     */
+    private Measurement measure(Scenario scenario) throws Exception {
+        PolicyDecision decision = decisionFor(scenario);
+        boolean prefixEligible = PREFIX_ELIGIBLE_ACTS.contains(decision.responsePlan().responseAct())
+                && decision.deliveryMode() == DeliveryMode.CAUTIOUS_SPECULATIVE;
+
+        AtomicLong clockMs = new AtomicLong(0);
+        List<String> sent = new ArrayList<>();
+        HoldbackDelivery holdback = new HoldbackDelivery(
+                new ApprovedUnitBuffer(),
+                candidate -> outputPreFilter.check(candidate).passed(),
+                sent::add,
+                clockMs::get);
+
+        // 아직 서버가 먼저 보내는 문장이 없다. 사용자가 처음 보는 것은 첫 승인 단위이므로
+        // 첫 화면 지연과 첫 실질 토큰 지연은 같은 값이다 — 그것이 이 커밋이 재현하는 상태다.
+        // 생성은 prefix 와 무관하게 진행된다 — 서버가 먼저 보내는 것은 전달이지 생성이 아니다.
+        clockMs.set(ASSUMED_TTFT_MS);
+        String generated = String.join("", scenario.chunks());
+        for (int i = 0; i < generated.length(); i++) {
+            clockMs.set(ASSUMED_TTFT_MS + Math.round(i / ASSUMED_CHARS_PER_SECOND * 1000));
+            holdback.onChunk(String.valueOf(generated.charAt(i)));
+        }
+        holdback.finish();
+
+        String delivered = String.join("", sent);
+        long substantiveMs = holdback.firstSubstantiveTokenMs();
+        // 노출은 상수가 아니라 결과로 잰다 — 전달된 텍스트를 다시 검사해서 통과하지 않는
+        // 내용이 섞였는지 본다. 값이 아니라 결과로 확인해야 게이트를 우회하는 변경을 잡는다.
+        int exposed = outputPreFilter.check(delivered).passed() ? 0 : delivered.length();
+
+        return new Measurement(
+                prefixEligible,
+                substantiveMs,
+                substantiveMs,
+                delivered,
+                exposed,
+                firstUnitLengthOf(scenario));
+    }
+
+    /** 실제 계획 규칙을 태운 정책 결정. 응답 행위를 하네스가 지정하지 않는다. */
+    private PolicyDecision decisionFor(Scenario scenario) {
+        PolicyDecision base = new PolicyDecision(
+                "pd_qa_" + scenario.name().hashCode(), DecisionAction.GENERATE, scenario.mode(),
+                scenario.delivery(), SecurityLevel.CLEAN, true, true, true,
+                InterventionHints.empty(), "qa", scenario.risk(), null,
+                JudgeStatus.SUCCEEDED, ModerationStatus.RESOLVED, ResponsePlan.unplanned());
+        return base.withResponsePlan(responsePlanner.plan(base));
     }
 
     /**
@@ -155,24 +302,42 @@ class DeliveryExposureQaTest {
         return buffer.drain().length();
     }
 
-    private void printReport(Map<String, Integer> holdback, Map<String, Integer> legacy,
-                             Map<String, Integer> firstUnit) {
+    private void printExposureReport(Map<String, Measurement> measured) {
         StringBuilder out = new StringBuilder();
         out.append("\n══════════════════════════════════════════════════════════════\n");
         out.append("  검증 전 노출 문자 수 (이슈 #306)\n");
         out.append("══════════════════════════════════════════════════════════════\n");
         out.append("  %-28s %10s %10s%n".formatted("시나리오", "이전(200자)", "승인 단위"));
-        legacy.forEach((name, chars) ->
-                out.append("  %-28s %10d %10d%n".formatted(name, chars, holdback.get(name))));
+        for (Scenario scenario : SCENARIOS) {
+            out.append("  %-28s %10d %10d%n".formatted(
+                    scenario.name(), legacyExposureOf(scenario),
+                    measured.get(scenario.name()).exposedChars()));
+        }
         out.append("\n  이전 값은 첫 검사(누적 200자) 전에 전달됐을 문자 수를 정의로 계산한 것이다.\n");
+        out.append("══════════════════════════════════════════════════════════════\n");
+        System.out.print(out);
+    }
 
-        out.append("\n  [추가 지연 추정 — 첫 문장을 기다리는 비용]\n");
-        out.append("  %-28s %10s %12s%n".formatted("시나리오", "첫 단위", "추정 지연"));
-        firstUnit.forEach((name, chars) -> out.append("  %-28s %10d %10.0fms%n"
-                .formatted(name, chars, chars / ASSUMED_CHARS_PER_SECOND * 1000)));
-        out.append("\n  초당 %.0f자 가정. 실측이 아니라 크기 감각을 위한 추정이며,\n"
-                .formatted(ASSUMED_CHARS_PER_SECOND));
-        out.append("  실제 값은 운영 trace 의 first_substantive_token_ms 로 대체돼야 한다.\n");
+    private void printLatencyReport(Map<String, Measurement> measured) {
+        StringBuilder out = new StringBuilder();
+        out.append("\n══════════════════════════════════════════════════════════════\n");
+        out.append("  첫 화면 지연 vs 첫 실질 토큰 지연 (P0-4)\n");
+        out.append("══════════════════════════════════════════════════════════════\n");
+        out.append("  %-24s %7s %9s %11s %9s%n"
+                .formatted("시나리오", "prefix", "첫 화면", "첫 실질 토큰", "개선"));
+        measured.forEach((name, m) -> out.append("  %-24s %7s %7dms %9dms %7s%n".formatted(
+                name,
+                m.prefixEligible() ? "O" : "-",
+                m.renderedMs(),
+                m.substantiveMs(),
+                m.deltaMs() < 0 ? "미전달" : m.deltaMs() + "ms")));
+        out.append("\n  가상 시계 기준. 첫 생성 토큰 %dms + 초당 %.0f자를 가정했고, 승인 단위 판정은\n"
+                .formatted(ASSUMED_TTFT_MS, ASSUMED_CHARS_PER_SECOND));
+        out.append("  실제 HoldbackDelivery·OutputPreFilter 가 수행한다.\n");
+        out.append("  \"미전달\"은 승인된 모델 콘텐츠가 하나도 없었던 턴이다 — 그 턴에서 사용자가\n");
+        out.append("  본 것은 서버 문구뿐이고, 나머지는 교체 경로가 처리한다.\n");
+        out.append("  실제 값은 운영 trace 의 first_rendered_token_ms / first_substantive_token_ms\n");
+        out.append("  로 대체돼야 한다.\n");
         out.append("══════════════════════════════════════════════════════════════\n");
         System.out.print(out);
     }


### PR DESCRIPTION
## 요약

P0-4 의 남은 절반이다. 이슈 #306 의 승인 단위 holdback 은 검증 전 노출을 0 으로 만들었지만
첫 문장이 완성될 때까지 화면이 비어 있어 **지연은 오히려 늘었다**. 로드맵 §5.6 이 적은 해법은
지연을 되돌리는 것이 아니라 지연되는 대상을 바꾸는 것이다 — 안전한 첫 반응은 서버가 검토한
고정 문구로 먼저 보내고, 변동하는 본문만 계약 검사를 통과한 뒤 연다.

**이 문장이 안전한 이유는 검사에 통과해서가 아니라 모델이 쓰지 않았기 때문이다.** 검증 전
노출 0 보장은 그대로다. 모델 토큰은 여전히 단위 게이트를 통과해야만 전달된다.

## 관련 이슈
- Refs #306 (승인 단위 holdback), 로드맵 §5.6 · §12 P0-4

## 변경 사항
- `SafePrefixCatalog` 추가 — 응답 행위별 검토된 첫 문장과 **허용 목록** 형태의 적용 조건.
  선택 실패는 예외를 삼켜 prefix 없이 진행한다(턴을 실패시키지 않는다).
- `ConversationOrchestrator` — GENERATE 분기 진입 직후, 프롬프트 조립·LLM 호출보다 **먼저**
  prefix 를 `delta` 로 보낸다. 전송 실패 시 prefix 없이 계속하고 응답에도 넣지 않는다.
- `ResponsePlan.reservingSentences()` — prefix 가 붙는 턴은 계약의 문장 상한을 하나 줄인다.
  사용자가 읽는 총 문장 수를 원래 계약 안에 유지한다. 상한은 줄이기만 한다.
- `PromptBuilder` — prefix 가 나간 턴에 "감정 인정은 이미 전달됐다"를 지시한다. **문구 자체는
  프롬프트에 넣지 않는다.**
- `AiDecisionLogger` / `AiTurnMetrics` — `first_rendered_token_ms` 가 이제 prefix 전송 시각을
  가리키고, `first_substantive_token_ms` 는 첫 승인 **모델** 콘텐츠를 계속 가리킨다.
  `safe_prefix_applied` 와 `mio.ai.turn.first.rendered` timer 를 추가했다.
- `DeliveryExposureQaTest` — 가상 시계로 두 지연을 시나리오별로 재고 차이를 표로 출력한다.
  LLM 호출이 없어 기존과 같이 일반 CI 에서 돌릴 수 있다.

### 리뷰 반영 (2차 푸시)

두 리뷰가 독립적으로 같은 결함을 찾았다(안전 HIGH / Java CRITICAL). 반영 내용:

- **위기 승격 시 렌더된 서버 문구를 지운다.** `OutputJudge` 는 사전 위험 라벨이 아니라 생성된
  텍스트를 보고 판정하므로 prefix 를 받는 MEDIUM·LOW 턴에서도 `CRISIS_FLOW` 가 나온다. 조기
  중단·스트림 종료 후 두 경로가 합류하는 `isCrisis` 지점에서 crisis 이벤트 **전에** 빈
  `delta.replace` 를 보낸다. `BUFFER` 경로의 위기 승격 지점에도 같은 호출을 뒀다 — 지금은
  대상이 아니지만 조건이 넓어질 때 한 분기만 빠지는 것이 이 결함의 형태였다.
- **문장 예산은 전달 성공 후에만 줄인다.** 선택 시점에 줄이면 전송이 실패한 턴에서 프롬프트
  지시는 빠지는데 상한만 남아 응답이 보상 없이 한 문장 짧아졌다.
- **`SafePrefixDelivery` 추출.** 전송·지우기·이어붙이기·첫 렌더 시각은 상태 없는 규칙이라
  `HoldbackDelivery` 옆으로 옮겼다(#306 이 만든 선례). 오케스트레이터는 1122 → 1088 줄.
- **`ResponsePlanTest` 추가.** `reservingSentences` 의 하한(1 미만 불가)·무효 예약·계획 밖
  턴은 운영 경로가 실행하지 않아 그대로 두면 검증되지 않는다.
- **`storedAssistantContent` 를 Awaitility 로.** `spring-boot-starter-test` 가 이미 가져오는
  의존이라 새로 추가하지 않았다. 기존 `awaitTrace()` 는 이 PR 범위 밖이라 그대로 뒀다.
- **문구 이어붙이기 공백 정리**, **`JudgeStatus.SKIPPED` 를 허용하는 이유 주석**(판정 미수행은
  판정 실패가 아니다).

### 어떤 행위가 prefix 를 받는가

| 조건 | 값 |
| --- | --- |
| action | `GENERATE` |
| deliveryMode | `CAUTIOUS_SPECULATIVE` 만 |
| judgeStatus / moderationStatus | `FAILED` 아님 / `RESOLVED` |
| securityLevel | `CLEAN` |
| riskLevel | `CLEAR_LOW` · `LOW` · `MEDIUM` |
| responseAct | `EMOTION_CHECK` · `CLARIFY_CONTEXT` (`CONSTRAINED` 계약) |

제외한 경로와 이유:

- **위기 고정 플로우 · 보안 거절 · 폴백** — 검토된 서버 문구가 이미 나가는 경로다. 앞에 문장을
  하나 더 얹으면 그 고정 응답의 형태가 바뀐다.
- **HIGH 위험 (`EMPATHIC_REFLECTION`)** — 로드맵 §5.6 의 예시는 `MEDIUM + EMPATHIC_REFLECTION`
  이지만 현재 구현에서 그 행위는 HIGH 에서만 나온다. 위기 안내 앞을 지우는 처리가 들어온
  지금도 HIGH 는 제외로 둔다 — 그 구간은 안전 확인이 감정 인정보다 우선이고, 서버가 먼저
  문장을 확정할 이유가 없다. `BUFFER` 전달이 대상에서 빠진 것도 같은 이유의 결과다.
- **Judge 실패 · L0 미해결 · 보안 SUSPICIOUS** — 위험 등급을 확인하지 못했거나 조작이 의심되는
  턴이다. 확인 불가는 붙일 근거가 아니다.
- **`SPECULATIVE` 전달** — 메울 대기 자체가 없다.
- **계약 없는 턴(`UNPLANNED`)** — 모델이 무엇을 쓸지 서버가 모른다.

### 감정 인정이 두 번 나가지 않게 한 방법

프롬프트로 알리는 쪽을 택했다(`[이미 전달됨]` 지시 + 문장 상한 −1). 전달 단계에서 잘라내는
방식은 택하지 않았다 — 모델 출력을 서버가 편집하면 **사용자가 읽은 텍스트와 저장·재생되는
텍스트가 갈라진다.** 그 어긋남은 idempotency 재생·체크포인트 요약·워킹 메모리에 그대로 번진다.

프롬프트에 **문구 자체는 넣지 않는다.** 넣으면 모델이 그대로 따라 쓰는 것이 가장 흔한 반복
실패가 되기 때문이다. 필요한 정보는 "이미 전달됐다"는 사실뿐이다. 이 선택의 잔여 위험은
의미상 유사한(문자열은 다른) 인정 문장이며, 실측은 이슈 #305 계열의 계약 준수율 측정에서
같이 보는 것이 맞다고 판단했다.

### 측정된 첫 화면 지연 개선

`DeliveryExposureQaTest` 출력(가상 시계, 첫 생성 토큰 600ms + 초당 30자 가정. 승인 단위 판정과
prefix 선택은 실제 `HoldbackDelivery` · `OutputPreFilter` · `SafePrefixCatalog` 가 수행):

| 시나리오 | prefix | 첫 화면 | 첫 실질 토큰 | 개선 |
| --- | --- | --- | --- | --- |
| 정상 공감 응답 | O | 0ms | 900ms | **900ms** |
| 긴 정상 응답 | O | 0ms | 1267ms | **1267ms** |
| 첫 문장이 위반 | O | 0ms | 미전달 | 서버 문구만 노출 후 교체 경로 |
| 중간 문장이 위반 | O | 0ms | 733ms | **733ms** |
| 종결 부호 없는 긴 출력 | O | 0ms | 3233ms | **3233ms** |
| 계획 밖 일반 대화 (대조군) | - | 733ms | 733ms | 0ms |
| HIGH 위험 응답 (대조군) | - | 900ms | 900ms | 0ms |

검증 전 노출은 모든 시나리오에서 여전히 0 이다(전달된 텍스트를 다시 검사해서 잰다).
가정한 TTFT 값이 달라져도 **차이의 방향**은 바뀌지 않는다 — prefix 는 TTFT 와 첫 승인 단위
양쪽 모두의 앞에 나간다. 절대값의 실측은 운영 trace 의 두 필드로 대체돼야 한다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [x] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

**안전 판정 자체는 바뀌지 않았지만 전달 경로를 건드렸으므로 체크했다.** `PolicyEngine` 의
판정, `OutputPreFilter` 기준, 승인 단위 게이트는 그대로다. 바뀐 것은 "검사를 통과한 모델
콘텐츠 앞에 서버 문구를 하나 더 보낸다"이다. **머지 전에 `integration/1.1.0` 기준
Crisis Eval (full path) 실행 결과를 이 PR 에 첨부해야 한다.**

### SSE 계약
**이벤트 타입과 순서 계약은 바뀌지 않았다.** prefix 는 같은 `msg_id` 를 쓰는 `delta` 이벤트
하나이고, 순서는 `session_meta → delta/crisis → done` 그대로다. `CAUTIOUS_SPECULATIVE` 는 이미
문장마다 `delta` 를 보내므로 클라이언트에는 delta 가 하나 더 오는 것과 같다. 새 이벤트 타입은
없다.

**다만 FE 가 확인해야 할 payload 동작이 하나 있다.** 위기로 승격한 prefix 턴은 crisis 이벤트
앞에 `safe_response` 가 **빈 문자열인 `delta.replace`** 를 보낸다. "메시지 전체 교체" 의미상
빈 값은 화면을 비우는 것이 맞지만, 빈 payload 를 무시하는 구현이라면 감정 인정 문장이 핫라인
위에 남는다. **FE 조율 항목으로 올린다 — 빈 `delta.replace` 를 화면 비움으로 처리하는지
확인이 필요하다.**

한 가지 동작 변화도 적어 둔다 — 조기 중단 후 안전 스냅샷으로 되돌릴 때의 `delta.replace`
payload 에 서버 문구가 **포함된다**(replace 는 메시지 전체를 갈아끼우므로 포함하지 않으면
화면에서 사라진다). 반면 판정이 응답을 교체한 `delta.replace` 와 위기 승격의 비움에는
포함하지 않는다 — 그쪽은 앞선 텍스트를 남기지 않는 것이 목적이다.

### 위기 승격 시 실제 SSE 순서 (측정값)

리뷰 지적(HIGH/CRITICAL)을 반영한 뒤 통합 테스트가 실제로 관측한 순서다.

| 승격 경로 | 응답 행위 | 이벤트 순서 |
| --- | --- | --- |
| 조기 중단 (승인 게이트 정지 → 비동기 판정) | `EMOTION_CHECK` | `session_meta → delta(prefix) → delta.replace("") → crisis → done` |
| 조기 중단 | `CLARIFY_CONTEXT` | `session_meta → delta(prefix) → delta.replace("") → crisis → done` |
| 스트림 종료 후 (계약 위반 → 판정 승격) | `EMOTION_CHECK` | `session_meta → delta(prefix) → delta×5 → delta.replace("") → crisis → done` |

두 경로는 `isCrisis` 한 지점으로 합류하므로 지우는 처리도 한 곳이다. 판정은 이벤트 목록이
아니라 **재구성한 화면 상태**로 한다 — 지우는 신호가 crisis 뒤에 가거나 다른 `msg_id` 로
나가면 이벤트 목록만으로는 통과해 버린다.

## 테스트
### 실행 커맨드
```bash
./gradlew compileJava compileTestJava
./gradlew test        # 1472 tests, 0 failures (-PllmTests 는 실행하지 않음)
```

DB 연동 테스트는 `mio-postgres` 컨테이너에 임시 DB(`mio_p04_prefix`, pgvector)를 만들어
`SPRING_DATASOURCE_URL`/`DB_URL` 로 가리켜 실행하고 끝나면 삭제했다. 공유 `mio` DB 와 커밋된
설정은 건드리지 않았다.

### 확인 내용
- `SafePrefixCatalogTest` — 대상/비대상 경로 전수(위기·보안 거절·폴백·HIGH·Judge 실패·L0
  미해결·SUSPICIOUS·UNPLANNED·SPECULATIVE), `select(null)` 이 예외 없이 빈 값,
  검토 문구가 질문 없는 한 문장이며 `OutputPreFilter`(위기 맥락 포함)와 계약 금지 표현을
  통과하는지.
- `DeliveryExposureQaTest` — 검증 전 노출 0 유지, **먼저 전달되는 문장이 검토 목록의 서버
  문구뿐이고 모델 출력에서 오지 않았음**, prefix 턴의 두 지연이 갈라지고 대조군은 같은지,
  **위기 승격 시나리오의 최종 화면에 서버 문구가 남지 않는지**.
- `ConversationOrchestratorContractIntegrationTest` (위기 승격) — 조기 중단·스트림 종료 후 두
  경로 × `EMOTION_CHECK`·`CLARIFY_CONTEXT` 에서 화면 상태를 재구성해 핫라인 위에 서버 문구가
  남지 않는지. **지우는 호출을 제거하면 세 테스트가 모두 실패하는 것을 확인했다.**
- `ConversationOrchestratorContractIntegrationTest` (문장 예산) — prefix 전송이 실패하면 상한이
  4문장 그대로이고 `[이미 전달됨]` 지시도 없는지, 성공하면 3문장으로 줄고 지시가 붙는지.
- `ResponsePlanTest` — 상한 1에서 예약해도 0으로 내려가지 않는지, 무효 예약과 계획 밖 턴이
  계획을 바꾸지 않는지.
- `ConversationOrchestratorContractIntegrationTest` — 실제 요청 경로에서 (1) 검토 문구가
  생성 텍스트보다 먼저 SSE 로 나가고 저장된 응답에도 남는지, (2) trace 의
  `first_rendered_token_ms < first_substantive_token_ms` 이고 `safe_prefix_applied=true` 인지,
  (3) Judge 실패 턴에서는 두 값이 **같고** `safe_prefix_applied=false` 인지.
- `PromptBuilderTest` — "이미 전달됨" 지시가 실리고, **검토 문구 자체는 프롬프트에 들어가지
  않는지**.
- `AiTurnMetricsTest` — `mio_ai_turn_first_rendered_seconds_bucket` export 와 두 timer 의
  값이 서로 다르게 기록되는지.

## 중점 리뷰 포인트
- **문구 검토가 이 PR 의 실제 리뷰 대상이다.** `SafePrefixCatalog.PREFIXES` 두 문장을 카피
  기준(진단 없음 / 사용자 단정 없음 / 의존 강화 없음 / 결과 보장 없음 / 질문 없음)으로 봐
  주세요. `emotion_def.acknowledgment_phrases`(V21 시드)의 검토된 표현을 감정 코드에 의존하지
  않도록 완화한 형태입니다 — 이 시점에는 어떤 감정인지 확정되지 않아 감정을 지목하면 단정이
  됩니다.
- HIGH 위험을 제외한 판단(위기 승격 시 화면에 남는 문제)이 맞는지.
- `delta.replace` 두 경로의 payload 차이가 의도대로인지.

## 배포 / 롤백
- Rollout: 코드 변경만. 마이그레이션·설정 변경 없음.
- Rollback: 커밋 revert. `SafePrefixCatalog.PREFIXES` 를 비우면 코드는 그대로 둔 채 기능만
  끌 수 있다(모든 턴이 prefix 없음으로 떨어지고 두 지연 값이 다시 같아진다).

### 리뷰가 LOW 로 남긴 항목에 대한 판단

위기로 승격한 턴의 저장 내용은 고정 위기 응답뿐이라 prefix 가 저장되지 않는다. **지우는
처리가 들어온 뒤로는 그게 맞는 상태다** — 최종 화면에도 그 문장이 남지 않으므로, 저장된
응답과 사용자가 마지막으로 본 화면이 일치한다. 따라서 별도 조치를 하지 않는다.

## 남긴 것 (의도적으로 하지 않음)
- **전달 단계 중복 제거** — 위 이유로 하지 않았다. 반복이 실측되면 별도로 다룬다.
- **`EMPATHIC_REFLECTION`(HIGH) · `BUFFER` 전달 · `SPECULATIVE` 턴** — 위 표의 이유.
- **슬롯 템플릿 렌더링(§5.6 후반)** — 이 PR 은 고정 prefix 까지다.
- **운영 p95 기준선** — 여기 표는 결정론적 하네스 값이다. 실측은 운영 trace 의
  `first_rendered_token_ms` / `first_substantive_token_ms` 를 모아야 한다.
- **로드맵 문서 갱신** — `docs/Mio_AI_시스템_통합개선_로드맵 .md` 의 P0-4 절이 아직 "뒤의 두
  값은 현재 같다"로 적혀 있다. 그 문서는 저장소에 추적되지 않아 이 PR 에 포함하지 않았고,
  머지 시 함께 갱신이 필요하다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (해당 없음 —
      SSE 계약·스키마·설정 변경 없음)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
