### PR TITLE
feat: 세션 반응-재방문 리텐션(returned_within_7d)과 재방문율 분석 API를 추가한다

### DIFF
--- a/src/main/java/com/mio/admin/controller/AdminAnalyticsController.java
+++ b/src/main/java/com/mio/admin/controller/AdminAnalyticsController.java
@@ -1,0 +1,26 @@
+package com.mio.admin.controller;
+
+import com.mio.admin.dto.ReactionRetentionResponse;
+import com.mio.admin.service.AdminReactionRetentionService;
+import com.mio.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 운영자용 분석 조회 (이슈 #476). {@code ROLE_ADMIN} 필요.
+ */
+@RestController
+@RequestMapping("/v1/admin/analytics")
+@RequiredArgsConstructor
+public class AdminAnalyticsController {
+
+    private final AdminReactionRetentionService adminReactionRetentionService;
+
+    @GetMapping("/reaction-retention")
+    public ResponseEntity<ApiResponse<ReactionRetentionResponse>> getReactionRetention() {
+        return ResponseEntity.ok(ApiResponse.ok(adminReactionRetentionService.getReactionRetention()));
+    }
+}

--- a/src/main/java/com/mio/admin/dto/ReactionRetentionResponse.java
+++ b/src/main/java/com/mio/admin/dto/ReactionRetentionResponse.java
@@ -1,0 +1,24 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+/**
+ * 반응 신호별 7일 재방문율 조회 응답 (이슈 #476, 개선안 문서 §4.4).
+ *
+ * <p>{@code retentionRate}는 상관관계이지, 비용이나 AI 응답이 리텐션을 만들었다는 인과 근거가
+ * 아니다. 표본이 작은 그룹의 비율은 참고용일 뿐이다.
+ */
+public record ReactionRetentionResponse(
+        @JsonProperty("by_reaction") List<ReactionGroup> byReaction
+) {
+    public record ReactionGroup(
+            @JsonProperty("reaction") String reaction,
+            @JsonProperty("session_count") long sessionCount,
+            @JsonProperty("returned_within_7d_count") long returnedWithin7dCount,
+            /** sessionCount가 0이면 null — 0%로 오독되지 않게 한다. */
+            @JsonProperty("retention_rate") Double retentionRate
+    ) {
+    }
+}

--- a/src/main/java/com/mio/admin/dto/SessionReactionsResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionReactionsResponse.java
@@ -6,10 +6,12 @@ import java.util.List;
 import java.util.UUID;
 
 /**
- * 세션 반응 신호 조회 응답 (이슈 #475, 개선안 문서 §4.2).
+ * 세션 반응 신호 조회 응답 (이슈 #475/#476, 개선안 문서 §4.2/§4.4).
  *
  * <p>검증된 치료 효과나 사용자 가치의 직접 증거가 아니라 모델 추정치·제품 반응 신호다.
  * {@code emotionTrend}는 모델이 추정한 신호이지 검증된 임상 결과가 아니다.
+ * {@code returnedWithin7d}는 상관관계이지, 비용이나 AI 응답이 리텐션을 만들었다는
+ * 인과 근거가 아니다.
  */
 public record SessionReactionsResponse(
         @JsonProperty("session_id") UUID sessionId,
@@ -20,7 +22,8 @@ public record SessionReactionsResponse(
         @JsonProperty("cbt_completion_reason") String cbtCompletionReason,
         @JsonProperty("emotion_trend") EmotionTrend emotionTrend,
         @JsonProperty("summary_viewed") boolean summaryViewed,
-        @JsonProperty("notified_before_session") Boolean notifiedBeforeSession
+        @JsonProperty("notified_before_session") Boolean notifiedBeforeSession,
+        @JsonProperty("returned_within_7d") Boolean returnedWithin7d
 ) {
     public record TodoReactionCounts(
             @JsonProperty("positive") long positive,

--- a/src/main/java/com/mio/admin/service/AdminReactionRetentionService.java
+++ b/src/main/java/com/mio/admin/service/AdminReactionRetentionService.java
@@ -1,0 +1,56 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.ReactionRetentionResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 반응 신호별 7일 재방문율 조회 (이슈 #476, 개선안 문서 §4.4).
+ *
+ * <p>{@code intervention_outcomes} 각 행(반응 인스턴스 하나)을 기준으로, 그 세션이 끝난 뒤
+ * 7일 안에 같은 유저의 다른 세션이 시작됐는지를 {@code user_reaction}별로 집계한다. 신규
+ * 계측 없이 {@code intervention_outcomes}·{@code sessions} 두 테이블만 쓴다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AdminReactionRetentionService {
+
+    private static final int RETENTION_WINDOW_DAYS = 7;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public ReactionRetentionResponse getReactionRetention() {
+        List<ReactionRetentionResponse.ReactionGroup> groups = jdbcTemplate.query("""
+                SELECT io.user_reaction AS reaction,
+                       COUNT(*) AS session_count,
+                       COUNT(next_session.started_at) AS returned_count
+                FROM intervention_outcomes io
+                JOIN sessions s ON s.id = io.session_id
+                LEFT JOIN LATERAL (
+                    SELECT s2.started_at
+                    FROM sessions s2
+                    WHERE s2.user_id = s.user_id
+                      AND s2.started_at > s.ended_at
+                      AND s2.started_at <= s.ended_at + (? || ' days')::interval
+                    ORDER BY s2.started_at ASC
+                    LIMIT 1
+                ) next_session ON true
+                WHERE s.status = 'ended' AND s.ended_at IS NOT NULL AND io.user_reaction IS NOT NULL
+                GROUP BY io.user_reaction
+                ORDER BY io.user_reaction
+                """,
+                (rs, rowNum) -> {
+                    long sessionCount = rs.getLong("session_count");
+                    long returnedCount = rs.getLong("returned_count");
+                    Double retentionRate = sessionCount > 0 ? (double) returnedCount / sessionCount : null;
+                    return new ReactionRetentionResponse.ReactionGroup(
+                            rs.getString("reaction"), sessionCount, returnedCount, retentionRate);
+                },
+                RETENTION_WINDOW_DAYS);
+
+        return new ReactionRetentionResponse(groups);
+    }
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionReactionsService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionReactionsService.java
@@ -48,6 +48,9 @@ public class AdminSessionReactionsService {
     /** 세션 시작 전 이 기간 안에 발송된 알림까지만 "이 세션을 유발했을 수 있다"고 본다. */
     private static final Duration NOTIFICATION_LOOKBACK = Duration.ofHours(24);
 
+    /** 이슈 #476 — 세션 종료 후 이 기간 안에 재방문했는지를 리텐션 신호로 본다. */
+    private static final int RETENTION_WINDOW_DAYS = 7;
+
     private final SessionRepository sessionRepository;
     private final MessageRepository messageRepository;
     private final InterventionOutcomeRepository interventionOutcomeRepository;
@@ -71,7 +74,8 @@ public class AdminSessionReactionsService {
                 session.getCbtCompletionReason(),
                 emotionTrend(sessionId),
                 session.getSummaryStatus() == SummaryStatus.VIEWED,
-                notifiedBeforeSession(userId, session.getStartedAt())
+                notifiedBeforeSession(userId, session.getStartedAt()),
+                returnedWithin7Days(userId, session)
         );
     }
 
@@ -127,5 +131,17 @@ public class AdminSessionReactionsService {
             return null;
         }
         return ProactiveCareLog.STATUS_OPENED.equals(logs.get(0).getNotificationStatus());
+    }
+
+    /**
+     * @return 세션이 아직 안 끝났으면 {@code null}(신호 없음), 끝났으면 그 뒤 7일 안에 이
+     *         유저의 다른 세션이 시작됐는지(이슈 #476)
+     */
+    private Boolean returnedWithin7Days(UUID userId, Session session) {
+        if (session.getEndedAt() == null) {
+            return null;
+        }
+        return sessionRepository.existsSessionStartedInWindow(
+                userId, session.getEndedAt(), session.getEndedAt().plusDays(RETENTION_WINDOW_DAYS));
     }
 }

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -152,6 +152,18 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
     void updateCbtCompletionReason(@Param("sessionId") UUID sessionId, @Param("reason") String reason);
 
     /**
+     * 리텐션 반응신호(이슈 #476) — {@code after}(보통 세션 endedAt) 뒤,
+     * {@code beforeOrEqual}(보통 endedAt + 7일) 안에 이 유저의 다른 세션이 시작됐는지.
+     */
+    @Query("""
+            SELECT COUNT(s) > 0 FROM Session s
+            WHERE s.user.id = :userId AND s.startedAt > :after AND s.startedAt <= :beforeOrEqual
+            """)
+    boolean existsSessionStartedInWindow(@Param("userId") UUID userId,
+                                         @Param("after") OffsetDateTime after,
+                                         @Param("beforeOrEqual") OffsetDateTime beforeOrEqual);
+
+    /**
      * 사용자의 모든 세션 ID (이슈 #373).
      *
      * <p>Redis 캐시 키가 {@code session:{sessionId}:*} 라 사용자 단위 purge 를 하려면

--- a/src/test/java/com/mio/admin/service/AdminReactionRetentionServiceIntegrationTest.java
+++ b/src/test/java/com/mio/admin/service/AdminReactionRetentionServiceIntegrationTest.java
@@ -1,0 +1,144 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.ReactionRetentionResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 반응 신호별 7일 재방문율 집계를 실제 DB로 검증한다 (이슈 #476).
+ *
+ * <p>LATERAL 조인 같은 DB 함수 의존 로직은 mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class AdminReactionRetentionServiceIntegrationTest {
+
+    @Autowired
+    private AdminReactionRetentionService service;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> insertedOutcomeIds = new ArrayList<>();
+    private final List<UUID> insertedSessionIds = new ArrayList<>();
+    private final List<UUID> insertedUserIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        insertedOutcomeIds.forEach(id -> jdbcTemplate.update("DELETE FROM intervention_outcomes WHERE id = ?", id));
+        insertedSessionIds.forEach(id -> jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", id));
+        insertedUserIds.forEach(id -> jdbcTemplate.update("DELETE FROM users WHERE id = ?", id));
+    }
+
+    @Test
+    @DisplayName("positive 2건 중 1건만 7일 안에 재방문하면 retention_rate가 0.5다")
+    void getReactionRetention_mixedReturns_computesRate() {
+        UUID user1 = insertUser();
+        UUID session1 = insertEndedSession(user1, "2026-08-01T10:00:00+09:00", "2026-08-01T10:30:00+09:00");
+        insertSession(user1, "2026-08-03T10:00:00+09:00", "ended"); // 7일 안 재방문
+        insertOutcome(user1, session1, "positive");
+
+        UUID user2 = insertUser();
+        UUID session2 = insertEndedSession(user2, "2026-08-01T10:00:00+09:00", "2026-08-01T10:30:00+09:00");
+        insertSession(user2, "2026-08-20T10:00:00+09:00", "ended"); // 7일 밖 재방문
+        insertOutcome(user2, session2, "positive");
+
+        ReactionRetentionResponse response = service.getReactionRetention();
+
+        ReactionRetentionResponse.ReactionGroup positive = findGroup(response, "positive");
+        assertThat(positive.sessionCount()).isEqualTo(2);
+        assertThat(positive.returnedWithin7dCount()).isEqualTo(1);
+        assertThat(positive.retentionRate()).isEqualTo(0.5);
+    }
+
+    @Test
+    @DisplayName("재방문이 하나도 없으면 retention_rate가 0.0이다 (null이 아니라 실제 0)")
+    void getReactionRetention_noReturns_rateIsZero() {
+        UUID user = insertUser();
+        UUID session = insertEndedSession(user, "2026-08-01T10:00:00+09:00", "2026-08-01T10:30:00+09:00");
+        insertOutcome(user, session, "negative");
+
+        ReactionRetentionResponse response = service.getReactionRetention();
+
+        ReactionRetentionResponse.ReactionGroup negative = findGroup(response, "negative");
+        assertThat(negative.sessionCount()).isEqualTo(1);
+        assertThat(negative.returnedWithin7dCount()).isEqualTo(0);
+        assertThat(negative.retentionRate()).isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("세션이 아직 종료 안 됐으면(active) 집계에서 제외된다")
+    void getReactionRetention_excludesUnendedSessions() {
+        UUID user = insertUser();
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at) " +
+                        "VALUES (?, ?, 'mio', 'active', '2026-08-01T10:00:00+09:00'::timestamptz)",
+                sessionId, user);
+        insertedSessionIds.add(sessionId);
+        insertOutcome(user, sessionId, "neutral");
+
+        ReactionRetentionResponse response = service.getReactionRetention();
+
+        assertThat(findGroupOptional(response, "neutral")).isEmpty();
+    }
+
+    private ReactionRetentionResponse.ReactionGroup findGroup(ReactionRetentionResponse response, String reaction) {
+        return findGroupOptional(response, reaction)
+                .orElseThrow(() -> new AssertionError("no group for reaction=" + reaction));
+    }
+
+    private Optional<ReactionRetentionResponse.ReactionGroup> findGroupOptional(
+            ReactionRetentionResponse response, String reaction) {
+        return response.byReaction().stream().filter(g -> g.reaction().equals(reaction)).findFirst();
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "reaction-retention-it-" + userId);
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private UUID insertEndedSession(UUID userId, String startedAt, String endedAt) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at) " +
+                        "VALUES (?, ?, 'mio', 'ended', ?::timestamptz, ?::timestamptz)",
+                sessionId, userId, startedAt, endedAt);
+        insertedSessionIds.add(sessionId);
+        return sessionId;
+    }
+
+    private void insertSession(UUID userId, String startedAt, String status) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at) " +
+                        "VALUES (?, ?, 'mio', ?, ?::timestamptz)",
+                sessionId, userId, status, startedAt);
+        insertedSessionIds.add(sessionId);
+    }
+
+    private void insertOutcome(UUID userId, UUID sessionId, String reaction) {
+        UUID outcomeId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO intervention_outcomes (id, user_id, session_id, intervention_kind, user_reaction) " +
+                        "VALUES (?, ?, ?, 'breathing_exercise', ?)",
+                outcomeId, userId, sessionId, reaction);
+        insertedOutcomeIds.add(outcomeId);
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminSessionReactionsServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionReactionsServiceTest.java
@@ -96,6 +96,7 @@ class AdminSessionReactionsServiceTest {
         assertThat(response.emotionTrend().delta()).isEqualTo(25);
         assertThat(response.summaryViewed()).isTrue();
         assertThat(response.notifiedBeforeSession()).isNull();
+        assertThat(response.returnedWithin7d()).isNull();
     }
 
     @Test
@@ -166,6 +167,52 @@ class AdminSessionReactionsServiceTest {
         SessionReactionsResponse response = service.getReactions(sessionId);
 
         assertThat(response.notifiedBeforeSession()).isFalse();
+    }
+
+    @Test
+    @DisplayName("세션 종료 후 7일 안에 재방문했으면 returned_within_7d가 true다 (이슈 #476)")
+    void getReactions_returnedWithin7Days_true() {
+        User user = User.builder().id(userId).build();
+        OffsetDateTime endedAt = startedAt.plusMinutes(30);
+        Session session = Session.builder()
+                .id(sessionId).user(user).characterId("mio")
+                .startedAt(startedAt).endedAt(endedAt)
+                .summaryStatus(SummaryStatus.PENDING)
+                .build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.empty());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of());
+        when(sessionRepository.existsSessionStartedInWindow(userId, endedAt, endedAt.plusDays(7)))
+                .thenReturn(true);
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.returnedWithin7d()).isTrue();
+    }
+
+    @Test
+    @DisplayName("세션이 아직 종료 안 됐으면 returned_within_7d는 false가 아니라 null이다 (이슈 #476)")
+    void getReactions_sessionNotEnded_returnedWithin7dIsNull() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder()
+                .id(sessionId).user(user).characterId("mio").startedAt(startedAt)
+                .summaryStatus(SummaryStatus.PENDING)
+                .build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(interventionOutcomeRepository.findBySessionId(sessionId)).thenReturn(List.of());
+        when(userMemoryPreferenceRepository.findByUserId(userId)).thenReturn(Optional.empty());
+        when(characterInteractionRepository.findByUserIdAndCharacterId(userId, "mio")).thenReturn(Optional.empty());
+        when(messageRepository.findBySession_IdOrderByCreatedAtAsc(sessionId)).thenReturn(List.of());
+        when(proactiveCareLogRepository.findMostRecentBeforeSessionStart(eq(userId), any(), any(), any()))
+                .thenReturn(List.of());
+
+        SessionReactionsResponse response = service.getReactions(sessionId);
+
+        assertThat(response.returnedWithin7d()).isNull();
     }
 
     private Session sessionWithCbtCompletionReason(User user, String reason, SummaryStatus summaryStatus) {


### PR DESCRIPTION
## 요약
지금까지의 반응 신호(#475)는 "이 세션이 좋았나"만 봅니다. `reactions` 응답에 `returned_within_7d`를 추가하고, 반응 신호별 7일 재방문율을 비교하는 `GET /v1/admin/analytics/reaction-retention`을 신설합니다. "비용 써서 만든 좋은 경험이 실제로 재방문으로 이어진다"를 숫자로 볼 수 있는 근거입니다.

## 관련 이슈
- Closes #476

## 스코프 메모
이슈 원안의 엔드포인트 설명에는 "cost·reaction 조합별"이라고 돼 있었지만, "완료 조건"은 "반응 신호별 재방문율 집계"만 요구합니다. cost 교차분석까지 넣으면 세션 비용 버킷 정의 등 별도 설계가 필요해져, 이번엔 반응 신호(positive/negative/neutral)별 집계만 구현했습니다. cost 교차분석이 필요하면 후속 이슈로 분리하는 게 좋을 것 같습니다.

## 변경 사항
- `SessionReactionsResponse`에 `returned_within_7d`(Boolean) 추가 — `SessionRepository.existsSessionStartedInWindow`로 계산(세션 endedAt 뒤 7일 안에 같은 유저의 다른 세션 시작 여부). 세션이 아직 안 끝났으면 `false`가 아니라 `null`
- `GET /v1/admin/analytics/reaction-retention` 신규(`AdminAnalyticsController`, `AdminReactionRetentionService`, `ReactionRetentionResponse`) — `intervention_outcomes`를 `user_reaction`별로 묶어 그 세션 종료 후 7일 안에 재방문한 비율을 계산. LATERAL 조인으로 "그 세션 이후 가장 빠른 다음 세션"만 찾음(JdbcTemplate, 신규 계측 없음)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (`reactions` 응답 필드 추가 + 신규 분석 엔드포인트)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
```
./gradlew compileJava compileTestJava
./gradlew test --tests "com.mio.admin.*"
./gradlew test
```
### 확인 내용
- `AdminSessionReactionsServiceTest`에 `returned_within_7d` true/null(미종료 세션) 케이스 추가 2건
- `AdminReactionRetentionServiceIntegrationTest`(실제 DB, LATERAL 조인 검증) — 재방문 섞인 경우 비율 계산, 재방문 0건이면 `0.0`(그룹 자체가 없는 게 아니라 명시적 0), 미종료(active) 세션은 집계에서 제외 3건
- 전체 스위트: 1568개 중 1565개 통과. 나머지 3개(`MioApplicationTests` 2건, `LockedEvalContaminationGuardTest` 1건)는 이 브랜치가 원인이 아님 — #475(PR #477) 때도 보고했던 것과 동일, 베이스 브랜치에서도 그대로 재현됨

## 중점 리뷰 포인트 (PR 올리기 전 자체 리뷰에서 확인한 것)
- **"모르는 것을 0으로 감추지 않는다" 원칙** — 세션이 아직 안 끝났을 땐 `returned_within_7d`가 `null`(재방문 신호를 아직 평가할 수 없음), 재방문율 계산 자체가 안 되는 그룹은 목록에서 아예 빠짐(0%로 표시 안 함) — 반면 실제로 재방문이 0건 관측된 그룹은 명시적으로 `0.0`으로 구분함(이건 "값을 모른다"가 아니라 "관측했더니 0이다"라 다른 케이스)
- **자기 세션 재방문 오탐 방지** — `existsSessionStartedInWindow`가 `startedAt > endedAt`으로 걸려 있어, 같은 세션 자기 자신이 "재방문"으로 잡힐 수 없음을 확인함(한 세션의 시작은 항상 자기 종료보다 앞서므로 자동 배제)
- **분석 엔드포인트 테스트의 한계** — `AdminReactionRetentionService.getReactionRetention()`은 스코프 파라미터 없이 테이블 전체를 집계하는 전역 쿼리라, 정수 카운트 자체를 단언하는 통합테스트는 로컬 개발 DB에 잔존 데이터가 있으면 흔들릴 수 있습니다. 다만 이 저장소의 기존 통합테스트들(`InfraCostAllocatorIntegrationTest` 등)도 같은 성격이라 컨벤션에 맞췄고, CI는 매번 새 Postgres 컨테이너를 쓰므로 실제 위험은 없습니다.

## 배포 / 롤백
- Rollout: DB 마이그레이션 없음(기존 테이블 조회만). 신규 엔드포인트 + 기존 `reactions` 응답에 필드 추가(additive)라 기존 클라이언트에 영향 없음
- Rollback: 코드만 이전 커밋으로 되돌리면 됨

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.

---
**참고**: 이 PR의 base는 `develop`이 아니라 `integration/1.1.0`입니다 — #475(PR #477)가 머지된 뒤 그 위에서 이어갔습니다(신규 기능은 `integration/1.1.0` 기준 팀 컨벤션).
