### PR TITLE
fix: A/B 아카이브의 외부 실패 비교가 값을 싣게 한다

### DIFF
--- a/src/test/java/com/mio/ai/qa/CellCostEstimateTest.java
+++ b/src/test/java/com/mio/ai/qa/CellCostEstimateTest.java
@@ -190,9 +190,17 @@ class CellCostEstimateTest {
         assertThat(estimate.hasReasoningModel()).isTrue();
         assertThat(estimate.withReasoningUsd())
                 .hasValueSatisfying(usd -> assertThat(usd).isGreaterThan(estimate.highUsd()));
-        assertThat(CellCostEstimator.render(projection))
+        String report = CellCostEstimator.render(projection);
+        assertThat(report)
                 .contains("추론 토큰 보정")
                 .contains("상한이 아니다");
+        assertThat(report)
+                .as("#473 과 같은 연산자 우선순위 버그 — formatted 가 마지막 리터럴에만 걸리면 "
+                        + "배수가 '×%%.1f' 리터럴로 남고 배수 값이 속성명 자리에 들어간다")
+                .doesNotContain("%.1f")
+                .doesNotContain("%s")
+                .contains("×%.1f 가정".formatted(CellCostEstimator.reasoningMultiplier()))
+                .contains("-D" + CellCostEstimator.REASONING_MULTIPLIER_PROPERTY);
     }
 
     @Test

