### PR TITLE
feat: 세션 반응 신호 7종 + 위기 후 대화지속 신호를 조회 API에 추가한다

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminSessionController.java
+++ b/src/main/java/com/mio/admin/controller/AdminSessionController.java
@@ -1,8 +1,10 @@
 package com.mio.admin.controller;
 
 import com.mio.admin.dto.SessionCostResponse;
+import com.mio.admin.dto.SessionReactionsResponse;
 import com.mio.admin.dto.SessionTimelineResponse;
 import com.mio.admin.service.AdminSessionCostService;
+import com.mio.admin.service.AdminSessionReactionsService;
 import com.mio.admin.service.AdminSessionService;
 import com.mio.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +29,7 @@ public class AdminSessionController {
 
     private final AdminSessionService adminSessionService;
     private final AdminSessionCostService adminSessionCostService;
+    private final AdminSessionReactionsService adminSessionReactionsService;
 
     @GetMapping("/{sessionId}")
     public ResponseEntity<ApiResponse<SessionTimelineResponse>> getTimeline(@PathVariable UUID sessionId) {
@@ -36,5 +39,10 @@ public class AdminSessionController {
     @GetMapping("/{sessionId}/cost")
     public ResponseEntity<ApiResponse<SessionCostResponse>> getCost(@PathVariable UUID sessionId) {
         return ResponseEntity.ok(ApiResponse.ok(adminSessionCostService.getCost(sessionId)));
+    }
+
+    @GetMapping("/{sessionId}/reactions")
+    public ResponseEntity<ApiResponse<SessionReactionsResponse>> getReactions(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminSessionReactionsService.getReactions(sessionId)));
     }
 }

