### PR TITLE
refactor: 나머지 LLM 호출부를 모델 카탈로그에 편입한다

### DIFF
--- a/src/main/java/com/mio/ai/llm/ModelRole.java
+++ b/src/main/java/com/mio/ai/llm/ModelRole.java
@@ -1,17 +1,20 @@
 package com.mio.ai.llm;
 
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
- * 대화 파이프라인에서 LLM 을 부르는 역할 (#479).
+ * LLM 을 부르는 역할 (#479, 전 호출부 편입 #482).
  *
  * <p>호출부는 모델 ID 가 아니라 역할을 말하고, 역할→모델 해석은 {@link ModelCatalog} 가 한다.
  * 벤치마크 하네스의 {@code CellModelRole} 과 같은 개념이다 — 평가가 역할 단위로 모델을
  * 갈아끼우며 비교하므로, 운영도 같은 단위로 갈아끼울 수 있어야 평가 결과를 그대로 적용할 수 있다.
  *
  * <p>기본값은 이 enum 이 도입되기 전 각 호출부에 하드코딩돼 있던 상수와 같다.
- * 여기 없는 역할(메모리 컨솔리데이션·리포트·체크인·임베딩)은 아직 호출부 상수를 쓴다 — 이슈 #482.
+ * 프로덕션 소스에 모델 리터럴이 이 파일 밖에 남지 않는 것을 테스트가 감시한다.
  */
 public enum ModelRole {
 
@@ -25,7 +28,37 @@ public enum ModelRole {
     OUTPUT_JUDGE("gpt-4o-mini"),
 
     /** CBT 메타데이터 분류 ({@code CbtMetadataClassifier}). */
-    CBT_CLASSIFIER("gpt-4o-mini");
+    CBT_CLASSIFIER("gpt-4o-mini"),
+
+    /** 턴 온톨로지 추출 ({@code LlmTurnOntologyExtractor}). */
+    ONTOLOGY_EXTRACTOR("gpt-4o-mini"),
+
+    /** 세션 내부 요약 ({@code SessionConsolidator}). */
+    SESSION_SUMMARY("gpt-4o-mini"),
+
+    /** 사용자 노출용 요약 렌더링 ({@code SessionSummaryRenderer}). */
+    SUMMARY_RENDERER("gpt-4o-mini"),
+
+    /** 대화 체크포인트 ({@code ConversationCheckpointService}). */
+    CHECKPOINT("gpt-4o-mini"),
+
+    /** Todo 행동 개인화 ({@code TodoActionPersonalizer}). */
+    TODO_PERSONALIZER("gpt-4o-mini"),
+
+    /** 에피소드 추출 ({@code ExtractorLlmClient}). */
+    EPISODE_EXTRACTOR("gpt-4o-mini"),
+
+    /** 주간 리플렉션 ({@code WeeklyReflectionJob}). */
+    WEEKLY_REFLECTION("gpt-4o-mini"),
+
+    /** 리포트 서사 ({@code ReportNarrativeService}). */
+    REPORT_NARRATIVE("gpt-4o-mini"),
+
+    /** 체크인 응답 ({@code CheckinAiResponseGenerator}). */
+    CHECKIN_RESPONSE("gpt-4o-mini"),
+
+    /** 임베딩 ({@code OpenAiLlmClient}). */
+    EMBEDDING("text-embedding-3-small");
 
     private final String defaultModel;
 
@@ -43,24 +76,34 @@ public enum ModelRole {
     }
 
     /**
-     * 설정 키 → 역할. kebab-case 외에 Spring relaxed binding 이 만들 수 있는 표기를 받는다:
-     * camelCase, snake_case, 그리고 환경 변수 경로의 점 표기. 두 단어 역할을
-     * {@code MIO_AI_MODELS_ROLES_INPUT_JUDGE} 로 넘기면 relaxed binding 이 맵 키를
-     * {@code input.judge} 로 만들기 때문에 {@code .} 도 정규화한다 — 운영자가 canary 롤백
-     * 중에 bracket 표기를 알아내야 기동하는 상황을 만들지 않는다.
+     * 설정 키 → 역할. 받는 표기는 <b>단어 경계가 맞는 것만</b>이다: kebab({@code input-judge}),
+     * snake({@code input_judge}), 환경 변수 relaxed binding 의 점 표기({@code input.judge} —
+     * {@code MIO_AI_MODELS_ROLES_INPUT_JUDGE} 가 이렇게 바인딩된다), camelCase({@code inputJudge}).
      *
-     * @throws IllegalStateException 어느 역할도 아니면 — 오타가 조용히 무시되면
-     *                               존재하지 않는 보호를 설정했다고 믿게 된다
+     * <p>구분자를 위치와 무관하게 지우는 정규화는 쓰지 않는다 — {@code gener.ation} 같은
+     * 기형 키가 해석되면 오타가 존재하지 않는 보호를 가장한다 (#483 리뷰 이월 지적).
+     *
+     * @throws IllegalStateException 어느 역할의 정당한 표기도 아니면
      */
     static ModelRole fromConfigKey(String key) {
-        String normalized = key.replace("-", "").replace("_", "").replace(".", "").toLowerCase();
+        String lowered = key.toLowerCase();
         return Arrays.stream(values())
-                .filter(role -> role.name().replace("_", "").toLowerCase().equals(normalized))
+                .filter(role -> role.acceptedKeys().contains(lowered))
                 .findFirst()
                 .orElseThrow(() -> new IllegalStateException(
                         "mio.ai.models.roles 에 모르는 역할 키가 있다: '%s' — 가능한 키: %s"
                                 .formatted(key, Arrays.stream(values())
                                         .map(ModelRole::configKey)
                                         .collect(Collectors.joining(", ")))));
+    }
+
+    /** 이 역할의 정당한 소문자 표기들. 구분자가 단어 경계 위치에만 있는 형태로 한정한다. */
+    private Set<String> acceptedKeys() {
+        String snake = name().toLowerCase();
+        return new HashSet<>(List.of(
+                snake,                       // input_judge
+                snake.replace('_', '-'),     // input-judge (yml kebab)
+                snake.replace('_', '.'),     // input.judge (환경 변수 relaxed binding)
+                snake.replace("_", "")));    // inputjudge (camelCase 소문자화)
     }
 }

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -34,7 +34,6 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
     private static final String CHAT_URL = "https://api.openai.com/v1/chat/completions";
     private static final String EMBEDDINGS_URL = "https://api.openai.com/v1/embeddings";
-    private static final String EMBEDDING_MODEL = "text-embedding-3-small";
     private static final String DONE_MARKER = "data: [DONE]";
     private static final String DATA_PREFIX = "data: ";
 
@@ -78,6 +77,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private final MeterRegistry meterRegistry;
     private final LlmCostCalculator costCalculator;
     private final AiCostEventWriter costEventWriter;
+    // 임베딩 모델은 카탈로그의 기동 해석을 따른다 (#482). 채팅 모델과 달리 요청에 실려
+    // 오지 않으므로 여기서 한 번 해석해 둔다.
+    private final String embeddingModel;
 
     public OpenAiLlmClient(
             @Value("${openai.api-key}") String apiKey,
@@ -85,13 +87,15 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             ObjectMapper objectMapper,
             MeterRegistry meterRegistry,
             LlmCostCalculator costCalculator,
-            AiCostEventWriter costEventWriter) {
+            AiCostEventWriter costEventWriter,
+            ModelCatalog modelCatalog) {
         this.apiKey = apiKey;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
         this.costCalculator = costCalculator;
         this.costEventWriter = costEventWriter;
+        this.embeddingModel = modelCatalog.modelFor(ModelRole.EMBEDDING);
     }
 
     private static final int MAX_RETRIES = 4;
@@ -338,7 +342,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         boolean terminalRecorded = false;
         try {
             String requestBody = objectMapper.writeValueAsString(
-                    Map.of("model", EMBEDDING_MODEL, "input", text));
+                    Map.of("model", embeddingModel, "input", text));
 
             HttpRequest httpRequest = HttpRequest.newBuilder()
                     .uri(URI.create(EMBEDDINGS_URL))
@@ -352,8 +356,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     httpRequest, HttpResponse.BodyHandlers.ofString());
 
             if (response.statusCode() != 200) {
-                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
+                recordOutcome(embeddingModel, MODE_EMBED, "error");
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(embeddingModel), component, userId, sessionId);
                 terminalRecorded = true;
                 throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
             }
@@ -361,8 +365,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             JsonNode root = objectMapper.readTree(response.body());
             JsonNode embeddingNode = root.path("data").path(0).path("embedding");
             if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
-                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
+                recordOutcome(embeddingModel, MODE_EMBED, "error");
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(embeddingModel), component, userId, sessionId);
                 terminalRecorded = true;
                 throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
             }