--- a/src/test/java/com/mio/ai/qa/CellCostEstimator.java
+++ b/src/test/java/com/mio/ai/qa/CellCostEstimator.java
@@ -441,9 +441,9 @@ final class CellCostEstimator {
         out.append("\n  [추론 토큰 보정 — 관측이 아니라 가정]\n");
         out.append("  ** o 계열·pro 계열은 내부 추론 토큰을 출력 단가로 과금한다. 스텁 견적에는 "
                 + "그 토큰이 통째로 없다. **\n");
-        out.append("  ** 그래서 추론 모델이 낀 셀의 금액은 상한이 아니다. 아래는 ×%.1f 가정을 "
+        out.append(("  ** 그래서 추론 모델이 낀 셀의 금액은 상한이 아니다. 아래는 ×%.1f 가정을 "
                 + "얹은 값이며, 실 실행 뒤에는 제공자 실측 토큰으로 대체한다 "
-                + "(-D%s 로 배수를 바꾼다). **%n"
+                + "(-D%s 로 배수를 바꾼다). **%n")
                 .formatted(reasoningMultiplier(), REASONING_MULTIPLIER_PROPERTY));
         withReasoning.forEach(estimate -> {
             out.append("    %-22s%n".formatted(estimate.variant().label()));

--- a/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceHarnessTest.java
@@ -187,6 +187,25 @@ class ContractComplianceHarnessTest {
     }
 
     @Test
+    @DisplayName("A/B manifest 의 외부 실패 비교 항목은 값이 채워진다 — #473")
+    void comparisonExtraFillsTheExternalFailureTally() {
+        ContractComplianceMetrics with = metricsOf(run(ContractPromptArm.WITH_CONTRACT_BLOCK,
+                new PromptSpy()));
+        ContractComplianceMetrics without = metricsOf(runWithFailureShape());
+
+        Map<String, String> extra = ContractComplianceReport.comparisonExtra(with, without);
+
+        assertThat(extra.get("ab_external_failure"))
+                .as("2026-08-17 재실행 아카이브(run_id c8b165d0)에 '%%d/%%d' 가 그대로 찍혔다 — "
+                        + "두 팔의 유실을 맞대는 항목이 값 없이 남으면 페어링 훼손을 볼 수 없다")
+                .doesNotContain("%d")
+                .contains("있음 0/%d".formatted(with.cases()))
+                .contains("없음 %d/%d".formatted(GENERATION_FAILURES, without.cases()));
+        assertThat(extra.get("ab_applicable")).doesNotContain("%d");
+        assertThat(extra.get("ab_violated")).doesNotContain("%d");
+    }
+
+    @Test
     @DisplayName("스텁 실행은 아카이브를 남기지 않는다")
     void stubRunsAreNotArchived() {
         CellRunner.Result result = run(ContractPromptArm.WITH_CONTRACT_BLOCK, new PromptSpy());

--- a/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
+++ b/src/test/java/com/mio/ai/qa/ContractComplianceReport.java
@@ -334,17 +334,23 @@ final class ContractComplianceReport {
     static Path archiveComparison(CellRunner.Result withRun, ContractComplianceMetrics with,
                                   ContractComplianceMetrics without, String report) {
         requireRealRun(withRun);
+        return EvalRunArchive.write("contract-compliance-ab",
+                manifest(withRun, with, comparisonExtra(with, without)), report);
+    }
+
+    /** A/B manifest 에만 실리는 항목. 두 팔의 수치를 한 값 안에서 맞댄다. */
+    static Map<String, String> comparisonExtra(ContractComplianceMetrics with,
+                                               ContractComplianceMetrics without) {
         Map<String, String> extra = new LinkedHashMap<>();
         extra.put("ab_arms", "%s / %s".formatted(with.arm().label(), without.arm().label()));
         extra.put("ab_applicable", "있음 %d / 없음 %d".formatted(with.applicable(), without.applicable()));
         extra.put("ab_violated", "있음 %d / 없음 %d".formatted(with.violated(), without.violated()));
         extra.put("ab_rate_with", with.violationRate().display());
         extra.put("ab_rate_without", without.violationRate().display());
-        extra.put("ab_external_failure", "있음 %d/%d · 없음 %d/%d — 두 팔의 유실이 다르면 페어링이 "
-                + "더 어긋난다".formatted(with.externalFailures(), with.cases(),
+        extra.put("ab_external_failure", ("있음 %d/%d · 없음 %d/%d — 두 팔의 유실이 다르면 페어링이 "
+                + "더 어긋난다").formatted(with.externalFailures(), with.cases(),
                         without.externalFailures(), without.cases()));
-        return EvalRunArchive.write("contract-compliance-ab",
-                manifest(withRun, with, extra), report);
+        return extra;
     }
 
     private static void requireRealRun(CellRunner.Result result) {


### PR DESCRIPTION
## 요약
`#472` 가 A/B manifest 에 넣은 `ab_external_failure`(두 팔의 외부 실패를 맞대어 페어링 훼손을 보이는 항목)가 포맷 문자열 그대로 기록되고 있었습니다. `formatted()` 가 문자열 연결식의 뒤쪽 리터럴에만 걸리는 연산자 우선순위 버그로, 2026-08-17 재실행 아카이브(run_id `c8b165d0`)에 `있음 %d/%d · 없음 %d/%d` 가 실제로 남았습니다.

## 관련 이슈
- Closes #473

## 변경 사항
- `ContractComplianceReport.archiveComparison()` 의 연결식을 괄호로 묶어 `formatted()` 가 전체에 걸리게 수정
- extra 맵 구성을 `comparisonExtra()` 로 추출 — 아카이브 파일을 쓰지 않고도(스텁 실행 금지 규칙 유지) 값이 채워지는지 검증 가능
- 회귀 테스트 추가: `ab_external_failure` 에 `%d` 가 남지 않고 두 팔의 실측값(있음 0/153 · 없음 25/153 재구성)이 실리는지 단언

## 영향 범위
해당 없음 — 평가 하네스(테스트 소스)의 아카이브 표기만 변경합니다. 프로덕션 코드·안전 판정 경로 변경 없음.

## 테스트
### 실행 커맨드
```bash
./gradlew build   # 통과 (전체 테스트, 실 LLM 제외)
./gradlew test --tests "com.mio.ai.qa.ContractComplianceHarnessTest"
```

### 확인 내용
- 신규 테스트가 수정 전 코드에서 컴파일 실패(RED) → 수정 후 통과(GREEN)
- 두 팔 각각의 manifest 는 `external_failure_turns` 를 정상 기록하므로 기존 아카이브의 데이터 유실은 없음 — 비교 항목의 표기 결함

## 중점 리뷰 포인트
- `comparisonExtra()` 추출이 `archiveComparison()` 의 동작(항목 순서 포함)을 바꾸지 않는지

## 배포 / 롤백
- Rollout: 머지만으로 충분 (다음 A/B 실행부터 값이 채워짐)
- Rollback: revert

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.