### PR TITLE
fix: 외부 실패 계량기가 판정 실패에 가려지지 않게 한다 (P0-3)

### DIFF
--- a/src/test/java/com/mio/ai/qa/CellCaseOutcome.java
+++ b/src/test/java/com/mio/ai/qa/CellCaseOutcome.java
@@ -258,6 +258,16 @@ record CellCaseOutcome(
      * 행위별 비교를 왜곡한다. {@code caseAborted} 는 타임아웃·예외로 케이스가 끝난 것이라
      * 원인이 모델이 아니라 동시성·rate limit 일 수 있다.
      *
+     * <h2>범위 — 전달 이후의 품질 축 호출은 여기 들어오지 않는다</h2>
+     *
+     * <p>이 축은 <b>계약 모집단과 행위 분포에 영향을 주는 실패</b>만 담는다. 전달·수용이 확정된
+     * <b>뒤에</b> 일어나는 품질 축 호출의 실패는 설계상 제외다 — {@code CbtMetadataClassifier} 가
+     * 그렇다. 그 호출이 실패해도 계약 분모는 줄지 않고 계획된 행위도 바뀌지 않으며, 영향은 이미
+     * 스스로 채점 대상에서 빠지는 축({@link CbtDeliveryJudgment#CLASSIFIER_FAILED}) 하나에
+     * 국한된다. {@code CellReport}·{@code CellMetrics} 도 같은 경계를 쓴다. 그래도 그 실패가
+     * 보이지 않으면 안 되므로 계약 manifest 가 {@code cbt_classifier_failures} 로 따로 싣는다
+     * (P0-3 MEDIUM-2) — 이 축에 섞지 않는 것과 감추는 것은 다르다.
+     *
      * @param generation  생성(또는 escalation 재생성) 호출이 실패했는가
      * @param judge       Input·Output 판정 호출이 실패해 폴백으로 접혔는가
      * @param caseAborted 케이스 자체가 타임아웃·예외로 중단됐는가

--- a/src/test/java/com/mio/ai/qa/CellCaseOutcome.java
+++ b/src/test/java/com/mio/ai/qa/CellCaseOutcome.java
@@ -77,6 +77,16 @@ record CellCaseOutcome(
         int responseQuestions,
         Acceptance acceptance,
         /**
+         * 이 턴에서 <b>실제로 일어난</b> 외부 실패 사실 — {@link #acceptance} 와 독립이다 (P0-3).
+         *
+         * <p>{@link #acceptance} 는 턴당 <b>하나</b>의 최종 라벨이라, 한 턴이 두 가지로 실패하면
+         * 하나가 다른 하나를 지운다. 계량기가 그 라벨을 세면 지워진 실패는 청구서에도 리포트에도
+         * 남지 않는다. 이 필드는 라벨이 아니라 <b>사실</b>을 담으므로 지워지지 않는다.
+         *
+         * @see ExternalFailure
+         */
+        ExternalFailure externalFailure,
+        /**
          * 케이스 타임아웃으로 끝났는가.
          *
          * <p>{@link Acceptance#REJECTED_EXTERNAL_FAILURE} 만으로는 "모델이 500 을 냈다" 와
@@ -222,12 +232,104 @@ record CellCaseOutcome(
         REJECTED_EMPTY_RESPONSE
     }
 
+    /**
+     * 한 턴에서 관측된 외부 실패 <b>사실</b>들 (P0-3, #305 유료 실행이 드러낸 결함).
+     *
+     * <h2>왜 {@link Acceptance} 로는 셀 수 없는가</h2>
+     *
+     * <p>{@code #305} 대조군은 153건 중 25건을 생성 호출 실패로 잃었다. 그런데 manifest 의
+     * 외부 실패 수는 <b>1</b> 이었다. {@code CellRunner.assemble()} 이 같은 턴의 InputJudge 도
+     * 실패했으면 {@link Acceptance#REJECTED_JUDGE_FAILURE} 로 덮어쓰는데, 25건 중 24건이 그
+     * 경우였기 때문이다(25 − 24 = 1). 그래서 실제로는 25/153 = <b>16.3%</b> 가 유실됐는데
+     * 10% 상한 가드는 0.65% 로 읽고 통과했다. 런북의 "외부 실패 10% 초과면 수치를 쓰지 않는다"
+     * 규칙이 정확히 그 상황에서 눈이 멀어 있었다.
+     *
+     * <p>원인은 덮어쓰기 자체가 아니다 — 턴에는 최종 라벨이 하나여야 하고, 그 라벨은 리포트가
+     * 거절 사유를 세는 데 쓰인다. 원인은 <b>계량기가 라벨을 셌다</b>는 것이다. 판정 실패와
+     * 생성 실패는 서로 다른 사실이고, 한 턴에서 둘이 동시에 일어날 수 있다. 그래서 사실은
+     * 사실대로 따로 남기고, 라벨은 라벨로 남긴다.
+     *
+     * <h2>세 축을 나눠 두는 이유</h2>
+     *
+     * <p>대응이 다르다. {@code generation} 은 모집단에서 턴을 <b>빼앗아 간다</b> — 본문이 없으면
+     * {@code ResponseContractValidator} 가 {@code notApplicable()} 을 돌려주므로 그 턴은 분모에서
+     * 사라진다. {@code judge} 는 턴을 빼앗지는 않지만 {@code PolicyEngine} 4번 분기가
+     * {@code MEDIUM}({@code EMOTION_CHECK}) 을 세우므로 <b>행위 분포를 한쪽으로 밀어</b>
+     * 행위별 비교를 왜곡한다. {@code caseAborted} 는 타임아웃·예외로 케이스가 끝난 것이라
+     * 원인이 모델이 아니라 동시성·rate limit 일 수 있다.
+     *
+     * @param generation  생성(또는 escalation 재생성) 호출이 실패했는가
+     * @param judge       Input·Output 판정 호출이 실패해 폴백으로 접혔는가
+     * @param caseAborted 케이스 자체가 타임아웃·예외로 중단됐는가
+     */
+    record ExternalFailure(boolean generation, boolean judge, boolean caseAborted) {
+
+        static final ExternalFailure NONE = new ExternalFailure(false, false, false);
+
+        /** 생성 호출이 외부 오류로 실패했다. */
+        static ExternalFailure ofGeneration() {
+            return new ExternalFailure(true, false, false);
+        }
+
+        /** 판정 호출이 외부 오류로 실패해 폴백 판정이 쓰였다. */
+        static ExternalFailure ofJudge() {
+            return new ExternalFailure(false, true, false);
+        }
+
+        /** 케이스가 타임아웃·예외로 중단됐다. 어느 호출까지 갔는지는 알 수 없다. */
+        static ExternalFailure ofCaseAbort() {
+            return new ExternalFailure(false, false, true);
+        }
+
+        /**
+         * 판정 실패 사실을 <b>더한다</b>. 기존 사실을 지우지 않는 것이 이 메서드의 요점이다.
+         *
+         * <p>{@code CellRunner.assemble()} 이 acceptance 를 덮어쓰는 자리에서 같이 불린다.
+         * 라벨은 덮어써도 사실은 누적된다.
+         */
+        ExternalFailure withJudge(boolean judgeFailed) {
+            return judgeFailed && !judge
+                    ? new ExternalFailure(generation, true, caseAborted)
+                    : this;
+        }
+
+        /** 이 턴에서 외부 실패가 <b>하나라도</b> 일어났는가. 10% 상한 가드가 이 값을 센다. */
+        boolean any() {
+            return generation || judge || caseAborted;
+        }
+
+        /**
+         * 이 실패가 턴을 계약 모집단에서 <b>빼앗아 갔는가</b>.
+         *
+         * <p>본문이 없으면 계약 검사가 {@code notApplicable()} 을 돌려주므로 분모에서 빠진다.
+         * 판정 실패만 일어난 턴은 생성이 정상으로 돌았으므로 분모에 남는다 — 대신 계획된 행위가
+         * 한쪽으로 쏠린다.
+         */
+        boolean removesBody() {
+            return generation || caseAborted;
+        }
+    }
+
     CellCaseOutcome {
         contractViolations = List.copyOf(contractViolations);
+        if (externalFailure == null) {
+            throw new IllegalArgumentException(
+                    "외부 실패 사실이 없다 — null 을 '실패 없음' 으로 접으면 계량기가 다시 눈이 먼다");
+        }
     }
 
     boolean accepted() {
         return acceptance == Acceptance.ACCEPTED;
+    }
+
+    /**
+     * 이 턴에서 외부 실패가 일어났는가 — {@link #acceptance} 라벨과 무관하다 (P0-3).
+     *
+     * <p>계량기는 이 값을 센다. {@code acceptance == REJECTED_EXTERNAL_FAILURE} 를 세면 같은
+     * 턴의 판정 실패가 라벨을 덮어쓴 만큼 계량기에서 사라진다.
+     */
+    boolean externalFailureObserved() {
+        return externalFailure.any();
     }
 
     /**

--- a/src/test/java/com/mio/ai/qa/CellRunner.java
+++ b/src/test/java/com/mio/ai/qa/CellRunner.java
@@ -30,6 +30,7 @@ import com.mio.ai.policy.PolicyEngine;
 import com.mio.ai.prompt.PromptBuilder;
 import com.mio.ai.qa.CellCaseOutcome.Acceptance;
 import com.mio.ai.qa.CellCaseOutcome.ContractOutcome;
+import com.mio.ai.qa.CellCaseOutcome.ExternalFailure;
 import com.mio.ai.qa.CellCaseOutcome.Exposure;
 import com.mio.ai.qa.LockedEvalSet.LockedCase;
 import com.mio.ai.qa.LockedEvalSet.Turn;
@@ -355,7 +356,7 @@ final class CellRunner {
                 CellCaseOutcome.CbtDeliveryJudgment.NOT_JUDGED,
                 false,
                 ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0,
-                Acceptance.REJECTED_EXTERNAL_FAILURE, timedOut,
+                Acceptance.REJECTED_EXTERNAL_FAILURE, ExternalFailure.ofCaseAbort(), timedOut,
                 timedOut ? caseTimeout().toMillis() : 0L, 0L,
                 calls.size(),
                 calls.stream().mapToLong(CellTokenLedger.Call::promptTokens).sum(),
@@ -492,6 +493,10 @@ final class CellRunner {
     /**
      * 전달 결과.
      *
+     * @param externalFailure 이 전달 경로에서 관측된 외부 실패 사실 (P0-3). {@code acceptance} 와
+     *                        나눠 들고 다니는 이유는 {@code assemble()} 이 acceptance 를 판정 실패
+     *                        라벨로 덮어쓰기 때문이다 — 라벨에서 사실을 되읽으면 그 순간 덮어쓴
+     *                        만큼이 계량기에서 사라진다
      * @param deliveredText 사용자에게 전달된 본문. CBT 분류기 입력으로만 쓰고
      *                      {@link CellCaseOutcome} 에는 싣지 않는다 — 결과 타입에 본문이 들어가면
      *                      리포트·아카이브로 새어 나갈 경로가 생긴다
@@ -500,15 +505,15 @@ final class CellRunner {
                             boolean outputJudgeCalled, boolean truncated, ContractOutcome contract,
                             List<String> contractViolations,
                             int responseSentences, int responseQuestions,
-                            Acceptance acceptance,
+                            Acceptance acceptance, ExternalFailure externalFailure,
                             String deliveredText, long firstSubstantiveMs) {
 
         /** 모델을 부르지 않은 경로(위기 고정·보안 거절·가드)의 전달 결과. */
         static Delivery withoutGeneration(Exposure exposure, Acceptance acceptance,
                                           long firstSubstantiveMs) {
             return new Delivery(exposure, false, false, false, false,
-                    ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0, acceptance, null,
-                    firstSubstantiveMs);
+                    ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0, acceptance,
+                    ExternalFailure.NONE, null, firstSubstantiveMs);
         }
     }
 
@@ -562,7 +567,8 @@ final class CellRunner {
         if (generated.failed()) {
             return new Delivery(exposureOf(decision), true, false, false, generated.truncated(),
                     ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0,
-                    Acceptance.REJECTED_EXTERNAL_FAILURE, null, firstSubstantiveMs);
+                    Acceptance.REJECTED_EXTERNAL_FAILURE, ExternalFailure.ofGeneration(), null,
+                    firstSubstantiveMs);
         }
         if (isEmpty(generated.text())) {
             return emptyResponse(decision, generated, firstSubstantiveMs);
@@ -579,7 +585,7 @@ final class CellRunner {
         if (!needsSecondLook) {
             return new Delivery(exposureOf(decision), true, false, false, generated.truncated(),
                     contractOutcome, contract.violations(), shape.sentences(), shape.questions(),
-                    Acceptance.ACCEPTED, generated.text(), firstSubstantiveMs);
+                    Acceptance.ACCEPTED, ExternalFailure.NONE, generated.text(), firstSubstantiveMs);
         }
         return secondLook(decision, plan, userMessage, priorTurns, caseKey, generated,
                 preFilter, contract, shape, firstSubstantiveMs, startNanos);
@@ -599,9 +605,11 @@ final class CellRunner {
      */
     private Delivery emptyResponse(PolicyDecision decision, Generated generated,
                                    long firstSubstantiveMs) {
+        // 빈 응답은 외부 실패가 아니다 — 호출은 성공했고 모델이 정상 응답으로 본문을 내지
+        // 않았다. 외부 실패로 세면 10% 가드가 모델 행동을 네트워크 장애로 읽는다.
         return new Delivery(exposureOf(decision), true, false, false, generated.truncated(),
                 ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0,
-                Acceptance.REJECTED_EMPTY_RESPONSE, null, firstSubstantiveMs);
+                Acceptance.REJECTED_EMPTY_RESPONSE, ExternalFailure.NONE, null, firstSubstantiveMs);
     }
 
     /** 공백만 있는 응답도 빈 응답이다 — 사용자가 보는 것이 없다는 점에서 다르지 않다. */
@@ -634,7 +642,7 @@ final class CellRunner {
                     contractOutcome == ContractOutcome.VIOLATED
                             ? Acceptance.REJECTED_CONTRACT
                             : Acceptance.REJECTED_OUTPUT_JUDGE,
-                    null, firstSubstantiveMs);
+                    ExternalFailure.NONE, null, firstSubstantiveMs);
         }
 
         OutputJudgeResult judged = outputJudge.judge(generated.text(), preFilter, caseKey, caseKey);
@@ -648,7 +656,10 @@ final class CellRunner {
                 ? Exposure.CRISIS_FLOW : exposureOf(decision),
                 true, false, true, generated.truncated(), contractOutcome, contract.violations(),
                 shape.sentences(), shape.questions(),
-                acceptance, acceptance == Acceptance.ACCEPTED ? generated.text() : null,
+                // OutputJudge 호출 실패도 외부 실패다. acceptance 는 판정 실패로 라벨되지만,
+                // 그 라벨이 사실을 대신하지 않는다.
+                acceptance, judged.failed() ? ExternalFailure.ofJudge() : ExternalFailure.NONE,
+                acceptance == Acceptance.ACCEPTED ? generated.text() : null,
                 firstSubstantiveMs);
     }
 
@@ -668,14 +679,16 @@ final class CellRunner {
             return new Delivery(exposureOf(decision), true, true, false, truncated,
                     outcomeOf(contract), contract.violations(),
                     firstPassShape.sentences(), firstPassShape.questions(),
-                    Acceptance.REJECTED_EXTERNAL_FAILURE, null, firstSubstantiveMs);
+                    Acceptance.REJECTED_EXTERNAL_FAILURE, ExternalFailure.ofGeneration(), null,
+                    firstSubstantiveMs);
         }
         if (isEmpty(retry.text())) {
             // 재생성이 빈 본문이면 회복이 아니다. "escalation 을 돌렸다" 는 사실이 전달을
             // 만들어 주지 않는다.
             return new Delivery(exposureOf(decision), true, true, false, truncated,
                     ContractOutcome.NOT_APPLICABLE, List.of(), 0, 0,
-                    Acceptance.REJECTED_EMPTY_RESPONSE, null, firstSubstantiveMs);
+                    Acceptance.REJECTED_EMPTY_RESPONSE, ExternalFailure.NONE, null,
+                    firstSubstantiveMs);
         }
         ResponseContractResult retryContract = contractValidator.validate(plan, retry.text());
         ContractOutcome retryOutcome = outcomeOf(retryContract);