--- a/src/main/java/com/mio/admin/dto/SessionReactionsResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionReactionsResponse.java
@@ -1,0 +1,39 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 세션 반응 신호 조회 응답 (이슈 #475, 개선안 문서 §4.2).
+ *
+ * <p>검증된 치료 효과나 사용자 가치의 직접 증거가 아니라 모델 추정치·제품 반응 신호다.
+ * {@code emotionTrend}는 모델이 추정한 신호이지 검증된 임상 결과가 아니다.
+ */
+public record SessionReactionsResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("user_id") UUID userId,
+        @JsonProperty("todo_reaction_counts") TodoReactionCounts todoReactionCounts,
+        @JsonProperty("disliked_patterns") List<String> dislikedPatterns,
+        @JsonProperty("character_affinity_score") Double characterAffinityScore,
+        @JsonProperty("cbt_completion_reason") String cbtCompletionReason,
+        @JsonProperty("emotion_trend") EmotionTrend emotionTrend,
+        @JsonProperty("summary_viewed") boolean summaryViewed,
+        @JsonProperty("notified_before_session") Boolean notifiedBeforeSession
+) {
+    public record TodoReactionCounts(
+            @JsonProperty("positive") long positive,
+            @JsonProperty("negative") long negative,
+            @JsonProperty("neutral") long neutral
+    ) {
+    }
+
+    /** startScore/endScore/delta 전부 null이면 이 세션에 감정점수가 기록된 메시지가 없다는 뜻이다. */
+    public record EmotionTrend(
+            @JsonProperty("start_score") Integer startScore,
+            @JsonProperty("end_score") Integer endScore,
+            @JsonProperty("delta") Integer delta
+    ) {
+    }
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionReactionsService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionReactionsService.java
@@ -1,0 +1,131 @@
+package com.mio.admin.service;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.admin.dto.SessionReactionsResponse;
+import com.mio.ai.domain.CharacterInteraction;
+import com.mio.ai.domain.CharacterInteractionRepository;
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.memory.episodic.InterventionOutcome;
+import com.mio.ai.memory.episodic.InterventionOutcomeRepository;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.notification.domain.ProactiveCareLog;
+import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SummaryStatus;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 운영자용 세션 반응 신호 조회 (이슈 #475, 개선안 문서 §4.1~§4.3).
+ *
+ * <p>새 UI·신규 계측 없이 기존 테이블만으로 뽑을 수 있는 반응 신호 9개 중 7개를 담당한다.
+ * 위기트리거 반응 2개(continued_engagement, hotline_resource_tapped)는 Track1 성격이라
+ * {@link AdminSessionService}의 세션조회 API 쪽에서 다룬다 — hotline_resource_tapped는 백엔드에
+ * 캡처 경로가 없어(핫라인 자원은 SSE로만 나가고 탭 이벤트를 받는 곳이 없음) 이번 스코프에서 뺐다.
+ *
+ * <p>세션 단위 원문(대화 내용)은 노출하지 않는다 — 숫자·enum·bool 신호만 반환해 Track2의
+ * 가명·집계 원칙과 충돌하지 않게 한다(§4.3 리뷰 반영).
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AdminSessionReactionsService {
+
+    /** 세션 시작 전 이 기간 안에 발송된 알림까지만 "이 세션을 유발했을 수 있다"고 본다. */
+    private static final Duration NOTIFICATION_LOOKBACK = Duration.ofHours(24);
+
+    private final SessionRepository sessionRepository;
+    private final MessageRepository messageRepository;
+    private final InterventionOutcomeRepository interventionOutcomeRepository;
+    private final UserMemoryPreferenceRepository userMemoryPreferenceRepository;
+    private final CharacterInteractionRepository characterInteractionRepository;
+    private final ProactiveCareLogRepository proactiveCareLogRepository;
+    private final ObjectMapper objectMapper;
+
+    @Transactional(readOnly = true)
+    public SessionReactionsResponse getReactions(UUID sessionId) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        UUID userId = session.getUser().getId();
+
+        return new SessionReactionsResponse(
+                sessionId,
+                userId,
+                todoReactionCounts(sessionId),
+                dislikedPatterns(userId),
+                characterAffinityScore(userId, session.getCharacterId()),
+                session.getCbtCompletionReason(),
+                emotionTrend(sessionId),
+                session.getSummaryStatus() == SummaryStatus.VIEWED,
+                notifiedBeforeSession(userId, session.getStartedAt())
+        );
+    }
+
+    private SessionReactionsResponse.TodoReactionCounts todoReactionCounts(UUID sessionId) {
+        List<InterventionOutcome> outcomes = interventionOutcomeRepository.findBySessionId(sessionId);
+        long positive = outcomes.stream().filter(o -> "positive".equals(o.getUserReaction())).count();
+        long negative = outcomes.stream().filter(o -> "negative".equals(o.getUserReaction())).count();
+        long neutral = outcomes.stream().filter(o -> "neutral".equals(o.getUserReaction())).count();
+        return new SessionReactionsResponse.TodoReactionCounts(positive, negative, neutral);
+    }
+
+    private List<String> dislikedPatterns(UUID userId) {
+        UserMemoryPreference pref = userMemoryPreferenceRepository.findByUserId(userId).orElse(null);
+        if (pref == null || pref.getDislikedPatterns() == null || pref.getDislikedPatterns().isBlank()) {
+            return List.of();
+        }
+        try {
+            return objectMapper.readValue(pref.getDislikedPatterns(), new TypeReference<List<String>>() {
+            });
+        } catch (Exception e) {
+            log.warn("Failed to parse disliked_patterns for userId={}", userId, e);
+            return List.of();
+        }
+    }
+
+    private Double characterAffinityScore(UUID userId, String characterId) {
+        return characterInteractionRepository.findByUserIdAndCharacterId(userId, characterId)
+                .map(CharacterInteraction::getAffinityScore)
+                .orElse(null);
+    }
+
+    private SessionReactionsResponse.EmotionTrend emotionTrend(UUID sessionId) {
+        List<Integer> scores = messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId).stream()
+                .map(Message::getEmotionScore)
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        if (scores.isEmpty()) {
+            return new SessionReactionsResponse.EmotionTrend(null, null, null);
+        }
+        Integer start = scores.get(0);
+        Integer end = scores.get(scores.size() - 1);
+        return new SessionReactionsResponse.EmotionTrend(start, end, end - start);
+    }
+
+    /**
+     * @return 세션 시작 {@link #NOTIFICATION_LOOKBACK} 이내에 발송된 알림이 없으면 {@code null}
+     *         (신호 없음 — 0으로 채우지 않는다), 있으면 열람(tapped) 여부
+     */
+    private Boolean notifiedBeforeSession(UUID userId, OffsetDateTime sessionStartedAt) {
+        List<ProactiveCareLog> logs = proactiveCareLogRepository.findMostRecentBeforeSessionStart(
+                userId, sessionStartedAt.minus(NOTIFICATION_LOOKBACK), sessionStartedAt, PageRequest.of(0, 1));
+        if (logs.isEmpty()) {
+            return null;
+        }
+        return ProactiveCareLog.STATUS_OPENED.equals(logs.get(0).getNotificationStatus());
+    }
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionService.java
@@ -68,13 +68,15 @@ public class AdminSessionService {
                 crisisEvents.stream().map(c -> c.getId().toString())
         ).toList();
 
+        List<Message> messages = messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId);
+
         List<TimelineItem> items = Stream.of(
-                        messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId).stream()
+                        messages.stream()
                                 .map(this::messageItem),
                         aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId).stream()
                                 .map(this::policyDecisionItem),
                         crisisEvents.stream()
