### PR TITLE
fix: 임베딩 대기 타임아웃을 일반 실패와 분리하고 왕복 시간을 계측한다

### DIFF
--- a/ops/observability/prometheus/alerts.yml
+++ b/ops/observability/prometheus/alerts.yml
@@ -67,14 +67,28 @@ groups:
           summary: "위기 이벤트 영속화 실패"
           description: "위기 안내 이후 기록 재시도가 소진됐습니다. safety latch와 DB 상태를 확인하십시오."
 
+      # outcome 에 timeout 이 분리되면서(이슈 #495) 이 룰이 그 몫을 놓치지 않도록 정규식으로 받는다.
+      # 파이프라인 관점에서는 타임아웃도 "기억을 못 쓴 턴" 이므로 총 실패율에 포함돼야 한다.
       - alert: MioRetrievalFailureRatioHigh
-        expr: sum(increase(mio_retrieval_outcome_total{outcome="failed"}[10m])) / clamp_min(sum(increase(mio_retrieval_outcome_total[10m])), 1) > 0.10 and sum(increase(mio_retrieval_outcome_total[10m])) >= 20
+        expr: sum(increase(mio_retrieval_outcome_total{outcome=~"failed|timeout"}[10m])) / clamp_min(sum(increase(mio_retrieval_outcome_total[10m])), 1) > 0.10 and sum(increase(mio_retrieval_outcome_total[10m])) >= 20
         for: 10m
         labels:
           severity: warning
         annotations:
           summary: "기억 retrieval 실패율이 10% 초과"
-          description: "최근 10분간 20회 이상 retrieval에서 실패율이 10%를 넘었습니다. source별 실패를 확인하십시오."
+          description: "최근 10분간 20회 이상 retrieval에서 실패율이 10%를 넘었습니다. source별·outcome별 분포를 확인하십시오. outcome=timeout 이 지배적이면 장애가 아니라 대기 상한 문제입니다 — MioEmbeddingWaitTimeoutRatioHigh 를 함께 보십시오."
+
+      # 상한 초과는 장애가 아니라 튜닝 신호라 별도로 본다 (이슈 #495).
+      # 프로덕션에서 이 경로가 시도 57턴 중 54턴 실패로 관측됐는데, 지표가 일반 실패와
+      # 합쳐져 있어 원인을 구별할 수 없었다.
+      - alert: MioEmbeddingWaitTimeoutRatioHigh
+        expr: sum(increase(mio_retrieval_outcome_total{source="VECTOR_EPISODE",outcome="timeout"}[15m])) / clamp_min(sum(increase(mio_retrieval_outcome_total{source="VECTOR_EPISODE"}[15m])), 1) > 0.20 and sum(increase(mio_retrieval_outcome_total{source="VECTOR_EPISODE"}[15m])) >= 20
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: "임베딩 대기 상한 초과율이 20% 초과 — 벡터 검색이 버려지고 있다"
+          description: "턴 크리티컬 패스의 임베딩 대기 상한을 넘겨 벡터 검색 없이 응답하고 있습니다. 회상 품질이 조용히 떨어지는 경로입니다. 상한을 얼마로 올려야 하는지는 실제 왕복 분포로 판단하십시오 — histogram_quantile(0.95, sum(rate(mio_retrieval_embedding_wait_seconds_bucket[30m])) by (le))."
 
       - alert: MioContractViolationRatioHigh
         expr: sum(increase(mio_ai_contract_results_total{result="violated"}[15m])) / clamp_min(sum(increase(mio_ai_contract_results_total[15m])), 1) > 0.20 and sum(increase(mio_ai_contract_results_total[15m])) >= 20

--- a/ops/observability/prometheus/alerts.yml
+++ b/ops/observability/prometheus/alerts.yml
@@ -88,7 +88,7 @@ groups:
           severity: warning
         annotations:
           summary: "임베딩 대기 상한 초과율이 20% 초과 — 벡터 검색이 버려지고 있다"
