### PR TITLE
feat: 역할→모델 카탈로그로 모델 변경을 설정으로 만든다

### DIFF
--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.memory.working.WorkingMessage;
 import com.mio.ai.safety.UserMessageSignal;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +20,6 @@ import java.util.UUID;
 @Slf4j
 public class CbtMetadataClassifier {
 
-    private static final String MODEL = "gpt-4o-mini";
     // JSON 분류 출력 상한. 예상 ~90 토큰.
     private static final int MAX_COMPLETION_TOKENS = 400;
 
@@ -46,6 +47,7 @@ public class CbtMetadataClassifier {
 
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
+    private final ModelCatalog modelCatalog;
 
     public CbtMetadataResult classify(
             String previousState,
@@ -63,7 +65,8 @@ public class CbtMetadataClassifier {
         }
 
         try {
-            LlmRequest request = LlmRequest.of(MODEL, SYSTEM_PROMPT, buildPrompt(
+            LlmRequest request = LlmRequest.of(modelCatalog.modelFor(ModelRole.CBT_CLASSIFIER),
+                    SYSTEM_PROMPT, buildPrompt(
                     previousState,
                     recentMessages,
                     userMessage,

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.policy.DeliveryMode;
 import com.mio.ai.policy.GenerationMode;
 import com.mio.ai.profile.SafetyProfile;
@@ -23,7 +25,6 @@ import java.util.UUID;
 @Slf4j
 public class InputJudge {
 
-    private static final String JUDGE_MODEL = "gpt-4o-mini";
     // JSON 판정 출력 상한. 예상 ~130 토큰이지만 여유를 크게 둔다 — JSON 은 잘리면 파싱이
     // 통째로 실패하고, 그러면 안전 판정이 사라진다 (fallback CLEAR_LOW + failed).
     private static final int JUDGE_MAX_COMPLETION_TOKENS = 500;
@@ -81,6 +82,7 @@ public class InputJudge {
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
+    private final ModelCatalog modelCatalog;
 
     public boolean shouldCallJudge(CombinedSignal combined, SafetyProfile profile) {
         return combined.requiresJudge();
@@ -90,7 +92,8 @@ public class InputJudge {
                                    UUID userId, UUID sessionId) {
         try {
             String contextPrompt = buildContextPrompt(profile, message);
-            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt)
+            LlmRequest request = LlmRequest.of(modelCatalog.modelFor(ModelRole.INPUT_JUDGE),
+                            SYSTEM_PROMPT, contextPrompt)
                     .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS)
                     .withAttribution("INPUT_JUDGE", userId, sessionId);
             String responseJson = llmClient.completeJson(request);

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -16,7 +18,6 @@ import java.util.UUID;
 @Slf4j
 public class OutputJudge {
 
-    private static final String JUDGE_MODEL = "gpt-4o-mini";
     // JSON 판정 출력 상한.
     //
     // REWRITE 판정은 rewritten_content 에 <b>본문을 다시 써서</b> 돌려준다. 본문 자체가
@@ -49,12 +50,14 @@ public class OutputJudge {
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
+    private final ModelCatalog modelCatalog;
 
     public OutputJudgeResult judge(String aiResponse, OutputPreFilterResult preFilterResult,
                                     UUID userId, UUID sessionId) {
         try {
             String userContent = buildJudgePrompt(aiResponse, preFilterResult);
-            LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent)
+            LlmRequest request = LlmRequest.of(modelCatalog.modelFor(ModelRole.OUTPUT_JUDGE),
+                            SYSTEM_PROMPT, userContent)
                     .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS)
                     .withAttribution("OUTPUT_JUDGE", userId, sessionId);
             String responseJson = llmClient.completeJson(request);

--- a/src/main/java/com/mio/ai/llm/ModelCatalog.java
+++ b/src/main/java/com/mio/ai/llm/ModelCatalog.java
@@ -1,0 +1,96 @@
+package com.mio.ai.llm;
+
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * 역할→모델 해석기 (#479). 모델 변경을 코드 수정이 아니라 설정으로 만든다.
+ *
+ * <p>해석은 기동 시점에 한 번 확정되고, 두 검증을 fail-closed 로 통과해야 한다.
+ *
+ * <ol>
+ *   <li><b>allowlist</b> — 해석된 모델이 {@code mio.ai.models.allowed} 밖이면 기동 실패.
+ *       allowlist 가 비어 있으면 {@link ModelRole} 기본 모델 집합만 허용된다 —
+ *       "설정을 안 했다"가 "전부 허용"이 되면 목록의 의미가 없다.</li>
+ *   <li><b>단가</b> — 해석된 모델이 {@code openai.pricing.models} 에 없으면 기동 실패.
+ *       단가 미등록 모델은 비용이 0 이 아니라 '미상'으로 쌓이는데, 그 사실을 지표로
+ *       사후에 아는 것과 기동에서 막는 것은 다른 일이다.</li>
+ * </ol>
+ *
+ * <p>토큰 상한과 프롬프트는 여기서 다루지 않는다 — 상한은 프롬프트 길이 지시와 같은 파일에
+ * 있어야 함께 바뀐다(호출부 상수). 이 카탈로그는 모델 ID 만 해석한다.
+ */
+@Component
+public class ModelCatalog {
+
+    private final Map<ModelRole, String> models;
+
+    public ModelCatalog(ModelCatalogProperties properties, LlmPricingProperties pricing) {
+        Map<ModelRole, String> resolved = new EnumMap<>(ModelRole.class);
+        for (ModelRole role : ModelRole.values()) {
+            resolved.put(role, role.defaultModel());
+        }
+        for (Map.Entry<String, String> entry : properties.getRoles().entrySet()) {
+            resolved.put(ModelRole.fromConfigKey(entry.getKey()), entry.getValue());
+        }
+        requireAllowed(resolved, effectiveAllowlist(properties));
+        requirePriced(resolved, pricing);
+        this.models = Map.copyOf(resolved);
+    }
+
+    public String modelFor(ModelRole role) {
+        return models.get(role);
+    }
+
+    /** 설정 없는 기본 카탈로그. 테스트가 프로덕션과 같은 기본 해석을 쓸 때 사용한다. */
+    public static ModelCatalog defaults() {
+        LlmPricingProperties pricing = new LlmPricingProperties();
+        Map<String, LlmPricingProperties.ModelPrice> table = new LinkedHashMap<>();
+        for (ModelRole role : ModelRole.values()) {
+            table.put(role.defaultModel(), new LlmPricingProperties.ModelPrice(
+                    BigDecimal.ONE, null, BigDecimal.ONE));
+        }
+        pricing.setModels(table);
+        return new ModelCatalog(new ModelCatalogProperties(), pricing);
+    }
+
+    private static Set<String> effectiveAllowlist(ModelCatalogProperties properties) {
+        if (!properties.getAllowed().isEmpty()) {
+            return Set.copyOf(properties.getAllowed());
+        }
+        return Arrays.stream(ModelRole.values())
+                .map(ModelRole::defaultModel)
+                .collect(Collectors.toUnmodifiableSet());
+    }
+
+    private static void requireAllowed(Map<ModelRole, String> resolved, Set<String> allowed) {
+        for (Map.Entry<ModelRole, String> entry : resolved.entrySet()) {
+            if (!allowed.contains(entry.getValue())) {
+                throw new IllegalStateException(
+                        "역할 %s 가 allowlist 밖의 모델 '%s' 로 해석됐다. mio.ai.models.allowed 에 "
+                                .formatted(entry.getKey().configKey(), entry.getValue())
+                                + "등재해야 하며, 등재는 PR 로만 한다 — 안전 게이트를 우회하지 않기 위해서다");
+            }
+        }
+    }
+
+    private static void requirePriced(Map<ModelRole, String> resolved, LlmPricingProperties pricing) {
+        Map<String, LlmPricingProperties.ModelPrice> table = pricing.getModels();
+        for (Map.Entry<ModelRole, String> entry : resolved.entrySet()) {
+            LlmPricingProperties.ModelPrice price = table.get(entry.getValue());
+            if (price == null || !price.isValid()) {
+                throw new IllegalStateException(
+                        "역할 %s 의 모델 '%s' 가 openai.pricing.models 에 없다. 단가 없이 운영하면 "
+                                .formatted(entry.getKey().configKey(), entry.getValue())
+                                + "비용이 '미상'으로 쌓인다 — 단가를 등록해야 기동한다");
+            }
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/llm/ModelCatalogProperties.java
+++ b/src/main/java/com/mio/ai/llm/ModelCatalogProperties.java
@@ -1,0 +1,46 @@
+package com.mio.ai.llm;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 역할→모델 설정 (#479).
+ *
+ * <pre>
+ * mio:
+ *   ai:
+ *     models:
+ *       allowed: [gpt-4o, gpt-4o-mini]   # 이 밖의 모델로는 기동 자체가 안 된다
+ *       roles:
+ *         generation: gpt-4o             # 생략하면 ModelRole 의 기본값
+ * </pre>
+ *
+ * <p>{@code allowed} 등재는 PR 로만 한다 — 모델 변경이 안전 게이트(Crisis Eval)를
+ * 우회하지 않게 하는 강제 지점이 이 목록이다. 검증 규칙은 {@link ModelCatalog} 에 있다.
+ */
+@ConfigurationProperties(prefix = "mio.ai.models")
+public class ModelCatalogProperties {
+
+    private Map<String, String> roles = new LinkedHashMap<>();
+    private List<String> allowed = new ArrayList<>();
+
+    public Map<String, String> getRoles() {
+        return Map.copyOf(roles);
+    }
+
+    public void setRoles(Map<String, String> roles) {
+        this.roles = roles != null ? new LinkedHashMap<>(roles) : new LinkedHashMap<>();
+    }
+
+    public List<String> getAllowed() {
+        return List.copyOf(allowed);
+    }
+
+    public void setAllowed(List<String> allowed) {
+        this.allowed = allowed != null ? new ArrayList<>(allowed) : new ArrayList<>();
+    }
+}

--- a/src/main/java/com/mio/ai/llm/ModelRole.java
+++ b/src/main/java/com/mio/ai/llm/ModelRole.java
@@ -1,0 +1,63 @@
+package com.mio.ai.llm;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * 대화 파이프라인에서 LLM 을 부르는 역할 (#479).
+ *
+ * <p>호출부는 모델 ID 가 아니라 역할을 말하고, 역할→모델 해석은 {@link ModelCatalog} 가 한다.
+ * 벤치마크 하네스의 {@code CellModelRole} 과 같은 개념이다 — 평가가 역할 단위로 모델을
+ * 갈아끼우며 비교하므로, 운영도 같은 단위로 갈아끼울 수 있어야 평가 결과를 그대로 적용할 수 있다.
+ *
+ * <p>기본값은 이 enum 이 도입되기 전 각 호출부에 하드코딩돼 있던 상수와 같다.
+ * 여기 없는 역할(메모리 컨솔리데이션·리포트·체크인·임베딩)은 아직 호출부 상수를 쓴다 — 이슈 #482.
+ */
+public enum ModelRole {
+
+    /** 메인 대화 생성 ({@code ConversationOrchestrator}). */
+    GENERATION("gpt-4o"),
+
+    /** 입력 안전·보안 판정 ({@code InputJudge}). */
+    INPUT_JUDGE("gpt-4o-mini"),
+
+    /** 출력 사후 판정 ({@code OutputJudge}). */
+    OUTPUT_JUDGE("gpt-4o-mini"),
+
+    /** CBT 메타데이터 분류 ({@code CbtMetadataClassifier}). */
+    CBT_CLASSIFIER("gpt-4o-mini");
+
+    private final String defaultModel;
+
+    ModelRole(String defaultModel) {
+        this.defaultModel = defaultModel;
+    }
+
+    public String defaultModel() {
+        return defaultModel;
+    }
+
+    /** 설정 파일에서 이 역할을 가리키는 키 (kebab-case). */
+    public String configKey() {
+        return name().toLowerCase().replace('_', '-');
+    }
+
+    /**
+     * 설정 키 → 역할. kebab-case 외에 Spring relaxed binding 이 만들 수 있는
+     * 표기(camelCase, snake_case)도 받는다.
+     *
+     * @throws IllegalStateException 어느 역할도 아니면 — 오타가 조용히 무시되면
+     *                               존재하지 않는 보호를 설정했다고 믿게 된다
+     */
+    static ModelRole fromConfigKey(String key) {
+        String normalized = key.replace("-", "").replace("_", "").toLowerCase();
+        return Arrays.stream(values())
+                .filter(role -> role.name().replace("_", "").toLowerCase().equals(normalized))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "mio.ai.models.roles 에 모르는 역할 키가 있다: '%s' — 가능한 키: %s"
+                                .formatted(key, Arrays.stream(values())
+                                        .map(ModelRole::configKey)
+                                        .collect(Collectors.joining(", ")))));
+    }
+}

--- a/src/main/java/com/mio/ai/llm/ModelRole.java
+++ b/src/main/java/com/mio/ai/llm/ModelRole.java
@@ -43,14 +43,17 @@ public enum ModelRole {
     }
 
     /**
-     * 설정 키 → 역할. kebab-case 외에 Spring relaxed binding 이 만들 수 있는
-     * 표기(camelCase, snake_case)도 받는다.
+     * 설정 키 → 역할. kebab-case 외에 Spring relaxed binding 이 만들 수 있는 표기를 받는다:
+     * camelCase, snake_case, 그리고 환경 변수 경로의 점 표기. 두 단어 역할을
+     * {@code MIO_AI_MODELS_ROLES_INPUT_JUDGE} 로 넘기면 relaxed binding 이 맵 키를
+     * {@code input.judge} 로 만들기 때문에 {@code .} 도 정규화한다 — 운영자가 canary 롤백
+     * 중에 bracket 표기를 알아내야 기동하는 상황을 만들지 않는다.
      *
      * @throws IllegalStateException 어느 역할도 아니면 — 오타가 조용히 무시되면
      *                               존재하지 않는 보호를 설정했다고 믿게 된다
      */
     static ModelRole fromConfigKey(String key) {
-        String normalized = key.replace("-", "").replace("_", "").toLowerCase();
+        String normalized = key.replace("-", "").replace("_", "").replace(".", "").toLowerCase();
         return Arrays.stream(values())
                 .filter(role -> role.name().replace("_", "").toLowerCase().equals(normalized))
                 .findFirst()

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -29,6 +29,8 @@ import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.llm.LlmUsage;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.memory.working.WorkingMessage;
@@ -98,7 +100,6 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 public class ConversationOrchestrator {
 
-    private static final String LLM_MODEL = "gpt-4o";
     // 출력 상한. 프롬프트가 "2-4문장"을 요구하고 실측 출력이 49~150 토큰이라 2.7배 여유다.
     // 상한이 없으면 폭주 응답 하나가 턴당 비용을 8.1배로 올린다 (기준선 문서 §5.7 R-1).
     private static final int LLM_MAX_COMPLETION_TOKENS = 400;
@@ -124,6 +125,7 @@ public class ConversationOrchestrator {
     private final ReactiveOntologyEligibility reactiveOntologyEligibility;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final CrisisFlowService crisisFlowService;
     private final CrisisFixedFlowCoordinator crisisFixedFlowCoordinator;
     private final SecurityRefusalTemplate securityRefusalTemplate;
@@ -390,7 +392,9 @@ public class ConversationOrchestrator {
                 List<WorkingMessage> historySlice = recentWorkingMessages.size() > 10
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
-                LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage)
+                LlmRequest llmRequest = LlmRequest.of(
+                                modelCatalog.modelFor(ModelRole.GENERATION),
+                                systemPrompt, historySlice, userMessage)
                         .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS)
                         .withAttribution("MAIN_GENERATION", userId, sessionId);
                 StringBuilder contentBuilder = new StringBuilder();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -140,6 +140,17 @@ openai:
         input: 0.02
         output: 0.00
 
+mio:
+  ai:
+    # 역할→모델 해석 (#479). 역할별 기본값은 ModelRole enum 에 있고, 여기서는
+    # allowlist 만 선언한다 — 이 목록 밖의 모델로 역할을 해석하면 기동이 실패한다.
+    # 등재는 PR 로만 한다: 모델 변경이 Crisis Eval 게이트를 우회하지 않게 하는 강제 지점이다.
+    # 역할을 바꾸려면 roles 블록을 쓴다. 예) roles: { generation: gpt-4.1-nano }
+    models:
+      allowed:
+        - gpt-4o
+        - gpt-4o-mini
+
 logging:
   level:
     com.mio: INFO

--- a/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
+++ b/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
@@ -32,7 +32,8 @@ class CbtMetadataClassifierTest {
                 }
                 ```
                 """);
-        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper());
+        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper(),
+                com.mio.ai.llm.ModelCatalog.defaults());
 
         CbtMetadataResult result = classifier.classify(
                 "socratic_asked",
@@ -65,7 +66,8 @@ class CbtMetadataClassifierTest {
                   "reconstructed_thought": "최악은 아닐 수 있다"
                 }
                 """);
-        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper());
+        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper(),
+                com.mio.ai.llm.ModelCatalog.defaults());
 
         CbtMetadataResult result = classifier.classify(
                 "completed",

--- a/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
+++ b/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.judge;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.safety.UserMessageSignal;
@@ -33,7 +34,7 @@ class CbtMetadataClassifierTest {
                 ```
                 """);
         CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper(),
-                com.mio.ai.llm.ModelCatalog.defaults());
+                ModelCatalog.defaults());
 
         CbtMetadataResult result = classifier.classify(
                 "socratic_asked",
@@ -67,7 +68,7 @@ class CbtMetadataClassifierTest {
                 }
                 """);
         CbtMetadataClassifier classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper(),
-                com.mio.ai.llm.ModelCatalog.defaults());
+                ModelCatalog.defaults());
 
         CbtMetadataResult result = classifier.classify(
                 "completed",

--- a/src/test/java/com/mio/ai/judge/InputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/InputJudgeTest.java
@@ -168,7 +168,8 @@ class InputJudgeTest {
             }
         };
         return new InputJudge(llmClient, new com.fasterxml.jackson.databind.ObjectMapper(),
-                new io.micrometer.core.instrument.simple.SimpleMeterRegistry());
+                new io.micrometer.core.instrument.simple.SimpleMeterRegistry(),
+                com.mio.ai.llm.ModelCatalog.defaults());
     }
 
     /**

--- a/src/test/java/com/mio/ai/judge/InputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/InputJudgeTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.judge;
 
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.moderation.ModerationResult;
@@ -169,7 +170,7 @@ class InputJudgeTest {
         };
         return new InputJudge(llmClient, new com.fasterxml.jackson.databind.ObjectMapper(),
                 new io.micrometer.core.instrument.simple.SimpleMeterRegistry(),
-                com.mio.ai.llm.ModelCatalog.defaults());
+                ModelCatalog.defaults());
     }
 
     /**

--- a/src/test/java/com/mio/ai/judge/ModelRoutingWiringTest.java
+++ b/src/test/java/com/mio/ai/judge/ModelRoutingWiringTest.java
@@ -1,0 +1,111 @@
+package com.mio.ai.judge;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmPricingProperties;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelCatalogProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 카탈로그 override 가 실제 나가는 요청의 모델을 바꾸는지 고정한다 (#479).
+ *
+ * <p>카탈로그를 주입해 놓고 호출부가 계속 상수를 쓰면 "설정으로 바꿀 수 있다"는 주장이
+ * 존재하지 않는 보호가 된다 — 값을 읽는 코드가 있는지는 컴파일이 아니라 이 테스트가 증명한다.
+ */
+class ModelRoutingWiringTest {
+
+    private static final String OVERRIDE_MODEL = "routed-model-x";
+
+    @Test
+    @DisplayName("InputJudge 는 카탈로그가 해석한 모델로 호출한다")
+    void inputJudgeUsesCatalogModel() {
+        CapturingLlmClient llm = new CapturingLlmClient();
+        InputJudge judge = new InputJudge(llm, new ObjectMapper(), new SimpleMeterRegistry(),
+                catalogWith("input-judge"));
+
+        judge.judge("메시지", null, null, UUID.randomUUID(), UUID.randomUUID());
+
+        assertThat(llm.lastRequest.get().model()).isEqualTo(OVERRIDE_MODEL);
+    }
+
+    @Test
+    @DisplayName("OutputJudge 는 카탈로그가 해석한 모델로 호출한다")
+    void outputJudgeUsesCatalogModel() {
+        CapturingLlmClient llm = new CapturingLlmClient();
+        OutputJudge judge = new OutputJudge(llm, new ObjectMapper(), new SimpleMeterRegistry(),
+                catalogWith("output-judge"));
+
+        judge.judge("응답 본문", OutputPreFilterResult.pass(), UUID.randomUUID(), UUID.randomUUID());
+
+        assertThat(llm.lastRequest.get().model()).isEqualTo(OVERRIDE_MODEL);
+    }
+
+    @Test
+    @DisplayName("CbtMetadataClassifier 는 카탈로그가 해석한 모델로 호출한다")
+    void cbtClassifierUsesCatalogModel() {
+        CapturingLlmClient llm = new CapturingLlmClient();
+        CbtMetadataClassifier classifier = new CbtMetadataClassifier(llm, new ObjectMapper(),
+                catalogWith("cbt-classifier"));
+
+        classifier.classify(null, List.of(), "발화", "응답", null, 0, false,
+                UUID.randomUUID(), UUID.randomUUID());
+
+        assertThat(llm.lastRequest.get().model()).isEqualTo(OVERRIDE_MODEL);
+    }
+
+    // ── 픽스처 ─────────────────────────────────────────────────────
+
+    /** 지정한 역할 하나만 {@value OVERRIDE_MODEL} 로 덮어쓴 카탈로그. */
+    private static ModelCatalog catalogWith(String roleKey) {
+        ModelCatalogProperties props = new ModelCatalogProperties();
+        props.setRoles(Map.of(roleKey, OVERRIDE_MODEL));
+        props.setAllowed(List.of("gpt-4o", "gpt-4o-mini", OVERRIDE_MODEL));
+
+        LlmPricingProperties pricing = new LlmPricingProperties();
+        Map<String, LlmPricingProperties.ModelPrice> table = new LinkedHashMap<>();
+        for (String model : List.of("gpt-4o", "gpt-4o-mini", OVERRIDE_MODEL)) {
+            table.put(model, new LlmPricingProperties.ModelPrice(
+                    BigDecimal.ONE, null, BigDecimal.ONE));
+        }
+        pricing.setModels(table);
+        return new ModelCatalog(props, pricing);
+    }
+
+    /** 요청을 붙잡고 무해한 JSON 을 돌려주는 가짜 클라이언트 — 모델 배선만 본다. */
+    private static final class CapturingLlmClient implements LlmClient {
+        final AtomicReference<LlmRequest> lastRequest = new AtomicReference<>();
+
+        @Override
+        public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
+            lastRequest.set(request);
+            throw new UnsupportedOperationException("이 테스트는 completeJson 경로만 쓴다");
+        }
+
+        @Override
+        public String completeText(LlmRequest request) {
+            lastRequest.set(request);
+            return "";
+        }
+
+        @Override
+        public String completeJson(LlmRequest request) {
+            lastRequest.set(request);
+            return "{}";
+        }
+    }
+}

--- a/src/test/java/com/mio/ai/judge/OutputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/OutputJudgeTest.java
@@ -144,6 +144,7 @@ class OutputJudgeTest {
                 return responseJson.get();
             }
         };
-        return new OutputJudge(llmClient, new ObjectMapper(), meterRegistry);
+        return new OutputJudge(llmClient, new ObjectMapper(), meterRegistry,
+                com.mio.ai.llm.ModelCatalog.defaults());
     }
 }

--- a/src/test/java/com/mio/ai/judge/OutputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/OutputJudgeTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.judge;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -145,6 +146,6 @@ class OutputJudgeTest {
             }
         };
         return new OutputJudge(llmClient, new ObjectMapper(), meterRegistry,
-                com.mio.ai.llm.ModelCatalog.defaults());
+                ModelCatalog.defaults());
     }
 }

--- a/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
+++ b/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
@@ -1,0 +1,133 @@
+package com.mio.ai.llm;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 역할→모델 해석과 fail-closed 검증 (#479).
+ *
+ * <p>이 카탈로그의 존재 이유는 두 가지다. 모델 변경이 코드 수정이 아니라 설정이 되게 하는 것,
+ * 그리고 그 설정이 <b>allowlist·단가표 밖으로는 절대 나가지 못하게</b> 기동 시점에 막는 것.
+ * 검증이 런타임으로 미뤄지면 미등록 모델의 비용이 '미상'으로 쌓이는 사고를 사후에야 알게 된다.
+ */
+class ModelCatalogTest {
+
+    @Test
+    @DisplayName("설정이 없으면 현행 상수와 같은 모델로 해석된다")
+    void defaultsMatchCurrentConstants() {
+        ModelCatalog catalog = ModelCatalog.defaults();
+
+        assertThat(catalog.modelFor(ModelRole.GENERATION)).isEqualTo("gpt-4o");
+        assertThat(catalog.modelFor(ModelRole.INPUT_JUDGE)).isEqualTo("gpt-4o-mini");
+        assertThat(catalog.modelFor(ModelRole.OUTPUT_JUDGE)).isEqualTo("gpt-4o-mini");
+        assertThat(catalog.modelFor(ModelRole.CBT_CLASSIFIER)).isEqualTo("gpt-4o-mini");
+    }
+
+    @Test
+    @DisplayName("역할 설정이 기본값을 덮어쓴다 — allowlist 등재 + 단가 등록이 전제")
+    void roleOverrideChangesResolution() {
+        ModelCatalog catalog = new ModelCatalog(
+                properties(Map.of("generation", "gpt-4.1-nano"),
+                        List.of("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano")),
+                pricing("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano"));
+
+        assertThat(catalog.modelFor(ModelRole.GENERATION)).isEqualTo("gpt-4.1-nano");
+        assertThat(catalog.modelFor(ModelRole.INPUT_JUDGE))
+                .as("덮어쓰지 않은 역할은 기본값을 유지한다")
+                .isEqualTo("gpt-4o-mini");
+    }
+
+    @Test
+    @DisplayName("yml kebab-case 키가 역할로 해석된다")
+    void kebabCaseKeysResolveToRoles() {
+        ModelCatalog catalog = new ModelCatalog(
+                properties(Map.of("cbt-classifier", "gpt-4o"),
+                        List.of("gpt-4o", "gpt-4o-mini")),
+                pricing("gpt-4o", "gpt-4o-mini"));
+
+        assertThat(catalog.modelFor(ModelRole.CBT_CLASSIFIER)).isEqualTo("gpt-4o");
+    }
+
+    @Test
+    @DisplayName("모르는 역할 키는 기동을 실패시킨다 — 오타가 조용히 무시되면 안 된다")
+    void unknownRoleKeyFailsStartup() {
+        assertThatThrownBy(() -> new ModelCatalog(
+                properties(Map.of("generaton", "gpt-4o"), List.of("gpt-4o", "gpt-4o-mini")),
+                pricing("gpt-4o", "gpt-4o-mini")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("generaton")
+                .hasMessageContaining("generation");
+    }
+
+    @Test
+    @DisplayName("allowlist 에 없는 모델로의 해석은 기동을 실패시킨다")
+    void modelOutsideAllowlistFailsStartup() {
+        assertThatThrownBy(() -> new ModelCatalog(
+                properties(Map.of("generation", "gpt-4.1-nano"),
+                        List.of("gpt-4o", "gpt-4o-mini")),
+                pricing("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("gpt-4.1-nano")
+                .hasMessageContaining("allowed");
+    }
+
+    @Test
+    @DisplayName("allowlist 를 비워두면 기본 모델 집합만 허용된다 — 비움이 전부 허용이 되면 안 된다")
+    void emptyAllowlistMeansDefaultsOnly() {
+        assertThatThrownBy(() -> new ModelCatalog(
+                properties(Map.of("generation", "gpt-4.1-nano"), List.of()),
+                pricing("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("gpt-4.1-nano");
+    }
+
+    @Test
+    @DisplayName("단가 미등록 모델로의 해석은 기동을 실패시킨다 — 비용 '미상' 사고를 기동에서 막는다")
+    void unpricedModelFailsStartup() {
+        assertThatThrownBy(() -> new ModelCatalog(
+                properties(Map.of("generation", "gpt-4.1-nano"),
+                        List.of("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano")),
+                pricing("gpt-4o", "gpt-4o-mini")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("gpt-4.1-nano")
+                .hasMessageContaining("openai.pricing.models");
+    }
+
+    @Test
+    @DisplayName("기본값 자체도 단가 검증을 통과해야 한다 — 기본값이라고 면제되면 검증이 반쪽이다")
+    void defaultsAreValidatedAgainstPricingToo() {
+        assertThatThrownBy(() -> new ModelCatalog(
+                properties(Map.of(), List.of("gpt-4o", "gpt-4o-mini")),
+                pricing("gpt-4o")))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("gpt-4o-mini");
+    }
+
+    // ── 픽스처 ─────────────────────────────────────────────────────
+
+    private static ModelCatalogProperties properties(Map<String, String> roles,
+                                                     List<String> allowed) {
+        ModelCatalogProperties props = new ModelCatalogProperties();
+        props.setRoles(roles);
+        props.setAllowed(allowed);
+        return props;
+    }
+
+    private static LlmPricingProperties pricing(String... models) {
+        LlmPricingProperties props = new LlmPricingProperties();
+        java.util.Map<String, LlmPricingProperties.ModelPrice> table = new java.util.LinkedHashMap<>();
+        for (String model : models) {
+            table.put(model, new LlmPricingProperties.ModelPrice(
+                    BigDecimal.ONE, null, BigDecimal.TEN));
+        }
+        props.setModels(table);
+        return props;
+    }
+}

--- a/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
+++ b/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
@@ -56,6 +56,20 @@ class ModelCatalogTest {
     }
 
     @Test
+    @DisplayName("환경 변수 relaxed binding 이 만드는 점 표기 키도 역할로 해석된다")
+    void envVarDottedKeysResolveToRoles() {
+        // MIO_AI_MODELS_ROLES_INPUT_JUDGE 는 Spring 이 맵 키 'input.judge' 로 바인딩한다.
+        // 운영 배포 수단이 환경 변수(.env·docker-compose)이므로 이 표기가 막히면
+        // canary 롤백 중 기동 실패로 이어진다.
+        ModelCatalog catalog = new ModelCatalog(
+                properties(Map.of("input.judge", "gpt-4o"),
+                        List.of("gpt-4o", "gpt-4o-mini")),
+                pricing("gpt-4o", "gpt-4o-mini"));
+
+        assertThat(catalog.modelFor(ModelRole.INPUT_JUDGE)).isEqualTo("gpt-4o");
+    }
+
+    @Test
     @DisplayName("모르는 역할 키는 기동을 실패시킨다 — 오타가 조용히 무시되면 안 된다")
     void unknownRoleKeyFailsStartup() {
         assertThatThrownBy(() -> new ModelCatalog(

--- a/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
@@ -10,6 +10,7 @@ import com.mio.ai.judge.RiskLevel;
 import com.mio.ai.judge.RiskVerdict;
 import com.mio.ai.judge.SecurityVerdict;
 import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMessage;
 import com.mio.ai.policy.DecisionAction;
@@ -56,7 +57,7 @@ class CbtMetadataQaTest {
 
     @BeforeEach
     void setUp() {
-        classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper());
+        classifier = new CbtMetadataClassifier(llmClient, new ObjectMapper(), ModelCatalog.defaults());
         policyEngine = new PolicyEngine(new EffectiveSecurityResolver());
         defaultProfile = new SafetyProfile(
                 "test_user", "default", Map.of(), List.of(), List.of(),

--- a/src/test/java/com/mio/ai/qa/CellClassifierFailureTest.java
+++ b/src/test/java/com/mio/ai/qa/CellClassifierFailureTest.java
@@ -5,6 +5,7 @@ import com.mio.ai.judge.CbtInterventionState;
 import com.mio.ai.judge.CbtMetadataClassifier;
 import com.mio.ai.judge.CbtMetadataResult;
 import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.qa.LockedEvalSet.LockedCase;
@@ -391,7 +392,7 @@ class CellClassifierFailureTest {
     @DisplayName("프로덕션이 예외를 삼킨다는 전제 자체를 고정한다 — 이것이 이 PR 의 출발점이다")
     void productionSwallowsClassifierExceptionsAndReturnsNone() {
         CbtMetadataClassifier classifier = new CbtMetadataClassifier(
-                new FixedJsonLlmClient(null, true), new ObjectMapper());
+                new FixedJsonLlmClient(null, true), new ObjectMapper(), ModelCatalog.defaults());
 
         CbtMetadataResult real = classifier.classify(null, List.of(), "사용자 발화",
                 "전달된 응답 본문", null, 0, false, UUID.randomUUID(), UUID.randomUUID());
@@ -406,7 +407,7 @@ class CellClassifierFailureTest {
     /** fixture 를 <b>프로덕션 분류기의 실경로</b>에 태운다. 리플렉션 없이 공개 API 만 쓴다. */
     private static CbtMetadataResult classifyThroughProduction(String classifierResponse) {
         CbtMetadataClassifier classifier = new CbtMetadataClassifier(
-                new FixedJsonLlmClient(classifierResponse, false), new ObjectMapper());
+                new FixedJsonLlmClient(classifierResponse, false), new ObjectMapper(), ModelCatalog.defaults());
         return classifier.classify(null, List.of(), "사용자 발화", "전달된 응답 본문",
                 null, 0, false, UUID.randomUUID(), UUID.randomUUID());
     }

--- a/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
+++ b/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.qa;
 
+import com.mio.ai.llm.ModelRole;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -10,8 +11,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,11 +25,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @DisplayName("[QA] A~E 셀 모델 registry")
 class CellModelRegistryTest {
 
-    /** 프로덕션 모델 상수의 위치. 상수가 private 이라 소스에서 읽는다. */
-    private static final Map<String, String> PRODUCTION_CONSTANTS = Map.of(
-            "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java", "LLM_MODEL",
-            "src/main/java/com/mio/ai/judge/InputJudge.java", "JUDGE_MODEL",
-            "src/main/java/com/mio/ai/judge/OutputJudge.java", "JUDGE_MODEL");
+    /**
+     * 벤치마크 역할 → 프로덕션 역할. 프로덕션 기본값의 진실의 원천이 호출부 상수에서
+     * {@link ModelRole} 로 옮겨졌다 (#479) — 소스 정규식 파싱 대신 enum 을 직접 읽는다.
+     * 프로덕션이 기본 모델을 바꾸면 이 대응을 통해 여기서 깨진다.
+     */
+    private static final Map<CellModelRole, ModelRole> PRODUCTION_ROLES = Map.of(
+            CellModelRole.GENERATION, ModelRole.GENERATION,
+            CellModelRole.INPUT_SAFETY, ModelRole.INPUT_JUDGE,
+            CellModelRole.OUTPUT_JUDGE, ModelRole.OUTPUT_JUDGE);
 
     @Test
     @DisplayName("상위 모델을 핀하지 않으면 셀 B·D·E 실행이 막히고, 메시지가 핀 방법을 알려준다")
@@ -59,18 +62,45 @@ class CellModelRegistryTest {
     }
 
     @Test
-    @DisplayName("운영 기본값이 프로덕션 상수와 같다 — 프로덕션이 모델을 바꾸면 여기서 깨진다")
+    @DisplayName("운영 기본값이 프로덕션 기본값과 같다 — 프로덕션이 모델을 바꾸면 여기서 깨진다")
     void operationalDefaultsTrackProductionConstants() {
         CellModelRegistry registry = CellModelRegistry.resolve(BenchmarkCell.A, Map.of());
-        Path root = LockedEvalContaminationScanner.findRepoRoot();
 
-        assertThat(registry.modelFor(CellModelRole.GENERATION)).isEqualTo(constant(root,
-                "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java", "LLM_MODEL"));
-        assertThat(registry.modelFor(CellModelRole.INPUT_SAFETY)).isEqualTo(constant(root,
-                "src/main/java/com/mio/ai/judge/InputJudge.java", "JUDGE_MODEL"));
-        assertThat(registry.modelFor(CellModelRole.OUTPUT_JUDGE)).isEqualTo(constant(root,
-                "src/main/java/com/mio/ai/judge/OutputJudge.java", "JUDGE_MODEL"));
-        assertThat(PRODUCTION_CONSTANTS).hasSize(3);
+        PRODUCTION_ROLES.forEach((cellRole, productionRole) ->
+                assertThat(registry.modelFor(cellRole))
+                        .as("벤치마크 %s 기본값이 프로덕션 %s 기본값과 어긋났다",
+                                cellRole, productionRole)
+                        .isEqualTo(productionRole.defaultModel()));
+        assertThat(PRODUCTION_ROLES).hasSize(3);
+    }
+
+    @Test
+    @DisplayName("프로덕션 4역할에는 하드코딩된 모델 상수가 남아 있지 않다 — #479 이후의 진실의 원천은 ModelRole 이다")
+    void productionCallSitesCarryNoModelConstants() {
+        Path root = LockedEvalContaminationScanner.findRepoRoot();
+        for (String file : new String[]{
+                "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java",
+                "src/main/java/com/mio/ai/judge/InputJudge.java",
+                "src/main/java/com/mio/ai/judge/OutputJudge.java",
+                "src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java"}) {
+            assertThat(sourceOf(root, file))
+                    .as("%s 에 모델 리터럴이 되살아나면 카탈로그와 두 개의 진실이 생긴다", file)
+                    .doesNotContainPattern("static final String \\w*MODEL\\w*\\s*=\\s*\"gpt-");
+        }
+    }
+
+    @Test
+    @DisplayName("메인 생성 호출부가 카탈로그의 GENERATION 해석을 읽는다 — canary 가 갈아끼울 바로 그 자리다")
+    void orchestratorReadsGenerationFromCatalog() {
+        // ConversationOrchestrator 는 의존 그래프가 커서 판정 클래스들처럼 요청 캡처
+        // 단위 테스트(ModelRoutingWiringTest)를 만들 수 없다. 대신 소스에서 카탈로그
+        // 조회가 유일한 모델 출처인지 고정한다 — 위 테스트가 상수 부활을 막고,
+        // 이 테스트가 조회 자체의 존재를 못박는다.
+        String source = sourceOf(LockedEvalContaminationScanner.findRepoRoot(),
+                "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java");
+        assertThat(source)
+                .contains("modelCatalog.modelFor(ModelRole.GENERATION)")
+                .doesNotContain("\"gpt-4o\"");
     }
 
     @Test
@@ -129,17 +159,9 @@ class CellModelRegistryTest {
                 .hasMessageContaining("알 수 없는 셀 이름");
     }
 
-    private static String constant(Path root, String file, String name) {
+    private static String sourceOf(Path root, String file) {
         try {
-            String source = Files.readString(root.resolve(file), StandardCharsets.UTF_8);
-            Matcher matcher = Pattern
-                    .compile("static final String " + name + "\\s*=\\s*\"([^\"]+)\"")
-                    .matcher(source);
-            assertThat(matcher.find())
-                    .as("%s 에서 상수 %s 를 찾지 못했다 — 프로덕션이 바뀌면 이 검사부터 고쳐야 한다",
-                            file, name)
-                    .isTrue();
-            return matcher.group(1);
+            return Files.readString(root.resolve(file), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/src/test/java/com/mio/ai/qa/CellRunner.java
+++ b/src/test/java/com/mio/ai/qa/CellRunner.java
@@ -13,6 +13,7 @@ import com.mio.ai.judge.OutputJudgeResult;
 import com.mio.ai.judge.OutputPreFilter;
 import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -219,12 +220,15 @@ final class CellRunner {
         this.llmClient = new RoleModelRewritingLlmClient(
                 clientFactory.create(ledger, registry.pricing()), registry.componentToModel());
         ObjectMapper mapper = new ObjectMapper();
-        this.inputJudge = new InputJudge(llmClient, mapper, ledger.meterRegistry());
-        this.outputJudge = new OutputJudge(llmClient, mapper, ledger.meterRegistry());
+        this.inputJudge = new InputJudge(llmClient, mapper, ledger.meterRegistry(),
+                ModelCatalog.defaults());
+        this.outputJudge = new OutputJudge(llmClient, mapper, ledger.meterRegistry(),
+                ModelCatalog.defaults());
         // 분류기에게만 프로브를 씌운다. 다른 역할의 호출은 그대로 지나가고, 분류기 자신의
         // 동작도 바뀌지 않는다 — 프로브는 예외를 다시 던지고 본문도 손대지 않는다.
         this.cbtClassifierProbe = new CbtClassifierProbe(llmClient);
-        this.cbtClassifier = new CbtMetadataClassifier(cbtClassifierProbe, mapper);
+        this.cbtClassifier = new CbtMetadataClassifier(cbtClassifierProbe, mapper,
+                ModelCatalog.defaults());
     }
 
     /** 실 LLM 실행. 과금된다. */

--- a/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
@@ -7,6 +7,7 @@ import com.mio.ai.judge.InputJudge;
 import com.mio.ai.judge.InputJudgeResult;
 import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmPricingProperties;
 import com.mio.ai.llm.OpenAiLlmClient;
 import com.mio.ai.moderation.ModerationResult;
@@ -149,7 +150,7 @@ class CrisisDetectionFullPathQaTest {
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
                         new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
                         mock(AiCostEventWriter.class)),
-                new ObjectMapper(), new SimpleMeterRegistry());
+                new ObjectMapper(), new SimpleMeterRegistry(), ModelCatalog.defaults());
     }
 
     @Test


### PR DESCRIPTION
## 요약
모델 ID 가 호출부마다 `private static final String` 으로 하드코딩되어 있어 모델 변경 = 코드 수정 + 재배포이고, P0-8 벤치마크가 확정한 후보(`gpt-4.1-nano`)의 잔여 게이트(shadow·canary+즉시 롤백)를 실행할 코드 지점이 없습니다. 파이프라인 4역할의 모델 해석을 `ModelCatalog` 로 옮겨 모델 변경을 설정으로 만들고, allowlist·단가표 검증을 기동 시점 fail-closed 로 겁니다. 벤치마크 하네스의 `CellModelRegistry.modelFor(role)` 과 같은 모양을 프로덕션에 만드는 것입니다.

## 관련 이슈
- Closes #479

## 변경 사항
- `ModelRole` — 파이프라인 4역할(`GENERATION`=gpt-4o · `INPUT_JUDGE`/`OUTPUT_JUDGE`/`CBT_CLASSIFIER`=gpt-4o-mini). 기본값 = 기존 상수와 동일
- `ModelCatalog` — 역할→모델 해석. 기동 시 두 검증: ① 해석된 모델이 `mio.ai.models.allowed` 밖이면 기동 실패 (등재는 PR 로만 — 설정 플립이 Crisis Eval 게이트를 우회하지 못하게 하는 강제 지점), ② `openai.pricing.models` 에 없으면 기동 실패 (비용 '미상' 적재 사고를 기동에서 차단)
- 호출부 4곳(`ConversationOrchestrator`·`InputJudge`·`OutputJudge`·`CbtMetadataClassifier`)의 상수 제거 → 카탈로그 조회
- `application.yml` 에 `mio.ai.models.allowed` 선언 (현행 2모델)
- **토큰 상한·프롬프트는 호출부에 유지** — 상한은 프롬프트 길이 지시와 같은 파일에 있어야 하고(HANDOFF 원칙), 추론 모델이 예산 400 에서 응답 0 이라는 Stage 1 실측이 근거

## 영향 범위
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. → `mio.ai.models.*` 신규, **기본값이 있어 설정 없이도 현행과 동일 동작**
- [x] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다. → InputJudge·OutputJudge 의 생성자에 카탈로그가 추가되나 **기본 해석이 기존 상수와 동일**하여 판정 동작 불변. 프롬프트·상한·파싱 무변경

> **Crisis Eval (full path) 실행 결과: 성공** — run [32040271694](https://github.com/Yarr-mio/mio_server/actions/runs/32040271694), 브랜치 `feat/#479-model-catalog` 기준

## 테스트
### 실행 커맨드
```bash
./gradlew build   # 통과 (전체 테스트)
./gradlew test --tests "com.mio.ai.llm.ModelCatalogTest" --tests "com.mio.ai.judge.ModelRoutingWiringTest"
```

### 확인 내용
- `ModelCatalogTest` 8건: 기본값=현행 상수, kebab-case 키, 오타 키 기동 실패, allowlist 밖 기동 실패, allowlist 비움=기본 집합만 허용, 단가 미등록 기동 실패(기본값 포함)
- `ModelRoutingWiringTest` 3건: **카탈로그 override 가 실제 나가는 `LlmRequest.model` 을 바꾸는지 요청 캡처로 증명** — 주입만 하고 상수를 계속 쓰는 '존재하지 않는 보호' 방지
- 신규 테스트는 구현 전 컴파일 실패(RED) 확인 후 GREEN

## 중점 리뷰 포인트
- allowlist 비어 있음 → 기본 모델 집합만 허용(전부 허용 아님)의 fail-closed 의미론
- `ModelRole.fromConfigKey` 의 relaxed binding 표기(kebab/camel/snake) 수용 범위
- 4 호출부 교체가 프롬프트·상한·귀속 태그를 건드리지 않는지

## 배포 / 롤백
- Rollout: 설정 무변경 배포 — 동작 동일. 이후 모델 변경은 allowlist 등재 PR + 설정으로
- Rollback: revert (설정 스키마는 기본값이 있어 구버전과 호환)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
