### PR TITLE
feat: 생성 모델 shadow 실행기를 넣는다

### DIFF
--- a/src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java
+++ b/src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java
@@ -36,7 +36,6 @@ public class GenerationCanaryRouter {
 
     static final String CANARY_KEY = "mio:ai:canary:generation";
     private static final String METRIC = "mio.model.canary";
-    private static final int BUCKETS = 100;
 
     private final ModelCatalog modelCatalog;
     private final StringRedisTemplate redisTemplate;
@@ -59,14 +58,14 @@ public class GenerationCanaryRouter {
             return defaultModel;
         }
 
-        Canary canary = parse(raw);
+        ModelTrafficSplit canary = ModelTrafficSplit.parse(raw);
         if (canary == null || !modelCatalog.isAllowed(canary.model())
                 || !modelCatalog.isPriced(canary.model())) {
             count("invalid_config");
             log.warn("canary 설정이 유효하지 않아 기본 모델로 라우팅: '{}'", raw);
             return defaultModel;
         }
-        if (bucketOf(userId) < canary.percent()) {
+        if (canary.selects(userId)) {
             count("candidate");
             return canary.model();
         }
@@ -74,34 +73,7 @@ public class GenerationCanaryRouter {
         return defaultModel;
     }
 
-    /** {@code "<모델> <percent>"}. 그 외 모양은 전부 무효 — 관대한 파싱은 오타를 삼킨다. */
-    private static Canary parse(String raw) {
-        String[] parts = raw.trim().split("\\s+");
-        if (parts.length != 2) {
-            return null;
-        }
-        try {
-            int percent = Integer.parseInt(parts[1]);
-            if (percent < 0 || percent > BUCKETS) {
-                return null;
-            }
-            return new Canary(parts[0], percent);
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
-
-    /**
-     * 사용자의 안정 버킷 [0, 100). {@link String#hashCode()} 는 명세에 고정된 알고리즘이라
-     * JVM·재시작·인스턴스 간에 같은 사용자가 항상 같은 버킷을 받는다.
-     */
-    private static int bucketOf(UUID userId) {
-        return Math.floorMod(userId.toString().hashCode(), BUCKETS);
-    }
-
     private void count(String outcome) {
         meterRegistry.counter(METRIC, "outcome", outcome).increment();
     }
-
-    private record Canary(String model, int percent) {}
 }

--- a/src/main/java/com/mio/ai/llm/ModelTrafficSplit.java
+++ b/src/main/java/com/mio/ai/llm/ModelTrafficSplit.java
@@ -1,0 +1,47 @@
+package com.mio.ai.llm;
+
+import java.util.UUID;
+
+/**
+ * 후보 모델 트래픽 분할 설정 — canary(#480)와 shadow(#481)가 공유한다.
+ *
+ * <p>둘 다 Redis 값 {@code "<모델> <percent>"} 를 읽고 같은 사용자 버킷 규칙으로 대상을
+ * 고른다. 규칙이 갈라지면 "canary 5% 와 shadow 5% 가 같은 사용자인가" 라는 질문에 답할 수
+ * 없게 된다 — 한 곳에 두는 이유다.
+ */
+public record ModelTrafficSplit(String model, int percent) {
+
+    public static final int BUCKETS = 100;
+
+    /**
+     * {@code "<모델> <percent>"}. 그 외 모양은 전부 {@code null} — 관대한 파싱은 오타를 삼킨다.
+     */
+    public static ModelTrafficSplit parse(String raw) {
+        String[] parts = raw.trim().split("\\s+");
+        if (parts.length != 2) {
+            return null;
+        }
+        try {
+            int percent = Integer.parseInt(parts[1]);
+            if (percent < 0 || percent > BUCKETS) {
+                return null;
+            }
+            return new ModelTrafficSplit(parts[0], percent);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * 사용자의 안정 버킷 [0, 100). {@link String#hashCode()} 는 명세에 고정된 알고리즘이라
+     * JVM·재시작·인스턴스 간에 같은 사용자가 항상 같은 버킷을 받는다.
+     */
+    public static int bucketOf(UUID userId) {
+        return Math.floorMod(userId.toString().hashCode(), BUCKETS);
+    }
+
+    /** 이 사용자가 후보 팔인가. percent 상향 시 기존 후보 팔 사용자는 유지된다(버킷 단조). */
+    public boolean selects(UUID userId) {
+        return bucketOf(userId) < percent;
+    }
+}

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -66,6 +66,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             "REPORT_NARRATIVE",
             "RETRIEVAL_QUERY_EMBEDDING",
             "SESSION_SUMMARY",
+            "SHADOW_GENERATION",
             "SUMMARY_RENDER",
             "SUMMARY_STORAGE_EMBEDDING",
             "TODO_PERSONALIZER",

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -125,6 +125,7 @@ public class ConversationOrchestrator {
     private final PromptBuilder promptBuilder;
     private final LlmClient llmClient;
     private final GenerationCanaryRouter generationCanaryRouter;
+    private final ShadowGenerationRunner shadowGenerationRunner;
     private final CrisisFlowService crisisFlowService;
     private final CrisisFixedFlowCoordinator crisisFixedFlowCoordinator;
     private final SecurityRefusalTemplate securityRefusalTemplate;
@@ -396,6 +397,9 @@ public class ConversationOrchestrator {
                                 systemPrompt, historySlice, userMessage)
                         .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS)
                         .withAttribution("MAIN_GENERATION", userId, sessionId);
+                // shadow (#481): 샘플이면 같은 입력을 후보 모델에 비동기 복제한다.
+                // 제출뿐이라 본 턴 지연에 영향이 없고, 어떤 실패도 여기로 전파되지 않는다.
+                shadowGenerationRunner.maybeShadow(llmRequest);
                 StringBuilder contentBuilder = new StringBuilder();
 
                 DeliveryMode deliveryMode = decision.deliveryMode();

--- a/src/main/java/com/mio/ai/orchestrator/ShadowGenerationRunner.java
+++ b/src/main/java/com/mio/ai/orchestrator/ShadowGenerationRunner.java
@@ -87,6 +87,13 @@ public class ShadowGenerationRunner {
                 log.warn("shadow 설정이 유효하지 않아 무시: '{}'", raw);
                 return;
             }
+            if (shadow.model().equals(primary.model())) {
+                // canary 가 같은 후보를 이미 본 응답으로 태우는 사용자다 — 여기서 또 부르면
+                // 지출만 2배고 신호는 0 이다 (본 경로가 같은 모델에 이미 사전 필터를 돈다).
+                // 겹침을 대시보드에서 보이게 세고 건너뛴다.
+                count("skipped_duplicate_of_primary");
+                return;
+            }
             if (shadow.percent() == 0 || !shadow.selects(primary.userId())) {
                 return;
             }

--- a/src/main/java/com/mio/ai/orchestrator/ShadowGenerationRunner.java
+++ b/src/main/java/com/mio/ai/orchestrator/ShadowGenerationRunner.java
@@ -1,0 +1,126 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.judge.OutputPreFilter;
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelTrafficSplit;
+import com.mio.ai.memory.consolidation.MemoryConsentChecker;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Executor;
+import java.util.concurrent.RejectedExecutionException;
+
+/**
+ * 생성 모델 shadow 실행기 (#481).
+ *
+ * <p>P0-8 잔여 게이트 "shadow 트래픽 회귀 확인"의 실행 지점이다. 샘플된 실 사용자 턴의
+ * 생성 요청을 후보 모델에 비동기 복제 호출하고, 결과는 <b>절대 전달하지 않고</b> 파생
+ * 판정만 계측한다.
+ *
+ * <pre>
+ * SET mio:ai:shadow:generation "gpt-4.1-nano 5"   # 5% 사용자 shadow
+ * DEL mio:ai:shadow:generation                     # 종료
+ * </pre>
+ *
+ * <p><b>본 응답 경로에 아무 비용도 지연도 더하지 않는다.</b> 호출 스레드에서 하는 일은
+ * Redis GET 한 번과 태스크 제출뿐이고, LLM 호출·동의 조회는 전부 비동기 태스크 안이다.
+ * 어떤 실패(Redis 장애·executor 포화·그림자 호출 실패)도 본 턴으로 전파되지 않는다.
+ *
+ * <p><b>기록하는 것은 파생 판정뿐이다.</b> 그림자 본문은 저장하지 않는다 — 본문 저장은
+ * 프라이버시 검토(로드맵 §10.4) 뒤의 후속이다. 남는 것: {@code mio.model.shadow} 카운터
+ * (사전 필터 통과/위반이 핵심 신호), 그리고 {@code SHADOW_GENERATION} 귀속으로
+ * 기존 {@code mio_llm_*} 지표·비용 이벤트에 실리는 토큰·지연·비용.
+ *
+ * <p>게이트는 canary 와 같다: allowlist 밖·단가 미등록 후보는 무시(fail-safe), 동의 철회
+ * 사용자는 제외(추가 전송은 필수가 아니다 — 동의 없이 나가면 P0-6 게이트를 우회한다).
+ * 버킷 규칙도 canary 와 공유해({@link ModelTrafficSplit}) "canary 5% 와 shadow 5% 가
+ * 같은 사용자인가"에 답할 수 있다.
+ */
+@Component
+@Slf4j
+public class ShadowGenerationRunner {
+
+    static final String SHADOW_KEY = "mio:ai:shadow:generation";
+    private static final String METRIC = "mio.model.shadow";
+    private static final String COMPONENT = "SHADOW_GENERATION";
+
+    private final ModelCatalog modelCatalog;
+    private final StringRedisTemplate redisTemplate;
+    private final MeterRegistry meterRegistry;
+    private final LlmClient llmClient;
+    private final OutputPreFilter outputPreFilter;
+    private final MemoryConsentChecker memoryConsentChecker;
+    private final Executor shadowExecutor;
+
+    public ShadowGenerationRunner(ModelCatalog modelCatalog,
+                                  StringRedisTemplate redisTemplate,
+                                  MeterRegistry meterRegistry,
+                                  LlmClient llmClient,
+                                  OutputPreFilter outputPreFilter,
+                                  MemoryConsentChecker memoryConsentChecker,
+                                  @Qualifier("shadowGenerationExecutor") Executor shadowExecutor) {
+        this.modelCatalog = modelCatalog;
+        this.redisTemplate = redisTemplate;
+        this.meterRegistry = meterRegistry;
+        this.llmClient = llmClient;
+        this.outputPreFilter = outputPreFilter;
+        this.memoryConsentChecker = memoryConsentChecker;
+        this.shadowExecutor = shadowExecutor;
+    }
+
+    /** 본 생성 요청을 받아 샘플이면 그림자 태스크를 제출한다. 어떤 경우에도 던지지 않는다. */
+    public void maybeShadow(LlmRequest primary) {
+        try {
+            String raw = redisTemplate.opsForValue().get(SHADOW_KEY);
+            if (raw == null || raw.isBlank()) {
+                return;
+            }
+            ModelTrafficSplit shadow = ModelTrafficSplit.parse(raw);
+            if (shadow == null || !modelCatalog.isAllowed(shadow.model())
+                    || !modelCatalog.isPriced(shadow.model())) {
+                count("invalid_config");
+                log.warn("shadow 설정이 유효하지 않아 무시: '{}'", raw);
+                return;
+            }
+            if (shadow.percent() == 0 || !shadow.selects(primary.userId())) {
+                return;
+            }
+            LlmRequest shadowRequest = new LlmRequest(shadow.model(), primary.messages(),
+                    primary.maxCompletionTokens(), COMPONENT, primary.userId(),
+                    primary.sessionId());
+            shadowExecutor.execute(() -> runShadow(shadowRequest));
+        } catch (RejectedExecutionException e) {
+            // executor 포화 — shadow 가 밀리면 버린다. 본 턴을 기다리게 하는 선택지는 없다.
+            count("rejected");
+        } catch (RuntimeException e) {
+            count("error");
+            log.warn("shadow 설정 조회 실패, 이 턴은 건너뜀: {}", e.getMessage());
+        }
+    }
+
+    private void runShadow(LlmRequest shadowRequest) {
+        try {
+            // 동의 조회는 DB 를 본다 — 호출 스레드가 아니라 여기서 한다. 조회 실패는
+            // MemoryConsentChecker 가 철회로 취급하므로(fail-closed) 그대로 따른다.
+            if (!memoryConsentChecker.isRetentionAllowed(shadowRequest.userId())) {
+                count("consent_excluded");
+                return;
+            }
+            String text = llmClient.completeText(shadowRequest);
+            boolean passed = outputPreFilter.check(text).passed();
+            count(passed ? "prefilter_passed" : "prefilter_failed");
+        } catch (RuntimeException e) {
+            count("shadow_failed");
+            log.warn("shadow 호출 실패 (본 턴 영향 없음): {}", e.getMessage());
+        }
+    }
+
+    private void count(String outcome) {
+        meterRegistry.counter(METRIC, "outcome", outcome).increment();
+    }
+}

--- a/src/main/java/com/mio/config/AiConfig.java
+++ b/src/main/java/com/mio/config/AiConfig.java
@@ -37,6 +37,22 @@ public class AiConfig {
         return executor;
     }
 
+    /**
+     * shadow 생성 전용 (#481). 의도적으로 작게 잡는다 — shadow 는 관측용 부하라 밀리면
+     * 버려야 하고(포화 시 TaskRejectedException → 러너가 rejected 로 계측), 본 트래픽의
+     * 리소스를 다투면 안 된다.
+     */
+    @Bean(name = "shadowGenerationExecutor")
+    public Executor shadowGenerationExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(1);
+        executor.setMaxPoolSize(2);
+        executor.setQueueCapacity(10);
+        executor.setThreadNamePrefix("shadow-generation-");
+        executor.initialize();
+        return executor;
+    }
+
     @Bean(name = "aiDecisionLoggerExecutor")
     public Executor aiDecisionLoggerExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();

--- a/src/test/java/com/mio/ai/orchestrator/ShadowGenerationRunnerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ShadowGenerationRunnerTest.java
@@ -1,0 +1,261 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.llm.LlmClient;
+import com.mio.ai.llm.LlmPricingProperties;
+import com.mio.ai.llm.LlmRequest;
+import com.mio.ai.llm.LlmStreamResult;
+import com.mio.ai.llm.ModelCatalog;
+import com.mio.ai.llm.ModelCatalogProperties;
+import com.mio.ai.llm.ModelRole;
+
+import com.mio.ai.judge.OutputPreFilter;
+import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.memory.consolidation.MemoryConsentChecker;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * shadow 실행기 (#481).
+ *
+ * <p>안전 성질 둘을 고정한다. <b>본 응답 경로에 아무 비용도 지연도 더하지 않는다</b> —
+ * LLM 호출·동의 조회는 전부 비동기 태스크 안에서 일어나고, 제출 실패·설정 오류·Redis 장애는
+ * 삼켜지고 계측만 남는다. 그리고 <b>미검증 모델·동의 철회 사용자에게는 절대 나가지 않는다</b> —
+ * allowlist·단가·동의 게이트가 canary 와 같은 fail-safe 로 걸린다.
+ */
+class ShadowGenerationRunnerTest {
+
+    private static final String SHADOW_MODEL = "gpt-4.1-nano";
+
+    private StringRedisTemplate redis;
+    private ValueOperations<String, String> values;
+    private SimpleMeterRegistry meters;
+    private RecordingLlmClient llm;
+    private OutputPreFilter preFilter;
+    private MemoryConsentChecker consent;
+    private List<Runnable> submitted;
+    private ShadowGenerationRunner runner;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        redis = mock(StringRedisTemplate.class);
+        values = mock(ValueOperations.class);
+        when(redis.opsForValue()).thenReturn(values);
+        meters = new SimpleMeterRegistry();
+        llm = new RecordingLlmClient("안전한 그림자 응답입니다.");
+        preFilter = mock(OutputPreFilter.class);
+        when(preFilter.check(anyString())).thenReturn(OutputPreFilterResult.pass());
+        consent = mock(MemoryConsentChecker.class);
+        when(consent.isRetentionAllowed(any())).thenReturn(true);
+        submitted = new ArrayList<>();
+        runner = new ShadowGenerationRunner(catalogAllowing(SHADOW_MODEL), redis, meters,
+                llm, preFilter, consent, submitted::add);
+    }
+
+    @Test
+    @DisplayName("설정이 없으면 아무것도 하지 않는다 — 제출도 호출도 없다")
+    void noConfigMeansNoShadow() {
+        when(values.get(anyString())).thenReturn(null);
+
+        runner.maybeShadow(primaryRequest());
+
+        assertThat(submitted).isEmpty();
+        assertThat(llm.lastRequest.get()).isNull();
+    }
+
+    @Test
+    @DisplayName("샘플된 턴은 그림자 모델·SHADOW_GENERATION 귀속으로 복제 호출된다")
+    void sampledTurnRunsShadowWithShadowModelAndComponent() {
+        when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 100");
+        LlmRequest primary = primaryRequest();
+
+        runner.maybeShadow(primary);
+        assertThat(llm.lastRequest.get())
+                .as("제출 시점에는 아직 호출이 없어야 한다 — 호출은 비동기 태스크의 몫이다")
+                .isNull();
+        submitted.forEach(Runnable::run);
+
+        LlmRequest shadow = llm.lastRequest.get();
+        assertThat(shadow.model()).isEqualTo(SHADOW_MODEL);
+        assertThat(shadow.component()).isEqualTo("SHADOW_GENERATION");
+        assertThat(shadow.messages()).isEqualTo(primary.messages());
+        assertThat(shadow.maxCompletionTokens()).isEqualTo(primary.maxCompletionTokens());
+        assertThat(meters.counter("mio.model.shadow", "outcome", "prefilter_passed").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("동의 철회 사용자는 그림자 대상이 아니다 — 조회는 비동기에서, 실패는 제외로")
+    void consentWithdrawnUsersAreExcluded() {
+        when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 100");
+        when(consent.isRetentionAllowed(any())).thenReturn(false);
+
+        runner.maybeShadow(primaryRequest());
+        submitted.forEach(Runnable::run);
+
+        assertThat(llm.lastRequest.get())
+                .as("추가 전송은 필수 아님 — 동의 없이 나가면 P0-6 게이트를 우회한다")
+                .isNull();
+        assertThat(meters.counter("mio.model.shadow", "outcome", "consent_excluded").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("percent 0 · allowlist 밖 · 단가 미등록 · 깨진 설정은 전부 무시된다")
+    void invalidOrDisabledConfigIsIgnored() {
+        for (String config : new String[]{SHADOW_MODEL + " 0", "model-nobody-approved 100",
+                "allowed-but-unpriced 100", SHADOW_MODEL + " abc", SHADOW_MODEL + " 101"}) {
+            when(values.get(anyString())).thenReturn(config);
+            runner.maybeShadow(primaryRequest());
+        }
+
+        assertThat(submitted).isEmpty();
+        assertThat(llm.lastRequest.get()).isNull();
+        assertThat(meters.counter("mio.model.shadow", "outcome", "invalid_config").count())
+                .as("percent 0 은 꺼짐이지 오류가 아니다 — 나머지 4건만 invalid")
+                .isEqualTo(4.0);
+    }
+
+    @Test
+    @DisplayName("Redis 장애·제출 거부·그림자 호출 실패는 삼켜지고 계측만 남는다")
+    void failuresAreSwallowedAndCounted() {
+        when(values.get(anyString())).thenThrow(new RuntimeException("connection refused"));
+        runner.maybeShadow(primaryRequest());
+        assertThat(meters.counter("mio.model.shadow", "outcome", "error").count()).isEqualTo(1.0);
+
+        // 제출 거부 (executor 포화)
+        ShadowGenerationRunner rejecting = new ShadowGenerationRunner(
+                catalogAllowing(SHADOW_MODEL), redisReturning(SHADOW_MODEL + " 100"), meters,
+                llm, preFilter, consent,
+                task -> { throw new java.util.concurrent.RejectedExecutionException("full"); });
+        rejecting.maybeShadow(primaryRequest());
+        assertThat(meters.counter("mio.model.shadow", "outcome", "rejected").count()).isEqualTo(1.0);
+
+        // 그림자 호출 자체가 실패
+        RecordingLlmClient failing = new RecordingLlmClient(null);
+        ShadowGenerationRunner failingRunner = new ShadowGenerationRunner(
+                catalogAllowing(SHADOW_MODEL), redisReturning(SHADOW_MODEL + " 100"), meters,
+                failing, preFilter, consent, submitted::add);
+        failingRunner.maybeShadow(primaryRequest());
+        submitted.forEach(Runnable::run);
+        assertThat(meters.counter("mio.model.shadow", "outcome", "shadow_failed").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("사전 필터에 걸린 그림자 응답은 prefilter_failed 로 남는다 — 이것이 shadow 의 존재 이유다")
+    void prefilterViolationIsTheSignalWeAreAfter() {
+        when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 100");
+        when(preFilter.check(anyString()))
+                .thenReturn(OutputPreFilterResult.fail(List.of("role_deviation")));
+
+        runner.maybeShadow(primaryRequest());
+        submitted.forEach(Runnable::run);
+
+        assertThat(meters.counter("mio.model.shadow", "outcome", "prefilter_failed").count())
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("같은 사용자는 canary 와 같은 버킷 규칙으로 샘플된다 — 팔이 턴마다 튀지 않는다")
+    void samplingIsStablePerUser() {
+        when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 37");
+
+        for (int i = 0; i < 30; i++) {
+            UUID userId = UUID.randomUUID();
+            int before = submitted.size();
+            runner.maybeShadow(requestFor(userId));
+            boolean sampledFirst = submitted.size() > before;
+            for (int j = 0; j < 3; j++) {
+                int prev = submitted.size();
+                runner.maybeShadow(requestFor(userId));
+                assertThat(submitted.size() > prev).isEqualTo(sampledFirst);
+            }
+        }
+    }
+
+    // ── 픽스처 ─────────────────────────────────────────────────────
+
+    private static LlmRequest primaryRequest() {
+        return requestFor(UUID.randomUUID());
+    }
+
+    private static LlmRequest requestFor(UUID userId) {
+        return LlmRequest.of("gpt-4o", "시스템 프롬프트", "사용자 발화")
+                .withMaxCompletionTokens(400)
+                .withAttribution("MAIN_GENERATION", userId, UUID.randomUUID());
+    }
+
+    @SuppressWarnings("unchecked")
+    private StringRedisTemplate redisReturning(String value) {
+        StringRedisTemplate template = mock(StringRedisTemplate.class);
+        ValueOperations<String, String> ops = mock(ValueOperations.class);
+        when(template.opsForValue()).thenReturn(ops);
+        when(ops.get(anyString())).thenReturn(value);
+        return template;
+    }
+
+    private static ModelCatalog catalogAllowing(String shadowModel) {
+        ModelCatalogProperties props = new ModelCatalogProperties();
+        List<String> models = new ArrayList<>(java.util.Arrays.stream(ModelRole.values())
+                .map(ModelRole::defaultModel).distinct().toList());
+        models.add(shadowModel);
+        models.add("allowed-but-unpriced");
+        props.setAllowed(models);
+        LlmPricingProperties pricing = new LlmPricingProperties();
+        java.util.Map<String, LlmPricingProperties.ModelPrice> table = new java.util.LinkedHashMap<>();
+        for (String model : models) {
+            if (!"allowed-but-unpriced".equals(model)) {
+                table.put(model, new LlmPricingProperties.ModelPrice(
+                        java.math.BigDecimal.ONE, null, java.math.BigDecimal.ONE));
+            }
+        }
+        pricing.setModels(table);
+        return new ModelCatalog(props, pricing);
+    }
+
+    /** 요청을 붙잡는 가짜 클라이언트. 본문이 null 이면 호출이 실패한다. */
+    private static final class RecordingLlmClient implements LlmClient {
+        final AtomicReference<LlmRequest> lastRequest = new AtomicReference<>();
+        private final String response;
+
+        RecordingLlmClient(String response) {
+            this.response = response;
+        }
+
+        @Override
+        public LlmStreamResult stream(LlmRequest request, Consumer<String> chunkHandler) {
+            throw new UnsupportedOperationException("shadow 는 completeText 만 쓴다");
+        }
+
+        @Override
+        public String completeText(LlmRequest request) {
+            lastRequest.set(request);
+            if (response == null) {
+                throw new IllegalStateException("LLM complete error");
+            }
+            return response;
+        }
+
+        @Override
+        public String completeJson(LlmRequest request) {
+            throw new UnsupportedOperationException("shadow 는 completeText 만 쓴다");
+        }
+    }
+}

--- a/src/test/java/com/mio/ai/orchestrator/ShadowGenerationRunnerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ShadowGenerationRunnerTest.java
@@ -159,6 +159,21 @@ class ShadowGenerationRunnerTest {
     }
 
     @Test
+    @DisplayName("본 응답이 이미 그 모델인 턴은 건너뛴다 — canary 와 겹치면 지출 2배·신호 0 이다")
+    void skipsWhenPrimaryAlreadyUsesTheShadowModel() {
+        when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 100");
+        LlmRequest canaryPrimary = new LlmRequest(SHADOW_MODEL,
+                primaryRequest().messages(), 400, "MAIN_GENERATION",
+                UUID.randomUUID(), UUID.randomUUID());
+
+        runner.maybeShadow(canaryPrimary);
+
+        assertThat(submitted).isEmpty();
+        assertThat(meters.counter("mio.model.shadow", "outcome", "skipped_duplicate_of_primary")
+                .count()).isEqualTo(1.0);
+    }
+
+    @Test
     @DisplayName("사전 필터에 걸린 그림자 응답은 prefilter_failed 로 남는다 — 이것이 shadow 의 존재 이유다")
     void prefilterViolationIsTheSignalWeAreAfter() {
         when(values.get(anyString())).thenReturn(SHADOW_MODEL + " 100");

--- a/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
+++ b/src/test/java/com/mio/ai/qa/CellModelRegistryTest.java
@@ -102,6 +102,7 @@ class CellModelRegistryTest {
         assertThat(sourceOf(root,
                 "src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java"))
                 .contains("generationCanaryRouter.modelFor(userId)")
+                .contains("shadowGenerationRunner.maybeShadow(llmRequest)")
                 .doesNotContain("\"gpt-4o\"");
         assertThat(sourceOf(root,
                 "src/main/java/com/mio/ai/llm/GenerationCanaryRouter.java"))


### PR DESCRIPTION
## 요약
P0-8 잔여 게이트 **shadow 트래픽 회귀 확인**의 실행 지점입니다. 샘플된 실 사용자 턴의 생성 요청을 후보 모델에 비동기 복제 호출하고, 결과는 **절대 전달하지 않고** 파생 판정만 계측합니다. `#484` canary 와 마찬가지로 dormant 로 머지됩니다 (Redis 키 없으면 아무 일도 없음).

## 관련 이슈
- #481 (실행기 구현 — 본문 저장·하위그룹 회귀 리포트는 프라이버시 검토(§10.4) 후 후속, 이슈에 기록)

## 변경 사항
- `ShadowGenerationRunner` — Redis 키 `mio:ai:shadow:generation`(`"<모델> <percent>"`)로 샘플링. 호출 스레드의 일은 Redis GET + 태스크 제출뿐, **LLM 호출·동의 조회는 전부 비동기 태스크 안** — 본 응답 지연 영향 0
- **기록은 파생 판정만**: `mio.model.shadow` 카운터(prefilter_passed/failed 가 핵심 신호, invalid_config/error/rejected/consent_excluded/shadow_failed), 토큰·지연·비용은 `SHADOW_GENERATION` 귀속으로 기존 `mio_llm_*`·비용 이벤트에 자동 탑재. **그림자 본문은 저장하지 않음** (본문 저장은 프라이버시 검토 후 후속)
- **동의 게이트**: `MemoryConsentChecker`(P0-6) 재사용 — 철회 사용자 제외, 조회 실패는 철회 취급(fail-closed). 추가 전송은 필수가 아니므로 동의 없이 나가면 안 됨
- **fail-safe**: allowlist 밖·단가 미등록 후보 무시, Redis 장애·executor 포화·그림자 호출 실패 전부 삼켜지고 계측만 남음
- `ModelTrafficSplit` 추출 — canary(#484)와 버킷·파싱 규칙 공유 ("canary 5% 와 shadow 5% 가 같은 사용자인가"에 답할 수 있어야 함)
- 전용 소형 executor(core 1 / max 2 / queue 10) — 포화 시 버림, shadow 가 본 트래픽과 리소스를 다투지 않음

## 영향 범위
- [x] **안전 판정 경로**가 바뀝니다. → 오케스트레이터 GENERATE 분기에 `maybeShadow(llmRequest)` 제출 1줄 추가. 판정·프롬프트·상한·전달 무변경. 키 없으면(기본) Redis GET 1회 외 동작 동일
- [x] 로깅 / 모니터링 → `mio.model.shadow` 카운터 신설 (outcome 태그 7값 고정 — 저카디널리티)

> **Crisis Eval (full path) 실행 결과: 성공** — run [32048047826](https://github.com/Yarr-mio/mio_server/actions/runs/32048047826), 브랜치 `feat/#481-shadow-runner` 기준

## 테스트
### 실행 커맨드
```bash
./gradlew cleanTest test   # 1,602건 중 실패 2건 = 이슈 #486 의 로컬 docs 위생(본 PR 무관, CI 에는 없음)
```

### 확인 내용
- `ShadowGenerationRunnerTest` 7건: 설정 없음=무동작, 샘플 턴의 모델·귀속·메시지 복제 검증(제출 시점 미호출 → 태스크 실행 시 호출), 동의 철회 제외, 무효 설정 4종 무시(percent 0 은 꺼짐이지 오류 아님), Redis 장애/제출 거부/호출 실패 삼킴+계측, prefilter 위반 신호, 사용자 단위 샘플 안정성
- canary 라우터가 공유 `ModelTrafficSplit` 으로 리팩터링된 뒤에도 기존 10건 전부 통과
- 소스 체인 단언에 shadow 훅 추가

## 중점 리뷰 포인트
- 핫패스 영향 0 주장: maybeShadow 가 던질 수 있는 경로가 정말 없는지
- 동의 게이트로 MemoryConsentChecker(메모리 동의)를 재사용한 것이 적절한 보수적 프록시인지
- ai.orchestrator 배치(ai.llm → ai.judge 역방향 의존 회피)

## 배포 / 롤백
- Rollout: dormant 배포. 시작은 후보 allowlist 등재 PR + 프라이버시 검토 후 `SET mio:ai:shadow:generation "gpt-4.1-nano 5"`
- Rollback: `DEL mio:ai:shadow:generation` — 다음 턴부터 즉시 중단

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