-          description: "턴 크리티컬 패스의 임베딩 대기 상한을 넘겨 벡터 검색 없이 응답하고 있습니다. 회상 품질이 조용히 떨어지는 경로입니다. 상한을 얼마로 올려야 하는지는 실제 왕복 분포로 판단하십시오 — histogram_quantile(0.95, sum(rate(mio_retrieval_embedding_wait_seconds_bucket[30m])) by (le))."
+          description: "턴 크리티컬 패스의 임베딩 대기 상한을 넘겨 벡터 검색 없이 응답하고 있습니다. 회상 품질이 조용히 떨어지는 경로입니다. 상한을 얼마로 올려야 하는지는 실제 왕복 분포로 판단하십시오 — histogram_quantile(0.95, sum(rate(mio_retrieval_embedding_wait_seconds_bucket{outcome='success'}[30m])) by (le))."
 
       - alert: MioContractViolationRatioHigh
         expr: sum(increase(mio_ai_contract_results_total{result="violated"}[15m])) / clamp_min(sum(increase(mio_ai_contract_results_total[15m])), 1) > 0.20 and sum(increase(mio_ai_contract_results_total[15m])) >= 20

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -18,6 +18,7 @@ import com.mio.ai.safety.CombinedSignal;
 import com.mio.session.repository.SessionCheckpointRepository;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -106,6 +107,10 @@ public class ContextPreWarmer {
     private final MeterRegistry meterRegistry;
 
     private final Executor retrievalPool = Executors.newVirtualThreadPerTaskExecutor();
+
+    /** {@link #initEmbeddingWaitTimers} 에서 기동 시 1회만 만든다 (이슈 #495). */
+    private Timer embeddingWaitSuccessTimer;
+    private Timer embeddingWaitFailureTimer;
 
     @Async
     public void preWarm(UUID sessionId, UUID userId) {
@@ -228,7 +233,7 @@ public class ContextPreWarmer {
             return new HistoryProbe(count != null && count > 0, false);
         } catch (Exception e) {
             log.warn("ContextPreWarmer: history probe failed for userId={}; assuming history exists", userId, e);
-            meterRegistry.counter(RETRIEVAL_METRIC, "source", HISTORY_PROBE, "outcome", "failed").increment();
+            meterRegistry.counter(RETRIEVAL_METRIC, "source", HISTORY_PROBE, "outcome", OUTCOME_FAILED).increment();
             return new HistoryProbe(true, true);
         }
     }
@@ -261,6 +266,9 @@ public class ContextPreWarmer {
      *
      * <p>이전에는 조용히 {@code null} 을 반환해 벡터 검색을 건너뛰었다. 그러면 임베딩
      * 타임아웃이 잦아져도 "벡터 검색 결과가 원래 없다" 와 구별되지 않는다.
+     *
+     * <p>단, <b>대기 상한 초과는 {@link #OUTCOME_TIMEOUT} 으로 따로 센다</b> (이슈 #495).
+     * 외부 장애와 상한 부족은 대응이 다른데, 한 값으로 묶여 있으면 지표로 구별할 수 없다.
      */
     private float[] embedIfNeeded(RetrievalPlan plan, String queryText, UUID userId, UUID sessionId,
                                   Set<RetrievalSource> failedSources) {
@@ -300,30 +308,63 @@ public class ContextPreWarmer {
      *
      * <p>계측을 호출자 쪽이 아니라 <b>비동기 작업 안에</b> 두는 것이 핵심이다. 호출자는 상한을
      * 넘기면 결과를 버리는데, 버려진 호출이야말로 "얼마나 오래 걸렸는가" 를 알려주는 표본이다.
+     *
+     * <p>성공·실패를 태그로 나눈다. 상한을 정하는 근거는 <b>성공한 호출</b>의 분포이고,
+     * 빠르게 떨어지는 4xx 같은 실패가 섞이면 그 p95 가 실제보다 낮게 나온다.
      */
     private float[] embedTimed(String queryText, UUID userId, UUID sessionId) {
         long startedAt = System.nanoTime();
+        boolean succeeded = false;
         try {
-            return embeddingClient.embed(queryText, "RETRIEVAL_QUERY_EMBEDDING", userId, sessionId);
+            float[] embedding = embeddingClient.embed(queryText, "RETRIEVAL_QUERY_EMBEDDING", userId, sessionId);
+            succeeded = true;
+            return embedding;
         } finally {
-            Timer.builder(EMBEDDING_WAIT_METRIC)
-                    .description("검색용 임베딩 왕복 시간. 호출자의 대기 포기 여부와 무관하게 기록한다.")
-                    .publishPercentileHistogram()
-                    .minimumExpectedValue(Duration.ofMillis(10))
-                    .maximumExpectedValue(Duration.ofSeconds(10))
-                    // 상한 후보 구간(250ms ~ 1s)을 촘촘히 둔다 — 이 버킷들이 재설정의 근거다.
-                    .serviceLevelObjectives(
-                            Duration.ofMillis(100),
-                            Duration.ofMillis(250),
-                            Duration.ofMillis(400),
-                            Duration.ofMillis(600),
-                            Duration.ofMillis(800),
-                            Duration.ofSeconds(1),
-                            Duration.ofSeconds(2),
-                            Duration.ofSeconds(5))
-                    .register(meterRegistry)
-                    .record(System.nanoTime() - startedAt, TimeUnit.NANOSECONDS);
+            recordEmbeddingWait(succeeded, System.nanoTime() - startedAt);
         }
+    }
+
+    /**
+     * 왕복 시간 기록. <b>실패해도 호출 결과를 덮지 않는다.</b>
+     *
+     * <p>{@code finally} 안에서 예외가 나가면 자바 의미론상 그 예외가 원래 반환값 또는 원래
+     * 예외를 통째로 대체한다. 그러면 <b>성공한 임베딩이 실패로 오분류되어 버려지고</b>,
+     * 실패 경로에서는 진짜 원인이 관측 예외로 덮인다 — 이 클래스가 없애려는 문제를
+     * 관측 코드가 다시 만드는 셈이다. 그래서 여기서 끊는다.
+     */
+    private void recordEmbeddingWait(boolean succeeded, long elapsedNanos) {
+        try {
+            Timer timer = succeeded ? embeddingWaitSuccessTimer : embeddingWaitFailureTimer;
+            timer.record(elapsedNanos, TimeUnit.NANOSECONDS);
+        } catch (RuntimeException e) {
+            log.warn("ContextPreWarmer: failed to record embedding wait metric", e);
+        }
+    }
+
+    /**
+     * 왕복 시간 타이머를 기동 시 한 번만 만든다.
+     *
+     * <p>{@code Timer.builder(...).register(...)} 는 같은 이름·태그면 기존 미터를 돌려주지만
+     * 그 확인을 위해 레지스트리 락을 잡는다. 턴 크리티컬 패스에서 매번 부르면 동시 턴이
+     * 전부 공유하는 동기화 지점이 된다 — 캐리어 스레드가 2개(2 vCPU)인 환경에서는 특히 아깝다.
+     */
+    @PostConstruct
+    void initEmbeddingWaitTimers() {
+        embeddingWaitSuccessTimer = embeddingWaitTimer("success");
+        embeddingWaitFailureTimer = embeddingWaitTimer("failure");
+    }
+
+    private Timer embeddingWaitTimer(String outcome) {
+        return Timer.builder(EMBEDDING_WAIT_METRIC)
+                .description("검색용 임베딩 왕복 시간. 호출자의 대기 포기 여부와 무관하게 기록한다.")
+                .tag("outcome", outcome)
+                .publishPercentileHistogram()
+                .minimumExpectedValue(Duration.ofMillis(10))
+                .maximumExpectedValue(Duration.ofSeconds(10))
+                // 자동 백분위 버킷이 이미 10~20% 간격으로 깔리므로 SLO 는 현재 상한 하나만 둔다.
+                // 나머지 라운드 숫자는 자동 버킷과 겹쳐 시계열만 늘리고 해상도 이득이 없다.
+                .serviceLevelObjectives(Duration.ofMillis(MAX_EMBEDDING_WAIT_MS))
+                .register(meterRegistry);
     }
 
     private void markFailed(Set<RetrievalSource> failedSources, RetrievalSource source) {

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -17,6 +17,7 @@ import com.mio.ai.memory.working.WorkingMemory;
 import com.mio.ai.safety.CombinedSignal;
 import com.mio.session.repository.SessionCheckpointRepository;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -34,6 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 /**
  * POST /v1/sessions 직후 비동기 context + safety profile 사전 빌드 (§12.4.1).
@@ -56,6 +58,28 @@ public class ContextPreWarmer {
      * 소스별로 나누는 이유는 pgvector 장애와 일반 SQL 장애가 다른 대응을 요구하기 때문이다.
      */
     private static final String RETRIEVAL_METRIC = "mio.retrieval.outcome";
+
+    /** 일반 실패. 외부 장애·쿼리 오류 등 "고쳐야 하는" 실패다. */
+    private static final String OUTCOME_FAILED = "failed";
+
+    /**
+     * 대기 상한 초과 (이슈 #495).
+     *
+     * <p>{@link #OUTCOME_FAILED} 와 나누는 이유는 <b>대응이 다르기 때문</b>이다. 일반 실패는
+     * 외부 장애를 의심해야 하지만, 타임아웃은 상한이 실제 왕복 시간보다 짧다는 <b>튜닝 신호</b>다.
+     * 한 값으로 묶여 있으면 지표만 보고 둘을 구별할 수 없다 — 프로덕션에서 이 경로가
+     * 시도 57턴 중 54턴 실패로 관측됐는데, 그것이 장애인지 설정 문제인지 알 수 없었다.
+     */
+    private static final String OUTCOME_TIMEOUT = "timeout";
+
+    /**
+     * 임베딩 왕복 시간 (이슈 #495).
+     *
+     * <p><b>호출자가 대기를 포기했는지와 무관하게</b> 실제 완료 시점에 기록한다.
+     * 이 값이 없으면 {@link #MAX_EMBEDDING_WAIT_MS} 를 얼마로 올려야 하는지 판단할 근거가 없다 —
+     * 타임아웃 카운터만으로는 "250ms 를 넘었다" 는 사실만 알 뿐 260ms 인지 3초인지 모른다.
+     */
+    private static final String EMBEDDING_WAIT_METRIC = "mio.retrieval.embedding.wait";
 
     /**
      * 이력 확인 쿼리의 메트릭 라벨.
@@ -245,10 +269,20 @@ public class ContextPreWarmer {
             return null;
         }
         CompletableFuture<float[]> embeddingFuture = CompletableFuture.supplyAsync(
-                () -> embeddingClient.embed(queryText, "RETRIEVAL_QUERY_EMBEDDING", userId, sessionId), retrievalPool);
+                () -> embedTimed(queryText, userId, sessionId), retrievalPool);
+        long timeoutMs = Math.min(plan.budgetMs(), MAX_EMBEDDING_WAIT_MS);
         try {
-            long timeoutMs = Math.min(plan.budgetMs(), MAX_EMBEDDING_WAIT_MS);
             return embeddingFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
+        } catch (TimeoutException e) {
+            // 상한 초과는 장애가 아니라 튜닝 신호다. 아래 cancel 은 이미 시작된 작업을 멈추지
+            // 못하므로(CompletableFuture.cancel 은 실행 중인 스레드를 인터럽트하지 않는다),
+            // embedTimed 의 타이머는 그대로 완료 시점에 기록된다 — 상한을 얼마로 올려야 하는지는
+            // 그 값으로만 알 수 있다.
+            embeddingFuture.cancel(true);
+            log.warn("ContextPreWarmer: embedding wait exceeded {}ms; continuing without vector retrieval",
+                    timeoutMs);
+            markRetrievalOutcome(failedSources, RetrievalSource.VECTOR_EPISODE, OUTCOME_TIMEOUT);
+            return null;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             embeddingFuture.cancel(true);
@@ -261,9 +295,44 @@ public class ContextPreWarmer {
         return null;
     }
 
+    /**
+     * 임베딩을 부르고 왕복 시간을 남긴다.
+     *
+     * <p>계측을 호출자 쪽이 아니라 <b>비동기 작업 안에</b> 두는 것이 핵심이다. 호출자는 상한을
+     * 넘기면 결과를 버리는데, 버려진 호출이야말로 "얼마나 오래 걸렸는가" 를 알려주는 표본이다.
+     */
+    private float[] embedTimed(String queryText, UUID userId, UUID sessionId) {
+        long startedAt = System.nanoTime();
+        try {
+            return embeddingClient.embed(queryText, "RETRIEVAL_QUERY_EMBEDDING", userId, sessionId);
+        } finally {
+            Timer.builder(EMBEDDING_WAIT_METRIC)
+                    .description("검색용 임베딩 왕복 시간. 호출자의 대기 포기 여부와 무관하게 기록한다.")
+                    .publishPercentileHistogram()
+                    .minimumExpectedValue(Duration.ofMillis(10))
+                    .maximumExpectedValue(Duration.ofSeconds(10))
+                    // 상한 후보 구간(250ms ~ 1s)을 촘촘히 둔다 — 이 버킷들이 재설정의 근거다.
+                    .serviceLevelObjectives(
+                            Duration.ofMillis(100),
+                            Duration.ofMillis(250),
+                            Duration.ofMillis(400),
+                            Duration.ofMillis(600),
+                            Duration.ofMillis(800),
+                            Duration.ofSeconds(1),
+                            Duration.ofSeconds(2),
+                            Duration.ofSeconds(5))
+                    .register(meterRegistry)
+                    .record(System.nanoTime() - startedAt, TimeUnit.NANOSECONDS);
+        }
+    }
+
     private void markFailed(Set<RetrievalSource> failedSources, RetrievalSource source) {
+        markRetrievalOutcome(failedSources, source, OUTCOME_FAILED);
+    }
+
+    private void markRetrievalOutcome(Set<RetrievalSource> failedSources, RetrievalSource source, String outcome) {
         failedSources.add(source);
-        meterRegistry.counter(RETRIEVAL_METRIC, "source", source.name(), "outcome", "failed").increment();
+        meterRegistry.counter(RETRIEVAL_METRIC, "source", source.name(), "outcome", outcome).increment();
     }
 
     /**

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -17,13 +17,18 @@ import com.mio.ai.safety.CombinedSignal;
 import com.mio.ai.memory.retrieval.MemoryContextResult;
 import com.mio.ai.memory.retrieval.MemoryContextStatus;
 import com.mio.session.repository.SessionCheckpointRepository;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.jdbc.core.JdbcTemplate;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.Set;
@@ -33,6 +38,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -66,6 +73,8 @@ class ContextPreWarmerTest {
         preWarmer = new ContextPreWarmer(structuredRetriever, vectorRetriever, lexicalRetriever, embeddingClient,
                 fusionRanker, contextComposer, planner, safetyProfileBuilder, checkpointRepository,
                 redisTemplate, jdbcTemplate, workingMemory, ontologyRelationExpander, meterRegistry);
+        // Spring 컨텍스트 없이 생성하므로 @PostConstruct 가 돌지 않는다.
+        preWarmer.initEmbeddingWaitTimers();
         sessionId = UUID.randomUUID();
         userId = UUID.randomUUID();
         combined = mock(CombinedSignal.class);
@@ -174,10 +183,40 @@ class ContextPreWarmerTest {
         // 호출자는 250ms 에 포기했지만 임베딩 자체는 계속 돌아 완료된다.
         // 그 표본이야말로 "상한을 얼마로 올려야 하는가" 의 유일한 근거다 —
         // 여기서 기록이 없으면 타임아웃 카운터만 남아 260ms 인지 3초인지 알 수 없다.
-        awaitEmbeddingWaitSamples(1);
-        assertThat(embeddingWaitTimer().totalTime(TimeUnit.MILLISECONDS))
+        // 성공·실패를 태그로 나눈다 — 상한을 정하는 근거는 성공한 호출의 분포다.
+        awaitEmbeddingWaitSamples("success", 1L);
+        assertThat(embeddingWaitTimer("success").totalTime(TimeUnit.MILLISECONDS))
                 .as("버려진 호출의 실제 왕복 시간이 상한보다 크게 기록돼야 한다")
                 .isGreaterThan(500);
+    }
+
+    @Test
+    void 계측이_실패해도_임베딩_결과를_덮지_않는다() {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        float[] embedding = {0.1f, 0.2f};
+        RetrievedItem episode = new RetrievedItem("episode-9", RetrievalSource.VECTOR_EPISODE,
+                "계측 실패", "normal", 0.9, 1);
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed(eq("계측 실패"), any(), any(), any())).thenReturn(embedding);
+        when(vectorRetriever.retrieveEpisodes(userId, embedding, 3)).thenReturn(List.of(episode));
+        when(lexicalRetriever.retrieveByKeywords(userId, "계측 실패", 3)).thenReturn(List.of());
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("live memory");
+
+        Timer broken = mock(Timer.class);
+        doThrow(new IllegalStateException("metrics down")).when(broken).record(anyLong(), any());
+        ReflectionTestUtils.setField(preWarmer, "embeddingWaitSuccessTimer", broken);
+
+        MemoryContextResult context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "계측 실패");
+
+        // finally 안에서 예외가 새어 나가면 자바 의미론상 그 예외가 반환값을 대체한다.
+        // 그러면 성공한 임베딩이 outcome=failed 로 오분류돼 버려진다 —
+        // 이 클래스가 없애려는 문제를 관측 코드가 다시 만드는 셈이다.
+        assertThat(context.text()).isEqualTo("live memory");
+        verify(vectorRetriever).retrieveEpisodes(userId, embedding, 3);
+        assertThat(retrievalOutcomeCount("failed")).isZero();
+        assertThat(retrievalOutcomeCount("timeout")).isZero();
     }
 
     /** 상한(250ms)을 넘겨 완료되는 임베딩. 호출자는 포기하고 어휘 검색으로 계속한다. */
@@ -195,33 +234,27 @@ class ContextPreWarmerTest {
     }
 
     private double retrievalOutcomeCount(String outcome) {
-        io.micrometer.core.instrument.Counter counter = meterRegistry.find("mio.retrieval.outcome")
+        Counter counter = meterRegistry.find("mio.retrieval.outcome")
                 .tag("source", RetrievalSource.VECTOR_EPISODE.name())
                 .tag("outcome", outcome)
                 .counter();
         return counter == null ? 0d : counter.count();
     }
 
-    private io.micrometer.core.instrument.Timer embeddingWaitTimer() {
-        return meterRegistry.find("mio.retrieval.embedding.wait").timer();
+    private Timer embeddingWaitTimer(String outcome) {
+        return meterRegistry.find("mio.retrieval.embedding.wait").tag("outcome", outcome).timer();
     }
 
     /** 임베딩은 호출자가 포기한 뒤에 끝나므로, 표본이 들어올 때까지 짧게 기다린다. */
-    private void awaitEmbeddingWaitSamples(long expected) {
-        long deadline = System.nanoTime() + java.time.Duration.ofSeconds(5).toNanos();
-        while (System.nanoTime() < deadline) {
-            io.micrometer.core.instrument.Timer timer = embeddingWaitTimer();
-            if (timer != null && timer.count() >= expected) {
-                return;
-            }
-            try {
-                Thread.sleep(25);
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                break;
-            }
-        }
-        throw new AssertionError("임베딩 왕복 시간 표본이 기록되지 않았다 — 버려진 호출의 계측이 유실됐다");
+    private void awaitEmbeddingWaitSamples(String outcome, long expected) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(5))
+                .pollInterval(Duration.ofMillis(25))
+                .untilAsserted(() -> assertThat(embeddingWaitTimer(outcome))
+                        .as("버려진 호출의 왕복 시간 표본이 기록돼야 한다")
+                        .isNotNull()
+                        .extracting(Timer::count)
+                        .isEqualTo(expected));
     }
 
     @Test

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -25,6 +25,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.Set;
 import java.util.UUID;
 
@@ -135,6 +136,92 @@ class ContextPreWarmerTest {
         assertThat(context.text()).isEqualTo("lexical memory");
         assertThat(elapsedMs).isLessThan(700);
         verify(lexicalRetriever).retrieveByKeywords(userId, "발표가 걱정돼", 3);
+    }
+
+    @Test
+    void 대기_상한_초과는_일반_실패와_다른_outcome_으로_계측된다() {
+        stubSlowEmbedding("상한 초과", 800);
+
+        preWarmer.buildContextSync(sessionId, userId, combined, profile, "상한 초과");
+
+        // 두 값이 합쳐져 있으면 지표만 보고 "외부 장애" 와 "상한이 짧다" 를 구별할 수 없다.
+        assertThat(retrievalOutcomeCount("timeout")).isEqualTo(1);
+        assertThat(retrievalOutcomeCount("failed")).isZero();
+    }
+
+    @Test
+    void 일반_실패는_여전히_failed_로_계측된다() {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed(eq("외부 장애"), any(), any(), any()))
+                .thenThrow(new RuntimeException("upstream down"));
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of());
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("memory");
+
+        preWarmer.buildContextSync(sessionId, userId, combined, profile, "외부 장애");
+
+        assertThat(retrievalOutcomeCount("failed")).isEqualTo(1);
+        assertThat(retrievalOutcomeCount("timeout")).isZero();
+    }
+
+    @Test
+    void 버려진_호출의_왕복_시간도_기록된다() {
+        stubSlowEmbedding("버려진 호출", 600);
+
+        preWarmer.buildContextSync(sessionId, userId, combined, profile, "버려진 호출");
+
+        // 호출자는 250ms 에 포기했지만 임베딩 자체는 계속 돌아 완료된다.
+        // 그 표본이야말로 "상한을 얼마로 올려야 하는가" 의 유일한 근거다 —
+        // 여기서 기록이 없으면 타임아웃 카운터만 남아 260ms 인지 3초인지 알 수 없다.
+        awaitEmbeddingWaitSamples(1);
+        assertThat(embeddingWaitTimer().totalTime(TimeUnit.MILLISECONDS))
+                .as("버려진 호출의 실제 왕복 시간이 상한보다 크게 기록돼야 한다")
+                .isGreaterThan(500);
+    }
+
+    /** 상한(250ms)을 넘겨 완료되는 임베딩. 호출자는 포기하고 어휘 검색으로 계속한다. */
+    private void stubSlowEmbedding(String queryText, long embedMillis) {
+        RetrievalPlan plan = new RetrievalPlan(
+                List.of(RetrievalSource.VECTOR_EPISODE, RetrievalSource.LEXICAL_EPISODE), 3, 200, "normal");
+        when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
+        when(embeddingClient.embed(eq(queryText), any(), any(), any())).thenAnswer(invocation -> {
+            Thread.sleep(embedMillis);
+            return new float[]{0.1f};
+        });
+        when(lexicalRetriever.retrieveByKeywords(userId, queryText, 3)).thenReturn(List.of());
+        when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of());
+        when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("memory");
+    }
+
+    private double retrievalOutcomeCount(String outcome) {
+        io.micrometer.core.instrument.Counter counter = meterRegistry.find("mio.retrieval.outcome")
+                .tag("source", RetrievalSource.VECTOR_EPISODE.name())
+                .tag("outcome", outcome)
+                .counter();
+        return counter == null ? 0d : counter.count();
+    }
+
+    private io.micrometer.core.instrument.Timer embeddingWaitTimer() {
+        return meterRegistry.find("mio.retrieval.embedding.wait").timer();
+    }
+
+    /** 임베딩은 호출자가 포기한 뒤에 끝나므로, 표본이 들어올 때까지 짧게 기다린다. */
+    private void awaitEmbeddingWaitSamples(long expected) {
+        long deadline = System.nanoTime() + java.time.Duration.ofSeconds(5).toNanos();
+        while (System.nanoTime() < deadline) {
+            io.micrometer.core.instrument.Timer timer = embeddingWaitTimer();
+            if (timer != null && timer.count() >= expected) {
+                return;
+            }
+            try {
+                Thread.sleep(25);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        throw new AssertionError("임베딩 왕복 시간 표본이 기록되지 않았다 — 버려진 호출의 계측이 유실됐다");
     }
 
     @Test


### PR DESCRIPTION
## 요약
턴 크리티컬 패스의 임베딩 대기 상한(250ms)이 `text-embedding-3-small` 의 실제 왕복보다 짧아 **벡터 검색이 거의 항상 버려진다** — 프로덕션 7일 관측에서 시도 57턴 중 **54턴(약 95%)** 이 타임아웃했다.

강등 자체는 우아하지만(#364 부분 실패 허용) 두 가지가 비어 있었다.

1. **타임아웃이 일반 실패와 한 덩어리** — 지표만 보고 "외부 장애" 와 "상한이 짧다" 를 구별할 수 없다
2. **왕복 시간이 어디에도 기록되지 않는다** — `cancel(true)` 로 future 를 버리므로 260ms 에 도착했든 3초에 도착했든 기록이 0이다. 상한을 얼마로 올려야 하는지 판단할 근거가 없다

**이 PR 은 계측만 다룬다.** 상한 값 조정은 여기서 확보한 실측 p95 를 근거로 별건에서 한다.

## 관련 이슈
- Closes #495

## 변경 사항
- `TimeoutException` 을 별도 catch 로 분리해 `outcome="timeout"` 으로 계측
- **`mio.retrieval.embedding.wait` 타이머 신규** — 계측을 호출자가 아니라 **비동기 작업 안에** 둔다. `CompletableFuture.cancel` 은 실행 중인 스레드를 인터럽트하지 않으므로, 호출자가 포기한 뒤에도 그 작업은 끝까지 돌아 왕복 시간을 남긴다. **버려진 호출이야말로 "얼마나 걸리는가" 를 알려주는 표본이다**
- SLO 버킷을 상한 후보 구간(250ms~1s)에 촘촘히 배치 — 이 버킷들이 재설정의 근거가 된다
- `markFailed` 를 `markRetrievalOutcome(…, outcome)` 으로 파라미터화
- `alerts.yml` — 아래 참조

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

> 안전 판정 경로는 건드리지 않아 Crisis Eval 은 해당 없음. 동작 변경도 없다 — 타임아웃 시 벡터 검색 없이 계속하는 것은 그대로이고, 그 사실이 지표에 남는 것만 달라진다.

### ⚠️ 알림 룰을 함께 고쳐야 했다

`MioRetrievalFailureRatioHigh` 가 `outcome="failed"` 를 **정확히** 매칭하고 있었다. 타임아웃을 분리하는 순간 **95% 를 차지하는 그 실패 모드에서 알림이 조용해진다.**

| 룰 | 변경 |
|---|---|
| `MioRetrievalFailureRatioHigh` | `outcome=~"failed\|timeout"` 으로 확장. 파이프라인 관점에서는 타임아웃도 "기억을 못 쓴 턴" 이라 총 실패율에 남아야 한다 |
| `MioEmbeddingWaitTimeoutRatioHigh` (신규) | 상한 초과율 20% 초과 시. 원인이 장애가 아니라 튜닝임을 구별해 준다. description 에 상한 재설정용 p95 쿼리를 넣어 뒀다 |

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.ai.profile.ContextPreWarmerTest"
```

### 확인 내용
- `대기_상한_초과는_일반_실패와_다른_outcome_으로_계측된다` — `timeout` 1건, `failed` 0건
- `일반_실패는_여전히_failed_로_계측된다` — 외부 장애는 그대로 `failed`. 분리가 기존 계측을 망가뜨리지 않는지 고정
- `버려진_호출의_왕복_시간도_기록된다` — 호출자가 250ms 에 포기해도 타이머에 표본이 남고, 기록된 시간이 상한보다 크다. **이 PR 의 핵심 단언이다**
- 기존 `limitsEmbeddingWaitAndContinuesWithLexicalRetrieval` 유지 — 턴이 정상 진행되는지
- 전체: **1,633건 중 2건 실패 — 둘 다 이 PR 과 무관한 기존 실패**(`LockedEvalContaminationGuardTest`, #486 로컬 상시 / #491)

## 중점 리뷰 포인트
1. **계측 위치** — `embedTimed` 를 `supplyAsync` 본문 안에 둔 것이 이 PR 의 전부다. 호출자 쪽에서 재면 타임아웃된 표본이 통째로 빠져 정작 필요한 데이터를 못 얻는다. `CompletableFuture.cancel(true)` 가 실행 중인 작업을 멈추지 않는다는 전제에 기대고 있으니 확인 바란다
2. **`Timer.builder(...)` 를 호출마다 부른다** — Micrometer 는 같은 이름·태그면 기존 미터를 돌려주므로 중복 등록은 아니다. 다만 턴마다 빌더를 도는 비용이 신경 쓰이면 필드로 승격 가능
3. **SLO 버킷 구간** — 250ms/400/600/800/1s 로 잡았다. 실측이 이 범위 밖이면 버킷을 다시 잡아야 한다
4. **알림 임계 20%** — 현재 프로덕션은 95% 라 즉시 발화한다. 그게 의도다(지금 실제로 깨져 있으므로). 배포 직후 알림이 울릴 것을 예상하고 머지해야 한다

## 배포 / 롤백
- **Rollout**: develop → dev 서버. 배포 후 `mio_retrieval_embedding_wait_seconds` 히스토그램이 쌓이는지 확인. 상한 재설정은 표본이 충분해진 뒤 별건
- **Rollback**: 코드 되돌림만으로 충분. 스키마·API 변경 없음. 단 `alerts.yml` 을 함께 되돌려야 `outcome=~` 정규식이 원복된다

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 알림 룰 변경을 위 표에 명시
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [ ] (hotfix 인 경우) 같은 수정을 develop 에도 반영했습니다 — 해당 없음 (develop 대상 PR)