@@ -686,7 +699,7 @@ final class CellRunner {
         return new Delivery(exposureOf(decision), true, true, false, truncated, retryOutcome,
                 retryContract.violations(), retryShape.sentences(), retryShape.questions(),
                 recovered ? Acceptance.ACCEPTED : Acceptance.REJECTED_CONTRACT,
-                recovered ? retry.text() : null, firstSubstantiveMs);
+                ExternalFailure.NONE, recovered ? retry.text() : null, firstSubstantiveMs);
     }
 
     /**
@@ -759,11 +772,27 @@ final class CellRunner {
         return result.passed() ? ContractOutcome.PASSED : ContractOutcome.VIOLATED;
     }
 
+    /**
+     * 케이스 결과 조립.
+     *
+     * <h2>라벨은 하나, 사실은 여럿 (P0-3)</h2>
+     *
+     * <p>{@code acceptance} 는 턴당 하나여야 한다 — 리포트의 거절 사유 분포가 그 라벨을 세고,
+     * 한 턴이 두 사유로 세어지면 합이 모집단을 넘는다. 그래서 InputJudge 가 실패하면 여기서
+     * {@link Acceptance#REJECTED_JUDGE_FAILURE} 로 <b>덮어쓴다</b>. 그 의미론은 그대로 둔다.
+     *
+     * <p><b>바뀐 것은 계량기가 그 라벨을 읽지 않는다는 것이다.</b> {@code #305} 유료 실행에서
+     * 생성 실패 25건 중 24건이 같은 턴의 InputJudge 도 실패해 이 덮어쓰기에 먹혔고, 외부 실패
+     * 집계가 25 대신 1 을 보고했다. 10% 가드는 16.3% 를 0.65% 로 읽고 통과했다. 이제 외부 실패
+     * 사실은 {@link ExternalFailure} 로 별도 필드에 실려 나가며, 판정 실패 사실은 그 필드에
+     * <b>더해진다</b>({@link ExternalFailure#withJudge}) — 지우지 않는다.
+     */
     private CellCaseOutcome assemble(LockedCase lockedCase, UUID caseKey, PolicyDecision decision,
                                      Delivery delivery, boolean judgeCalled,
                                      InputJudgeResult judgeResult, CbtClassification cbt,
                                      long firstSubstantiveMs, long totalMs) {
         List<CellTokenLedger.Call> calls = ledger.callsFor(caseKey);
+        boolean inputJudgeFailed = judgeResult != null && judgeResult.failed();
         return new CellCaseOutcome(
                 lockedCase.id(), lockedCase.subgroup(), lockedCase.axis(),
                 lockedCase.deterministicLayer(), caseKey,
@@ -780,8 +809,8 @@ final class CellRunner {
                 delivery.truncated(),
                 delivery.contract(), delivery.contractViolations(),
                 delivery.responseSentences(), delivery.responseQuestions(),
-                judgeResult != null && judgeResult.failed()
-                        ? Acceptance.REJECTED_JUDGE_FAILURE : delivery.acceptance(),
+                inputJudgeFailed ? Acceptance.REJECTED_JUDGE_FAILURE : delivery.acceptance(),
+                delivery.externalFailure().withJudge(inputJudgeFailed),
                 false, totalMs, firstSubstantiveMs, calls.size(),
                 calls.stream().mapToLong(CellTokenLedger.Call::promptTokens).sum(),
                 calls.stream().mapToLong(CellTokenLedger.Call::completionTokens).sum());

--- a/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
@@ -397,6 +397,198 @@ class ContractComplianceHarnessTest {
                 .isNotEqualTo("$0.000000");
     }
 
+    // ── P0-3 MEDIUM-1: 이탈 자리는 분할이다 ────────────────────────────
+
+    /**
+     * 계획 이탈과 생성 실패가 <b>겹친</b> 턴 수.
+     *
+     * <p>Judge 가 보안을 {@code SUSPICIOUS} 로 올리고 등급이 {@code CLEAR_LOW} 면
+     * {@code PolicyEngine} 6번 분기가 {@code GENERATE} 를 내고 플래너는 {@code unplanned()} 를
+     * 돌려준다 — <b>계획은 계약 밖인데 생성은 실제로 돈다.</b> 그 턴의 생성까지 실패시키면 예전
+     * 집계에서 이탈②와 이탈③에 <b>동시에</b> 들어갔다.
+     */
+    private static final int OVERLAPPING_ESCAPES = 40;
+
+    @Test
+    @DisplayName("P0-3: 계획 이탈과 생성 실패가 겹친 턴은 정확히 한 이탈 자리에만 든다")
+    void overlappingEscapesLandInExactlyOneBucket() {
+        CellRunner.Result result = runWithPlannerAndGenerationOverlap();
+        List<CellCaseOutcome> outcomes = result.outcomes();
+        ContractComplianceMetrics metrics = metricsOf(result);
+
+        // ── 이 테스트가 헛돌지 않는다는 것을 먼저 못 박는다 ──────────────
+        //
+        // 겹침이 실제로 없으면 아래 단언은 전부 자명하게 통과한다. 예전 술어 넷을 그대로 재현해
+        // 두 자리 이상에 걸리는 턴이 정말 있는지 센다.
+        assertThat(outcomes).filteredOn(o -> legacyBucketCount(o) >= 2)
+                .as("겹치는 턴이 없으면 이 테스트는 아무것도 검사하지 않는다 — "
+                        + "PolicyEngine 6번 분기나 플래너가 바뀌었을 수 있다")
+                .hasSize(OVERLAPPING_ESCAPES);
+
+        // ── 예전 합산이 무엇을 냈는지 못 박는다 ────────────────────────
+        int legacySum = (int) outcomes.stream().mapToLong(
+                ContractComplianceHarnessTest::legacyBucketCount).sum();
+        assertThat(metrics.notApplicable() - legacySum)
+                .as("예전에는 한 턴을 두 번 세면서 notApplicable 은 한 번 세어 "
+                        + "'설명되지 않은 이탈' 이 음수가 됐다 — 없는 네 번째 이탈을 쫓게 된다")
+                .isNegative();
+
+        // ── 분할: 계획 층이 이긴다 ────────────────────────────────────
+        assertThat(metrics.unplanned())
+                .as("계획 단계에서 이미 계약 밖이 된 턴은 이탈② 다 — 생성이 성공했어도 "
+                        + "모집단에 들어오지 않으므로 그것이 이탈의 원인이다")
+                .isEqualTo(OVERLAPPING_ESCAPES);
+        assertThat(metrics.noBodyEscapes())
+                .as("같은 턴을 이탈③ 으로 또 세면 합계가 계약 밖 건수를 넘는다")
+                .isZero();
+        assertThat(metrics.explainedEscapes()).isEqualTo(metrics.notApplicable());
+        assertThat(metrics.unexplainedEscapes())
+                .as("분할이므로 0 이다 — 음수도 양수도 될 수 없다")
+                .isZero();
+
+        // ── 생성 실패 사실은 사라지지 않는다 ───────────────────────────
+        assertThat(metrics.generationFailures())
+                .as("이탈 분할이 이탈②를 골랐다는 것이 생성 실패를 없애지는 않는다 — "
+                        + "두 축은 다른 물음에 답한다")
+                .isEqualTo(OVERLAPPING_ESCAPES);
+        assertThat(metrics.externalFailures()).isEqualTo(OVERLAPPING_ESCAPES);
+
+        System.out.print(ContractComplianceReport.render(result, metrics));
+    }
+
+    @Test
+    @DisplayName("P0-3: 모든 계약 밖 턴이 정확히 한 자리를 받는다 — 두 실패 모양 모두에서")
+    void everyEscapeGetsExactlyOneBucket() {
+        for (CellRunner.Result result : List.of(runWithFailureShape(),
+                runWithPlannerAndGenerationOverlap())) {
+            ContractComplianceMetrics metrics = metricsOf(result);
+            int partitioned = 0;
+            for (ContractComplianceMetrics.Escape escape
+                    : ContractComplianceMetrics.Escape.values()) {
+                partitioned += metrics.escapeCount(escape);
+            }
+            assertThat(partitioned)
+                    .as("분할 합이 계약 밖 턴 수와 같아야 한다 (팔 %s)", metrics.arm().label())
+                    .isEqualTo(metrics.notApplicable());
+            assertThat(result.outcomes()).allSatisfy(outcome -> {
+                ContractComplianceMetrics.Escape escape =
+                        ContractComplianceMetrics.escapeOf(outcome);
+                if (outcome.contract() == ContractOutcome.NOT_APPLICABLE) {
+                    assertThat(escape).as("계약 밖 턴은 자리를 하나 받아야 한다").isNotNull();
+                } else {
+                    assertThat(escape).as("모집단에 남은 턴은 이탈 자리를 갖지 않는다").isNull();
+                }
+            });
+        }
+    }
+
+    /**
+     * 예전 집계의 술어 넷을 그대로 재현해 이 턴이 <b>몇 자리에</b> 걸리는지 센다.
+     *
+     * <p>2 이상이 나오는 턴이 MEDIUM-1 이 지적한 겹침이다. 고친 코드를 부르지 않고 여기 따로
+     * 적어 두는 이유는, 이 함수가 <b>결함의 모양</b>을 기록하기 때문이다 — 분할 구현이 나중에
+     * 바뀌어도 이 테스트는 여전히 같은 것을 묻는다.
+     */
+    private static long legacyBucketCount(CellCaseOutcome o) {
+        long count = 0;
+        if (o.observedResponseAct() == ResponseAct.CRISIS_ASSESSMENT) {
+            count++;
+        }
+        if (o.observedResponseAct() == ResponseAct.SECURITY_REFUSAL) {
+            count++;
+        }
+        if (o.observedResponseAct() == ResponseAct.UNPLANNED) {
+            count++;
+        }
+        if (o.contract() == ContractOutcome.NOT_APPLICABLE
+                && (o.externalFailure().removesBody()
+                || o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE)) {
+            count++;
+        }
+        return count;
+    }
+
+    /**
+     * 앞 {@value #OVERLAPPING_ESCAPES} 건을 <b>계획 이탈 + 생성 실패</b>로 만든다.
+     *
+     * <p>InputJudge 가 보안 {@code SUSPICIOUS} 를 돌려주게 하고(등급은 {@code CLEAR_LOW} 유지)
+     * 같은 케이스의 생성 호출을 실패시킨다. 판정 호출 자체는 <b>성공</b>한다 — 판정 실패까지
+     * 섞으면 무엇이 겹침을 만들었는지 흐려진다.
+     */
+    private static CellRunner.Result runWithPlannerAndGenerationOverlap() {
+        CellTokenLedger keys = new CellTokenLedger();
+        Set<UUID> overlapping = ContractEvalSet.CASES.stream()
+                .limit(OVERLAPPING_ESCAPES)
+                .map(c -> keys.keyFor(c.id()))
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+
+        CellVariant variant = CellVariant.of(BenchmarkCell.A, ContractPromptArm.WITH_CONTRACT_BLOCK);
+        try {
+            return CellRunner.withClientFactory(variant,
+                    CellModelRegistry.resolveForEstimate(BenchmarkCell.A, Map.of()),
+                    (ledger, pricing) -> new FailingLlmClient(new StubLlmClient(ledger, pricing),
+                            overlapping, Set.of(), overlapping))
+                    .run(ContractEvalSet.CASES, false, IDENTITY);
+        } catch (Exception e) {
+            throw new IllegalStateException("겹침 모양 재구성 실행이 죽었다", e);
+        }
+    }
+
+    @Test
+    @DisplayName("P0-3: 외부 실패 상한은 세트에 사전 등록되고 가드가 그 값을 읽는다")
+    void theExternalFailureThresholdIsPreRegistered() {
+        ContractEvalSet.RunValidity registered = ContractEvalSet.RUN_VALIDITY;
+
+        assertThat(ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE)
+                .as("가드가 사전 등록값과 다른 값을 읽으면 등록이 아무것도 구속하지 않는다")
+                .isEqualTo(registered.maxExternalFailureShare());
+        assertThat(registered.maxExternalFailureShare())
+                .as("이 실행 시점의 사전 등록값을 못 박는다 — 바꾸려면 이 테스트도 같이 바뀌어야 하고, "
+                        + "그러면 변경이 PR diff 에 보인다")
+                .isEqualTo(0.10);
+
+        // 상한 하나가 실패 모드 둘을 다룬다는 사실이 데이터에 남아 있어야 한다 (MEDIUM-3).
+        // 근거 없이 값을 바꿀 수 있으면 사전 등록이 형식이 된다.
+        assertThat(registered.tradeoff())
+                .as("문턱의 교환 기록이 비면 나중에 그 문턱을 왜 이렇게 뒀는지 아무도 모른다")
+                .isNotEmpty()
+                .anySatisfy(line -> assertThat(line).contains("생성 호출 실패"))
+                .anySatisfy(line -> assertThat(line).contains("판정 호출 실패"))
+                .anySatisfy(line -> assertThat(line).contains("검토한 대안"))
+                .anySatisfy(line -> assertThat(line).contains("채택하지 않은 이유"))
+                .anySatisfy(line -> assertThat(line).contains("팀 승인 대기"));
+        assertThat(registered.rationale()).contains("사후 합리화");
+    }
+
+    @Test
+    @DisplayName("P0-3: CBT 분류 실패는 외부 실패 축 밖이지만 manifest 에는 보인다")
+    void cbtClassifierFailuresAreOutOfScopeButVisible() {
+        CellRunner.Result result = run(ContractPromptArm.WITH_CONTRACT_BLOCK, new PromptSpy());
+        ContractComplianceMetrics metrics = metricsOf(result);
+
+        assertThat(metrics.cbtClassifierCalls())
+                .as("분류기를 한 번도 부르지 않으면 이 경계를 검사할 대상이 없다")
+                .isPositive();
+        assertThat(result.outcomes())
+                .as("분류 실패는 ExternalFailure 축에 섞이지 않는다 — 전달·수용 이후 호출이다")
+                .allSatisfy(o -> {
+                    if (o.cbtClassifierFailed()) {
+                        assertThat(o.externalFailure().any())
+                                .as("케이스 %s: 분류 실패만으로 외부 실패가 되면 10%% 가드가 "
+                                        + "모집단과 무관한 축의 실패로 실행을 막는다", o.caseId())
+                                .isFalse();
+                    }
+                });
+
+        Map<String, String> metadata = ContractComplianceReport
+                .manifest(result, metrics, Map.of()).toMetadata();
+        assertThat(metadata.get("cbt_classifier_failures"))
+                .as("축에서 빼는 것과 감추는 것은 다르다 — 건수와 그 경계가 manifest 에 있어야 한다")
+                .contains("%d/%d회".formatted(metrics.cbtClassifierFailures(),
+                        metrics.cbtClassifierCalls()))
+                .contains("ExternalFailure 축에 넣지 않는다");
+    }
+
     @Test
     @DisplayName("P0-3: 세트가 선언한 이탈과 리포트가 이름 붙이는 이탈이 같은 수다")
     void declaredEscapesMatchWhatTheReportNames() {
@@ -434,7 +626,8 @@ class ContractComplianceHarnessTest {
             return CellRunner.withClientFactory(variant,
                     CellModelRegistry.resolveForEstimate(BenchmarkCell.A, Map.of()),
                     (ledger, pricing) -> new FailingLlmClient(
-                            new StubLlmClient(ledger, pricing), generationFailures, judgeFailures))
+                            new StubLlmClient(ledger, pricing), generationFailures, judgeFailures,
+                            Set.of()))
                     .run(ContractEvalSet.CASES, false, IDENTITY);
         } catch (Exception e) {
             throw new IllegalStateException("실패 모양 재구성 실행이 죽었다", e);
@@ -442,14 +635,30 @@ class ContractComplianceHarnessTest {
     }
 
     /**
-     * 지정한 케이스에서 외부 호출을 실패시키는 클라이언트.
+     * 지정한 케이스에서 외부 호출을 실패시키거나 Judge 보안 판정을 올리는 클라이언트.
      *
      * <p>실패 서명을 {@code #305} 실행의 로그와 같게 둔다 — {@code LLM streaming error} 는 생성
      * 스트리밍, {@code LLM complete error} 는 판정 호출이었다. 케이스 귀속은
      * {@code LlmRequest.userId}(= caseKey) 로 하며, 이는 원장이 쓰는 것과 같은 키다.
+     *
+     * @param suspiciousJudgements InputJudge 가 보안 {@code SUSPICIOUS} 를 돌려줄 케이스. 등급은
+     *                             {@code CLEAR_LOW} 로 두므로 {@code PolicyEngine} 6번 분기를 타고
+     *                             플래너가 {@code unplanned()} 를 낸다 — 계획 이탈(이탈②)을
+     *                             만드는 유일한 무과금 경로다
      */
     private record FailingLlmClient(LlmClient delegate, Set<UUID> generationFailures,
-                                    Set<UUID> judgeFailures) implements LlmClient {
+                                    Set<UUID> judgeFailures,
+                                    Set<UUID> suspiciousJudgements) implements LlmClient {
+
+        /** 룰이 CLEAN 이어도 EffectiveSecurityResolver 가 SUSPICIOUS 로 올리게 하는 판정. */
+        private static final String SUSPICIOUS_INPUT_JUDGE_JSON = """
+                {"security":{"level":"SUSPICIOUS","attack_types":["PROMPT_INJECTION"],
+                             "require_output_security_guard":true},
+                 "risk":{"risk_level":"CLEAR_LOW","risk_types":[],"crisis_attribution":"NONE",
+                         "recommended_generation_mode":"NORMAL","recommended_delivery":"SPECULATIVE",
+                         "require_output_safety_guard":false},
+                 "confidence":0.9}
+                """;
 
         @Override
         public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
@@ -466,11 +675,14 @@ class ContractComplianceHarnessTest {
 
         @Override
         public String completeJson(LlmRequest request) {
+            boolean inputJudge = CellModelRole.INPUT_SAFETY.component().equals(request.component());
             // InputJudge 만 실패시킨다. OutputJudge·CBT 분류까지 함께 실패시키면 무엇이 계량기를
             // 가렸는지가 흐려진다 — #305 에서 생성 실패를 덮어쓴 것은 InputJudge 였다.
-            if (CellModelRole.INPUT_SAFETY.component().equals(request.component())
-                    && judgeFailures.contains(request.userId())) {
+            if (inputJudge && judgeFailures.contains(request.userId())) {
                 throw new IllegalStateException("LLM complete error");
+            }
+            if (inputJudge && suspiciousJudgements.contains(request.userId())) {
+                return SUSPICIOUS_INPUT_JUDGE_JSON;
             }
             return delegate.completeJson(request);
         }

--- a/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
@@ -20,11 +20,14 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
+import static org.assertj.core.api.Assertions.within;
 
 /**
  * 계약 준수 하네스 자체 검사 (이슈 #305). 모델을 부르지 않는다.
@@ -208,6 +211,269 @@ class ContractComplianceHarnessTest {
                 .isEqualTo(EvalRunManifest.TuningExposure.USED_FOR_TUNING.attestation());
         assertThat(metadata.get("dataset")).isEqualTo(ContractEvalSet.VERSION);
         assertThat(metadata.get("scope")).contains("contract compliance (dev-gold)");
+    }
+
+    // ── P0-3: 외부 실패 계량기가 판정 실패에 가려지지 않는다 ──────────
+
+    /**
+     * {@code #305} 유료 실행이 실제로 낸 실패 모양 (아카이브 {@code RUN-NOTES.md} 3번).
+     *
+     * <p>대조군 153건 중 <b>생성 호출 25건</b>이 실패했고(관측 서명 {@code LLM streaming error}),
+     * 그중 <b>24건</b>은 같은 턴의 InputJudge 호출도 실패했다({@code LLM complete error}).
+     * 이 모양을 그대로 재구성한다 — 숫자를 맞추는 것이 목적이 아니라, 저 실행에서 계량기가
+     * 무엇을 놓쳤는지가 이 모양에서만 드러나기 때문이다.
+     */
+    private static final int GENERATION_FAILURES = 25;
+    private static final int JUDGE_FAILURES_AMONG_THEM = 24;
+
+    /** {@code #305} 대조군 세트 크기. 이 값이 곧 외부 실패 비율의 분모다. */
+    private static final int RUN_CASES = 153;
+
+    @Test
+    @DisplayName("P0-3: 판정 실패가 생성 실패를 덮어써도 외부 실패 계량기는 25건을 센다 — #305 재구성")
+    void externalFailureTallySurvivesTheJudgeFailureLabel() {
+        assertThat(ContractEvalSet.CASES)
+                .as("#305 실행과 같은 분모여야 16.3% 를 재구성할 수 있다")
+                .hasSize(RUN_CASES);
+
+        ContractComplianceMetrics metrics = metricsOf(runWithFailureShape());
+
+        // ── 사실: 두 실패가 서로를 지우지 않는다 ──────────────────────
+        assertThat(metrics.generationFailures())
+                .as("생성 호출 실패 사실이 판정 실패 라벨에 먹히면 안 된다")
+                .isEqualTo(GENERATION_FAILURES);
+        assertThat(metrics.judgeFailures())
+                .as("판정 호출 실패도 같은 턴에서 따로 세어져야 한다")
+                .isEqualTo(JUDGE_FAILURES_AMONG_THEM);
+        assertThat(metrics.externalFailures())
+                .as("한 턴에서 두 실패가 겹쳐도 그 턴은 한 번 세고, 겹침 때문에 사라지지는 않는다")
+                .isEqualTo(GENERATION_FAILURES);
+
+        // ── 비율: 0.65% 가 아니라 16.3% 로 읽힌다 ─────────────────────
+        assertThat(metrics.externalFailureShare() * 100)
+                .as("#305 manifest 는 external_failure_calls=1 → 0.65%% 로 읽고 통과했다. "
+                        + "실제 유실은 %d/%d = 16.3%% 다",
+                        GENERATION_FAILURES, RUN_CASES)
+                .isCloseTo(16.3, within(0.1));
+        assertThat((double) (GENERATION_FAILURES - JUDGE_FAILURES_AMONG_THEM) / RUN_CASES * 100)
+                .as("예전 계량기가 읽던 값을 못 박아 둔다 — 25 − 24 = 1 → 0.65%%")
+                .isCloseTo(0.65, within(0.01));
+
+        // ── 가드: 같은 데이터에서 이제 거절한다 ────────────────────────
+        assertThat(metrics.externalFailureWithinLimit())
+                .as("외부 실패 %.1f%% 가 상한 %.0f%% 를 넘었는데 가드가 통과시키면 P0-3 이 그대로 남는다",
+                        metrics.externalFailureShare() * 100,
+                        ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE * 100)
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("P0-3: acceptance 는 여전히 턴당 하나 — 판정 실패 라벨이 우선한다")
+    void acceptanceStillCarriesExactlyOneLabelPerTurn() {
+        List<CellCaseOutcome> outcomes = runWithFailureShape().outcomes();
+
+        // 라벨 의미론은 바뀌지 않았다. 바뀐 것은 계량기가 라벨을 읽지 않는다는 것뿐이다.
+        assertThat(outcomes).filteredOn(o ->
+                        o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_JUDGE_FAILURE)
+                .as("판정이 실패한 턴은 여전히 REJECTED_JUDGE_FAILURE 로 라벨된다")
+                .hasSize(JUDGE_FAILURES_AMONG_THEM);
+        assertThat(outcomes).filteredOn(o ->
+                        o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EXTERNAL_FAILURE)
+                .as("라벨만 세면 25건 중 1건만 남는다 — 이 값이 #305 manifest 의 1 이다")
+                .hasSize(GENERATION_FAILURES - JUDGE_FAILURES_AMONG_THEM);
+
+        // 두 라벨의 턴 모두 외부 실패 사실을 들고 있다.
+        assertThat(outcomes).filteredOn(CellCaseOutcome::externalFailureObserved)
+                .as("라벨이 무엇이든 외부 실패가 일어난 턴은 사실을 들고 있어야 한다")
+                .hasSize(GENERATION_FAILURES)
+                .allSatisfy(o -> assertThat(o.externalFailure().generation()).isTrue());
+    }
+
+    @Test
+    @DisplayName("P0-3: 계약 밖 25건이 이탈③으로 이름을 얻고 합계가 검산된다")
+    void theThirdEscapeIsNamedAndAudited() {
+        CellRunner.Result result = runWithFailureShape();
+        ContractComplianceMetrics metrics = metricsOf(result);
+
+        assertThat(metrics.notApplicable())
+                .as("#305 대조군의 '계약 밖 25건' 을 재구성한다")
+                .isEqualTo(GENERATION_FAILURES);
+        assertThat(metrics.crisisRouted()).as("이탈① 은 0 이었다").isZero();
+        assertThat(metrics.unplanned()).as("이탈② 는 0 이었다").isZero();
+        assertThat(metrics.securityRefusal()).as("보안 거절도 0 이었다").isZero();
+        assertThat(metrics.noBodyEscapes())
+                .as("설명 줄이 모두 0 인데 계약 밖 25건이 남는 상태를 이탈③ 이 메운다")
+                .isEqualTo(GENERATION_FAILURES);
+        assertThat(metrics.unexplainedEscapes())
+                .as("이탈 합계가 계약 밖 건수와 맞지 않으면 또 이름 없는 이탈이 있다는 뜻이다")
+                .isZero();
+
+        String report = ContractComplianceReport.render(result, metrics);
+        System.out.print(report);
+        assertThat(report)
+                .as("리포트가 세 번째 이탈을 이름으로 찍어야 '계약 밖 N건' 이 다시 미설명으로 남지 않는다")
+                .contains("이탈③ 생성 본문 없음")
+                .contains("이탈 합계 ①+②+③+보안거절");
+        assertThat(report)
+                .as("무과금 게이트의 보장 범위가 플래너 층이라는 것을 리포트가 스스로 적어야 한다")
+                .contains("플래너 층에 한정");
+        assertThat(report)
+                .as("상한을 넘긴 실행은 리포트가 인용 금지를 찍어야 한다")
+                .contains("외부 실패가 상한을 넘었다");
+    }
+
+    @Test
+    @DisplayName("P0-3: manifest 가 외부 실패를 턴 단위·내역과 함께 싣는다")
+    void manifestCarriesTheHonestExternalFailureTally() {
+        CellRunner.Result result = runWithFailureShape();
+        Map<String, String> metadata = ContractComplianceReport
+                .manifest(result, metricsOf(result), Map.of()).toMetadata();
+
+        assertThat(metadata.get("external_failure_turns"))
+                .as("#305 manifest 는 이 자리에 1 을 적었다")
+                .isEqualTo(String.valueOf(GENERATION_FAILURES));
+        assertThat(metadata.get("external_failure_share")).startsWith("0.1634");
+        assertThat(metadata.get("external_failure_within_limit")).isEqualTo("false");
+        assertThat(metadata.get("external_failure_breakdown"))
+                .isEqualTo("생성 %d · 판정 %d · 케이스 중단 0"
+                        .formatted(GENERATION_FAILURES, JUDGE_FAILURES_AMONG_THEM));
+        assertThat(metadata.get("no_body_escapes")).isEqualTo(String.valueOf(GENERATION_FAILURES));
+        assertThat(metadata)
+                .as("단위가 '호출' 이 아니었던 옛 키를 남겨 두면 같은 이름이 두 정의를 갖는다")
+                .doesNotContainKey("external_failure_calls");
+    }
+
+    // ── P0-3: reporting_unit 은 보고 대상 세트를 말한다 ────────────────
+
+    @Test
+    @DisplayName("P0-3: reporting_unit 이 잠금 세트의 고정 문구를 쓰지 않는다")
+    void reportingUnitDescribesTheContractSet() {
+        CellRunner.Result result = run(ContractPromptArm.WITH_CONTRACT_BLOCK, new PromptSpy());
+        ContractComplianceMetrics metrics = metricsOf(result);
+        Map<String, String> metadata = ContractComplianceReport
+                .manifest(result, metrics, Map.of()).toMetadata();
+
+        String unit = metadata.get("reporting_unit");
+        assertThat(unit)
+                .as("이 세트의 하위 그룹은 51건씩이라 하한 30 을 넘는다 — 잠금 세트 문구는 거짓이 된다")
+                .doesNotContain(LockedEvalSet.REPORTING.reportableUnit())
+                .doesNotContain("어느 하위 그룹도");
+        assertThat(unit)
+                .as("보고 대상 세트와 이번 실행의 관측값을 말해야 한다")
+                .contains(ContractEvalSet.VERSION)
+                .contains("CLARIFY_CONTEXT=" + ContractEvalSet.CASES.size());
+        assertThat(metadata.get("reporting_min_subgroup_n"))
+                .as("하한 자체는 두 세트가 공유한다")
+                .isEqualTo(String.valueOf(LockedEvalSet.REPORTING.minSubgroupN()));
+        assertThat(ContractEvalSet.intendedDistribution().values())
+                .as("선언 하위 그룹이 모두 하한을 넘는다는 전제가 이 문구의 근거다")
+                .allSatisfy(n -> assertThat(n)
+                        .isGreaterThanOrEqualTo(LockedEvalSet.REPORTING.minSubgroupN()));
+    }
+
+    // ── P0-3: 원가가 리포트·manifest 에 실린다 ─────────────────────────
+
+    @Test
+    @DisplayName("P0-3: 리포트와 manifest 가 토큰·원가를 싣는다 — 견적 대비 실비를 답할 수 있다")
+    void costIsRenderedSoEstimateVersusActualIsAnswerable() {
+        CellRunner.Result result = run(ContractPromptArm.WITH_CONTRACT_BLOCK, new PromptSpy());
+        ContractComplianceMetrics metrics = metricsOf(result);
+
+        assertThat(ContractComplianceReport.render(result, metrics))
+                .as("#305 는 이 줄이 없어 실비를 어디에서도 확인할 수 없었다")
+                .contains("[토큰·원가")
+                .contains("총 원가")
+                .contains("단가 미등록 호출");
+
+        Map<String, String> metadata = ContractComplianceReport
+                .manifest(result, metrics, Map.of()).toMetadata();
+        assertThat(metadata)
+                .as("CellReport 와 같은 키를 써야 두 아카이브를 같은 도구로 읽을 수 있다")
+                .containsKeys("llm_calls", "prompt_tokens", "completion_tokens",
+                        "cost_total_usd", "unpriced_calls", "usage_missing_calls");
+        assertThat(Long.parseLong(metadata.get("prompt_tokens"))).isPositive();
+        assertThat(metadata.get("cost_total_usd"))
+                .as("단가를 아는 실행이면 금액이, 모르면 '미상' 이 나온다 — 0 은 나오지 않는다")
+                .isNotEqualTo("$0.000000");
+    }
+
+    @Test
+    @DisplayName("P0-3: 세트가 선언한 이탈과 리포트가 이름 붙이는 이탈이 같은 수다")
+    void declaredEscapesMatchWhatTheReportNames() {
+        // 세트의 산문과 실행의 집계가 갈리는 것이 P0-3 의 본질이었다. 한쪽만 고치면 여기서 깨진다.
+        assertThat(ContractEvalSet.declaredEscapes())
+                .as("리포트는 이탈① ② ③ 을 이름으로 찍는다 — 세트 선언도 셋이어야 한다")
+                .hasSize(3)
+                .anySatisfy(e -> assertThat(e).startsWith("JUDGE_HARD_CRISIS"))
+                .anySatisfy(e -> assertThat(e).startsWith("JUDGE_SECURITY"))
+                .anySatisfy(e -> assertThat(e).startsWith("NO_BODY"));
+        assertThat(ContractEvalSet.declaredEscapes())
+                .as("이탈③ 이 어느 필드로 세어지는지 세트가 스스로 적어야 한다")
+                .anySatisfy(e -> assertThat(e).contains("no_body_escapes"));
+    }
+
+    /**
+     * {@code #305} 대조군의 실패 모양으로 스텁 실행을 돌린다.
+     *
+     * <p>앞 {@value #GENERATION_FAILURES} 건의 생성 호출을 실패시키고, 그중 앞
+     * {@value #JUDGE_FAILURES_AMONG_THEM} 건은 InputJudge 호출도 실패시킨다. 실패시키는 방법은
+     * 프로덕션이 실제로 받는 것과 같다 — 클라이언트가 {@link RuntimeException} 을 던지고,
+     * {@code CellRunner} 와 {@code InputJudge} 가 각자 그것을 잡는다.
+     */
+    private static CellRunner.Result runWithFailureShape() {
+        CellTokenLedger keys = new CellTokenLedger();
+        List<UUID> failing = ContractEvalSet.CASES.stream()
+                .limit(GENERATION_FAILURES)
+                .map(c -> keys.keyFor(c.id()))
+                .toList();
+        Set<UUID> generationFailures = Set.copyOf(failing);
+        Set<UUID> judgeFailures = Set.copyOf(failing.subList(0, JUDGE_FAILURES_AMONG_THEM));
+
+        CellVariant variant = CellVariant.of(BenchmarkCell.A, ContractPromptArm.WITHOUT_CONTRACT_BLOCK);
+        try {
+            return CellRunner.withClientFactory(variant,
+                    CellModelRegistry.resolveForEstimate(BenchmarkCell.A, Map.of()),
+                    (ledger, pricing) -> new FailingLlmClient(
+                            new StubLlmClient(ledger, pricing), generationFailures, judgeFailures))
+                    .run(ContractEvalSet.CASES, false, IDENTITY);
+        } catch (Exception e) {
+            throw new IllegalStateException("실패 모양 재구성 실행이 죽었다", e);
+        }
+    }
+
+    /**
+     * 지정한 케이스에서 외부 호출을 실패시키는 클라이언트.
+     *
+     * <p>실패 서명을 {@code #305} 실행의 로그와 같게 둔다 — {@code LLM streaming error} 는 생성
+     * 스트리밍, {@code LLM complete error} 는 판정 호출이었다. 케이스 귀속은
+     * {@code LlmRequest.userId}(= caseKey) 로 하며, 이는 원장이 쓰는 것과 같은 키다.
+     */
+    private record FailingLlmClient(LlmClient delegate, Set<UUID> generationFailures,
+                                    Set<UUID> judgeFailures) implements LlmClient {
+
+        @Override
+        public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
+            if (generationFailures.contains(request.userId())) {
+                throw new IllegalStateException("LLM streaming error");
+            }
+            return delegate.stream(request, chunkHandler);
+        }
+
+        @Override
+        public String completeText(LlmRequest request) {
+            return delegate.completeText(request);
+        }
+
+        @Override
+        public String completeJson(LlmRequest request) {
+            // InputJudge 만 실패시킨다. OutputJudge·CBT 분류까지 함께 실패시키면 무엇이 계량기를
+            // 가렸는지가 흐려진다 — #305 에서 생성 실패를 덮어쓴 것은 InputJudge 였다.
+            if (CellModelRole.INPUT_SAFETY.component().equals(request.component())
+                    && judgeFailures.contains(request.userId())) {
+                throw new IllegalStateException("LLM complete error");
+            }
+            return delegate.completeJson(request);
+        }
     }
 
     // ── 실행 도우미 ────────────────────────────────────────────────

--- a/src/test/java/com/mio/ai/qa/ContractComplianceLlmTest.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceLlmTest.java
@@ -62,14 +62,6 @@ class ContractComplianceLlmTest {
 
     private static final String SAMPLE_PROPERTY = "mio.eval.sampleSize";
 
-    /**
-     * 외부 실패 상한 (비율).
-     *
-     * <p>실패한 턴은 계약 모집단에 들어오지 않는다. 실패가 많으면 남은 모집단이 실패하지 않은
-     * 쪽으로 치우쳐, 위반율이 네트워크 사정을 재는 값이 된다.
-     */
-    private static final double MAX_EXTERNAL_FAILURE_SHARE = 0.10;
-
     @Test
     @Timeout(value = 90, unit = TimeUnit.MINUTES)
     @DisplayName("계약 지시 유무로 두 팔을 돌리고 행위별 위반율·분포를 기록한다")
@@ -117,18 +109,34 @@ class ContractComplianceLlmTest {
         metrics.forEach((arm, m) -> {
             assertThat(m.applicable())
                     .as("%s 팔에서 계약 적용 턴이 하한 미만이다 (%d) — P0-8 3단계와 같이 "
-                            + "건수만 인용할 수 있는 실행이 됐다. 룰 레이어는 전 케이스를 계약 "
-                            + "경로로 보내므로(ContractEvalSetTest), 원인은 Judge 판정이 만든 두 "
-                            + "이탈 중 하나다: 위기 승격 %d건 · 보안 의심 %d건",
-                            arm.label(), m.applicable(), m.crisisRouted(), m.unplanned())
+                            + "건수만 인용할 수 있는 실행이 됐다. 이탈은 셋이다: "
+                            + "① Judge 위기 승격 %d건 · ② Judge 보안 의심 %d건 · "
+                            + "③ 생성 본문 없음 %d건. ①②만 무과금 게이트(ContractEvalSetTest)가 "
+                            + "닫으며, 그 게이트는 플래너 층까지만 보므로 ③은 여기서만 보인다",
+                            arm.label(), m.applicable(), m.crisisRouted(), m.unplanned(),
+                            m.noBodyEscapes())
                     .isGreaterThanOrEqualTo(LockedEvalSet.REPORTING.minSubgroupN());
             assertThat(m.violationRate())
                     .as("%s 팔의 총계 위반율이 보고 가능해야 한다", arm.label())
                     .isInstanceOf(ReportableRate.Reported.class);
-            assertThat((double) m.externalFailures() / m.cases())
-                    .as("%s 팔의 외부 실패가 많다 (%d/%d) — 남은 모집단이 편향된다",
-                            arm.label(), m.externalFailures(), m.cases())
-                    .isLessThanOrEqualTo(MAX_EXTERNAL_FAILURE_SHARE);
+            // 외부 실패는 acceptance 라벨이 아니라 관측된 사실로 센다 (P0-3). #305 실행은
+            // 생성 실패 25건 중 24건이 같은 턴의 판정 실패 라벨에 먹혀 이 검사가 16.3% 를
+            // 0.65% 로 읽고 통과했다.
+            assertThat(m.externalFailureWithinLimit())
+                    .as("%s 팔의 외부 실패가 상한을 넘었다 — %d/%d턴 (%.1f%%) > %.0f%%. "
+                            + "내역: 생성 %d · 판정 %d · 케이스 중단 %d. 남은 %d건은 무작위 표본이 "
+                            + "아니므로 위반율을 인용할 수 없다",
+                            arm.label(), m.externalFailures(), m.cases(),
+                            m.externalFailureShare() * 100,
+                            ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE * 100,
+                            m.generationFailures(), m.judgeFailures(), m.abortedCases(),
+                            m.applicable())
+                    .isTrue();
+            assertThat(m.unexplainedEscapes())
+                    .as("%s 팔의 계약 밖 %d건 중 %d건이 어느 이탈로도 설명되지 않는다 — "
+                            + "'계약 밖 N건' 이 다시 설명 없이 남았다",
+                            arm.label(), m.notApplicable(), m.unexplainedEscapes())
+                    .isZero();
         });
 
         assertThat(runs.values())

--- a/src/test/java/com/mio/ai/qa/ContractComplianceMetrics.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceMetrics.java
@@ -44,11 +44,13 @@ record ContractComplianceMetrics(
         int notApplicable,
         int unchecked,
         int generationCalled,
-        /** Judge 가 위기로 올려 고정 플로우로 빠진 턴 — 계약 모집단에서 빠진 이유 중 하나. */
-        int crisisRouted,
-        int securityRefusal,
-        /** 계획 범위 밖으로 남은 턴. 룰이 Judge 로 올렸는데도 여기 오면 설계 가정이 틀린 것이다. */
-        int unplanned,
+        /**
+         * 이탈 <b>분할</b> — 계약 밖 턴 하나가 정확히 한 자리에만 들어간다 (P0-3 MEDIUM-1).
+         *
+         * <p>{@link Escape} 참조. 예전에는 네 개의 독립 술어로 각각 세어 한 턴이 두 자리에
+         * 들어갈 수 있었다.
+         */
+        Map<Escape, Integer> escapes,
         /**
          * 외부 실패가 <b>일어난</b> 턴 수 — {@code acceptance} 라벨과 독립이다 (P0-3).
          *
@@ -65,14 +67,15 @@ record ContractComplianceMetrics(
         int abortedCases,
         int emptyResponses,
         /**
-         * 이탈③ — 생성 본문이 없어 계약 검사가 {@code notApplicable()} 을 돌려준 턴 (P0-3).
+         * CBT 분류 실패 (P0-3 MEDIUM-2).
          *
-         * <p>{@code ContractEvalSetTest} 의 "전 케이스가 계약 경로로 간다" 보장은 <b>플래너
-         * 층</b>에 한정된다. 그 테스트는 생성을 돌리지 않으므로 이 이탈을 구조적으로 볼 수 없다.
-         * {@code #305} 대조군의 {@code 계약 밖 25건} 이 정확히 이것이었고, 리포트가 그 25건을
-         * 설명하는 세 줄이 모두 0 이었다.
+         * <p><b>{@link CellCaseOutcome.ExternalFailure} 축에는 들어가지 않는다</b> — 분류 호출은
+         * 전달·수용이 끝난 뒤에 일어나므로 계약 분모를 줄이지도, 계획된 행위 분포를 밀지도 않는다.
+         * 그래도 manifest 에 싣는 이유는 그 축이 <b>얼마나 안 재졌는지</b>를 아카이브만 보고도 알 수
+         * 있어야 하기 때문이다. {@code CellReport} 와 같은 경계를 쓴다.
          */
-        int noBodyEscapes,
+        int cbtClassifierFailures,
+        int cbtClassifierCalls,
         Map<ResponseAct, ActStats> byAct,
         Map<String, Integer> violationTypes,
         Shape shape) {
@@ -80,6 +83,117 @@ record ContractComplianceMetrics(
     ContractComplianceMetrics {
         byAct = Map.copyOf(byAct);
         violationTypes = Map.copyOf(violationTypes);
+        escapes = Map.copyOf(escapes);
+    }
+
+    /**
+     * 계약 밖 턴 하나가 속하는 이탈 자리 (P0-3 MEDIUM-1).
+     *
+     * <h2>왜 분할이어야 하는가</h2>
+     *
+     * <p>예전에는 이탈을 네 개의 <b>독립 술어</b>로 각각 셌다 — {@code act == CRISIS_ASSESSMENT},
+     * {@code act == SECURITY_REFUSAL}, {@code act == UNPLANNED}, 그리고 "본문이 없다". 앞 셋은
+     * 서로 배타적이지만 <b>넷째와는 겹친다.</b>
+     *
+     * <p>겹치는 경로가 실재한다. Judge 가 보안을 {@code SUSPICIOUS} 로 올리고 등급이 {@code LOW}
+     * 이면 {@code PolicyEngine} 6번 분기가 {@code GENERATE} + {@code allowGeneration=true} 를 내고
+     * {@code ResponsePlanner.planGeneration()} 은 {@code unplanned()} 를 돌려준다. 즉 <b>계획은
+     * 계약 밖인데 생성은 실제로 돈다.</b> 그 턴의 생성 호출까지 실패하면 이탈②와 이탈③을 동시에
+     * 만족하고, 합계가 한 턴을 두 번 세면서 {@code notApplicable} 은 한 번 센다 →
+     * {@link #unexplainedEscapes()} 가 0 이 아니라 <b>음수</b>가 된다. 가드는 fail-closed 라
+     * 잘못된 수치가 나가지는 않지만, 실제로는 없는 네 번째 이탈을 쫓게 된다.
+     *
+     * <p>그래서 술어 하나를 고치는 대신 <b>구조를 바꾼다.</b> 턴마다 자리를 하나만 배정하면
+     * 겹침이 생길 수 있는 자리 자체가 없어진다.
+     *
+     * <h2>배정 순서 — 먼저 이탈한 층이 이긴다</h2>
+     *
+     * <p>플래너 층 이탈이 생성 층 이탈보다 앞선다. {@code unplanned()} 로 계획된 턴은 생성이
+     * <b>성공했더라도</b> 계약 모집단에 들어오지 않는다 — 계약이 걸리지 않은 계획이기 때문이다
+     * ({@code ResponsePlan.unplanned()} 은 {@code GenerationFreedom.OPEN} 이라
+     * {@code isContractEnforced()} 가 거짓이고, 검사기는 항상 {@code notApplicable()} 을 돌려준다).
+     * 그 턴이 모집단을 떠난 <b>원인</b>은 플래너 이탈이고, 생성 실패는 그 위에 겹친 별개의 사실이다.
+     *
+     * <p>그 별개의 사실이 사라지지는 않는다 — {@link CellCaseOutcome.ExternalFailure} 축이 따로
+     * 센다. 이탈 분할은 "왜 모집단을 떠났는가" 를, 외부 실패 축은 "무엇이 실패했는가" 를 답한다.
+     * 두 물음을 한 칸에 밀어 넣은 것이 P0-3 의 원래 결함이었다.
+     */
+    enum Escape {
+        /** 이탈① Judge 가 위기로 올려 고정 플로우로 빠졌다. */
+        JUDGE_HARD_CRISIS,
+        /** 이탈② Judge 보안 판정이 non-CLEAN + 등급 LOW 이하 → 계획 범위 밖. */
+        JUDGE_SECURITY,
+        /** 보안 거절 — 룰이 공격으로 확정해 고정 문구를 낸 턴. */
+        SECURITY_REFUSAL,
+        /** 이탈③ 생성 본문이 없어 계약 검사가 {@code notApplicable()} 을 돌려줬다. */
+        NO_BODY,
+        /**
+         * 어느 이탈로도 설명되지 않는다 — 이름 없는 이탈이다.
+         *
+         * <p>0 이 아니면 리포트가 경고를 찍고 유료 실행 가드가 실패한다. 그때 고쳐야 하는 것은
+         * 수치가 아니라 이탈 분류다.
+         */
+        UNEXPLAINED;
+
+        /** 계약 모집단에 남은 턴은 이탈이 아니다 — 분할에 자리를 갖지 않는다. */
+        static final Escape IN_POPULATION = null;
+    }
+
+    /**
+     * 이 턴이 속하는 이탈 자리. 계약 모집단에 남은 턴은 {@code null} 이다.
+     *
+     * <p>배정은 <b>위에서 아래로 한 번</b> 일어난다. 순서의 근거는 {@link Escape} javadoc 에 있다.
+     */
+    static Escape escapeOf(CellCaseOutcome outcome) {
+        if (outcome.contract() != ContractOutcome.NOT_APPLICABLE) {
+            return Escape.IN_POPULATION;
+        }
+        // 플래너 층 — 계획 단계에서 이미 계약 밖이 된 턴.
+        if (outcome.observedResponseAct() == ResponseAct.CRISIS_ASSESSMENT) {
+            return Escape.JUDGE_HARD_CRISIS;
+        }
+        if (outcome.observedResponseAct() == ResponseAct.SECURITY_REFUSAL) {
+            return Escape.SECURITY_REFUSAL;
+        }
+        if (outcome.observedResponseAct() == ResponseAct.UNPLANNED) {
+            return Escape.JUDGE_SECURITY;
+        }
+        // 생성 층 — 계획은 계약을 걸었는데 볼 본문이 없다.
+        if (outcome.externalFailure().removesBody()
+                || outcome.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE) {
+            return Escape.NO_BODY;
+        }
+        return Escape.UNEXPLAINED;
+    }
+
+    int escapeCount(Escape escape) {
+        return escapes.getOrDefault(escape, 0);
+    }
+
+    /** 이탈① Judge 위기 승격. */
+    int crisisRouted() {
+        return escapeCount(Escape.JUDGE_HARD_CRISIS);
+    }
+
+    /** 이탈② Judge 보안 의심 → 계획 범위 밖. */
+    int unplanned() {
+        return escapeCount(Escape.JUDGE_SECURITY);
+    }
+
+    int securityRefusal() {
+        return escapeCount(Escape.SECURITY_REFUSAL);
+    }
+
+    /**
+     * 이탈③ 생성 본문 없음 (P0-3).
+     *
+     * <p>{@code ContractEvalSetTest} 의 "전 케이스가 계약 경로로 간다" 보장은 <b>플래너 층</b>에
+     * 한정된다. 그 테스트는 생성을 돌리지 않으므로 이 이탈을 구조적으로 볼 수 없다.
+     * {@code #305} 대조군의 {@code 계약 밖 25건} 이 정확히 이것이었고, 리포트가 그 25건을 설명하는
+     * 세 줄이 모두 0 이었다.
+     */
+    int noBodyEscapes() {
+        return escapeCount(Escape.NO_BODY);
     }
 
     /**
@@ -88,10 +202,17 @@ record ContractComplianceMetrics(
      * <p>실패한 턴은 계약 모집단에 들어오지 않는다. 실패가 많으면 남은 모집단이 실패하지 않은
      * 쪽으로 치우쳐, 위반율이 네트워크 사정을 재는 값이 된다.
      *
-     * <p>가드와 하네스 자체 검사가 <b>같은 상수</b>를 읽는다. 값을 두 곳에 적으면 한쪽만 고쳐도
+     * <p>가드와 하네스 자체 검사가 <b>같은 값</b>을 읽는다. 값을 두 곳에 적으면 한쪽만 고쳐도
      * 테스트가 통과해, 가드가 실제로 어디서 트립하는지 아무도 모르게 된다.
+     *
+     * <p><b>값은 세트에 사전 등록돼 있다</b> ({@code runValidity.maxExternalFailureShare},
+     * P0-3 MEDIUM-3). 자바 상수로 두면 실행 결과를 보고 조용히 고칠 수 있고, 그러면 상한이 아니라
+     * 사후 합리화가 된다. 이 문턱이 <b>실패 모드 둘을 한 값으로 다룬다</b>는 사실과 검토했으나
+     * 채택하지 않은 대안도 같은 자리에 기록돼 있다 —
+     * {@link ContractEvalSet.RunValidity#tradeoff()}.
      */
-    static final double MAX_EXTERNAL_FAILURE_SHARE = 0.10;
+    static final double MAX_EXTERNAL_FAILURE_SHARE =
+            ContractEvalSet.RUN_VALIDITY.maxExternalFailureShare();
 
     /** 총계 위반율. 행위별로 하한에 못 미쳐도 총계는 낼 수 있는 경우가 있다. */
     ReportableRate violationRate() {
@@ -123,14 +244,40 @@ record ContractComplianceMetrics(
      *
      * <p>{@code #305} 대조군은 {@code 계약 밖 25건} 을 찍고 설명 줄은 모두 0 이었다. 합계를
      * 리포트가 스스로 맞춰 보면 그 상태가 다음 실행에서 조용히 지나가지 않는다.
+     *
+     * <p>이탈이 <b>분할</b>이므로 이 합은 구조적으로 {@code notApplicable} 을 넘을 수 없다
+     * (P0-3 MEDIUM-1). 예전에는 독립 술어의 합이라 한 턴이 두 번 세어질 수 있었고, 그러면
+     * {@link #unexplainedEscapes()} 가 음수가 됐다.
      */
     int explainedEscapes() {
-        return crisisRouted + unplanned + securityRefusal + noBodyEscapes;
+        return crisisRouted() + unplanned() + securityRefusal() + noBodyEscapes();
     }
 
-    /** 어느 이탈로도 설명되지 않은 계약 밖 턴. 0 이 아니면 리포트가 경고를 찍는다. */
+    /**
+     * 어느 이탈로도 설명되지 않은 계약 밖 턴. 0 이 아니면 리포트가 경고를 찍는다.
+     *
+     * <p>분할이므로 <b>음수가 될 수 없다.</b> {@link #escapes} 의 값이 계약 밖 턴을 정확히 한 번씩
+     * 덮기 때문이다 — {@link #assertPartitions()} 가 그 불변식을 생성 시점에 확인한다.
+     */
     int unexplainedEscapes() {
-        return notApplicable - explainedEscapes();
+        return escapeCount(Escape.UNEXPLAINED);
+    }
+
+    /**
+     * 이탈 분할이 실제로 분할인지 확인한다 (P0-3 MEDIUM-1).
+     *
+     * <p>지표를 만드는 자리에서 한 번 검사한다. 리포트나 가드가 이 불변식을 <b>가정</b>하는 대신
+     * 여기서 깨지게 두는 것이 요점이다 — 배정 순서를 나중에 고치면서 자리를 겹치게 만들면 그
+     * 실수가 리포트 숫자가 되기 전에 드러난다.
+     */
+    private void assertPartitions() {
+        int partitioned = escapes.values().stream().mapToInt(Integer::intValue).sum();
+        if (partitioned != notApplicable) {
+            throw new IllegalStateException(
+                    ("이탈 분할이 계약 밖 턴을 정확히 덮지 않는다 — 분할 합 %d ≠ 계약 밖 %d. "
+                            + "자리 배정이 겹치거나 빠졌다: %s")
+                            .formatted(partitioned, notApplicable, escapes));
+        }
     }
 
     /**
@@ -202,7 +349,7 @@ record ContractComplianceMetrics(
                     violationTypes(actOutcomes), Shape.of(actOutcomes)));
         }
 
-        return new ContractComplianceMetrics(
+        ContractComplianceMetrics metrics = new ContractComplianceMetrics(
                 result.variant().contractArm(),
                 outcomes.size(),
                 scored.size(),
@@ -210,12 +357,7 @@ record ContractComplianceMetrics(
                 count(outcomes, ContractOutcome.NOT_APPLICABLE),
                 count(outcomes, ContractOutcome.UNCHECKED),
                 (int) outcomes.stream().filter(CellCaseOutcome::generationCalled).count(),
-                (int) outcomes.stream()
-                        .filter(o -> o.observedResponseAct() == ResponseAct.CRISIS_ASSESSMENT).count(),
-                (int) outcomes.stream()
-                        .filter(o -> o.observedResponseAct() == ResponseAct.SECURITY_REFUSAL).count(),
-                (int) outcomes.stream()
-                        .filter(o -> o.observedResponseAct() == ResponseAct.UNPLANNED).count(),
+                escapePartition(outcomes),
                 // 외부 실패는 acceptance 라벨이 아니라 관측된 사실을 센다 (P0-3). 라벨을 세면
                 // 같은 턴의 판정 실패가 생성 실패를 덮어쓴 만큼이 집계에서 사라진다.
                 (int) outcomes.stream().filter(CellCaseOutcome::externalFailureObserved).count(),
@@ -225,25 +367,31 @@ record ContractComplianceMetrics(
                 (int) outcomes.stream()
                         .filter(o -> o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE)
                         .count(),
-                (int) outcomes.stream().filter(ContractComplianceMetrics::noBodyEscape).count(),
+                (int) outcomes.stream().filter(CellCaseOutcome::cbtClassifierFailed).count(),
+                (int) outcomes.stream().filter(CellCaseOutcome::cbtClassifierCalled).count(),
                 byAct, violationTypes(scored), Shape.of(scored));
+        metrics.assertPartitions();
+        return metrics;
     }
 
     /**
-     * 이탈③ — 생성 본문이 없어 계약 모집단에서 빠진 턴 (P0-3).
+     * 계약 밖 턴을 이탈 자리로 <b>분할</b>한다 (P0-3 MEDIUM-1).
      *
-     * <p>둘 중 하나다. (1) 생성 호출이 외부 오류로 실패했다(타임아웃·예외로 케이스가 중단된
-     * 경우 포함), (2) 모델이 정상 응답으로 빈 본문을 돌려줬다. 어느 쪽이든
-     * {@code ResponseContractValidator} 는 볼 본문이 없어 {@code notApplicable()} 을 돌려준다.
-     *
-     * <p>{@code contract == NOT_APPLICABLE} 조건을 함께 본다. 판정 호출만 실패한 턴은 생성이
-     * 정상으로 돌아 분모에 남으므로 이탈이 아니다 — 그 턴을 여기 세면 이탈 합계가 계약 밖 건수를
-     * 넘고, 그러면 합계 검산이 아무것도 잡지 못한다.
+     * <p>턴마다 {@link #escapeOf} 를 한 번 불러 그 결과만 센다. 자리별 술어를 따로 세지 않으므로
+     * 한 턴이 두 자리에 들어갈 경로가 코드상 존재하지 않는다.
      */
-    private static boolean noBodyEscape(CellCaseOutcome outcome) {
-        return outcome.contract() == ContractOutcome.NOT_APPLICABLE
-                && (outcome.externalFailure().removesBody()
-                || outcome.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE);
+    private static Map<Escape, Integer> escapePartition(List<CellCaseOutcome> outcomes) {
+        Map<Escape, Integer> counts = new LinkedHashMap<>();
+        for (Escape escape : Escape.values()) {
+            counts.put(escape, 0);
+        }
+        for (CellCaseOutcome outcome : outcomes) {
+            Escape escape = escapeOf(outcome);
+            if (escape != Escape.IN_POPULATION) {
+                counts.merge(escape, 1, Integer::sum);
+            }
+        }
+        return counts;
     }
 
     private static boolean scored(CellCaseOutcome outcome) {

--- a/src/test/java/com/mio/ai/qa/ContractComplianceMetrics.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceMetrics.java
@@ -26,6 +26,12 @@ import java.util.TreeMap;
  * {@code NOT_APPLICABLE}(계획 밖·고정 응답·본문 없음)과 {@code UNCHECKED}(검사 지점 없는 전달)을
  * 분모에 넣으면 위반율이 실제보다 낮아 보인다.
  *
+ * <p><b>이탈은 셋이며 셋을 모두 이름으로 센다</b> (P0-3). ① Judge 위기 승격
+ * ({@link #crisisRouted}), ② Judge 보안 의심({@link #unplanned}), ③ 생성 본문 없음
+ * ({@link #noBodyEscapes}). ①②는 플래너 층 이탈이라 무과금 게이트({@code ContractEvalSetTest})
+ * 가 소진성을 증명하지만, ③은 <b>생성 층</b>이라 그 게이트가 구조적으로 볼 수 없다.
+ * {@code #305} 대조군이 {@code 계약 밖 25건} 을 찍고 설명 줄이 모두 0 이었던 것이 ③이다.
+ *
  * <p>비율은 전부 {@link ReportableRate} 를 지난다. 하한({@code minSubgroupN=30}) 미달 행위는
  * <b>비율이 계산되지 않는다</b> — P0-8 3단계가 n=12 로 겪은 상황을 다시 만들지 않기 위해서가
  * 아니라, 그 상황이 오더라도 수치가 인용되지 않게 하기 위해서다.
@@ -43,8 +49,30 @@ record ContractComplianceMetrics(
         int securityRefusal,
         /** 계획 범위 밖으로 남은 턴. 룰이 Judge 로 올렸는데도 여기 오면 설계 가정이 틀린 것이다. */
         int unplanned,
+        /**
+         * 외부 실패가 <b>일어난</b> 턴 수 — {@code acceptance} 라벨과 독립이다 (P0-3).
+         *
+         * <p>{@code #305} 유료 실행은 이 값을 {@code acceptance == REJECTED_EXTERNAL_FAILURE} 로
+         * 셌고, 생성 실패 25건 중 24건이 같은 턴의 판정 실패 라벨에 먹혀 <b>1</b> 을 보고했다.
+         * 지금은 {@link CellCaseOutcome#externalFailureObserved()} 를 센다.
+         */
         int externalFailures,
+        /** 그중 생성(또는 escalation 재생성) 호출이 실패한 턴. 이 턴들이 분모를 빼앗아 간다. */
+        int generationFailures,
+        /** 그중 판정 호출이 실패한 턴. 분모는 남기지만 계획된 행위를 EMOTION_CHECK 쪽으로 민다. */
+        int judgeFailures,
+        /** 그중 타임아웃·예외로 케이스 자체가 중단된 턴. */
+        int abortedCases,
         int emptyResponses,
+        /**
+         * 이탈③ — 생성 본문이 없어 계약 검사가 {@code notApplicable()} 을 돌려준 턴 (P0-3).
+         *
+         * <p>{@code ContractEvalSetTest} 의 "전 케이스가 계약 경로로 간다" 보장은 <b>플래너
+         * 층</b>에 한정된다. 그 테스트는 생성을 돌리지 않으므로 이 이탈을 구조적으로 볼 수 없다.
+         * {@code #305} 대조군의 {@code 계약 밖 25건} 이 정확히 이것이었고, 리포트가 그 25건을
+         * 설명하는 세 줄이 모두 0 이었다.
+         */
+        int noBodyEscapes,
         Map<ResponseAct, ActStats> byAct,
         Map<String, Integer> violationTypes,
         Shape shape) {
@@ -54,9 +82,55 @@ record ContractComplianceMetrics(
         violationTypes = Map.copyOf(violationTypes);
     }
 
+    /**
+     * 외부 실패 상한 (비율). 넘으면 이 실행의 수치를 쓰지 않는다.
+     *
+     * <p>실패한 턴은 계약 모집단에 들어오지 않는다. 실패가 많으면 남은 모집단이 실패하지 않은
+     * 쪽으로 치우쳐, 위반율이 네트워크 사정을 재는 값이 된다.
+     *
+     * <p>가드와 하네스 자체 검사가 <b>같은 상수</b>를 읽는다. 값을 두 곳에 적으면 한쪽만 고쳐도
+     * 테스트가 통과해, 가드가 실제로 어디서 트립하는지 아무도 모르게 된다.
+     */
+    static final double MAX_EXTERNAL_FAILURE_SHARE = 0.10;
+
     /** 총계 위반율. 행위별로 하한에 못 미쳐도 총계는 낼 수 있는 경우가 있다. */
     ReportableRate violationRate() {
         return ReportableRate.of("계약 위반율(총계)", violated, applicable);
+    }
+
+    /**
+     * 외부 실패로 잃은 턴의 비율 (P0-3).
+     *
+     * <p>분모는 시도한 전 케이스다. 남은 모집단을 분모로 쓰면 실패가 늘수록 분모도 줄어 비율이
+     * 실제보다 작게 나온다 — 계량기가 자기 실패를 감추는 계산이 된다.
+     */
+    double externalFailureShare() {
+        return cases == 0 ? 0.0 : (double) externalFailures / cases;
+    }
+
+    /**
+     * 이 실행의 수치를 인용해도 되는가 (외부 실패 기준).
+     *
+     * <p>{@code #305} 실행은 16.3% 를 잃었고 이 검사가 0.65% 로 읽어 통과했다. 지금은
+     * {@link #externalFailures} 가 라벨이 아니라 사실을 세므로 같은 데이터에서 거짓이 된다.
+     */
+    boolean externalFailureWithinLimit() {
+        return externalFailureShare() <= MAX_EXTERNAL_FAILURE_SHARE;
+    }
+
+    /**
+     * 설명된 이탈의 합 — 이 값이 {@link #notApplicable} 과 어긋나면 이름 없는 이탈이 또 생겼다.
+     *
+     * <p>{@code #305} 대조군은 {@code 계약 밖 25건} 을 찍고 설명 줄은 모두 0 이었다. 합계를
+     * 리포트가 스스로 맞춰 보면 그 상태가 다음 실행에서 조용히 지나가지 않는다.
+     */
+    int explainedEscapes() {
+        return crisisRouted + unplanned + securityRefusal + noBodyEscapes;
+    }
+
+    /** 어느 이탈로도 설명되지 않은 계약 밖 턴. 0 이 아니면 리포트가 경고를 찍는다. */
+    int unexplainedEscapes() {
+        return notApplicable - explainedEscapes();
     }
 
     /**
@@ -142,13 +216,34 @@ record ContractComplianceMetrics(
                         .filter(o -> o.observedResponseAct() == ResponseAct.SECURITY_REFUSAL).count(),
                 (int) outcomes.stream()
                         .filter(o -> o.observedResponseAct() == ResponseAct.UNPLANNED).count(),
-                (int) outcomes.stream()
-                        .filter(o -> o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EXTERNAL_FAILURE)
-                        .count(),
+                // 외부 실패는 acceptance 라벨이 아니라 관측된 사실을 센다 (P0-3). 라벨을 세면
+                // 같은 턴의 판정 실패가 생성 실패를 덮어쓴 만큼이 집계에서 사라진다.
+                (int) outcomes.stream().filter(CellCaseOutcome::externalFailureObserved).count(),
+                (int) outcomes.stream().filter(o -> o.externalFailure().generation()).count(),
+                (int) outcomes.stream().filter(o -> o.externalFailure().judge()).count(),
+                (int) outcomes.stream().filter(o -> o.externalFailure().caseAborted()).count(),
                 (int) outcomes.stream()
                         .filter(o -> o.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE)
                         .count(),
+                (int) outcomes.stream().filter(ContractComplianceMetrics::noBodyEscape).count(),
                 byAct, violationTypes(scored), Shape.of(scored));
+    }
+
+    /**
+     * 이탈③ — 생성 본문이 없어 계약 모집단에서 빠진 턴 (P0-3).
+     *
+     * <p>둘 중 하나다. (1) 생성 호출이 외부 오류로 실패했다(타임아웃·예외로 케이스가 중단된
+     * 경우 포함), (2) 모델이 정상 응답으로 빈 본문을 돌려줬다. 어느 쪽이든
+     * {@code ResponseContractValidator} 는 볼 본문이 없어 {@code notApplicable()} 을 돌려준다.
+     *
+     * <p>{@code contract == NOT_APPLICABLE} 조건을 함께 본다. 판정 호출만 실패한 턴은 생성이
+     * 정상으로 돌아 분모에 남으므로 이탈이 아니다 — 그 턴을 여기 세면 이탈 합계가 계약 밖 건수를
+     * 넘고, 그러면 합계 검산이 아무것도 잡지 못한다.
+     */
+    private static boolean noBodyEscape(CellCaseOutcome outcome) {
+        return outcome.contract() == ContractOutcome.NOT_APPLICABLE
+                && (outcome.externalFailure().removesBody()
+                || outcome.acceptance() == CellCaseOutcome.Acceptance.REJECTED_EMPTY_RESPONSE);
     }
 
     private static boolean scored(CellCaseOutcome outcome) {

--- a/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
@@ -106,11 +106,14 @@ final class ContractComplianceReport {
         sb.append("          등급이 HIGH·MEDIUM 이면 앞 분기가 먼저 걸려 계약이 유지된다.\n");
         sb.append("      이탈③ 생성 본문 없음    %4d건  → ResponseContractValidator.notApplicable()%n"
                 .formatted(metrics.noBodyEscapes()));
-        sb.append("        ↑ 생성 실패 %d건 · 빈 응답 %d건. 본문이 없으면 계약 검사가 볼 것이 없어\n"
-                .formatted(metrics.generationFailures() + metrics.abortedCases(),
-                        metrics.emptyResponses()));
-        sb.append("          notApplicable() 을 돌려주고, 그 턴은 위반도 준수도 아닌 채 분모에서 빠진다.\n");
-        sb.append("          플래너 층 게이트(ContractEvalSetTest)는 생성을 돌리지 않아 이 경로를 못 본다.\n");
+        sb.append("        ↑ 본문이 없으면 계약 검사가 볼 것이 없어 notApplicable() 을 돌려주고, 그 턴은\n");
+        sb.append("          위반도 준수도 아닌 채 분모에서 빠진다. 플래너 층 게이트(ContractEvalSetTest)는\n");
+        sb.append("          생성을 돌리지 않아 이 경로를 못 본다.\n");
+        sb.append("""
+                ↑ 이탈은 분할이다 — 한 턴은 한 자리에만 든다. 계획 단계에서 이미 계약 밖이 된 턴(①②)의
+                  생성이 실패해도 그 턴은 ①② 에 남는다(먼저 이탈한 층이 원인이다). 생성 실패의 전체
+                  건수는 아래 [외부 실패] 의 '생성 호출 실패' 이고, 그 축은 따로 센다.
+        """);
         sb.append("      보안 거절          %4d건%n".formatted(metrics.securityRefusal()));
         appendEscapeAudit(sb, metrics);
         sb.append("    미검사          %4d건  ← 계약은 있으나 검사 지점이 없는 전달%n"
@@ -155,7 +158,13 @@ final class ContractComplianceReport {
               ↑ 한 턴이 두 가지로 실패할 수 있으므로 세 줄의 합은 외부 실패 턴 수보다 클 수 있다.
                 acceptance 라벨은 턴당 하나지만 이 집계는 라벨이 아니라 사실을 센다 — #305 실행은
                 생성 실패 25건 중 24건이 같은 턴의 판정 실패 라벨에 먹혀 1건으로 보고됐다.
+              ↑ 상한 하나가 위 두 실패 모드를 함께 다룬다. 생성 실패는 모집단을 줄이고 판정 실패는
+                행위 분포를 민다 — 대가가 다른데 문턱은 같다. 그 교환과 검토한 대안은 세트의
+                runValidity.singleThresholdTradeoff 에 사전 등록돼 있다 (팀 승인 대기).
         """);
+        sb.append("    CBT 분류 실패    %4d/%d회  ← 이 축에 넣지 않는다: 전달·수용 이후 호출이라%n"
+                .formatted(metrics.cbtClassifierFailures(), metrics.cbtClassifierCalls()));
+        sb.append("                            계약 분모도 행위 분포도 바꾸지 않는다 (보이게만 둔다)\n");
         if (!metrics.externalFailureWithinLimit()) {
             sb.append(("    ⚠ 외부 실패가 상한을 넘었다 — 이 실행의 위반율을 인용하지 않는다. "
                     + "남은 %d건은 무작위 표본이 아니다.%n")
@@ -408,6 +417,17 @@ final class ContractComplianceReport {
         extra.put("external_failure_breakdown", "생성 %d · 판정 %d · 케이스 중단 %d".formatted(
                 metrics.generationFailures(), metrics.judgeFailures(), metrics.abortedCases()));
         extra.put("external_failure_within_limit", String.valueOf(metrics.externalFailureWithinLimit()));
+        // 문턱이 어디에 사전 등록됐는지와, 그것이 실패 모드 둘을 한 값으로 다룬다는 사실을 같은
+        // manifest 에 싣는다 (P0-3 MEDIUM-3). 아카이브만 읽는 쪽도 그 교환을 알 수 있어야 한다.
+        extra.put("external_failure_threshold_registry", "%s (%s)".formatted(
+                ContractEvalSet.RUN_VALIDITY.version(), ContractEvalSet.RESOURCE));
+        extra.put("external_failure_threshold_tradeoff",
+                String.join(" / ", ContractEvalSet.RUN_VALIDITY.tradeoff()));
+        // CBT 분류 실패는 ExternalFailure 축에 넣지 않는다 (전달·수용 이후 호출). 그래도 그 축이
+        // 얼마나 안 재졌는지는 아카이브만 보고 알 수 있어야 한다 (P0-3 MEDIUM-2).
+        extra.put("cbt_classifier_failures", "%d/%d회 — %s".formatted(
+                metrics.cbtClassifierFailures(), metrics.cbtClassifierCalls(),
+                CBT_CLASSIFIER_SCOPE_NOTE));
         extra.putAll(costFields(result));
         extra.put("reporting_min_subgroup_n",
                 String.valueOf(LockedEvalSet.REPORTING.minSubgroupN()));
@@ -482,6 +502,17 @@ final class ContractComplianceReport {
                         suppressed.isEmpty() ? "없음" : String.join(" ", suppressed),
                         metrics.applicable(), metrics.violationRate().display());
     }
+
+    /**
+     * CBT 분류 실패가 외부 실패 축 <b>밖에</b> 있는 이유 (P0-3 MEDIUM-2).
+     *
+     * <p>경계를 manifest 에 같이 적는다. 값만 실으면 나중에 읽는 쪽이 "왜 이건 외부 실패에 안
+     * 들어갔나" 를 코드에서 되짚어야 한다.
+     */
+    static final String CBT_CLASSIFIER_SCOPE_NOTE =
+            "전달·수용 이후 호출이라 ExternalFailure 축에 넣지 않는다 (계약 분모·행위 분포를 "
+                    + "바꾸지 않고, 영향은 스스로 채점에서 빠지는 CBT 축 하나에 국한된다). "
+                    + "CellReport 와 같은 경계다";
 
     /** 이 실행이 무엇을 재구성했는지. 셀 벤치마크와 같은 경로를 돌되 세트만 다르다. */
     static final String SCOPE = "contract compliance (dev-gold) — "

--- a/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
@@ -42,26 +42,9 @@ final class ContractComplianceReport {
             sb.append("  ⚠ 스텁 실행 — 모델이 쓴 문장이 아니다. 판정에 쓸 수 없다\n");
         }
 
-        sb.append("\n  [모집단]\n");
-        sb.append("    계약 적용       %4d건 / %d건%n".formatted(metrics.applicable(), metrics.cases()));
-        sb.append("    계약 밖         %4d건%n".formatted(metrics.notApplicable()));
-        sb.append("""
-              ↑ 룰 레이어는 전 케이스를 계약 경로로 보낸다 (ContractEvalSetTest). 여기 남는 것은
-                Judge 판정이 만든 이탈 둘뿐이며, 무과금으로 닫을 수 없는 것도 그 둘뿐이다.
-        """);
-        sb.append("      이탈① Judge 위기 승격    %4d건  → 고정 플로우%n"
-                .formatted(metrics.crisisRouted()));
-        sb.append("      이탈② Judge 보안 의심    %4d건  → GUARDED · 계획 범위 밖%n"
-                .formatted(metrics.unplanned()));
-        sb.append("        ↑ 룰이 CLEAN 이어도 Judge 가 non-CLEAN 이면 EffectiveSecurityResolver 가\n");
-        sb.append("          SUSPICIOUS 로 올리고, 등급이 LOW 이하면 planGeneration 이 unplanned 로 떨어진다.\n");
-        sb.append("          등급이 HIGH·MEDIUM 이면 앞 분기가 먼저 걸려 계약이 유지된다.\n");
-        sb.append("      보안 거절          %4d건%n".formatted(metrics.securityRefusal()));
-        sb.append("    미검사          %4d건  ← 계약은 있으나 검사 지점이 없는 전달%n"
-                .formatted(metrics.unchecked()));
-        sb.append("    생성 호출       %4d건  ·  외부 실패 %d건 · 빈 응답 %d건%n"
-                .formatted(metrics.generationCalled(), metrics.externalFailures(),
-                        metrics.emptyResponses()));
+        appendPopulation(sb, metrics);
+        appendExternalFailures(sb, metrics);
+        appendCost(sb, result);
 
         sb.append("\n  [응답 행위별 계약 위반율]\n");
         for (ResponseAct act : ContractEvalSet.CONTRACT_ACTS) {
@@ -87,6 +70,126 @@ final class ContractComplianceReport {
 
         sb.append(LINE).append('\n');
         return sb.toString();
+    }
+
+    /**
+     * 모집단과 <b>이탈 셋</b>.
+     *
+     * <h2>보장의 실제 범위 — 플래너 층까지다 (P0-3)</h2>
+     *
+     * <p>예전 문구는 "룰 레이어는 전 케이스를 계약 경로로 보낸다 (ContractEvalSetTest). 여기
+     * 남는 것은 Judge 판정이 만든 이탈 둘뿐" 이라고 적었다. 그 보장은 <b>참이지만 플래너 층에
+     * 한정된다</b> — {@code ContractEvalSetTest} 는 룰·정책·플래너만 돌리고 생성은 돌리지 않는다.
+     * 생성 본문이 없어 계약 검사가 {@code notApplicable()} 을 돌려주는 이탈은 그 테스트가
+     * 구조적으로 볼 수 없고, 문구는 그 사실을 말하지 않았다.
+     *
+     * <p>{@code #305} 대조군은 {@code 계약 밖 25건} 을 찍었고 그것을 설명하는 세 줄이 모두 0
+     * 이었다. 25건 전부가 이름 없는 세 번째 이탈이었다. 그래서 이제 <b>셋을 모두 이름으로 찍고
+     * 합계를 검산한다</b> — 합이 맞지 않으면 리포트가 스스로 경고한다.
+     */
+    private static void appendPopulation(StringBuilder sb, ContractComplianceMetrics metrics) {
+        sb.append("\n  [모집단]\n");
+        sb.append("    계약 적용       %4d건 / %d건%n".formatted(metrics.applicable(), metrics.cases()));
+        sb.append("    계약 밖         %4d건%n".formatted(metrics.notApplicable()));
+        sb.append("""
+              ↑ ContractEvalSetTest 의 "전 케이스가 계약 경로로 간다" 보장은 <플래너 층에 한정>된다.
+                룰·정책·플래너까지는 무과금으로 닫혀 있고 그 층의 이탈은 Judge 판정이 만든 둘뿐이다.
+                이탈③은 생성 층에서 생기므로 그 테스트가 구조적으로 볼 수 없다 — 지불 전에 닫히는
+                것은 ①②뿐이고, ③은 실행 후 이 리포트에서만 보인다.
+        """);
+        sb.append("      이탈① Judge 위기 승격    %4d건  → 고정 플로우%n"
+                .formatted(metrics.crisisRouted()));
+        sb.append("      이탈② Judge 보안 의심    %4d건  → GUARDED · 계획 범위 밖%n"
+                .formatted(metrics.unplanned()));
+        sb.append("        ↑ 룰이 CLEAN 이어도 Judge 가 non-CLEAN 이면 EffectiveSecurityResolver 가\n");
+        sb.append("          SUSPICIOUS 로 올리고, 등급이 LOW 이하면 planGeneration 이 unplanned 로 떨어진다.\n");
+        sb.append("          등급이 HIGH·MEDIUM 이면 앞 분기가 먼저 걸려 계약이 유지된다.\n");
+        sb.append("      이탈③ 생성 본문 없음    %4d건  → ResponseContractValidator.notApplicable()%n"
+                .formatted(metrics.noBodyEscapes()));
+        sb.append("        ↑ 생성 실패 %d건 · 빈 응답 %d건. 본문이 없으면 계약 검사가 볼 것이 없어\n"
+                .formatted(metrics.generationFailures() + metrics.abortedCases(),
+                        metrics.emptyResponses()));
+        sb.append("          notApplicable() 을 돌려주고, 그 턴은 위반도 준수도 아닌 채 분모에서 빠진다.\n");
+        sb.append("          플래너 층 게이트(ContractEvalSetTest)는 생성을 돌리지 않아 이 경로를 못 본다.\n");
+        sb.append("      보안 거절          %4d건%n".formatted(metrics.securityRefusal()));
+        appendEscapeAudit(sb, metrics);
+        sb.append("    미검사          %4d건  ← 계약은 있으나 검사 지점이 없는 전달%n"
+                .formatted(metrics.unchecked()));
+        sb.append("    생성 호출       %4d건%n".formatted(metrics.generationCalled()));
+    }
+
+    /** 이탈 합계 검산. {@code 계약 밖 N건} 이 다시 설명 없이 남는 일을 리포트가 스스로 막는다. */
+    private static void appendEscapeAudit(StringBuilder sb, ContractComplianceMetrics metrics) {
+        sb.append("      ── 이탈 합계 ①+②+③+보안거절 %4d건 / 계약 밖 %d건%n"
+                .formatted(metrics.explainedEscapes(), metrics.notApplicable()));
+        if (metrics.unexplainedEscapes() != 0) {
+            sb.append(("        ⚠ 설명되지 않은 계약 밖 %d건 — 이름 없는 네 번째 이탈이거나 "
+                    + "이탈 정의가 겹친다.%n").formatted(metrics.unexplainedEscapes()));
+            sb.append("          이 수치를 인용하기 전에 이탈 분류를 먼저 고친다.\n");
+        }
+    }
+
+    /**
+     * 외부 실패 — <b>사실</b>로 센 값 (P0-3).
+     *
+     * <p>{@code #305} 리포트는 이 값을 {@code acceptance} 라벨에서 읽어 25건을 1건으로 적었다.
+     * 지금은 {@link CellCaseOutcome#externalFailureObserved()} 를 세고, 판정·생성·중단을 나눠
+     * 찍는다 — 셋의 대응이 다르기 때문이다.
+     */
+    private static void appendExternalFailures(StringBuilder sb, ContractComplianceMetrics metrics) {
+        sb.append("\n  [외부 실패 — 이 실행을 인용할 수 있는가]\n");
+        sb.append("    외부 실패 턴    %4d건 / %d건 (%.1f%%)  상한 %.0f%%%n".formatted(
+                metrics.externalFailures(), metrics.cases(),
+                metrics.externalFailureShare() * 100,
+                ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE * 100));
+        sb.append("      생성 호출 실패   %4d건  ← 본문을 빼앗아 분모에서 턴을 없앤다 (이탈③)%n"
+                .formatted(metrics.generationFailures()));
+        sb.append("      판정 호출 실패   %4d건  ← 분모는 남기지만 PolicyEngine 4번 분기가 MEDIUM 을%n"
+                .formatted(metrics.judgeFailures()));
+        sb.append("                            세워 행위 분포를 EMOTION_CHECK 쪽으로 민다\n");
+        sb.append("      케이스 중단      %4d건  ← 타임아웃·예외. 원인이 모델이 아니라 동시성일 수 있다%n"
+                .formatted(metrics.abortedCases()));
+        sb.append("      빈 응답          %4d건  ← 외부 실패가 아니다. 호출은 성공하고 모델이 본문을 안 냈다%n"
+                .formatted(metrics.emptyResponses()));
+        sb.append("""
+              ↑ 한 턴이 두 가지로 실패할 수 있으므로 세 줄의 합은 외부 실패 턴 수보다 클 수 있다.
+                acceptance 라벨은 턴당 하나지만 이 집계는 라벨이 아니라 사실을 센다 — #305 실행은
+                생성 실패 25건 중 24건이 같은 턴의 판정 실패 라벨에 먹혀 1건으로 보고됐다.
+        """);
+        if (!metrics.externalFailureWithinLimit()) {
+            sb.append(("    ⚠ 외부 실패가 상한을 넘었다 — 이 실행의 위반율을 인용하지 않는다. "
+                    + "남은 %d건은 무작위 표본이 아니다.%n")
+                    .formatted(metrics.applicable()));
+        }
+    }
+
+    /**
+     * 토큰·원가 (P0-3).
+     *
+     * <p>{@code #305} 실행은 실비를 보고할 수 없었다 — 이 리포트가 {@link CellTokenLedger} 를
+     * 렌더링하지 않았기 때문이다({@link CellReport} 는 {@code 총 원가} 를 싣는다). 그래서
+     * "견적 대비 실비" 라는 물음에 아카이브·콘솔 어디에서도 답할 수 없었다. 원장은 이미
+     * {@code CellRunner.Result} 에 실려 오므로 새로 재는 것이 없고 늘어나는 호출도 없다.
+     *
+     * <p>단가 미등록 호출이 하나라도 있으면 총액은 {@code 미상} 이다 — 아는 부분만 더해 총액이라
+     * 부르면 실제보다 작은 수를 총액이라 부르는 것이다({@link CellTokenLedger#totalCostUsd()}).
+     */
+    private static void appendCost(StringBuilder sb, CellRunner.Result result) {
+        CellTokenLedger ledger = result.ledger();
+        List<CellTokenLedger.Call> calls = ledger.calls();
+        sb.append("\n  [토큰·원가 — 견적 대비 실비를 답할 수 있게 한다]\n");
+        sb.append("    LLM 호출        %4d건%n".formatted(calls.size()));
+        sb.append("    토큰            prompt %d / completion %d%n"
+                .formatted(ledger.promptTokens(), ledger.completionTokens()));
+        sb.append("    총 원가         %s%n"
+                .formatted(CellPricingBook.format(ledger.totalCostUsd())));
+        sb.append("    단가 미등록 호출 %4d건  ← 0 이 아니라 '모름'. 하나라도 있으면 총액은 미상이다%n"
+                .formatted(ledger.unpricedCalls()));
+        sb.append("    사용량 미수신    %4d건  ← 0 토큰이 아니라 '모름'%n"
+                .formatted(ledger.usageMissingCalls()));
+        if (result.stubMode()) {
+            sb.append("      ↑ 스텁 토큰은 실측이 아니라 문자 기반 추정이다 — 원가로 인용할 수 없다\n");
+        }
     }
 
     private static void appendTypes(StringBuilder sb, Map<String, Integer> types) {
@@ -215,19 +318,22 @@ final class ContractComplianceReport {
     static Path archive(CellRunner.Result result, ContractComplianceMetrics metrics, String report) {
         requireRealRun(result);
         return EvalRunArchive.write("contract-compliance-%s".formatted(metrics.arm().fileToken()),
-                manifest(result, metrics, extraFor(result, metrics)), report);
+                manifest(result, metrics, Map.of()), report);
     }
 
     /** A/B 비교 자체의 실행 기록. 두 팔의 수치가 한 파일에서 맞대어진다. */
     static Path archiveComparison(CellRunner.Result withRun, ContractComplianceMetrics with,
                                   ContractComplianceMetrics without, String report) {
         requireRealRun(withRun);
-        Map<String, String> extra = extraFor(withRun, with);
+        Map<String, String> extra = new LinkedHashMap<>();
         extra.put("ab_arms", "%s / %s".formatted(with.arm().label(), without.arm().label()));
         extra.put("ab_applicable", "있음 %d / 없음 %d".formatted(with.applicable(), without.applicable()));
         extra.put("ab_violated", "있음 %d / 없음 %d".formatted(with.violated(), without.violated()));
         extra.put("ab_rate_with", with.violationRate().display());
         extra.put("ab_rate_without", without.violationRate().display());
+        extra.put("ab_external_failure", "있음 %d/%d · 없음 %d/%d — 두 팔의 유실이 다르면 페어링이 "
+                + "더 어긋난다".formatted(with.externalFailures(), with.cases(),
+                        without.externalFailures(), without.cases()));
         return EvalRunArchive.write("contract-compliance-ab",
                 manifest(withRun, with, extra), report);
     }
@@ -239,8 +345,20 @@ final class ContractComplianceReport {
         }
     }
 
+    /**
+     * 실행 manifest.
+     *
+     * <p><b>표준 항목은 호출부가 넘기지 않는다</b> (P0-3). 예전에는 모집단·이탈·외부 실패 항목이
+     * 호출부가 {@code extra} 로 넘겨야만 실렸고, 그래서 {@code extra} 를 비워 부르는 경로에서는
+     * 정직성 항목이 통째로 사라진 manifest 가 나왔다. 지금은 {@link #standardFields} 가 항상
+     * 붙고 {@code extra} 는 그 위에 얹힌다 — A/B 처럼 이 실행에만 있는 항목을 위한 자리다.
+     *
+     * @param extra 이 호출에만 해당하는 추가 항목. 표준 항목과 키가 겹치면 덮어쓴다
+     */
     static EvalRunManifest manifest(CellRunner.Result result, ContractComplianceMetrics metrics,
                                     Map<String, String> extra) {
+        Map<String, String> fields = standardFields(result, metrics);
+        fields.putAll(extra);
         return new EvalRunManifest(
                 SCOPE,
                 "계약 준수 실측 [%s]".formatted(metrics.arm().label()),
@@ -259,11 +377,12 @@ final class ContractComplianceReport {
                 Map.of("contract_violation_rate",
                         "행위별·총계 모두 minSubgroupN=%d 미만이면 미보고"
                                 .formatted(LockedEvalSet.REPORTING.minSubgroupN())),
-                extra);
+                fields);
     }
 
-    private static Map<String, String> extraFor(CellRunner.Result result,
-                                                ContractComplianceMetrics metrics) {
+    /** 어느 호출 경로에서도 빠지지 않는 표준 항목 (P0-3). */
+    private static Map<String, String> standardFields(CellRunner.Result result,
+                                                      ContractComplianceMetrics metrics) {
         Map<String, String> extra = new LinkedHashMap<>(ContractEvalSet.manifestFields());
         extra.put("run_id", result.identity().runId().toString());
         extra.put("contract_arm", metrics.arm().label());
@@ -274,8 +393,25 @@ final class ContractComplianceReport {
         extra.put("crisis_routed", String.valueOf(metrics.crisisRouted()));
         extra.put("unplanned_turns", String.valueOf(metrics.unplanned()));
         extra.put("empty_responses", String.valueOf(metrics.emptyResponses()));
-        extra.put("external_failure_calls", String.valueOf(metrics.externalFailures()));
-        extra.putAll(LockedEvalSet.REPORTING.asManifestFields());
+        // 이탈③ 과 검산을 manifest 에도 싣는다. 리포트 본문만 고치면 아카이브를 기계로 읽는
+        // 쪽에서는 여전히 "계약 밖 N건" 이 설명 없이 남는다.
+        extra.put("no_body_escapes", String.valueOf(metrics.noBodyEscapes()));
+        extra.put("escape_audit", "설명된 이탈 %d / 계약 밖 %d (미설명 %d)".formatted(
+                metrics.explainedEscapes(), metrics.notApplicable(), metrics.unexplainedEscapes()));
+        // 키 이름이 바뀌었다 (P0-3). 예전 external_failure_calls 는 acceptance 라벨을 센 값이라
+        // 단위가 "호출" 도 아니었고 같은 턴의 판정 실패에 덮였다 — #305 는 25건을 1 로 적었다.
+        // 옛 키를 그대로 두면 아카이브를 읽는 쪽이 같은 이름에서 다른 정의를 계속 읽는다.
+        extra.put("external_failure_turns", String.valueOf(metrics.externalFailures()));
+        extra.put("external_failure_share", "%.4f (상한 %.2f)".formatted(
+                metrics.externalFailureShare(),
+                ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE));
+        extra.put("external_failure_breakdown", "생성 %d · 판정 %d · 케이스 중단 %d".formatted(
+                metrics.generationFailures(), metrics.judgeFailures(), metrics.abortedCases()));
+        extra.put("external_failure_within_limit", String.valueOf(metrics.externalFailureWithinLimit()));
+        extra.putAll(costFields(result));
+        extra.put("reporting_min_subgroup_n",
+                String.valueOf(LockedEvalSet.REPORTING.minSubgroupN()));
+        extra.put("reporting_unit", reportingUnit(metrics));
         for (ResponseAct act : ContractEvalSet.CONTRACT_ACTS) {
             ContractComplianceMetrics.ActStats stats = metrics.byAct().get(act);
             extra.put("act_" + act.name().toLowerCase(java.util.Locale.ROOT),
@@ -295,6 +431,56 @@ final class ContractComplianceReport {
         extra.put("elapsed", elapsed(result));
         extra.put("dataset_purpose", ContractEvalSet.purpose());
         return extra;
+    }
+
+    /**
+     * 토큰·원가 manifest 항목 (P0-3).
+     *
+     * <p>{@link CellReport} 는 {@code prompt_tokens}·{@code completion_tokens}·
+     * {@code cost_total_usd} 를 싣는데 이 리포트는 싣지 않았다. 그래서 {@code #305} 유료 실행은
+     * 견적($0.72~$1.34)을 낸 뒤 실비를 <b>어디에서도</b> 확인할 수 없었다. 키 이름을
+     * {@code CellReport} 와 같게 두어 두 아카이브를 같은 도구로 읽을 수 있게 한다.
+     */
+    private static Map<String, String> costFields(CellRunner.Result result) {
+        CellTokenLedger ledger = result.ledger();
+        Map<String, String> fields = new LinkedHashMap<>();
+        fields.put("llm_calls", String.valueOf(ledger.calls().size()));
+        fields.put("prompt_tokens", String.valueOf(ledger.promptTokens()));
+        fields.put("completion_tokens", String.valueOf(ledger.completionTokens()));
+        fields.put("cost_total_usd", CellPricingBook.format(ledger.totalCostUsd()));
+        fields.put("unpriced_calls", String.valueOf(ledger.unpricedCalls()));
+        fields.put("usage_missing_calls", String.valueOf(ledger.usageMissingCalls()));
+        return fields;
+    }
+
+    /**
+     * 이 세트의 보고 단위 (P0-3).
+     *
+     * <p>예전에는 {@code LockedEvalSet.REPORTING.asManifestFields()} 를 그대로 실어
+     * <b>잠금 세트의</b> 고정 문구("현재 어느 하위 그룹도 minSubgroupN 을 넘지 않는다")가 나갔다.
+     * 이 세트에는 맞지 않는다 — {@code #305} 실행의 하위 그룹은 51건씩이었고 하한 30 을 넘었다.
+     * 하한 자체는 두 세트가 공유하므로 {@code reporting_min_subgroup_n} 은 그대로 쓰고, 단위
+     * 문구만 <b>보고 대상인 세트와 이번 실행의 관측값</b>에서 만든다.
+     *
+     * <p>선언 분포(정적)와 관측 행위별 n(동적)을 같이 적는다. 행위별 배정은 InputJudge 판정이
+     * 정하므로 선언값이 곧 관측값이 아니고, 실제로 비율을 막거나 여는 것은 관측값이다.
+     */
+    static String reportingUnit(ContractComplianceMetrics metrics) {
+        int floor = LockedEvalSet.REPORTING.minSubgroupN();
+        List<String> reportable = new java.util.ArrayList<>();
+        List<String> suppressed = new java.util.ArrayList<>();
+        for (ResponseAct act : ContractEvalSet.CONTRACT_ACTS) {
+            int n = metrics.byAct().get(act).applicable();
+            (n >= floor ? reportable : suppressed).add("%s=%d".formatted(act.name(), n));
+        }
+        return ("세트 %s · 선언 하위 그룹 %s (모두 하한 %d 이상). 이번 실행의 보고 단위는 "
+                + "관측 행위별 n 과 총계이며, 비율을 낼 수 있는 행위는 [%s] · 하한 미달로 건수만 "
+                + "인용하는 행위는 [%s] 이다. 총계 계약 적용 %d건 → %s.")
+                .formatted(ContractEvalSet.VERSION,
+                        ContractEvalSet.intendedDistribution(), floor,
+                        reportable.isEmpty() ? "없음" : String.join(" ", reportable),
+                        suppressed.isEmpty() ? "없음" : String.join(" ", suppressed),
+                        metrics.applicable(), metrics.violationRate().display());
     }
 
     /** 이 실행이 무엇을 재구성했는지. 셀 벤치마크와 같은 경로를 돌되 세트만 다르다. */

--- a/src/test/java/com/mio/ai/qa/ContractEvalSet.java
+++ b/src/test/java/com/mio/ai/qa/ContractEvalSet.java
@@ -142,6 +142,48 @@ final class ContractEvalSet {
     }
 
     /**
+     * 실행 유효성 상한의 <b>사전 등록</b> ({@code runValidity}, P0-3 MEDIUM-3).
+     *
+     * <p>{@code go-no-go}·{@code screening-elimination} 과 같은 규율을 쓴다 — 문턱은 데이터에
+     * 등록하고, 실행 결과를 보고 값을 고치는 것은 상한이 아니라 사후 합리화다.
+     * {@link ContractComplianceMetrics#MAX_EXTERNAL_FAILURE_SHARE} 가 이 값을 읽으므로 가드와
+     * 사전 등록이 갈라질 수 없다.
+     *
+     * @param maxExternalFailureShare 외부 실패 턴 비율의 상한
+     * @param tradeoff                이 문턱이 실패 모드 둘을 한 값으로 다룬다는 사실과 검토했으나
+     *                                채택하지 않은 대안. 비어 있으면 로딩이 실패한다 — 문턱을
+     *                                근거 없이 바꾸지 못하게 하는 것이 이 필드의 목적이다
+     */
+    record RunValidity(String version, double maxExternalFailureShare, String rationale,
+                       List<String> tradeoff) {
+
+        RunValidity {
+            tradeoff = List.copyOf(tradeoff);
+            if (maxExternalFailureShare <= 0 || maxExternalFailureShare > 1) {
+                throw new IllegalStateException(
+                        "외부 실패 상한이 비율이 아니다: " + maxExternalFailureShare);
+            }
+            if (rationale.isBlank() || tradeoff.isEmpty()) {
+                throw new IllegalStateException(
+                        "사전 등록 문턱에 근거·교환 기록이 없다 — 근거 없이 바꿀 수 있는 문턱은 문턱이 아니다");
+            }
+        }
+    }
+
+    static final RunValidity RUN_VALIDITY = readRunValidity();
+
+    private static RunValidity readRunValidity() {
+        JsonNode node = ROOT.path("runValidity");
+        List<String> tradeoff = new ArrayList<>();
+        node.path("singleThresholdTradeoff").forEach(v -> tradeoff.add(v.asText()));
+        return new RunValidity(
+                text(node, "version"),
+                node.path("maxExternalFailureShare").asDouble(),
+                text(node, "rationale"),
+                tradeoff);
+    }
+
+    /**
      * 세트가 <b>선언한</b> 모집단 이탈 목록 ({@code reporting.escapes}).
      *
      * <p>P0-3 이 읽기 시작했다. 이 목록은 지금까지 아무도 읽지 않는 산문이었고, 그래서 실행이

--- a/src/test/java/com/mio/ai/qa/ContractEvalSet.java
+++ b/src/test/java/com/mio/ai/qa/ContractEvalSet.java
@@ -49,12 +49,26 @@ import java.util.Map;
  * {@code InputJudgeResult} 로 <b>실제</b> {@code PolicyEngine}·{@code ResponsePlanner} 를
  * 등급 × 보안 판정 전 조합에 통과시켜 확인한다.
  *
- * <p><b>보장은 무조건이 아니라 "Judge 판정 modulo" 다.</b> 이탈이 정확히 둘 있고 둘 다 Judge 가
- * 내리는 판정이라 무과금으로 닫을 수 없다 — (1) Judge 가 {@code HARD_CRISIS} 로 올리는 경우,
- * (2) Judge 자신의 보안 판정이 non-CLEAN 이라 {@code EffectiveSecurityResolver} 가
- * {@code SUSPICIOUS} 로 올리고 등급이 {@code LOW} 이하인 경우. 실행이 각각
- * {@code crisis_routed}·{@code unplanned_turns} 로 세어 보고하며, <b>이름 없는 세 번째 이탈이
- * 생기면 테스트가 실패한다.</b>
+ * <p><b>보장은 무조건이 아니라 "플래너 층까지, Judge 판정 modulo" 다.</b> 그 층의 이탈이 정확히
+ * 둘 있고 둘 다 Judge 가 내리는 판정이라 무과금으로 닫을 수 없다 — (1) Judge 가
+ * {@code HARD_CRISIS} 로 올리는 경우, (2) Judge 자신의 보안 판정이 non-CLEAN 이라
+ * {@code EffectiveSecurityResolver} 가 {@code SUSPICIOUS} 로 올리고 등급이 {@code LOW} 이하인
+ * 경우. 실행이 각각 {@code crisis_routed}·{@code unplanned_turns} 로 세어 보고하며,
+ * <b>플래너 층에 이름 없는 이탈이 생기면 테스트가 실패한다.</b>
+ *
+ * <h2>보장이 닿지 않는 곳 — 이탈③ 생성 본문 없음 (P0-3)</h2>
+ *
+ * <p><b>위 보장은 플래너 층에 한정된다.</b> {@link ContractEvalSetTest} 는 룰·정책·플래너만
+ * 돌리고 생성은 돌리지 않으므로, 계획까지 정상으로 갔다가 <b>생성이 본문을 내지 못해</b>
+ * 모집단에서 빠지는 이탈을 구조적으로 볼 수 없다. 본문이 없으면
+ * {@code ResponseContractValidator} 가 {@code notApplicable()} 을 돌려주고 그 턴은 위반도 준수도
+ * 아닌 채 분모에서 사라진다.
+ *
+ * <p>{@code #305} 유료 실행의 대조군이 그것이었다 — {@code 계약 밖 25건} 을 찍었는데 그것을
+ * 설명하는 세 줄(위기 승격·보안 의심·보안 거절)이 모두 0 이었다. 25건 전부가 생성 호출 실패였다.
+ * 그래서 실행 리포트가 이 이탈을 {@code no_body_escapes} 로 <b>이름을 붙여 세고</b> 이탈 합계를
+ * 계약 밖 건수와 검산한다({@code ContractComplianceMetrics.unexplainedEscapes}). 지불 전에 닫히는
+ * 것은 여전히 ①②뿐이고, ③은 실행 후에만 보인다 — 그것이 이 보장의 실제 범위다.
  *
  * <p><b>행위별</b> 분포는 그래도 실행 전에 확정할 수 없다 — 어느 행위가 계획되는지는 Judge
  * 판정이 정하기 때문이다. {@code expected.responseAct} 는 정답 라벨이 아니라 <b>설계 의도</b>이며,
@@ -125,6 +139,25 @@ final class ContractEvalSet {
         ROOT.path("distribution").fields()
                 .forEachRemaining(e -> out.put(e.getKey(), e.getValue().asInt()));
         return Map.copyOf(out);
+    }
+
+    /**
+     * 세트가 <b>선언한</b> 모집단 이탈 목록 ({@code reporting.escapes}).
+     *
+     * <p>P0-3 이 읽기 시작했다. 이 목록은 지금까지 아무도 읽지 않는 산문이었고, 그래서 실행이
+     * 실제로 세는 이탈과 세트가 선언한 이탈이 <b>조용히 갈릴 수 있었다</b>. #305 실행에서
+     * 정확히 그 일이 일어났다 — 세트는 "이탈은 둘" 이라고 적었고 실행은 세 번째 이탈로 25건을
+     * 잃었다. 이제 {@code ContractComplianceHarnessTest} 가 이 값을 리포트가 이름 붙이는 이탈
+     * 수와 맞대므로, 한쪽만 바뀌면 무과금 테스트가 실패한다.
+     */
+    static List<String> declaredEscapes() {
+        List<String> escapes = new ArrayList<>();
+        ROOT.path("reporting").path("escapes").forEach(node -> escapes.add(node.asText()));
+        if (escapes.isEmpty()) {
+            throw new IllegalStateException(
+                    "세트가 이탈을 하나도 선언하지 않았다 — 모집단 논증이 없는 세트는 실행에 쓰지 않는다");
+        }
+        return List.copyOf(escapes);
     }
 
     /** 실행 manifest 의 {@code extra} 에 실을 세트 출처 항목. */

--- a/src/test/java/com/mio/ai/qa/ContractEvalSetTest.java
+++ b/src/test/java/com/mio/ai/qa/ContractEvalSetTest.java
@@ -58,7 +58,13 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link ResponsePlanner} 를 통과시킨다 — 등급({@code HARD_CRISIS·HIGH·MEDIUM·LOW·CLEAR_LOW})
  * × Judge 보안 판정({@code CLEAN·SUSPICIOUS}) + 호출 실패, 총 11칸.
  *
- * <h2>보장의 실제 범위 — 이탈은 <b>둘</b>이다</h2>
+ * <h2>보장의 실제 범위 — <b>플래너 층까지</b>이고, 그 층의 이탈은 둘이다</h2>
+ *
+ * <p><b>이 테스트가 검사하는 층을 먼저 적는다.</b> 여기서 도는 것은 정규화 → 보안 룰 →
+ * SafetyL1 → 신호 결합 → (합성 Judge) → {@link PolicyEngine} → {@link ResponsePlanner} 까지다.
+ * <b>생성은 돌지 않는다.</b> 그래서 이 테스트의 소진성 증명은 "계획이 계약 행위로 가는가" 에
+ * 대한 것이고, "그 계획으로 생성한 응답이 계약 검사까지 도달하는가" 는 다루지 않는다.
+ * 그 구별은 {@code #305} 실행이 실제로 요구했다 — 아래 "이 테스트가 볼 수 없는 이탈" 을 본다.
  *
  * <p>Judge 가 위기로 올리지도 의심하지도 않으면({@link JudgeCell#benign()}) 전 케이스가 세 계약
  * 행위 중 하나로 간다.
@@ -80,9 +86,25 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       로 센다. (등급이 HIGH·MEDIUM 이면 5·6번 분기가 먼저 걸려 계약이 유지된다.)</li>
  * </ol>
  *
- * <p>그래서 이 세트의 보장은 <b>"Judge 의 위기 승격과 보안 판정 modulo"</b> 다. 무조건적 보장이
- * 아니다. 대신 {@link #theJudgeMatrixHasExactlyTwoNamedEscapes()} 가 <b>이름 없는 세 번째 이탈이
- * 생기면 실패</b>하므로, 분기 순서가 바뀌어 보장이 조용히 좁아지는 일은 막는다.
+ * <p>그래서 이 세트의 보장은 <b>"플래너 층까지, Judge 의 위기 승격과 보안 판정 modulo"</b> 다.
+ * 무조건적 보장이 아니다. 대신 {@link #theJudgeMatrixHasExactlyTwoNamedEscapes()} 가 <b>플래너
+ * 층에 이름 없는 이탈이 생기면 실패</b>하므로, 분기 순서가 바뀌어 이 층의 보장이 조용히 좁아지는
+ * 일은 막는다.
+ *
+ * <h2>이 테스트가 볼 수 없는 이탈 — 이탈③ 생성 본문 없음 (P0-3)</h2>
+ *
+ * <p>이 테스트는 생성을 돌리지 않으므로, 계획까지 정상으로 갔다가 <b>생성이 본문을 내지 못해</b>
+ * 모집단에서 빠지는 이탈을 <b>구조적으로</b> 잡을 수 없다. 본문이 없으면
+ * {@code ResponseContractValidator} 가 {@code notApplicable()} 을 돌려주고 그 턴은 위반도 준수도
+ * 아닌 채 분모에서 사라진다. 이것은 이 테스트의 결함이 아니라 <b>범위</b>다 — 생성을 돌리려면
+ * 모델을 불러야 하고, 그러면 이 테스트는 "지불 전 게이트" 가 아니게 된다.
+ *
+ * <p>{@code #305} 유료 실행의 대조군이 정확히 그 상태였다. {@code 계약 밖 25건} 을 찍었는데
+ * 리포트가 그 25건을 설명하는 세 줄이 모두 0 이었고, 25건 전부가 생성 호출 실패였다. 그래서
+ * <b>실행 쪽</b>이 그 이탈에 이름을 붙여 세고({@code no_body_escapes}) 이탈 합계를 계약 밖
+ * 건수와 검산한다({@code ContractComplianceMetrics.unexplainedEscapes}). 이 테스트가 보장하는
+ * 것과 실행이 관측해야 하는 것을 이렇게 나눠 둔다 — 여기서 "세 번째 이탈이 없다" 를 주장하면
+ * 그 주장은 생성 층에 대해 근거가 없다.
  *
  * <p>행위별 분포는 여전히 보장하지 않는다 — 그것은 Judge 판정이 정하며, 하한 미달 행위의
  * 비율은 {@link ReportableRate} 가 막는다.
@@ -124,10 +146,14 @@ class ContractEvalSetTest {
     // ── 실행 가능한 소진성 증명 ─────────────────────────────────────
 
     /**
-     * 케이스 하나가 한 Judge 판정에서 도달하는 자리.
+     * 케이스 하나가 한 Judge 판정에서 도달하는 <b>플래너 층</b>의 자리.
      *
-     * <p>{@link #OTHER} 가 하나라도 나오면 이 세트의 모집단 논증에 <b>이름 없는 이탈</b>이
-     * 생겼다는 뜻이다. 그때 고쳐야 하는 것은 테스트가 아니라 논증이다.
+     * <p>{@link #OTHER} 가 하나라도 나오면 이 세트의 모집단 논증에 <b>플래너 층의 이름 없는
+     * 이탈</b>이 생겼다는 뜻이다. 그때 고쳐야 하는 것은 테스트가 아니라 논증이다.
+     *
+     * <p>여기 없는 이탈이 하나 더 있다 — 생성이 본문을 내지 못해 분모에서 빠지는 이탈③. 이
+     * enum 은 생성을 돌지 않는 층의 어휘라 그 값을 담지 않는다. 실행 쪽이
+     * {@code no_body_escapes} 로 센다 (P0-3, 클래스 javadoc).
      */
     private enum PlanOutcome {
         /** 세 계약 행위 중 하나로 계획됐고 계약 검사가 걸린다. */
@@ -186,7 +212,7 @@ class ContractEvalSetTest {
     }
 
     @Test
-    @DisplayName("등급×보안판정 전 조합을 실제 PolicyEngine·ResponsePlanner 에 통과시킨다 — 이탈은 딱 둘뿐이다")
+    @DisplayName("등급×보안판정 전 조합을 실제 PolicyEngine·ResponsePlanner 에 통과시킨다 — 플래너 층의 이탈은 딱 둘뿐이다")
     void theJudgeMatrixHasExactlyTwoNamedEscapes() {
         List<JudgeCell> matrix = judgeMatrix();
         Map<PlanOutcome, Integer> census = new EnumMap<>(PlanOutcome.class);
@@ -212,8 +238,9 @@ class ContractEvalSetTest {
         escapeCells.forEach(cell -> System.out.printf("  이탈 칸: %s%n", cell));
 
         assertThat(unexplained)
-                .as("논증에 이름이 없는 이탈 경로가 생겼다. PolicyEngine·ResponsePlanner 의 분기 "
-                        + "순서가 바뀌었을 가능성이 높고, 그러면 '지불 전 보장' 문장을 먼저 고쳐야 한다:%n  %s",
+                .as("플래너 층 논증에 이름이 없는 이탈 경로가 생겼다. PolicyEngine·ResponsePlanner 의 "
+                        + "분기 순서가 바뀌었을 가능성이 높고, 그러면 '지불 전 보장' 문장을 먼저 고쳐야 "
+                        + "한다. (생성 층의 이탈③은 이 테스트의 범위가 아니다 — 클래스 javadoc):%n  %s",
                         unexplained)
                 .isEmpty();
         assertThat(census.getOrDefault(PlanOutcome.ESCAPE_JUDGE_HARD_CRISIS, 0))

--- a/src/test/resources/eval/contract/mio-contract-eval-v1.json
+++ b/src/test/resources/eval/contract/mio-contract-eval-v1.json
@@ -52,6 +52,22 @@
     "status": "SINGLE_AUTHOR_PENDING_SECOND_PASS",
     "notes": "expected.responseAct 은 '사람이 합의한 정답' 이 아니라 '이 케이스를 어느 계약 행위로 보내려고 썼는가' 라는 설계 의도다. 실제 행위는 InputJudge 판정에 달려 있으므로 실행이 관측한 분포를 그대로 보고한다."
   },
+  "runValidity": {
+    "version": "mio-contract-runvalidity-v1",
+    "registeredOn": "2026-08-17",
+    "source": "docs/eval/contract-compliance.md §5 · 이슈 #471 (P0-3)",
+    "rationale": "사전 등록한 상한이다. 실행 결과를 보고 값을 고치면 그건 상한이 아니라 사후 합리화다. 값을 바꾸는 변경은 개정 이력을 남기고 PR 에서 따로 검토한다. ContractComplianceMetrics.MAX_EXTERNAL_FAILURE_SHARE 가 이 값을 읽으므로 가드와 사전 등록이 갈라질 수 없다.",
+    "maxExternalFailureShare": 0.1,
+    "maxExternalFailureShareNote": "생성·판정·케이스 중단을 합친 외부 실패 턴이 전 케이스에서 이 비율을 넘으면 이 실행의 위반율을 인용하지 않는다. 분모는 시도한 전 케이스다 — 남은 모집단을 분모로 삼으면 실패가 늘수록 분모도 줄어 계량기가 자기 실패를 가린다.",
+    "singleThresholdTradeoff": [
+      "한 개의 10% 상한이 실패 모드 둘을 동시에 다룬다 — 그 사실을 여기 기록해 둔다 (P0-3 MEDIUM-3).",
+      "생성 호출 실패는 본문을 빼앗아 턴을 계약 분모에서 없앤다(이탈③). 모집단이 직접 줄어들므로 상한이 분명히 필요하다.",
+      "판정 호출 실패는 분모를 남긴다. PolicyEngine 4번 분기가 MEDIUM 을 세워 행위 분포를 EMOTION_CHECK 쪽으로 미는 것이 영향이다. 그래서 생성이 정상이고 판정만 rate limit 에 걸린 실행은 계약 모집단과 위반율이 온전할 수 있는데도 인용이 막힌다 — 그 오판의 대가는 유료 전수 재실행이다.",
+      "검토한 대안: 판정 실패 비율은 그것이 특정 행위의 minSubgroupN 을 위협할 때만 트립시키고, 생성 실패는 지금처럼 바로 트립시키는 두 갈래 상한.",
+      "채택하지 않은 이유: 그 대안은 행위별 모집단이 트립 산정에 들어가 가드가 복잡해진다. 그리고 이 PR 은 계량기를 고치는 PR 이다 — 가드를 느슨하게 하는 변경을 같은 PR 에 섞지 않는다. 현재는 엄격한 쪽을 택해 fail-closed 를 유지한다.",
+      "상태: 팀 승인 대기. 다음 재실행에서 판정 실패만으로 상한을 넘기는 사례가 실제로 나오면 그 사례를 근거로 개정을 상정한다. 집계가 external_failure_breakdown 으로 내역을 싣으므로 그 사례를 사후에 구분할 수 있다."
+    ]
+  },
   "reporting": {
     "minSubgroupN": 30,
     "rule": "행위별 위반율은 그 행위의 계약 적용 모집단이 minSubgroupN 미만이면 산출하지 않는다. ReportableRate 가 잠금 세트의 같은 하한을 읽어 강제한다.",

--- a/src/test/resources/eval/contract/mio-contract-eval-v1.json
+++ b/src/test/resources/eval/contract/mio-contract-eval-v1.json
@@ -55,10 +55,11 @@
   "reporting": {
     "minSubgroupN": 30,
     "rule": "행위별 위반율은 그 행위의 계약 적용 모집단이 minSubgroupN 미만이면 산출하지 않는다. ReportableRate 가 잠금 세트의 같은 하한을 읽어 강제한다.",
-    "populationNote": "무과금 테스트가 합성 InputJudgeResult 로 실제 PolicyEngine·ResponsePlanner 를 등급×보안판정 전 조합에 통과시켜 모집단을 검사한다. 보장은 무조건이 아니라 'Judge 판정 modulo' 다 — 이탈이 정확히 둘 있고 둘 다 Judge 가 내리는 판정이라 무과금으로 닫을 수 없다. (1) Judge 가 HARD_CRISIS 로 올리는 경우, (2) Judge 의 보안 판정이 non-CLEAN 이라 EffectiveSecurityResolver 가 SUSPICIOUS 로 올리고 등급이 LOW 이하인 경우. 실행이 각각 crisis_routed·unplanned_turns 로 세어 보고하며, 이름 없는 세 번째 이탈이 생기면 테스트가 실패한다. 행위별 분포는 여전히 보장되지 않고 실행이 관측한 값을 쓴다.",
+    "populationNote": "무과금 테스트가 합성 InputJudgeResult 로 실제 PolicyEngine·ResponsePlanner 를 등급×보안판정 전 조합에 통과시켜 모집단을 검사한다. 보장은 무조건이 아니고 층에도 한정된다 — '플래너 층까지, Judge 판정 modulo' 다. 그 층의 이탈이 정확히 둘 있고 둘 다 Judge 가 내리는 판정이라 무과금으로 닫을 수 없다. (1) Judge 가 HARD_CRISIS 로 올리는 경우, (2) Judge 의 보안 판정이 non-CLEAN 이라 EffectiveSecurityResolver 가 SUSPICIOUS 로 올리고 등급이 LOW 이하인 경우. 실행이 각각 crisis_routed·unplanned_turns 로 세어 보고하며, 플래너 층에 이름 없는 이탈이 생기면 테스트가 실패한다. 그 층 밖에 이탈이 하나 더 있다 — ContractEvalSetTest 는 생성을 돌리지 않으므로, 계획까지 정상으로 갔다가 생성이 본문을 내지 못해 모집단에서 빠지는 이탈(no_body_escapes)을 구조적으로 볼 수 없다. 이슈 #305 실행이 그 이탈로 대조군 25건을 잃고도 어느 설명 줄에도 잡히지 않아 드러났다(P0-3). 행위별 분포는 여전히 보장되지 않고 실행이 관측한 값을 쓴다.",
     "escapes": [
       "JUDGE_HARD_CRISIS — Judge 가 위기로 올려 고정 플로우로 빠진다 (crisis_routed)",
-      "JUDGE_SECURITY — Judge 보안 판정이 non-CLEAN + 등급 LOW 이하 → GUARDED · 계획 범위 밖 (unplanned_turns)"
+      "JUDGE_SECURITY — Judge 보안 판정이 non-CLEAN + 등급 LOW 이하 → GUARDED · 계획 범위 밖 (unplanned_turns)",
+      "NO_BODY — 생성 호출 실패·케이스 중단·빈 응답으로 볼 본문이 없어 ResponseContractValidator 가 notApplicable() 을 돌려준다 → 분모에서 빠짐 (no_body_escapes). 생성 층 이탈이라 이 세트의 무과금 게이트가 볼 수 없다 (P0-3)"
     ]
   },
   "distribution": {


### PR DESCRIPTION
## 요약

`#305` 계약 준수율 유료 실행(커밋 `f586ea9`, 2026-08-17 06:11~06:25)의 대조군은 153건 중
**25건(16.3%)** 을 생성 호출 실패로 잃었다. 그런데 manifest 의 `external_failure_calls` 는 **1**
이었고, `MAX_EXTERNAL_FAILURE_SHARE = 0.10` 가드는 그것을 **0.65%** 로 읽고 통과했다. 런북의
"외부 실패 10% 초과면 수치를 쓰지 않는다" 규칙이 정확히 그 규칙이 필요한 상황에서 눈이 멀어
있었다.

원인은 **계량기가 라벨을 셌다**는 것이다. `CellRunner.assemble()` 은 `judgeResult.failed()` 이면
`delivery.acceptance()` 를 `REJECTED_JUDGE_FAILURE` 로 덮어쓴다. 생성 실패 25건 중 **24건**이 같은
턴의 InputJudge 도 실패해 그 덮어쓰기에 먹혔다(25 − 24 = 1). 판정 실패와 생성 실패는 서로 다른
사실이고 한 턴에서 동시에 일어날 수 있는데, 하나가 다른 하나를 지웠다.

이 PR 은 **집계를 `acceptance` 와 독립으로** 만들고, 같은 실행에서 함께 드러난 나머지 셋
(이름 없는 세 번째 이탈 · `reporting_unit` 오기 · 원가 미기재)을 함께 닫는다. **`src/test` 만
바꿨고 `src/main` 은 한 줄도 건드리지 않았다.**

## 관련 이슈

- Closes #471
- 실행 근거: #305 · 같은 유형의 하네스 결함: #468

## 변경 사항

**1. 외부 실패를 `acceptance` 와 독립으로 센다**

- `CellCaseOutcome.ExternalFailure`(생성 · 판정 · 케이스 중단) 를 새로 두고, `Delivery` 가 실패를
  **관측한 자리에서** 채운다. `assemble()` 은 `acceptance` 를 여전히 덮어쓰지만 사실에는
  `withJudge()` 로 판정 실패를 **더한다** — 지우지 않는다.
- `acceptance` 의미론은 그대로다. 턴당 라벨은 하나이고 판정 실패가 우선한다 — 리포트의 거절 사유
  분포가 그 라벨을 세므로, 한 턴이 두 사유로 세어지면 합이 모집단을 넘는다.
- `ContractComplianceMetrics` 가 `externalFailureObserved()` 를 센다. 상한 `0.10` 은 **그대로**다 —
  가드를 느슨하게 한 것이 아니라 가드가 읽는 값을 고쳤다. 상수를 한 곳으로 모아 유료 실행 가드와
  무과금 검사가 같은 값을 읽는다.
- 세 축을 나눠 싣는다. 생성 실패는 본문을 빼앗아 턴을 분모에서 없애고, 판정 실패는 분모는 남기지만
  `PolicyEngine` 4번 분기가 `MEDIUM` 을 세워 행위 분포를 `EMOTION_CHECK` 쪽으로 민다. 빈 응답은
  외부 실패로 세지 않는다 — 호출은 성공했고 모델이 본문을 내지 않은 것이다.

**2. 이름 없는 세 번째 이탈에 이름을 붙이고 보장 범위를 바로잡는다**

- `이탈③ 생성 본문 없음`(`no_body_escapes`) 을 리포트·manifest 에 찍는다. `#305` 대조군의
  `계약 밖 25건` 이 정확히 이것이었고, 설명하는 세 줄이 모두 0 이었다.
- **이탈 합계를 검산한다.** `이탈 합계 ①+②+③+보안거절` 이 `계약 밖` 과 어긋나면 리포트가 스스로
  `⚠ 설명되지 않은 계약 밖 N건` 을 찍고, 유료 실행 가드(`unexplainedEscapes == 0`)가 실패한다.
- `ContractEvalSetTest` 의 보장이 **플래너 층에 한정된다**는 사실을 javadoc·`PlanOutcome` enum·
  실패 메시지·`DisplayName`·세트 파일에 명시했다. 그 테스트는 생성을 돌리지 않으므로 이 이탈을
  구조적으로 볼 수 없다 — 결함이 아니라 범위다. 예전 문구는 "이름 없는 세 번째 이탈이 생기면
  테스트가 실패한다" 로 읽혀 실제로 오독을 만들었다.
- 세트 파일 `reporting.escapes` 에 `NO_BODY` 를 더하고, `ContractEvalSet.declaredEscapes()` 로 그
  선언을 읽어 무과금 테스트가 리포트가 이름 붙이는 이탈 수와 맞댄다 — 산문과 집계가 조용히
  갈리는 것이 이 결함의 본질이었다.

**3. `reporting_unit` 이 보고 대상 세트를 말한다**

- 예전에는 `LockedEvalSet.REPORTING` 의 고정 문구("현재 어느 하위 그룹도 `minSubgroupN` 을 넘지
  않는다")가 그대로 나갔고 이 세트에는 **거짓**이었다 — `#305` 의 하위 그룹은 51건씩이라 하한 30 을
  넘었다. 하한 자체는 두 세트가 공유하므로 `reporting_min_subgroup_n` 은 그대로 두고, 단위 문구만
  세트의 선언 분포와 **이번 실행의 관측 행위별 n** 에서 만든다.

**4. 원가를 싣는다 (배선함)**

- `#305` 는 견적 $0.7178~$1.3398(점추정 $0.9570) 을 낸 뒤 **실비를 어디에서도 확인할 수 없었다** —
  `ContractComplianceReport` 가 `CellTokenLedger` 를 렌더링하지 않았기 때문이다(`CellReport` 는
  `총 원가`·`cost_total_usd` 를 싣는다). 이제 리포트에 `[토큰·원가]` 절이 있고 manifest 가
  `cost_total_usd` 를 싣는다. 키 이름은 `CellReport` 와 같게 둬 두 아카이브를 같은 도구로 읽는다.
- 원장은 이미 실행 결과에 실려 오므로 **새로 재는 것도, 늘어나는 호출도 없다.** 단가 미등록 호출이
  하나라도 있으면 총액은 `미상` 이다.

**5. 표준 manifest 항목이 호출부에 의존하지 않는다**

- 모집단·이탈·외부 실패 항목이 호출부가 `extra` 로 넘겨야만 실렸고, `extra` 를 비워 부르는 경로에서
  정직성 항목이 통째로 사라진 manifest 가 나올 수 있었다. 이제 `standardFields()` 가 항상 붙고
  `extra` 는 그 위에 얹힌다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

**`src/main` 변경 없음** — 전부 `src/test` · `src/test/resources` 다. 프로덕션 동작은 바뀌지 않는다.

평가 아카이브를 읽는 쪽에 영향이 둘 있다.

1. **`external_failure_calls` 키가 없어졌다.** 그 키는 단위가 "호출" 도 아니었고(턴을 셌다) 라벨을
   세어 판정 실패에 덮였다. 같은 이름이 두 정의를 갖지 않게 `external_failure_turns` 로 바꿨다.
   `#305` 아카이브의 `external_failure_calls = 1` 과 새 키를 같은 수치로 비교하면 안 된다.
2. **`contract_set_sha256` 이 `1f9a5e4a…` → `3b363ae3…` 로 움직인다** (리뷰 후속의 `runValidity` 신설까지 반영한 최종 값). 세트 파일의
   `reporting.populationNote`·`reporting.escapes` 문구만 고쳤다. **153건 케이스는 바이트 단위로
   그대로다** (`cases` 배열 해시 `82c0bbdd4e41da241beab444a83dc4a82c12cbf5f33ffa82dc601967d295f374`
   불변). 해시가 다르다는 이유로 케이스가 바뀌었다고 읽지 않는다.

## 테스트

### 실행 커맨드

```bash
./gradlew compileTestJava
./gradlew test --tests "com.mio.ai.qa.*"
./gradlew test          # 전체
```

임시 DB(`mio-postgres` 컨테이너 · pgvector)를 만들어 `SPRING_DATASOURCE_URL`/`DB_URL` 과 비-OpenAI
더미 시크릿을 주입해 돌리고 실행 후 삭제했다. **실 LLM 호출 없음 — `-PllmTests` 를 쓰지 않았다.**

### 확인 내용

**전체 1,556건 통과 · 실패 0 · 스킵 0.** `com.mio.ai.qa.*` 38건 통과
(`ContractComplianceHarnessTest` 22건 · `ContractEvalSetTest` 12건 · `CostEstimateTest` 4건).
수치는 리뷰 후속(MEDIUM 3건)까지 반영한 최종 실행이다.

핵심은 **`#305` 의 실패 모양을 그대로 재구성한 무과금 테스트**다. 153건 중 앞 25건의 생성 호출을
실패시키고 그중 앞 24건은 InputJudge 도 실패시킨다(관측 서명 `LLM streaming error` 25건 ·
`LLM complete error` 24건과 같은 모양). 실패는 클라이언트가 예외를 던지고 `CellRunner`·`InputJudge`
가 각자 잡는 방식으로, 프로덕션이 실제로 받는 것과 같게 만든다.

| 검사 | 결과 |
| --- | --- |
| 외부 실패 사실이 25/24 로 따로 세어진다 | ✅ 하나가 다른 하나를 지우지 않는다 |
| 비율이 **16.3%** 로 읽힌다 | ✅ 예전 계량기의 **0.65%** (25 − 24 = 1) 도 함께 못 박았다 |
| 같은 데이터에서 10% 가드가 **거절**한다 | ✅ `externalFailureWithinLimit() == false` |
| `acceptance` 는 여전히 턴당 하나 | ✅ 판정 실패 24건 + 외부 실패 1건 — 라벨 의미론 불변 |
| `계약 밖 25건` 이 이탈③ 으로 설명되고 합계가 맞는다 | ✅ 미설명 0건 |
| `reporting_unit` 이 잠금 세트 문구를 쓰지 않는다 | ✅ 세트 버전·관측 행위별 n 을 싣는다 |
| 리포트·manifest 에 원가가 실린다 | ✅ `총 원가`·`cost_total_usd` |
| 세트 선언 이탈 수 == 리포트가 이름 붙이는 이탈 수 | ✅ 셋 |

재구성 실행이 실제로 찍은 리포트:

```
  [모집단]
    계약 적용        128건 / 153건
    계약 밖           25건
      ↑ ContractEvalSetTest 의 "전 케이스가 계약 경로로 간다" 보장은 <플래너 층에 한정>된다.
      이탈① Judge 위기 승격       0건  → 고정 플로우
      이탈② Judge 보안 의심       0건  → GUARDED · 계획 범위 밖
      이탈③ 생성 본문 없음      25건  → ResponseContractValidator.notApplicable()
      보안 거절             0건
      ── 이탈 합계 ①+②+③+보안거절   25건 / 계약 밖 25건

  [외부 실패 — 이 실행을 인용할 수 있는가]
    외부 실패 턴      25건 / 153건 (16.3%)  상한 10%
      생성 호출 실패     25건  ← 본문을 빼앗아 분모에서 턴을 없앤다 (이탈③)
      판정 호출 실패     24건  ← 분모는 남기지만 PolicyEngine 4번 분기가 MEDIUM 을
                            세워 행위 분포를 EMOTION_CHECK 쪽으로 민다
      케이스 중단         0건
      빈 응답             0건  ← 외부 실패가 아니다
    ⚠ 외부 실패가 상한을 넘었다 — 이 실행의 위반율을 인용하지 않는다. 남은 128건은 무작위 표본이 아니다.
```

## 중점 리뷰 포인트

- **`acceptance` 를 덮어쓰는 것을 없애지 않았다.** 라벨은 턴당 하나여야 하고(거절 사유 분포가 그것을
  센다) 판정 실패가 우선한다는 의미론도 그대로다. 고친 것은 **계량기가 그 라벨을 읽지 않는다**는
  것뿐이다. 이 선택이 맞는지 봐 주세요 — 대안은 라벨을 복수로 만드는 것이었는데, 그러면 거절 사유
  분포의 합이 모집단을 넘는다.
- **판정 호출 실패를 외부 실패로 센다.** 그 턴은 계약 분모에 **남는다**(생성이 정상으로 돌았다).
  그래도 세는 이유는 계획된 행위가 `EMOTION_CHECK` 쪽으로 쏠려 행위별 비교를 왜곡하기 때문이다 —
  `#305` 에서 `EMOTION_CHECK` 가 38 → 29 로 하한 아래로 떨어진 것이 그 결과다. 가드가 **더
  엄격해지는** 방향이라 정직성 가드를 느슨하게 한 것은 아니지만, 이 정의에 이견이 있으면 말씀해
  주세요.
- **이탈③ 정의의 겹침.** `contract == NOT_APPLICABLE && (생성 실패 | 케이스 중단 | 빈 응답)` 으로
  좁혀, 판정만 실패한 턴이 이탈로 세어지지 않게 했다. 그렇지 않으면 이탈 합계가 계약 밖 건수를
  넘고 검산이 아무것도 잡지 못한다.
- **세트 파일 해시 이동.** 케이스는 불변이지만 `contract_set_sha256` 이 움직인다. 케이스 무결성
  신호로 그 값을 쓰는 도구가 있으면 알려 주세요 — 되돌리고 문구를 코드 쪽에만 둘 수도 있다.

## 배포 / 롤백

- **Rollout:** 테스트 코드만 변경. 배포 영향 없음. 머지 후 다음 유료 실행부터 새 manifest 키가
  나온다.
- **Rollback:** 커밋 되돌리기로 충분하다. 프로덕션 의존이 없다.

## 후속

- **`#305` 실행 수치는 인용하지 않는다.** 대조군의 128건은 무작위 표본이 아니다(유실이
  `EMOTION_CHECK` 쪽에 치우쳤다). 이 PR 머지 후 재실행이 필요하다.
- 런북 `docs/eval/contract-compliance.md` 는 이 저장소에서 추적되지 않아 이 PR 에 포함되지 않았다.
  §2 머리말·§2-1·§2-2(이탈 표를 셋으로)·§4-1(견적 대비 실비)·§4-3(manifest 키)·§5(트러블슈팅)·
  §6(보장 범위)을 별도로 갱신했다.

---

## 리뷰 후속 (APPROVE 이후 · MEDIUM 3건)

**MEDIUM-1 (수정) — 이탈 자리를 분할로 만들었다.** `480f513`, `e1f23d0`

리뷰가 찾은 겹침은 실재한다. Judge 가 보안을 `SUSPICIOUS` 로 올리고 등급이 `LOW` 면
`PolicyEngine` 6번 분기가 `GENERATE` + `allowGeneration=true` 를 내고
`ResponsePlanner.planGeneration()` 은 `unplanned()` 를 돌려준다 — **계획은 계약 밖인데 생성은 실제로
돈다.** 그 턴의 생성까지 실패하면 이탈②와 이탈③을 동시에 만족하고, 합계가 한 턴을 두 번 세면서
`계약 밖` 은 한 번 세어 `미설명` 이 **음수**가 된다.

술어 하나를 패치하지 않고 **구조를 바꿨다.** `Escape` enum + `escapeOf()` 가 턴마다 자리를 하나만
배정하고, 자리별 건수는 그 분할에서만 나온다 — 겹침이 생길 수 있는 자리 자체가 없다.
`assertPartitions()` 가 분할 합과 `계약 밖` 을 지표 생성 시점에 맞춰 보므로, 나중에 배정 순서를
고치다 자리를 겹치게 만들면 리포트 숫자가 되기 전에 깨진다.

배정 순서는 **"먼저 이탈한 층이 이긴다"** — 플래너 층(①②)이 생성 층(③)보다 앞선다.
`ResponsePlan.unplanned()` 은 `GenerationFreedom.OPEN` 이라 `isContractEnforced()` 가 거짓이고
검사기가 항상 `notApplicable()` 을 돌려주므로, 그 턴은 **생성이 성공했더라도** 모집단에 들어오지
않는다. 원인은 플래너 이탈이고 생성 실패는 그 위에 겹친 별개의 사실이다. 그 사실은 사라지지 않는다 —
**이탈 분할은 "왜 모집단을 떠났는가", 외부 실패 축은 "무엇이 실패했는가" 를 답한다.**

새 테스트가 그 모양을 직접 만든다(40건이 계획 이탈 + 생성 실패). 리뷰가 지적한 대로 기존 재구성
테스트는 `crisisRouted = unplanned = securityRefusal = 0` 이라 자리 간 상호작용이 검증되지 않았다.

| 단언 | 결과 |
| --- | --- |
| 겹치는 턴이 정말 40건 있다 (예전 술어 넷 중 2개 이상에 걸림) | ✅ **비어 있지 않은 테스트임을 먼저 증명** |
| 예전 합산이 음수를 냈다 (계약 밖 40 − 술어 합 80) | ✅ `-40` |
| 분할이 플래너 층을 고른다 | ✅ 이탈② 40 · 이탈③ **0** |
| 합계 = 계약 밖, 미설명 0 | ✅ 40/40 · 0 |
| 생성 실패 사실은 유지된다 | ✅ 외부 실패 40 · 생성 호출 실패 40 |
| 두 실패 모양 모두에서 계약 밖 턴이 정확히 한 자리를 받는다 | ✅ |

**MEDIUM-2 (문서화) — CBT 분류 실패는 축 밖으로 유지.** `fb26833`

판단은 유지했다. `ExternalFailure` javadoc 에 범위 절을 넣어 **전달·수용 이후의 품질 축 호출은
설계상 제외**임을 적었고(`CellReport`·`CellMetrics` 와 같은 경계), manifest 에
`cbt_classifier_failures` 를 건수 + 경계 설명과 함께 실었다 — 축에서 빼는 것과 감추는 것은 다르다.
PR #469 가 이미 계산하는 값이라 새로 재는 것은 없다. 테스트가 "분류 실패만으로는 `ExternalFailure`
가 서지 않는다"와 "manifest 에는 보인다"를 함께 고정한다.

**MEDIUM-3 (교환 기록) — 문턱을 바꾸지 않고 사전 등록했다.** `fb26833`

값도 구조도 그대로 두고, 세트에 `runValidity` 블록을 신설해 **값·근거·검토한 대안·채택하지 않은
이유·팀 승인 대기 상태**를 등록했다. `MAX_EXTERNAL_FAILURE_SHARE` 가 그 값을 읽으므로 가드와 사전
등록이 갈라질 경로가 없다(`go-no-go`·`screening-elimination` 과 같은 규율). `RunValidity` 는 근거나
교환 기록이 비면 **로딩 자체를 거부한다** — 근거 없이 바꿀 수 있는 문턱은 문턱이 아니다.

기록한 교환: 생성 실패는 모집단을 줄이고, 판정 실패는 분모를 남긴 채 행위 분포를 `EMOTION_CHECK`
쪽으로 민다. 그래서 생성이 정상이고 판정만 rate limit 에 걸린 실행은 모집단·위반율이 온전할 수
있는데도 인용이 막히며, 오판의 대가는 유료 전수 재실행이다. 검토한 대안은 "판정 실패는 특정 행위의
`minSubgroupN` 을 위협할 때만 트립" 이고, 채택하지 않은 이유는 가드가 복잡해지는 것과 **계량기를
고치는 PR 에 가드를 느슨하게 하는 변경을 섞지 않는다**는 것이다. **개정 조건도 미리 적었다** — 다음
재실행에서 판정 실패만으로 상한을 넘기는 사례가 나오면 `external_failure_breakdown` 을 근거로 개정을
상정한다. 미리 적어 뒀으므로 그때의 변경은 사후 합리화가 아니라 예고된 개정이다.

### 재검증

`./gradlew test --tests "com.mio.ai.qa.*"` 및 전체 — **1,556건 통과 · 실패 0 · 스킵 0**
(`ContractComplianceHarnessTest` 22건). 새 임시 DB(`mio` superuser · TCP `-h 127.0.0.1` · pgvector),
비-OpenAI 더미 시크릿, 실행 후 삭제. `-PllmTests` 미사용. **`src/main` 변경 여전히 0.**

### 해시 재고지

`runValidity` 신설로 `contract_set_sha256` 이 한 번 더 움직였다: `1f9a5e4a…` → `1f771450…` →
**`3b363ae3…`**. 153건 케이스는 여전히 바이트 단위로 그대로다(`cases` 해시 `82c0bbdd…` 불변).
리뷰가 확인한 대로 이 값을 무결성 신호로 소비하는 코드는 없다.

### 런북

`docs/eval/contract-compliance.md`(저장소 밖, 커밋 아님)에 §2-2 "이탈은 **분할**이다" 소절, §4-3
manifest 키 3개, **§4-4 "상한은 사전 등록한다 — 그리고 그 교환을 적어 둔다"** 절, §5 트러블슈팅 2행,
§6 외부 실패 축 범위 항목을 추가했다.

---

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