@@ -372,27 +376,27 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             }
 
             // 임베딩도 과금 대상이다. 빼면 mio.llm.cost.usd 가 실제 지출보다 낮게 나온다.
-            LlmUsage usage = extractUsage(root, EMBEDDING_MODEL);
-            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "success");
-            recordUsage(MODE_EMBED, usage != null ? usage : LlmUsage.unresolved(EMBEDDING_MODEL),
+            LlmUsage usage = extractUsage(root, embeddingModel);
+            recordOutcome(embeddingModel, MODE_EMBED, "success");
+            recordUsage(MODE_EMBED, usage != null ? usage : LlmUsage.unresolved(embeddingModel),
                     component, userId, sessionId);
 
             return result;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "interrupted");
-            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
+            recordOutcome(embeddingModel, MODE_EMBED, "interrupted");
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(embeddingModel), component, userId, sessionId);
             throw new RuntimeException("Embeddings request interrupted", e);
         } catch (RuntimeException e) {
             if (!terminalRecorded) {
-                recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "aborted");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
+                recordOutcome(embeddingModel, MODE_EMBED, "aborted");
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(embeddingModel), component, userId, sessionId);
             }
             throw e;
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
-            recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
+            recordOutcome(embeddingModel, MODE_EMBED, "error");
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(embeddingModel), component, userId, sessionId);
             throw new RuntimeException("Embeddings request failed", e);
         }
     }

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -1,6 +1,8 @@
 package com.mio.ai.memory.consolidation;
 
 import com.mio.ai.AiCacheKeys;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -39,7 +41,6 @@ import java.util.UUID;
 public class ConversationCheckpointService {
 
     static final int CHECKPOINT_INTERVAL = 20;
-    private static final String CHECKPOINT_MODEL = "gpt-4o-mini";
     // 체크포인트 요약 출력 상한. 프롬프트가 200자를 요구한다 (~142 토큰).
     private static final int CHECKPOINT_MAX_COMPLETION_TOKENS = 400;
     private static final String CHECKPOINT_SYSTEM_PROMPT = """
@@ -63,6 +64,7 @@ public class ConversationCheckpointService {
     private final SessionCheckpointRepository checkpointRepository;
     private final UserRepository userRepository;
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final MessageEncryptor messageEncryptor;
     private final JdbcTemplate jdbcTemplate;
     private final StringRedisTemplate redisTemplate;
@@ -168,7 +170,7 @@ public class ConversationCheckpointService {
         StringBuilder sb = new StringBuilder();
         try {
             LlmStreamResult result = llmClient.stream(
-                    LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines))
+                    LlmRequest.of(modelCatalog.modelFor(ModelRole.CHECKPOINT), CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines))
                             .withMaxCompletionTokens(CHECKPOINT_MAX_COMPLETION_TOKENS)
                             .withAttribution("CHECKPOINT_SUMMARY", userId, sessionId),
                     sb::append

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -1,6 +1,8 @@
 package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -21,7 +23,6 @@ import java.util.UUID;
 @Slf4j
 public class ExtractorLlmClient {
 
-    private static final String MODEL = "gpt-4o-mini";
     // JSON 추출 출력 상한. 항목 최대 3개라 여유를 둔다.
     private static final int MAX_COMPLETION_TOKENS = 600;
 
@@ -91,6 +92,7 @@ public class ExtractorLlmClient {
             """;
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final ObjectMapper objectMapper;
 
     public ExtractorResult extract(String sessionSummary, UUID userId, UUID sessionId) {
@@ -101,7 +103,7 @@ public class ExtractorLlmClient {
         StringBuilder responseBuilder = new StringBuilder();
         try {
             LlmStreamResult result = llmClient.stream(
-                    LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary)
+                    LlmRequest.of(modelCatalog.modelFor(ModelRole.EPISODE_EXTRACTOR), SYSTEM_PROMPT, sessionSummary)
                             .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                             .withAttribution("EXTRACTOR", userId, sessionId),
                     responseBuilder::append

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -7,6 +7,8 @@ import com.mio.ai.domain.MemoryEmbedding;
 import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.crisis.CrisisTodoDecision;
 import com.mio.ai.crisis.CrisisTodoSafetyGate;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.memory.ontology.OntologyValidator;
 import com.mio.ai.llm.LlmRequest;
@@ -65,7 +67,6 @@ import java.util.stream.Collectors;
 @Slf4j
 public class SessionConsolidator {
 
-    private static final String SUMMARY_MODEL = "gpt-4o-mini";
     // 요약 출력 상한. 프롬프트가 500자를 요구하고 한국어 1자 ≈ 0.71 토큰이라 ~355 토큰,
     // 2배 이상 여유를 둔다. 잘리면 세션 요약이 문장 중간에서 끊긴 채 저장된다.
     private static final int SUMMARY_MAX_COMPLETION_TOKENS = 800;
@@ -93,6 +94,7 @@ public class SessionConsolidator {
     private final UserBeliefRepository beliefRepository;
     private final BeliefEvidenceAccumulator evidenceAccumulator;
     private final ExtractorLlmClient extractorLlmClient;
+    private final ModelCatalog modelCatalog;
     private final LlmClient llmClient;
     private final MessageEncryptor messageEncryptor;
     private final BeliefIdentityHasher beliefIdentityHasher;
@@ -520,7 +522,7 @@ public class SessionConsolidator {
     private String generateSummary(String conversationText, UUID userId, UUID sessionId) {
         StringBuilder sb = new StringBuilder();
         LlmStreamResult result = llmClient.stream(
-                LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText)
+                LlmRequest.of(modelCatalog.modelFor(ModelRole.SESSION_SUMMARY), SUMMARY_SYSTEM_PROMPT, conversationText)
                         .withMaxCompletionTokens(SUMMARY_MAX_COMPLETION_TOKENS)
                         .withAttribution("SESSION_SUMMARY", userId, sessionId),
                 sb::append

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
@@ -1,5 +1,7 @@
 package com.mio.ai.memory.consolidation;
 
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -33,7 +35,6 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class SessionSummaryRenderer {
 
-    private static final String MODEL = "gpt-4o-mini";
     // 2~3문장 200자를 요구한다. 한국어 1자 ≈ 0.71 토큰이라 ~142 토큰, 2배 이상 여유를 둔다.
     private static final int MAX_COMPLETION_TOKENS = 400;
     private static final int MAX_LENGTH = 200;
@@ -79,6 +80,7 @@ public class SessionSummaryRenderer {
                     "분명(히|해요|합니다)|틀림없(이|어요)|당신은 .{0,12}(사람이|성격이)"));
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
 
     /**
      * @param internalSummary 내부용 요약({@code summary_text})
@@ -94,7 +96,7 @@ public class SessionSummaryRenderer {
         try {
             StringBuilder response = new StringBuilder();
             LlmStreamResult result = llmClient.stream(
-                    LlmRequest.of(MODEL, buildSystemPrompt(persona), "세션 기록:\n" + internalSummary)
+                    LlmRequest.of(modelCatalog.modelFor(ModelRole.SUMMARY_RENDERER), buildSystemPrompt(persona), "세션 기록:\n" + internalSummary)
                             .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                             .withAttribution("SUMMARY_RENDER", userId, sessionId),
                     response::append);

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
@@ -2,6 +2,8 @@ package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.memory.ontology.BehaviorTemplate;
@@ -30,7 +32,6 @@ import java.util.regex.Pattern;
 @RequiredArgsConstructor
 public class TodoActionPersonalizer {
 
-    private static final String MODEL = "gpt-4o-mini";
     // 템플릿 개인화 출력 상한. 템플릿 수만큼 문장을 만들어야 해 여유를 둔다.
     private static final int MAX_COMPLETION_TOKENS = 600;
     private static final int MAX_ACTION_LENGTH = 120;
@@ -79,6 +80,7 @@ public class TodoActionPersonalizer {
                     + "|순간에|상황에|도중에|중에|탓에|때문에|이라서|라서)(?:,|\\s))");
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final ObjectMapper objectMapper;
 
     /**
@@ -95,7 +97,7 @@ public class TodoActionPersonalizer {
         try {
             StringBuilder response = new StringBuilder();
             llmClient.stream(
-                    LlmRequest.of(MODEL, SYSTEM_PROMPT, buildUserMessage(sessionSummary, triggerTags, templates))
+                    LlmRequest.of(modelCatalog.modelFor(ModelRole.TODO_PERSONALIZER), SYSTEM_PROMPT, buildUserMessage(sessionSummary, triggerTags, templates))
                             .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                             .withAttribution("TODO_PERSONALIZER", userId, sessionId),
                     response::append

--- a/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
@@ -2,6 +2,8 @@ package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mio.ai.domain.UserSelfModel;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.repository.UserSelfModelRepository;
@@ -53,6 +55,7 @@ public class WeeklyReflectionJob {
 
     private final JdbcTemplate jdbcTemplate;
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final UserSelfModelRepository selfModelRepository;
     private final ObjectMapper objectMapper;
     private final MemoryConsentChecker memoryConsentChecker;
@@ -194,7 +197,8 @@ public class WeeklyReflectionJob {
 
     private String generateText(String systemPrompt, String context, UUID userId) {
         try {
-            return llmClient.completeText(LlmRequest.of("gpt-4o-mini", systemPrompt, context)
+            return llmClient.completeText(LlmRequest.of(modelCatalog.modelFor(ModelRole.WEEKLY_REFLECTION),
+                    systemPrompt, context)
                     .withMaxCompletionTokens(REFLECTION_MAX_COMPLETION_TOKENS)
                     .withAttribution("WEEKLY_REFLECTION", userId, null));
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
@@ -2,6 +2,8 @@ package com.mio.ai.memory.ontology;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,6 @@ import java.util.UUID;
 @Slf4j
 public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
 
-    private static final String MODEL = "gpt-4o-mini";
     // JSON 추출 출력 상한. 예상 ~40 토큰. 잘리면 파싱 실패로 추출이 비어 반환된다.
     private static final int MAX_COMPLETION_TOKENS = 400;
     private static final String SYSTEM_PROMPT = """
@@ -34,6 +35,7 @@ public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
             """;
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -42,7 +44,7 @@ public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
             return TurnOntologySignal.empty();
         }
         try {
-            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+            String response = llmClient.completeJson(LlmRequest.of(modelCatalog.modelFor(ModelRole.ONTOLOGY_EXTRACTOR), SYSTEM_PROMPT, userMessage)
                     .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                     .withAttribution("ONTOLOGY_EXTRACTOR", userId, sessionId));
             JsonNode node = objectMapper.readTree(stripCodeFence(response));

--- a/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
+++ b/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
@@ -1,5 +1,7 @@
 package com.mio.checkin.service;
 
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class CheckinAiResponseGenerator {
 
-    private static final String MODEL = "gpt-4o-mini";
     // 체크인 응답 출력 상한. 프롬프트가 150자를 요구한다 (~107 토큰).
     private static final int MAX_COMPLETION_TOKENS = 400;
     private static final String SYSTEM_PROMPT = """
@@ -34,6 +35,7 @@ public class CheckinAiResponseGenerator {
             """;
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final JdbcTemplate jdbcTemplate;
 
     @Async
@@ -41,7 +43,7 @@ public class CheckinAiResponseGenerator {
                                 UUID userId) {
         try {
             String userMessage = buildPrompt(emotionType, conditionScore, timeOfDay);
-            String response = llmClient.completeText(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+            String response = llmClient.completeText(LlmRequest.of(modelCatalog.modelFor(ModelRole.CHECKIN_RESPONSE), SYSTEM_PROMPT, userMessage)
                     .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                     .withAttribution("CHECKIN_RESPONSE", userId, null));
 

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -1,6 +1,8 @@
 package com.mio.report.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelRole;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.report.dto.ReportCommonDto.DistortionDto;
@@ -16,7 +18,6 @@ import java.util.UUID;
 @Slf4j
 public class ReportNarrativeService {
 
-    private static final String MODEL = "gpt-4o-mini";
     // 리포트 서술 출력 상한. 프롬프트가 3문장·100자를 요구한다.
     private static final int MAX_COMPLETION_TOKENS = 400;
 
@@ -32,6 +33,7 @@ public class ReportNarrativeService {
             """;
 
     private final LlmClient llmClient;
+    private final ModelCatalog modelCatalog;
     private final ObjectMapper objectMapper;
 
     public record NarrativeResult(String narrative, String coachingDirection) {
@@ -44,7 +46,7 @@ public class ReportNarrativeService {
                                     List<DistortionDto> distortionTop3, UUID userId) {
         String userMessage = buildUserMessage(periodLabel, checkinCount, avgEmotionScore, distortionTop3);
         try {
-            String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
+            String response = llmClient.completeJson(LlmRequest.of(modelCatalog.modelFor(ModelRole.REPORT_NARRATIVE), SYSTEM_PROMPT, userMessage)
                     .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
                     .withAttribution("REPORT_NARRATIVE", userId, null));
             return parseResponse(response);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,6 +150,7 @@ mio:
       allowed:
         - gpt-4o
         - gpt-4o-mini
+        - text-embedding-3-small
 
 logging:
   level:

--- a/src/test/java/com/mio/ai/judge/ModelRoutingWiringTest.java
+++ b/src/test/java/com/mio/ai/judge/ModelRoutingWiringTest.java
@@ -7,11 +7,13 @@ import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
 import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.ModelCatalogProperties;
+import com.mio.ai.llm.ModelRole;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -74,11 +76,17 @@ class ModelRoutingWiringTest {
     private static ModelCatalog catalogWith(String roleKey) {
         ModelCatalogProperties props = new ModelCatalogProperties();
         props.setRoles(Map.of(roleKey, OVERRIDE_MODEL));
-        props.setAllowed(List.of("gpt-4o", "gpt-4o-mini", OVERRIDE_MODEL));
+
+        // 검증 대상이 아닌 역할 기본값(임베딩 포함)도 allowlist·단가 검증을 통과해야
+        // 카탈로그가 생성된다 — 전 역할 기본값을 깔고 override 모델만 얹는다.
+        List<String> models = new java.util.ArrayList<>(
+                Arrays.stream(ModelRole.values()).map(ModelRole::defaultModel).distinct().toList());
+        models.add(OVERRIDE_MODEL);
+        props.setAllowed(models);
 
         LlmPricingProperties pricing = new LlmPricingProperties();
         Map<String, LlmPricingProperties.ModelPrice> table = new LinkedHashMap<>();
-        for (String model : List.of("gpt-4o", "gpt-4o-mini", OVERRIDE_MODEL)) {
+        for (String model : models) {
             table.put(model, new LlmPricingProperties.ModelPrice(
                     BigDecimal.ONE, null, BigDecimal.ONE));
         }

--- a/src/test/java/com/mio/ai/llm/GenerationCanaryRouterTest.java
+++ b/src/test/java/com/mio/ai/llm/GenerationCanaryRouterTest.java
@@ -192,13 +192,17 @@ class GenerationCanaryRouterTest {
 
     private static ModelCatalog catalog(List<String> allowed, List<String> priced) {
         ModelCatalogProperties props = new ModelCatalogProperties();
-        props.setAllowed(allowed);
+        List<String> withEmbedding = new java.util.ArrayList<>(allowed);
+        withEmbedding.add(ModelRole.EMBEDDING.defaultModel());
+        props.setAllowed(withEmbedding);
         LlmPricingProperties pricing = new LlmPricingProperties();
         Map<String, LlmPricingProperties.ModelPrice> table = new LinkedHashMap<>();
         for (String model : priced) {
             table.put(model, new LlmPricingProperties.ModelPrice(
                     BigDecimal.ONE, null, BigDecimal.ONE));
         }
+        table.putIfAbsent(ModelRole.EMBEDDING.defaultModel(),
+                new LlmPricingProperties.ModelPrice(BigDecimal.ONE, null, BigDecimal.ONE));
         pricing.setModels(table);
         return new ModelCatalog(props, pricing);
     }

--- a/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
+++ b/src/test/java/com/mio/ai/llm/ModelCatalogTest.java
@@ -28,6 +28,40 @@ class ModelCatalogTest {
         assertThat(catalog.modelFor(ModelRole.INPUT_JUDGE)).isEqualTo("gpt-4o-mini");
         assertThat(catalog.modelFor(ModelRole.OUTPUT_JUDGE)).isEqualTo("gpt-4o-mini");
         assertThat(catalog.modelFor(ModelRole.CBT_CLASSIFIER)).isEqualTo("gpt-4o-mini");
+
+        // #482 로 편입된 잔여 역할 — 기본값은 편입 전 각 호출부의 상수와 같다.
+        assertThat(catalog.modelFor(ModelRole.EMBEDDING)).isEqualTo("text-embedding-3-small");
+        for (ModelRole role : new ModelRole[]{ModelRole.ONTOLOGY_EXTRACTOR,
+                ModelRole.SESSION_SUMMARY, ModelRole.SUMMARY_RENDERER, ModelRole.CHECKPOINT,
+                ModelRole.TODO_PERSONALIZER, ModelRole.EPISODE_EXTRACTOR,
+                ModelRole.WEEKLY_REFLECTION, ModelRole.REPORT_NARRATIVE,
+                ModelRole.CHECKIN_RESPONSE}) {
+            assertThat(catalog.modelFor(role)).isEqualTo("gpt-4o-mini");
+        }
+    }
+
+    @Test
+    @DisplayName("역할 키 정규화는 경계 인지다 — 기형 키가 해석되면 오타가 보호를 가장한다 (#483 리뷰 이월)")
+    void separatorNormalizationIsBoundaryAware() {
+        // 받아야 하는 표기: kebab(yml) · snake · dot(환경 변수 relaxed binding) · camelCase
+        for (String valid : new String[]{"input-judge", "input_judge", "input.judge",
+                "inputJudge", "INPUT_JUDGE"}) {
+            ModelCatalog catalog = new ModelCatalog(
+                    properties(Map.of(valid, "gpt-4o"), List.of("gpt-4o", "gpt-4o-mini")),
+                    pricing("gpt-4o", "gpt-4o-mini"));
+            assertThat(catalog.modelFor(ModelRole.INPUT_JUDGE))
+                    .as("정당한 표기 '%s' 는 해석돼야 한다", valid)
+                    .isEqualTo("gpt-4o");
+        }
+        // 거부해야 하는 표기: 구분자가 단어 경계 밖에 있는 기형 키
+        for (String malformed : new String[]{"gener.ation", "in.put.judge", "input..judge",
+                "i-nput-judge", "gener_ation"}) {
+            assertThatThrownBy(() -> new ModelCatalog(
+                    properties(Map.of(malformed, "gpt-4o"), List.of("gpt-4o", "gpt-4o-mini")),
+                    pricing("gpt-4o", "gpt-4o-mini")))
+                    .as("기형 키 '%s' 는 기동을 실패시켜야 한다", malformed)
+                    .isInstanceOf(IllegalStateException.class);
+        }
     }
 
     @Test
@@ -143,7 +177,14 @@ class ModelCatalogTest {
                                                      List<String> allowed) {
         ModelCatalogProperties props = new ModelCatalogProperties();
         props.setRoles(roles);
-        props.setAllowed(allowed);
+        if (!allowed.isEmpty()) {
+            // 픽스처 편의 — 검증 대상이 아닌 EMBEDDING 기본값이 allowlist 검사에 걸리지 않게 한다.
+            List<String> withEmbedding = new java.util.ArrayList<>(allowed);
+            withEmbedding.add(ModelRole.EMBEDDING.defaultModel());
+            props.setAllowed(withEmbedding);
+        } else {
+            props.setAllowed(allowed);
+        }
         return props;
     }
 
@@ -154,6 +195,8 @@ class ModelCatalogTest {
             table.put(model, new LlmPricingProperties.ModelPrice(
                     BigDecimal.ONE, null, BigDecimal.TEN));
         }
+        table.putIfAbsent(ModelRole.EMBEDDING.defaultModel(),
+                new LlmPricingProperties.ModelPrice(BigDecimal.ONE, null, BigDecimal.TEN));
         props.setModels(table);
         return props;
     }

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -529,7 +529,8 @@ class OpenAiLlmClientTest {
 
     private OpenAiLlmClient client(HttpClient httpClient, AiCostEventWriter costEventWriter) {
         return new OpenAiLlmClient("test-key", httpClient, new ObjectMapper(),
-                meterRegistry, new LlmCostCalculator(pricing), costEventWriter);
+                meterRegistry, new LlmCostCalculator(pricing), costEventWriter,
+                ModelCatalog.defaults());
     }
 
     private AiCostEventWriter rejectingCostEventWriter() {

--- a/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -30,7 +31,7 @@ class ExtractorLlmClientTruncationTest {
     @DisplayName("절단된 응답은 파싱 가능해도 비운다 — 누락 필드가 기본값으로 굳는 것을 막는다")
     void truncatedResponseYieldsEmptyResult() {
         ExtractorLlmClient client = new ExtractorLlmClient(
-                stubClient(TRUNCATED_BUT_PARSEABLE, true), new ObjectMapper());
+                stubClient(TRUNCATED_BUT_PARSEABLE, true), ModelCatalog.defaults(), new ObjectMapper());
 
         ExtractorResult result = client.extract("세션 요약 본문", null, null);
 
@@ -45,7 +46,7 @@ class ExtractorLlmClientTruncationTest {
     @DisplayName("같은 응답이 절단되지 않았다면 그대로 파싱한다 — 절단 여부만이 차이다")
     void sameResponseIsParsedWhenNotTruncated() {
         ExtractorLlmClient client = new ExtractorLlmClient(
-                stubClient(TRUNCATED_BUT_PARSEABLE, false), new ObjectMapper());
+                stubClient(TRUNCATED_BUT_PARSEABLE, false), ModelCatalog.defaults(), new ObjectMapper());
 
         ExtractorResult result = client.extract("세션 요약 본문", null, null);
 

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.crisis.CrisisEpisodePromoter;
 import com.mio.ai.crisis.CrisisTodoDecision;
 import com.mio.ai.crisis.CrisisTodoSafetyGate;
@@ -121,6 +122,7 @@ class SessionConsolidatorTest {
                 beliefRepository,
                 evidenceAccumulator,
                 extractorLlmClient,
+                ModelCatalog.defaults(),
                 llmClient,
                 messageEncryptor,
                 beliefIdentityHasher,

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.memory.consolidation;
 
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -34,7 +35,7 @@ class SessionSummaryRendererTest {
     @BeforeEach
     void setUp() {
         llmClient = mock(LlmClient.class);
-        renderer = new SessionSummaryRenderer(llmClient);
+        renderer = new SessionSummaryRenderer(llmClient, ModelCatalog.defaults());
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.consolidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import com.mio.ai.llm.LlmStreamResult;
@@ -31,7 +32,7 @@ class TodoActionPersonalizerTest {
     @BeforeEach
     void setUp() {
         llmClient = mock(LlmClient.class);
-        personalizer = new TodoActionPersonalizer(llmClient, new ObjectMapper());
+        personalizer = new TodoActionPersonalizer(llmClient, ModelCatalog.defaults(), new ObjectMapper());
     }
 
     @Test

--- a/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.ontology;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +20,7 @@ class LlmTurnOntologyExtractorTest {
                 {"distortionCode":"mind_reading","beliefKind":"null","polarity":null}
                 ```
                 """);
-        LlmTurnOntologyExtractor extractor = new LlmTurnOntologyExtractor(llmClient, new ObjectMapper());
+        LlmTurnOntologyExtractor extractor = new LlmTurnOntologyExtractor(llmClient, ModelCatalog.defaults(), new ObjectMapper());
 
         TurnOntologySignal signal = extractor.extract("다들 나를 싫어하는 것 같아", null, null);
 

--- a/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
+++ b/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
@@ -10,7 +10,9 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -161,6 +163,36 @@ class CellModelRegistryTest {
         assertThatThrownBy(() -> BenchmarkCell.parse("A,Z"))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("알 수 없는 셀 이름");
+    }
+
+    @Test
+    @DisplayName("프로덕션 소스 전체에 모델 리터럴이 카탈로그 밖에 없다 — #482 이후 두 개의 진실 금지")
+    void noModelLiteralsOutsideTheCatalog() throws IOException {
+        Path main = LockedEvalContaminationScanner.findRepoRoot().resolve("src/main/java");
+        Pattern literal = Pattern.compile("\"(gpt-|text-embedding-|o3|o4-mini)");
+
+        try (var files = Files.walk(main)) {
+            List<String> offenders = files
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> !p.endsWith("ModelRole.java"))
+                    .filter(p -> {
+                        try {
+                            return Files.readAllLines(p, StandardCharsets.UTF_8).stream()
+                                    .map(String::trim)
+                                    // 주석은 모델을 언급할 수 있다 — 코드 라인만 본다
+                                    .filter(line -> !line.startsWith("//") && !line.startsWith("*")
+                                            && !line.startsWith("/*"))
+                                    .anyMatch(line -> literal.matcher(line).find());
+                        } catch (IOException e) {
+                            throw new UncheckedIOException(e);
+                        }
+                    })
+                    .map(p -> main.relativize(p).toString())
+                    .toList();
+            assertThat(offenders)
+                    .as("모델 ID 하드코딩이 남은 파일 — ModelRole 에 역할을 추가하고 카탈로그를 주입할 것")
+                    .isEmpty();
+        }
     }
 
     private static String sourceOf(Path root, String file) {

--- a/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
+++ b/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
@@ -165,6 +165,11 @@ class CellModelRegistryTest {
                 .hasMessageContaining("알 수 없는 셀 이름");
     }
 
+    /**
+     * 이 sweep 은 <b>쉬운 실수 방지용</b>이다 — 상수 복붙으로 모델 리터럴이 되살아나는 것을
+     * 잡는다. 문자열 연결({@code "gp" + "t-..."}) 같은 의도적 우회는 못 잡고, 코드 라인 뒤
+     * 인라인 주석에 인용부호로 모델을 언급하면 오탐한다. 그 수준의 회피·언급은 리뷰 몫이다.
+     */
     @Test
     @DisplayName("프로덕션 소스 전체에 모델 리터럴이 카탈로그 밖에 없다 — #482 이후 두 개의 진실 금지")
     void noModelLiteralsOutsideTheCatalog() throws IOException {

--- a/src/test/java/com/mio/ai/qa/CellRunner.java
+++ b/src/test/java/com/mio/ai/qa/CellRunner.java
@@ -236,7 +236,8 @@ final class CellRunner {
         return new CellRunner(variant, registry, new CellTokenLedger(),
                 (ledger, pricing) -> new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(),
                         new ObjectMapper(), ledger.meterRegistry(),
-                        new LlmCostCalculator(pricing.asProperties()), ledger.writer()),
+                        new LlmCostCalculator(pricing.asProperties()), ledger.writer(),
+                        ModelCatalog.defaults()),
                 false);
     }
 

--- a/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
@@ -149,7 +149,7 @@ class CrisisDetectionFullPathQaTest {
         inputJudge = new InputJudge(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
                         new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
-                        mock(AiCostEventWriter.class)),
+                        mock(AiCostEventWriter.class), ModelCatalog.defaults()),
                 new ObjectMapper(), new SimpleMeterRegistry(), ModelCatalog.defaults());
     }
 

--- a/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmPricingProperties;
@@ -58,7 +59,8 @@ class ExtractorEpisodeTypeQaTest {
         extractor = new ExtractorLlmClient(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
                         new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
-                        mock(AiCostEventWriter.class)),
+                        mock(AiCostEventWriter.class), ModelCatalog.defaults()),
+                ModelCatalog.defaults(),
                 new ObjectMapper()
         );
     }

--- a/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmPricingProperties;
@@ -40,7 +41,8 @@ class ExtractorLlmScaleTest {
         extractor = new ExtractorLlmClient(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
                         new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
-                        mock(AiCostEventWriter.class)),
+                        mock(AiCostEventWriter.class), ModelCatalog.defaults()),
+                ModelCatalog.defaults(),
                 new ObjectMapper()
         );
     }

--- a/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.mio.checkin.service;
 
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import org.junit.jupiter.api.Test;
@@ -24,7 +25,7 @@ class CheckinAiResponseGeneratorTest {
         UUID checkinId = UUID.randomUUID();
         UUID userId = UUID.randomUUID();
         when(llmClient.completeText(any(LlmRequest.class))).thenReturn("오늘도 잘 버텼어요.");
-        CheckinAiResponseGenerator generator = new CheckinAiResponseGenerator(llmClient, jdbcTemplate);
+        CheckinAiResponseGenerator generator = new CheckinAiResponseGenerator(llmClient, ModelCatalog.defaults(), jdbcTemplate);
 
         generator.generateAndSave(checkinId, "anxious", 3, "morning", userId);
 

--- a/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
+++ b/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
@@ -1,6 +1,7 @@
 package com.mio.report.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.llm.ModelCatalog;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ class ReportNarrativeServiceTest {
         LlmClient llmClient = mock(LlmClient.class);
         when(llmClient.completeJson(any(LlmRequest.class)))
                 .thenReturn("{\"narrative\":\"이번 주도 잘 해냈어요.\",\"coaching_direction\":\"작은 휴식을 이어가요.\"}");
-        ReportNarrativeService service = new ReportNarrativeService(llmClient, new ObjectMapper());
+        ReportNarrativeService service = new ReportNarrativeService(llmClient, ModelCatalog.defaults(), new ObjectMapper());
 
         ReportNarrativeService.NarrativeResult result = service.generate("이번 주", 2, 42.0, List.of(), null);
 


### PR DESCRIPTION
## 요약
`#483` 이 파이프라인 4역할만 카탈로그로 옮기고 남겨둔 10곳을 `ModelRole` 로 편입해, 모델 해석 메커니즘 두 개(카탈로그 vs 호출부 상수)가 공존하는 상태를 해소합니다. `#483` 리뷰가 이월한 정규화 지적(점 표기 content-blind)도 역할이 4→14개로 늘어나는 이 시점에 함께 조입니다.

## 관련 이슈
- Closes #482

## 변경 사항
- `ModelRole` 에 10역할 추가 (기본값 = 편입 전 각 호출부 상수와 동일): 온톨로지 추출·세션 요약·요약 렌더러·체크포인트·Todo 개인화·에피소드 추출·주간 리플렉션·리포트 서사·체크인 응답 (gpt-4o-mini) · 임베딩 (text-embedding-3-small)
- 호출부 10곳의 상수 제거 → 카탈로그 조회. `OpenAiLlmClient` 의 임베딩 모델은 기동 시 1회 해석
- **정규화 조임 (#483 리뷰 이월)**: `fromConfigKey` 를 구분자 무조건 제거에서 **정당한 표기 집합과의 정확 일치**(kebab/snake/dot/camelCase — 구분자가 단어 경계 위치에만)로 변경. `gener.ation`·`in.put.judge` 같은 기형 키는 이제 기동 실패
- **sweep 테스트 신설**: `src/main/java` 전체에서 모델 리터럴이 `ModelRole` 밖에 남으면 실패 (주석 제외)
- `application.yml` allowlist 에 `text-embedding-3-small` 등재 (임베딩이 역할이 되면서 기동 검증 대상에 포함)

## 영향 범위
- [ ] **안전 판정 경로** — 해당 없음: SafetyL1/InputJudge/PolicyEngine/OutputPreFilter/OutputJudge 무변경. 이번 편입 대상은 메모리·리포트·체크인·임베딩 경로로, Crisis Eval 재실행 대상이 아님
- [x] 환경 변수 또는 외부 설정 변경 → `mio.ai.models.allowed` 에 임베딩 모델 추가 (기본 동작 불변)

## 테스트
### 실행 커맨드
```bash
./gradlew cleanTest test   # 전체 통과
```

### 확인 내용
- `ModelCatalogTest`: 14역할 기본값 = 현행 상수, **경계 인지 정규화** (정당 표기 5종 해석 · 기형 키 5종 기동 실패 — 기존 코드에서 RED 확인)
- `CellModelRegistryTest.noModelLiteralsOutsideTheCatalog`: 편입 전 10개 파일에서 RED → 편입 후 GREEN
- 동작 불변: 각 호출부는 모델 리터럴만 카탈로그 조회로 바뀌고 프롬프트·토큰 상한·귀속 태그 무변경

## 중점 리뷰 포인트
- 14역할 이름의 표기 집합 간 충돌 부재 (경계 인지 정규화의 전제)
- `OpenAiLlmClient` 임베딩 모델의 기동 시 1회 해석이 적절한지 (임베딩은 요청에 모델이 실려 오지 않는 유일한 경로)
- 안전 판정 경로 무변경 판단이 맞는지

## 배포 / 롤백
- Rollout: 설정 무변경 배포 — 동작 동일
- Rollback: revert

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.