-                                .map(this::crisisEventItem),
+                                .map(c -> crisisEventItem(c, messages)),
                         auditResourceIds.stream()
                                 .flatMap(resourceId -> auditLogRepository.findByResourceIdOrderByCreatedAtAsc(resourceId).stream())
                                 .map(this::auditLogItem)
@@ -115,7 +117,7 @@ public class AdminSessionService {
         return new TimelineItem(d.getCreatedAt(), data);
     }
 
-    private TimelineItem crisisEventItem(CrisisEvent c) {
+    private TimelineItem crisisEventItem(CrisisEvent c, List<Message> sessionMessages) {
         Map<String, Object> data = new LinkedHashMap<>();
         data.put("type", "crisis_event");
         data.put("at", c.getCreatedAt().toString());
@@ -124,6 +126,10 @@ public class AdminSessionService {
         data.put("operator_reviewed", c.isOperatorReviewed());
         data.put("review_action", c.getReviewAction());
         data.put("operator_note", c.getOperatorNote());
+        // 위기트리거 후 대화 지속여부 (이슈 #475, §4.2) — 신규 계측 없이 이 위기 이벤트 시각
+        // 이후에 메시지가 더 있었는지로 판단한다. "효과 증명"이 아니라 참여 지속 신호일 뿐이다.
+        data.put("continued_engagement", sessionMessages.stream()
+                .anyMatch(m -> m.getCreatedAt().isAfter(c.getCreatedAt())));
         return new TimelineItem(c.getCreatedAt(), data);
     }
 

--- a/src/main/java/com/mio/ai/domain/CharacterInteractionRepository.java
+++ b/src/main/java/com/mio/ai/domain/CharacterInteractionRepository.java
@@ -1,0 +1,11 @@
+package com.mio.ai.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface CharacterInteractionRepository extends JpaRepository<CharacterInteraction, UUID> {
+
+    Optional<CharacterInteraction> findByUserIdAndCharacterId(UUID userId, String characterId);
+}

--- a/src/main/java/com/mio/ai/memory/episodic/InterventionOutcomeRepository.java
+++ b/src/main/java/com/mio/ai/memory/episodic/InterventionOutcomeRepository.java
@@ -15,4 +15,6 @@ public interface InterventionOutcomeRepository extends JpaRepository<Interventio
             LIMIT 20
             """)
     List<InterventionOutcome> findRecentByUserId(UUID userId);
+
+    List<InterventionOutcome> findBySessionId(UUID sessionId);
 }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -1032,6 +1032,16 @@ public class ConversationOrchestrator {
                         sessionId)
                 : CbtMetadataResult.none();
 
+        if (metadata.completionReason() != null) {
+            try {
+                // 운영자 반응신호 조회(이슈 #475)에서 쓰기 위해 세션에 남긴다 — 지금까지는
+                // DoneEvent SSE로만 나가고 DB에는 없어서 세션 종료 후에는 조회할 방법이 없었다.
+                sessionRepository.updateCbtCompletionReason(sessionId, metadata.completionReason());
+            } catch (Exception e) {
+                log.warn("Failed to persist cbtCompletionReason for sessionId={} — continuing", sessionId, e);
+            }
+        }
+
         UUID emotionScoreTargetId = null;
         if (metadata.shouldCreateEmotionScoreTarget()) {
             try {

--- a/src/main/java/com/mio/notification/repository/ProactiveCareLogRepository.java
+++ b/src/main/java/com/mio/notification/repository/ProactiveCareLogRepository.java
@@ -17,6 +17,24 @@ public interface ProactiveCareLogRepository extends JpaRepository<ProactiveCareL
     Optional<ProactiveCareLog> findByIdAndUser_Id(UUID id, UUID userId);
 
     /**
+     * "알림 후 실제 참여" 반응신호(이슈 #475) — 세션 시작 직전 발송된 알림이 있었는지, 있었다면
+     * 열람됐는지 확인한다. {@code windowStart}~{@code sessionStartedAt} 구간에서 가장 최근 것 하나.
+     */
+    @Query("""
+            SELECT log FROM ProactiveCareLog log
+            WHERE log.user.id = :userId
+              AND log.sentAt >= :windowStart
+              AND log.sentAt <= :sessionStartedAt
+            ORDER BY log.sentAt DESC, log.id DESC
+            """)
+    List<ProactiveCareLog> findMostRecentBeforeSessionStart(
+            @Param("userId") UUID userId,
+            @Param("windowStart") OffsetDateTime windowStart,
+            @Param("sessionStartedAt") OffsetDateTime sessionStartedAt,
+            Pageable pageable
+    );
+
+    /**
      * 실제로 발송된 상태({@code DELIVERED_STATUSES})의 이력만 재발송 억제 대상으로 본다.
      * 실패·미발송 이력은 재시도를 막지 않는다.
      */

--- a/src/main/java/com/mio/session/domain/Session.java
+++ b/src/main/java/com/mio/session/domain/Session.java
@@ -75,6 +75,10 @@ public class Session {
     @Column(name = "updated_at")
     private OffsetDateTime updatedAt;
 
+    /** user_reframed_thought / user_declined / max_questions_reached / stabilized / not_applicable */
+    @Column(name = "cbt_completion_reason")
+    private String cbtCompletionReason;
+
     @PrePersist
     protected void onCreate() {
         startedAt = OffsetDateTime.now(ZoneOffset.UTC);

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -143,6 +143,14 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
             @Param("lastMessageAt") OffsetDateTime lastMessageAt
     );
 
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            UPDATE Session s
+            SET s.cbtCompletionReason = :reason
+            WHERE s.id = :sessionId
+            """)
+    void updateCbtCompletionReason(@Param("sessionId") UUID sessionId, @Param("reason") String reason);
+
     /**
      * 사용자의 모든 세션 ID (이슈 #373).
      *

--- a/src/main/resources/db/migration/V76__add_cbt_completion_reason_to_sessions.sql
+++ b/src/main/resources/db/migration/V76__add_cbt_completion_reason_to_sessions.sql
@@ -1,0 +1,8 @@
+-- 이슈 #475 — CBT 개입 성공여부(completion_reason)는 지금까지 SSE(DoneEvent)로만 클라이언트에
+-- 나가고 DB에는 저장되지 않았다. chat_session_ended 이벤트에도 실리지만 그 파이프라인은
+-- CloudWatch 로그 라인일 뿐 Postgres 테이블이 아니라 admin API에서 조회할 수 없다 — 세션에
+-- 직접 저장해 운영자 반응신호 조회(GET /v1/admin/sessions/{id}/reactions)에서 쓸 수 있게 한다.
+
+ALTER TABLE sessions ADD COLUMN cbt_completion_reason TEXT;
+
+COMMENT ON COLUMN sessions.cbt_completion_reason IS 'user_reframed_thought / user_declined / max_questions_reached / stabilized / not_applicable — CbtMetadataResult.completionReason, null이면 CBT 개입이 없었거나 아직 안 끝남';

--- a/src/test/java/com/mio/admin/service/AdminSessionReactionsServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionReactionsServiceTest.java
@@ -1,0 +1,198 @@
+package com.mio.admin.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.admin.dto.SessionReactionsResponse;
+import com.mio.ai.domain.CharacterInteraction;
+import com.mio.ai.domain.CharacterInteractionRepository;
+import com.mio.ai.domain.UserMemoryPreference;
+import com.mio.ai.memory.episodic.InterventionOutcome;
+import com.mio.ai.memory.episodic.InterventionOutcomeRepository;
+import com.mio.ai.repository.UserMemoryPreferenceRepository;
+import com.mio.notification.domain.ProactiveCareLog;
+import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageRole;
+import com.mio.session.domain.Session;
+import com.mio.session.domain.SummaryStatus;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #475 — 세션 반응 신호 7종(hotline_resource_tapped 제외) 조회 검증. */
+@ExtendWith(MockitoExtension.class)
+class AdminSessionReactionsServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private InterventionOutcomeRepository interventionOutcomeRepository;
+    @Mock private UserMemoryPreferenceRepository userMemoryPreferenceRepository;
+    @Mock private CharacterInteractionRepository characterInteractionRepository;
+    @Mock private ProactiveCareLogRepository proactiveCareLogRepository;
+
+    private AdminSessionReactionsService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+    private final OffsetDateTime startedAt = OffsetDateTime.parse("2026-08-17T10:00:00+09:00");
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminSessionReactionsService(
+                sessionRepository, messageRepository, interventionOutcomeRepository,
+                userMemoryPreferenceRepository, characterInteractionRepository,
+                proactiveCareLogRepository, new ObjectMapper());
+    }
+
+    @Test
+    @DisplayName("투두 반응·감정추이·요약조회·CBT완료사유를 세션·유저 데이터에서 채운다")
+    void getReactions_aggregatesAllSignals() {
+        User user = User.builder().id(userId).build();
+        Session session = sessionWithCbtCompletionReason(user, "stabilized", SummaryStatus.VIEWED);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of(
+                outcome("positive"), outcome("positive"), outcome("negative"), outcome("neutral")));
+
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.of(
+                UserMemoryPreference.builder().userId(userId).dislikedPatterns("[\"breathing_exercise\"]").build()));
+
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.of(
+                CharacterInteraction.builder().userId(userId).characterId("mio").affinityScore(0.7).build()));
+
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of(
+                messageWithEmotionScore(30), messageWithEmotionScore(null), messageWithEmotionScore(55)));
+
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of());
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.sessionId()).isEqualTo(sessionId);
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.todoReactionCounts().positive()).isEqualTo(2);
+        assertThat(response.todoReactionCounts().negative()).isEqualTo(1);
+        assertThat(response.todoReactionCounts().neutral()).isEqualTo(1);
+        assertThat(response.dislikedPatterns()).containsExactly("breathing_exercise");
+        assertThat(response.characterAffinityScore()).isEqualTo(0.7);
+        assertThat(response.cbtCompletionReason()).isEqualTo("stabilized");
+        assertThat(response.emotionTrend().startScore()).isEqualTo(30);
+        assertThat(response.emotionTrend().endScore()).isEqualTo(55);
+        assertThat(response.emotionTrend().delta()).isEqualTo(25);
+        assertThat(response.summaryViewed()).isTrue();
+        assertThat(response.notifiedBeforeSession()).isNull();
+    }
+
+    @Test
+    @DisplayName("감정점수가 기록된 메시지가 하나도 없으면 감정추이는 전부 null이다(0으로 채우지 않음)")
+    void getReactions_noScoredMessages_emotionTrendAllNull() {
+        User user = User.builder().id(userId).build();
+        Session session = sessionWithCbtCompletionReason(user, null, SummaryStatus.PENDING);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.empty());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                .thenReturn(List.of(messageWithEmotionScore(null)));
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of());
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.emotionTrend().startScore()).isNull();
+        assertThat(response.emotionTrend().endScore()).isNull();
+        assertThat(response.emotionTrend().delta()).isNull();
+        assertThat(response.characterAffinityScore()).isNull();
+        assertThat(response.dislikedPatterns()).isEmpty();
+        assertThat(response.summaryViewed()).isFalse();
+    }
+
+    @Test
+    @DisplayName("세션 시작 전 발송된 알림을 열람했으면 notified_before_session이 true다")
+    void getReactions_notificationOpened_notifiedTrue() {
+        User user = User.builder().id(userId).build();
+        Session session = sessionWithCbtCompletionReason(user, null, SummaryStatus.PENDING);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.empty());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+
+        ProactiveCareLog openedLog = ProactiveCareLog.builder()
+                .user(user).triggerCode("checkin_reminder_morning")
+                .notificationStatus(ProactiveCareLog.STATUS_OPENED)
+                .build();
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of(openedLog));
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.notifiedBeforeSession()).isTrue();
+    }
+
+    @Test
+    @DisplayName("세션 시작 전 발송된 알림이 열람 안 됐으면 notified_before_session이 false다")
+    void getReactions_notificationSentNotOpened_notifiedFalse() {
+        User user = User.builder().id(userId).build();
+        Session session = sessionWithCbtCompletionReason(user, null, SummaryStatus.PENDING);
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.empty());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+
+        ProactiveCareLog sentLog = ProactiveCareLog.builder()
+                .user(user).triggerCode("checkin_reminder_morning")
+                .notificationStatus(ProactiveCareLog.STATUS_SENT)
+                .build();
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of(sentLog));
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.notifiedBeforeSession()).isFalse();
+    }
+
+    private Session sessionWithCbtCompletionReason(User user, String reason, SummaryStatus summaryStatus) {
+        return Session.builder()
+                .id(sessionId).user(user).characterId("mio").startedAt(startedAt)
+                .summaryStatus(summaryStatus)
+                .cbtCompletionReason(reason)
+                .build();
+    }
+
+    private InterventionOutcome outcome(String reaction) {
+        return InterventionOutcome.builder()
+                .user(User.builder().id(userId).build())
+                .sessionId(sessionId)
+                .interventionKind("breathing_exercise")
+                .userReaction(reaction)
+                .build();
+    }
+
+    private Message messageWithEmotionScore(Integer score) {
+        return Message.builder()
+                .id(UUID.randomUUID())
+                .role(MessageRole.USER)
+                .contentCiphertext(new byte[]{1})
+                .contentDekId("dek")
+                .emotionScore(score)
+                .createdAt(OffsetDateTime.now())
+                .build();
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminSessionServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionServiceTest.java
@@ -8,6 +8,8 @@ import com.mio.common.audit.AuditLog;
 import com.mio.common.audit.AuditLogRepository;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.crisis.domain.CrisisEvent;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageRole;
 import com.mio.session.domain.Session;
 import com.mio.session.repository.MessageRepository;
 import com.mio.session.repository.SessionRepository;
@@ -109,5 +111,75 @@ class AdminSessionServiceTest {
         assertThat(response.timeline().get(0))
                 .containsEntry("type", "audit_log")
                 .containsEntry("action", "USER_WITHDRAW");
+    }
+
+    @Test
+    @DisplayName("위기 이벤트 이후에 메시지가 있으면 continued_engagement가 true다 (이슈 #475)")
+    void getTimeline_messageAfterCrisisEvent_continuedEngagementTrue() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        OffsetDateTime crisisAt = OffsetDateTime.now();
+        CrisisEvent crisisEvent = CrisisEvent.builder()
+                .id(UUID.randomUUID()).user(user).session(session)
+                .triggerType("keyword").severity(2).operatorReviewed(false)
+                .createdAt(crisisAt)
+                .build();
+        when(crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                .thenReturn(List.of(crisisEvent));
+
+        Message afterMessage = Message.builder()
+                .id(UUID.randomUUID()).session(session).user(user)
+                .role(MessageRole.USER).contentCiphertext(new byte[]{1}).contentDekId("dek")
+                .createdAt(crisisAt.plusMinutes(1))
+                .build();
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of(afterMessage));
+        when(messageEncryptor.decrypt(any())).thenReturn("hi".getBytes());
+        when(aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.sumCostUsdBySessionId(sessionId)).thenReturn(BigDecimal.ZERO);
+        when(auditLogRepository.findByResourceIdOrderByCreatedAtAsc(any())).thenReturn(List.of());
+
+        SessionTimelineResponse response = service.getTimeline(sessionId);
+
+        var crisisItem = response.timeline().stream()
+                .filter(item -> "crisis_event".equals(item.get("type")))
+                .findFirst().orElseThrow();
+        assertThat(crisisItem).containsEntry("continued_engagement", true);
+    }
+
+    @Test
+    @DisplayName("위기 이벤트 이후에 메시지가 없으면 continued_engagement가 false다 (이슈 #475)")
+    void getTimeline_noMessageAfterCrisisEvent_continuedEngagementFalse() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+
+        OffsetDateTime crisisAt = OffsetDateTime.now();
+        CrisisEvent crisisEvent = CrisisEvent.builder()
+                .id(UUID.randomUUID()).user(user).session(session)
+                .triggerType("keyword").severity(2).operatorReviewed(false)
+                .createdAt(crisisAt)
+                .build();
+        when(crisisEventRepository.findBySession_IdOrderByCreatedAtAsc(sessionId))
+                .thenReturn(List.of(crisisEvent));
+
+        Message beforeMessage = Message.builder()
+                .id(UUID.randomUUID()).session(session).user(user)
+                .role(MessageRole.USER).contentCiphertext(new byte[]{1}).contentDekId("dek")
+                .createdAt(crisisAt.minusMinutes(1))
+                .build();
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of(beforeMessage));
+        when(messageEncryptor.decrypt(any())).thenReturn("hi".getBytes());
+        when(aiPolicyDecisionRepository.findBySessionIdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(aiPolicyDecisionRepository.sumCostUsdBySessionId(sessionId)).thenReturn(BigDecimal.ZERO);
+        when(auditLogRepository.findByResourceIdOrderByCreatedAtAsc(any())).thenReturn(List.of());
+
+        SessionTimelineResponse response = service.getTimeline(sessionId);
+
+        var crisisItem = response.timeline().stream()
+                .filter(item -> "crisis_event".equals(item.get("type")))
+                .findFirst().orElseThrow();
+        assertThat(crisisItem).containsEntry("continued_engagement", false);
     }
 }


