### PR TITLE
feat: 생성 모델 canary 라우팅을 넣는다

### DIFF
--- a/src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java
+++ b/src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java
@@ -1,0 +1,107 @@
+package com.mio.ai.llm;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+/**
+ * 생성 모델 canary 라우팅 (#480).
+ *
+ * <p>운영자가 Redis 키 하나로 후보 모델을 일부 트래픽에 태운다.
+ *
+ * <pre>
+ * SET mio:ai:canary:generation "gpt-4.1-nano 5"   # 후보 5%
+ * SET mio:ai:canary:generation "gpt-4.1-nano 0"   # 즉시 롤백 (새 턴부터)
+ * DEL mio:ai:canary:generation                     # canary 종료
+ * </pre>
+ *
+ * <p>턴마다 키를 읽으므로 변경은 재배포 없이 다음 턴부터 반영된다. 팔 배정은 사용자 ID 의
+ * 안정 해시 버킷이라 같은 사용자는 세션이 바뀌어도 같은 팔이고, percent 를 올릴 때 기존
+ * 후보 팔 사용자가 기본 팔로 튀지 않는다(버킷 단조).
+ *
+ * <p><b>안전 성질 — 확신이 없으면 기본 모델이다.</b> 설정 없음·파싱 실패·범위 밖 percent·
+ * allowlist 밖 후보·단가 미등록 후보·Redis 장애 전부 카탈로그 기본 해석으로 떨어지고
+ * {@code mio.model.canary} 카운터에 남는다. canary 는 검증된 후보를 태우는 장치이지,
+ * 장애나 오타가 미검증 모델로 새는 통로가 아니다. allowlist 등재는 PR 로만 하므로
+ * 이 키로는 allowlist 밖 모델을 절대 태울 수 없다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GenerationCanaryRouter {
+
+    static final String CANARY_KEY = "mio:ai:canary:generation";
+    private static final String METRIC = "mio.model.canary";
+    private static final int BUCKETS = 100;
+
+    private final ModelCatalog modelCatalog;
+    private final StringRedisTemplate redisTemplate;
+    private final MeterRegistry meterRegistry;
+
+    /** 이 턴의 생성 모델. canary 미설정·불신 시 카탈로그의 {@code GENERATION} 해석이다. */
+    public String modelFor(UUID userId) {
+        String defaultModel = modelCatalog.modelFor(ModelRole.GENERATION);
+        String raw;
+        try {
+            raw = redisTemplate.opsForValue().get(CANARY_KEY);
+        } catch (RuntimeException e) {
+            // 라우팅을 '모른다'가 미검증 모델이 되면 안 된다 — 기본 팔로 간다.
+            count("error");
+            log.warn("canary 설정 조회 실패, 기본 모델로 라우팅: {}", e.getMessage());
+            return defaultModel;
+        }
+        if (raw == null || raw.isBlank()) {
+            count("default");
+            return defaultModel;
+        }
+
+        Canary canary = parse(raw);
+        if (canary == null || !modelCatalog.isAllowed(canary.model())
+                || !modelCatalog.isPriced(canary.model())) {
+            count("invalid_config");
+            log.warn("canary 설정이 유효하지 않아 기본 모델로 라우팅: '{}'", raw);
+            return defaultModel;
+        }
+        if (bucketOf(userId) < canary.percent()) {
+            count("candidate");
+            return canary.model();
+        }
+        count("default");
+        return defaultModel;
+    }
+
+    /** {@code "<모델> <percent>"}. 그 외 모양은 전부 무효 — 관대한 파싱은 오타를 삼킨다. */
+    private static Canary parse(String raw) {
+        String[] parts = raw.trim().split("\\s+");
+        if (parts.length != 2) {
+            return null;
+        }
+        try {
+            int percent = Integer.parseInt(parts[1]);
+            if (percent < 0 || percent > BUCKETS) {
+                return null;
+            }
+            return new Canary(parts[0], percent);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 사용자의 안정 버킷 [0, 100). {@link String#hashCode()} 는 명세에 고정된 알고리즘이라
+     * JVM·재시작·인스턴스 간에 같은 사용자가 항상 같은 버킷을 받는다.
+     */
+    private static int bucketOf(UUID userId) {
+        return Math.floorMod(userId.toString().hashCode(), BUCKETS);
+    }
+
+    private void count(String outcome) {
+        meterRegistry.counter(METRIC, "outcome", outcome).increment();
+    }
+
+    private record Canary(String model, int percent) {}
+}

--- a/src/main/java/com/mio/ai/llm/ModelCatalog.java
+++ b/src/main/java/com/mio/ai/llm/ModelCatalog.java
@@ -31,6 +31,8 @@ import java.util.stream.Collectors;
 public class ModelCatalog {
 
     private final Map<ModelRole, String> models;
+    private final Set<String> allowed;
+    private final Set<String> priced;
 
     public ModelCatalog(ModelCatalogProperties properties, LlmPricingProperties pricing) {
         Map<ModelRole, String> resolved = new EnumMap<>(ModelRole.class);
@@ -40,13 +42,29 @@ public class ModelCatalog {
         for (Map.Entry<String, String> entry : properties.getRoles().entrySet()) {
             resolved.put(ModelRole.fromConfigKey(entry.getKey()), entry.getValue());
         }
-        requireAllowed(resolved, effectiveAllowlist(properties));
+        Set<String> allowlist = effectiveAllowlist(properties);
+        requireAllowed(resolved, allowlist);
         requirePriced(resolved, pricing);
         this.models = Map.copyOf(resolved);
+        this.allowed = allowlist;
+        this.priced = pricing.getModels().entrySet().stream()
+                .filter(entry -> entry.getValue() != null && entry.getValue().isValid())
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toUnmodifiableSet());
     }
 
     public String modelFor(ModelRole role) {
         return models.get(role);
+    }
+
+    /** 이 모델로 라우팅해도 되는가. 기동 검증과 같은 allowlist 를 런타임 라우팅(#480)도 본다. */
+    public boolean isAllowed(String model) {
+        return allowed.contains(model);
+    }
+
+    /** 이 모델의 단가가 등록돼 있는가. 미등록 모델로 라우팅하면 비용이 '미상'으로 쌓인다. */
+    public boolean isPriced(String model) {
+        return priced.contains(model);
     }
 
     /** 설정 없는 기본 카탈로그. 테스트가 프로덕션과 같은 기본 해석을 쓸 때 사용한다. */

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -29,8 +29,7 @@ import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.llm.LlmUsage;
-import com.mio.ai.llm.ModelCatalog;
-import com.mio.ai.llm.ModelRole;
+import com.mio.ai.llm.GenerationCanaryRouter;
 import com.mio.ai.memory.working.SessionDelta;
 import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.memory.working.WorkingMessage;
@@ -125,7 +124,7 @@ public class ConversationOrchestrator {
     private final ReactiveOntologyEligibility reactiveOntologyEligibility;
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
-    private final ModelCatalog modelCatalog;
+    private final GenerationCanaryRouter generationCanaryRouter;
     private final CrisisFlowService crisisFlowService;
     private final CrisisFixedFlowCoordinator crisisFixedFlowCoordinator;
     private final SecurityRefusalTemplate securityRefusalTemplate;
@@ -393,7 +392,7 @@ public class ConversationOrchestrator {
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
                 LlmRequest llmRequest = LlmRequest.of(
-                                modelCatalog.modelFor(ModelRole.GENERATION),
+                                generationCanaryRouter.modelFor(userId),
                                 systemPrompt, historySlice, userMessage)
                         .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS)
                         .withAttribution("MAIN_GENERATION", userId, sessionId);

--- a/src/test/java/com/mio/ai/llm/GenerationCanaryRouterTest.java
+++ b/src/test/java/com/mio/ai/llm/GenerationCanaryRouterTest.java
@@ -1,0 +1,205 @@
+package com.mio.ai.llm;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+/**
+ * 생성 모델 canary 라우팅 (#480).
+ *
+ * <p>이 라우터의 안전 성질은 하나다 — <b>확신이 없으면 기본 모델이다.</b> 설정 없음, 파싱 실패,
+ * allowlist 밖, 단가 미등록, Redis 장애 전부 기본 팔로 떨어진다. canary 는 검증된 후보를
+ * 일부 트래픽에 태우는 장치이지, 장애 시 미검증 모델로 새는 통로가 아니다.
+ */
+class GenerationCanaryRouterTest {
+
+    private static final String CANDIDATE = "gpt-4.1-nano";
+
+    private StringRedisTemplate redis;
+    private ValueOperations<String, String> values;
+    private SimpleMeterRegistry meters;
+    private GenerationCanaryRouter router;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redis = mock(StringRedisTemplate.class);
+        values = mock(ValueOperations.class);
+        when(redis.opsForValue()).thenReturn(values);
+        meters = new SimpleMeterRegistry();
+        router = new GenerationCanaryRouter(catalogAllowing(CANDIDATE), redis, meters);
+    }
+
+    @Test
+    @DisplayName("설정이 없으면 카탈로그 기본 모델이다")
+    void noConfigMeansDefault() {
+        when(values.get(anyString())).thenReturn(null);
+
+        assertThat(router.modelFor(UUID.randomUUID()))
+                .isEqualTo(ModelRole.GENERATION.defaultModel());
+    }
+
+    @Test
+    @DisplayName("percent 100 이면 모든 사용자가 후보 팔이다")
+    void fullPercentRoutesEveryoneToCandidate() {
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 100");
+
+        for (int i = 0; i < 20; i++) {
+            assertThat(router.modelFor(UUID.randomUUID())).isEqualTo(CANDIDATE);
+        }
+    }
+
+    @Test
+    @DisplayName("percent 0 은 즉시 롤백이다 — 새 턴부터 전원 기본 팔")
+    void zeroPercentIsTheRollbackPath() {
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 0");
+
+        for (int i = 0; i < 20; i++) {
+            assertThat(router.modelFor(UUID.randomUUID()))
+                    .isEqualTo(ModelRole.GENERATION.defaultModel());
+        }
+    }
+
+    @Test
+    @DisplayName("같은 사용자는 항상 같은 팔이다 — 세션이 바뀌어도")
+    void sameUserAlwaysSameArm() {
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 37");
+
+        for (int i = 0; i < 50; i++) {
+            UUID userId = UUID.randomUUID();
+            String first = router.modelFor(userId);
+            for (int j = 0; j < 5; j++) {
+                assertThat(router.modelFor(userId)).isEqualTo(first);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("percent 를 올리면 후보 팔 사용자는 후보 팔에 남는다 — 버킷이 단조라 팔이 튀지 않는다")
+    void raisingPercentKeepsExistingCandidateUsers() {
+        List<UUID> users = java.util.stream.Stream.generate(UUID::randomUUID)
+                .limit(200).toList();
+
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 10");
+        List<UUID> onCandidateAt10 = users.stream()
+                .filter(u -> CANDIDATE.equals(router.modelFor(u)))
+                .toList();
+
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 40");
+        for (UUID user : onCandidateAt10) {
+            assertThat(router.modelFor(user))
+                    .as("10%% 에서 후보였던 사용자가 40%% 로 올리자 기본 팔로 튀면 대화 연속성이 깨진다")
+                    .isEqualTo(CANDIDATE);
+        }
+    }
+
+    @Test
+    @DisplayName("allowlist 밖 후보는 무시된다 — canary 가 안전 게이트를 우회하는 통로가 되면 안 된다")
+    void candidateOutsideAllowlistIsIgnored() {
+        when(values.get(anyString())).thenReturn("model-nobody-approved 100");
+
+        assertThat(router.modelFor(UUID.randomUUID()))
+                .isEqualTo(ModelRole.GENERATION.defaultModel());
+        assertThat(meters.counter("mio.model.canary", "outcome", "invalid_config").count())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("단가 미등록 후보는 무시된다 — 비용 '미상' 트래픽을 canary 가 만들면 안 된다")
+    void unpricedCandidateIsIgnored() {
+        router = new GenerationCanaryRouter(
+                catalogAllowingButUnpriced("allowed-but-unpriced"), redis, meters);
+        when(values.get(anyString())).thenReturn("allowed-but-unpriced 100");
+
+        assertThat(router.modelFor(UUID.randomUUID()))
+                .isEqualTo(ModelRole.GENERATION.defaultModel());
+        assertThat(meters.counter("mio.model.canary", "outcome", "invalid_config").count())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("깨진 설정 값은 기본 팔 + 계측이다 — 조용히 무시되지도, 턴을 죽이지도 않는다")
+    void malformedConfigFallsBackAndCounts() {
+        for (String broken : new String[]{"gpt-4.1-nano", "gpt-4.1-nano abc",
+                "gpt-4.1-nano 101", "gpt-4.1-nano -1", "a b c d"}) {
+            when(values.get(anyString())).thenReturn(broken);
+            assertThat(router.modelFor(UUID.randomUUID()))
+                    .as("깨진 설정 '%s' 는 기본 팔이어야 한다", broken)
+                    .isEqualTo(ModelRole.GENERATION.defaultModel());
+        }
+        assertThat(meters.counter("mio.model.canary", "outcome", "invalid_config").count())
+                .isGreaterThanOrEqualTo(5);
+
+        // 공백 값은 깨진 설정이 아니라 설정 부재다 — 기본 팔로 가되 invalid 로 세지 않는다.
+        when(values.get(anyString())).thenReturn("   ");
+        assertThat(router.modelFor(UUID.randomUUID()))
+                .isEqualTo(ModelRole.GENERATION.defaultModel());
+        assertThat(meters.counter("mio.model.canary", "outcome", "invalid_config").count())
+                .isEqualTo(5.0);
+    }
+
+    @Test
+    @DisplayName("Redis 장애 시 기본 팔이다 — 라우팅을 '모른다'가 미검증 모델이 되면 안 된다")
+    void redisFailureFallsBackToDefault() {
+        when(values.get(anyString())).thenThrow(new RuntimeException("connection refused"));
+
+        assertThat(router.modelFor(UUID.randomUUID()))
+                .isEqualTo(ModelRole.GENERATION.defaultModel());
+        assertThat(meters.counter("mio.model.canary", "outcome", "error").count())
+                .isGreaterThan(0);
+    }
+
+    @Test
+    @DisplayName("팔 배정이 계측된다 — 배포 전후 비교의 분모가 여기서 나온다")
+    void armAssignmentIsCounted() {
+        when(values.get(anyString())).thenReturn(CANDIDATE + " 100");
+        router.modelFor(UUID.randomUUID());
+        when(values.get(anyString())).thenReturn(null);
+        router.modelFor(UUID.randomUUID());
+
+        assertThat(meters.counter("mio.model.canary", "outcome", "candidate").count())
+                .isEqualTo(1.0);
+        assertThat(meters.counter("mio.model.canary", "outcome", "default").count())
+                .isEqualTo(1.0);
+    }
+
+    // ── 픽스처 ─────────────────────────────────────────────────────
+
+    private static ModelCatalog catalogAllowing(String candidate) {
+        return catalog(List.of("gpt-4o", "gpt-4o-mini", candidate),
+                List.of("gpt-4o", "gpt-4o-mini", candidate));
+    }
+
+    private static ModelCatalog catalogAllowingButUnpriced(String candidate) {
+        return catalog(List.of("gpt-4o", "gpt-4o-mini", candidate),
+                List.of("gpt-4o", "gpt-4o-mini"));
+    }
+
+    private static ModelCatalog catalog(List<String> allowed, List<String> priced) {
+        ModelCatalogProperties props = new ModelCatalogProperties();
+        props.setAllowed(allowed);
+        LlmPricingProperties pricing = new LlmPricingProperties();
+        Map<String, LlmPricingProperties.ModelPrice> table = new LinkedHashMap<>();
+        for (String model : priced) {
+            table.put(model, new LlmPricingProperties.ModelPrice(
+                    BigDecimal.ONE, null, BigDecimal.ONE));
+        }
+        pricing.setModels(table);
+        return new ModelCatalog(props, pricing);
+    }
+}

--- a/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
+++ b/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
@@ -124,6 +124,19 @@ class ModelCatalogTest {
                 .hasMessageContaining("gpt-4o-mini");
     }
 
+    @Test
+    @DisplayName("allowlist·단가 멤버십을 노출한다 — canary 라우터(#480)가 후보를 검증하는 데 쓴다")
+    void exposesAllowlistAndPricingMembership() {
+        ModelCatalog catalog = new ModelCatalog(
+                properties(Map.of(), List.of("gpt-4o", "gpt-4o-mini", "gpt-4.1-nano")),
+                pricing("gpt-4o", "gpt-4o-mini"));
+
+        assertThat(catalog.isAllowed("gpt-4.1-nano")).isTrue();
+        assertThat(catalog.isAllowed("model-nobody-approved")).isFalse();
+        assertThat(catalog.isPriced("gpt-4o")).isTrue();
+        assertThat(catalog.isPriced("gpt-4.1-nano")).isFalse();
+    }
+
     // ── 픽스처 ─────────────────────────────────────────────────────
 
     private static ModelCatalogProperties properties(Map<String, String> roles,

--- a/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
+++ b/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
@@ -90,17 +90,21 @@ class CellModelRegistryTest {
     }
 
     @Test
-    @DisplayName("메인 생성 호출부가 카탈로그의 GENERATION 해석을 읽는다 — canary 가 갈아끼울 바로 그 자리다")
-    void orchestratorReadsGenerationFromCatalog() {
+    @DisplayName("메인 생성 호출부가 canary 라우터를 거쳐 카탈로그의 GENERATION 해석을 읽는다")
+    void orchestratorReadsGenerationThroughCanaryRouter() {
         // ConversationOrchestrator 는 의존 그래프가 커서 판정 클래스들처럼 요청 캡처
-        // 단위 테스트(ModelRoutingWiringTest)를 만들 수 없다. 대신 소스에서 카탈로그
-        // 조회가 유일한 모델 출처인지 고정한다 — 위 테스트가 상수 부활을 막고,
-        // 이 테스트가 조회 자체의 존재를 못박는다.
-        String source = sourceOf(LockedEvalContaminationScanner.findRepoRoot(),
-                "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java");
-        assertThat(source)
-                .contains("modelCatalog.modelFor(ModelRole.GENERATION)")
+        // 단위 테스트(ModelRoutingWiringTest)를 만들 수 없다. 대신 소스에서 라우팅 체인
+        // (orchestrator → canary router → catalog)이 유일한 모델 출처인지 고정한다 —
+        // 위 테스트가 상수 부활을 막고, 이 테스트가 조회 자체의 존재를 못박는다.
+        Path root = LockedEvalContaminationScanner.findRepoRoot();
+        assertThat(sourceOf(root,
+                "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java"))
+                .contains("generationCanaryRouter.modelFor(userId)")
                 .doesNotContain("\"gpt-4o\"");
+        assertThat(sourceOf(root,
+                "src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java"))
+                .as("라우터의 기본 팔은 카탈로그 해석이어야 한다 — 여기가 끊기면 canary 미설정 시 모델 출처가 사라진다")
+                .contains("modelCatalog.modelFor(ModelRole.GENERATION)");
     }
 
     @Test


### PR DESCRIPTION
## 요약
P0-8 잔여 게이트 **canary + 즉시 롤백**의 실행 지점입니다. `#483` 카탈로그 위에 사용자 버킷 기반 비율 라우팅을 얹어, 벤치마크가 확정한 후보(`gpt-4.1-nano`)를 일부 트래픽에만 태우고 설정 플립만으로 롤백할 수 있게 합니다.

## 관련 이슈
- #480 (런타임 라우팅 구현 — 롤백 훈련 1회 수행은 배포 후 별도 기록)

## 변경 사항
- `GenerationCanaryRouter` — 턴마다 Redis 키 `mio:ai:canary:generation`(값 `"<모델> <percent>"`)을 읽어 팔을 가른다. 변경·롤백(percent 0 / DEL)이 재배포 없이 다음 턴부터 반영
- 팔 배정 = 사용자 ID 안정 해시 버킷(`String.hashCode` — 명세 고정이라 JVM·인스턴스 간 동일). 같은 사용자는 항상 같은 팔, percent 상향 시 기존 후보 팔 사용자는 후보 팔 유지(버킷 단조 — 대화 연속성)
- **fail-safe to baseline**: 설정 없음·파싱 실패·범위 밖 percent·allowlist 밖·단가 미등록·Redis 장애 → 전부 기본 모델 + `mio.model.canary` 카운터(outcome=candidate/default/invalid_config/error). **allowlist 등재는 PR 로만 하므로 이 키로는 미검증 모델을 태울 수 없다**
- `ModelCatalog.isAllowed()/isPriced()` 노출 — 라우터의 후보 검증에 사용
- `ConversationOrchestrator` 생성 모델 출처: 카탈로그 직접 조회 → 라우터 경유. 소스 단언이 orchestrator → router → catalog 체인 고정

## 영향 범위
- [x] **안전 판정 경로**가 바뀝니다. → 오케스트레이터의 생성 모델 해석 경로 변경. canary 미설정 시(기본 상태) 동작은 `#483` 과 동일 — 판정·프롬프트·상한 무변경
- [x] 로깅 / 모니터링 포인트가 변경됩니다. → `mio.model.canary` 카운터 신설. 팔별 지연·비용은 기존 `mio_llm_*` 의 model 태그로 분리 조회

> **Crisis Eval (full path) 실행 결과: 성공** — run [32044017424](https://github.com/Yarr-mio/mio_server/actions/runs/32044017424), 브랜치 `feat/#480-generation-canary` 기준

## 테스트
### 실행 커맨드
```bash
./gradlew cleanTest test   # 전체 통과 (up-to-date no-op 방지를 위해 cleanTest 강제)
./gradlew test --tests "com.mio.ai.llm.GenerationCanaryRouterTest"
```

### 확인 내용
- `GenerationCanaryRouterTest` 10건: 설정 없음→기본, percent 100/0, 같은 사용자 팔 고정, **percent 상향 시 버킷 단조**, allowlist 밖/단가 미등록/깨진 설정/Redis 장애 → 기본 팔 + 계측, 공백 값=설정 부재(invalid 아님), 팔 배정 계측
- `ModelCatalogTest` 멤버십 노출 1건 추가
- 신규 테스트 RED(컴파일/단언 실패) 확인 후 GREEN

## 중점 리뷰 포인트
- fail-safe 의미론: '모른다'가 후보 팔이 되는 경로가 정말 없는지
- 버킷 함수의 안정성·단조성 주장
- Redis 키를 턴마다 읽는 비용 (working memory 등 기존 턴당 Redis 접근과 동급)

## 배포 / 롤백
- Rollout: 머지·배포 후에도 canary 는 **꺼진 상태**(키 없음). 시작은 `SET mio:ai:canary:generation "gpt-4.1-nano 5"` — 단, nano 는 allowlist 등재 PR 이 선행돼야 한다
- Rollback: `SET ... "<모델> 0"` 또는 `DEL` — 새 턴부터 즉시 기본 팔

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