### PR DESCRIPTION
## 요약
새 UI·신규 계측 없이 지금 바로 뽑을 수 있는 반응 신호를 세션조회 API에 통합합니다. `GET /v1/admin/sessions/{id}/reactions` 신설(반응 신호 7종) + 기존 `GET /v1/admin/sessions/{id}`의 `crisis_event` 항목에 `continued_engagement` 필드 추가.

## 관련 이슈
- Closes #475

## 구현 전 코드 확인에서 발견한 스코프 조정 (원안 대비 2건)
1. **`hotline_resource_tapped` 제외** — 핫라인 자원은 `CrisisFlowService`가 SSE(`SseEventDto.CrisisEvent.Resources`)로만 클라이언트에 푸시하고, "탭 여부"를 서버가 알 방법이 없습니다. `event-whitelist.yml`에 신규 이벤트 등록(강민석 이벤트 로그 명세 소유) + 앱 쪽 탭 핸들러 구현이 선행돼야 해서 이번 스코프에서 뺐습니다. 이슈 본문에 스코프 조정 사유를 남겨뒀고, 앱팀·이벤트 스펙 조율 후 후속 이슈로 분리할 예정입니다.
2. **`cbt_completion_reason`을 DB에 새로 저장** — 지금까지 `ConversationOrchestrator`가 SSE(`DoneEvent`)로만 클라이언트에 보내고 DB엔 없었습니다(`chat_session_ended` 이벤트에도 실리지만 그 파이프라인은 Postgres가 아니라 CloudWatch 로그 라인이라 admin API에서 조회 불가). `sessions.cbt_completion_reason` 컬럼을 추가하고(V76), 세션 종료 대화 턴에서 계산되는 즉시 저장하도록 구현했습니다.

## 변경 사항
- `GET /v1/admin/sessions/{id}/reactions` 신규(`AdminSessionController`에 추가, `AdminSessionReactionsService`, `SessionReactionsResponse`)
  - 투두 개입 반응 카운트 — `InterventionOutcome.userReaction`(session_id로 조회, 신규 `findBySessionId`)
  - 비선호 패턴 — `UserMemoryPreference.dislikedPatterns`(유저 레벨)
  - 캐릭터 애착도 — `CharacterInteraction.affinityScore`(신규 `CharacterInteractionRepository`)
  - CBT 개입 완료사유 — `Session.cbtCompletionReason`(신규 컬럼, V76)
  - 세션 내 감정 개선폭 — `Message.emotionScore` 첫값/끝값/델타(점수 기록된 메시지 없으면 전부 `null`, 0 아님)
  - 요약 조회 여부 — `Session.summaryStatus == VIEWED`
  - 알림 후 실제 참여 — 세션 시작 24시간 전 이내 `ProactiveCareLog` 유무·열람여부(로그 자체가 없으면 `null`, false 아님)
- `AdminSessionService.crisisEventItem`에 `continued_engagement`(위기 이벤트 시각 이후 메시지 존재 여부) 추가 — 신규 계측 없이 이미 조회한 메시지 목록 재사용
- `ConversationOrchestrator`에 `cbt_completion_reason` 영속화 로직 추가 — 실패해도 응답 흐름은 안 막음(try/catch, 인접한 `emotionScoreTargetId` 생성과 동일 패턴)
- 세션 단위 원문(대화 내용)은 응답에 없음 — 숫자·enum·bool 신호만 반환해 Track2 가명·집계 원칙과 충돌 방지

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (신규 엔드포인트 + 기존 `crisis_event` 항목 필드 추가)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. (V76, `sessions.cbt_completion_reason` 컬럼)
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test --tests "com.mio.admin.service.*" --tests "com.mio.ai.orchestrator.*"
./gradlew test
```
### 확인 내용
- `AdminSessionReactionsServiceTest`(mock) — 7개 신호 정상 집계, 감정점수 없는 세션은 감정추이 전부 `null`(0 아님), 알림 열람/미열람/알림없음 3가지 케이스 5건
- `AdminSessionServiceTest`에 `continued_engagement` true/false 케이스 추가 2건
- 전체 스위트: 1563개 중 1560개 통과. 나머지 3개(`MioApplicationTests` 2건, `LockedEvalContaminationGuardTest` 1건)는 이 브랜치가 원인이 아님 — `git stash -u`로 베이스(`integration/1.1.0` HEAD)에서 단독 재현 확인함(전자는 기존에 보고했던 로컬 DB flyway 체크섬 드리프트 V18/V56/V57, 후자는 베이스 브랜치에서도 그대로 실패)

## 중점 리뷰 포인트 (PR 올리기 전 자체 리뷰에서 확인한 것)
- **오케스트레이터 변경에 전용 테스트 없음** — `ConversationOrchestrator`의 `cbt_completion_reason` 저장 로직은 인접한 `emotionScoreTargetId` 생성과 동일하게 try/catch로 격리된 단순 side-effect이고, 이 클래스의 기존 테스트(`ConversationOrchestratorContractIntegrationTest` 등)도 이 수준의 개별 side-effect는 전용 테스트가 없는 걸 확인함 — 기존 투자 수준에 맞춰 별도 추가하지 않음. 필요하다고 판단되면 알려주시면 추가하겠습니다.
- **"모르는 것을 0으로 감추지 않는다" 원칙 재확인** — 감정추이 3필드, `notified_before_session` 전부 근거 데이터가 없으면 `null` 반환(0/false로 채우지 않음)
- **`InterventionOutcome`은 `session_id`가 raw UUID 컬럼이라(연관관계 아님)** `findBySessionId` 파생 쿼리가 정확히 그 컬럼에 매핑되는지 확인함
- **Flyway 버전 충돌 방지** — 브랜치 생성 시점에 `V59`로 만들었다가, `integration/1.1.0`에 이미 `V75`까지 있는 걸 뒤늦게 발견해 `V76`으로 정정함(이 레포에 버전 충돌 이력이 있는 걸 참고해 실제 적용 전에 재확인)

## 배포 / 롤백
- Rollout: Flyway 마이그레이션(V76) 자동 적용. 신규 엔드포인트라 기존 API에는 영향 없음(단 `crisis_event` 응답에 필드 하나 추가 — additive)
- Rollback: 코드만 이전 커밋으로 되돌리면 됨. `cbt_completion_reason` 컬럼은 그대로 둬도 무해(참조하는 다른 로직 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `integration/1.1.0`입니다 — 신규 기능은 이 브랜치 기준으로 진행하는 팀 컨벤션에 맞췄습니다.
