### PR TITLE
hotfix: AI 비용 원장·조회 API 파트만 선배포한다 (#431 #433 #434 #437 #438)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,10 @@ dependencies {
     implementation("me.paulschwarz:spring-dotenv:4.0.0")
     // Firebase Admin SDK — Android FCM push
     implementation("com.google.firebase:firebase-admin:9.4.1")
+    // AWS CloudWatch — 인프라 비용 배치 캐싱(이슈 #437). AWS/Billing EstimatedCharges 지표를 읽는다 —
+    // Cost Explorer(ce:GetCostAndUsage, 건당 $0.01)보다 이쪽이 무료라 이걸로 전환함(리뷰 반영).
+    // 크리덴셜은 EC2 인스턴스 역할 기본 체인.
+    implementation("software.amazon.awssdk:cloudwatch:2.28.11")
 
     // Lombok
     compileOnly("org.projectlombok:lombok")

--- a/src/main/java/com/mio/admin/controller/AdminSessionController.java
+++ b/src/main/java/com/mio/admin/controller/AdminSessionController.java
@@ -1,6 +1,8 @@
 package com.mio.admin.controller;
 
+import com.mio.admin.dto.SessionCostResponse;
 import com.mio.admin.dto.SessionTimelineResponse;
+import com.mio.admin.service.AdminSessionCostService;
 import com.mio.admin.service.AdminSessionService;
 import com.mio.common.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,9 +26,15 @@ import java.util.UUID;
 public class AdminSessionController {
 
     private final AdminSessionService adminSessionService;
+    private final AdminSessionCostService adminSessionCostService;
 
     @GetMapping("/{sessionId}")
     public ResponseEntity<ApiResponse<SessionTimelineResponse>> getTimeline(@PathVariable UUID sessionId) {
         return ResponseEntity.ok(ApiResponse.ok(adminSessionService.getTimeline(sessionId)));
+    }
+
+    @GetMapping("/{sessionId}/cost")
+    public ResponseEntity<ApiResponse<SessionCostResponse>> getCost(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(ApiResponse.ok(adminSessionCostService.getCost(sessionId)));
     }
 }

--- a/src/main/java/com/mio/admin/controller/AdminUserController.java
+++ b/src/main/java/com/mio/admin/controller/AdminUserController.java
@@ -1,0 +1,36 @@
+package com.mio.admin.controller;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.admin.service.AdminUserCostService;
+import com.mio.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/**
+ * 운영자용 유저 단위 조회 (이슈 #434).
+ *
+ * <p>{@code ROLE_ADMIN} 필요 — {@code /v1/admin/**} 전체가 {@code SecurityConfig}에서
+ * 일괄 게이트된다({@code AdminSessionController}와 동일).
+ */
+@RestController
+@RequestMapping("/v1/admin/users")
+@RequiredArgsConstructor
+public class AdminUserController {
+
+    private final AdminUserCostService adminUserCostService;
+
+    /** @param month "yyyy-MM" 형식. 생략하면 이번 달(Asia/Seoul 기준) */
+    @GetMapping("/{userId}/cost-monthly")
+    public ResponseEntity<ApiResponse<UserMonthlyCostResponse>> getMonthlyCost(
+            @PathVariable UUID userId,
+            @RequestParam(required = false) String month) {
+        return ResponseEntity.ok(ApiResponse.ok(adminUserCostService.getMonthlyCost(userId, month)));
+    }
+}

--- a/src/main/java/com/mio/admin/dto/SessionCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionCostResponse.java
@@ -8,9 +8,10 @@ import java.util.UUID;
 /**
  * 세션당 비용 조회 응답 (이슈 #433).
  *
- * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 AWS Cost Explorer 연동이
- * 아직 없어 {@code null}이다 — 0으로 채우면 "인프라 비용이 없다"로 오독되므로, 모르는 값은
- * 비워서 API 응답 자체가 미지원임을 드러낸다("모르는 것을 0으로 감추지 않는다" 원칙).
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 인프라 비용 배치
+ * ({@code InfraCostSyncJob})가 해당 월을 아직 캐싱하지 않았으면 {@code null}이다 — 0으로 채우면
+ * "인프라 비용이 없다"로 오독되므로, 모르는 값은 비워서 API 응답 자체가 미지원임을 드러낸다
+ * ("모르는 것을 0으로 감추지 않는다" 원칙).
  */
 public record SessionCostResponse(
         @JsonProperty("session_id") UUID sessionId,

--- a/src/main/java/com/mio/admin/dto/SessionCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/SessionCostResponse.java
@@ -1,0 +1,24 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 세션당 비용 조회 응답 (이슈 #433).
+ *
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 AWS Cost Explorer 연동이
+ * 아직 없어 {@code null}이다 — 0으로 채우면 "인프라 비용이 없다"로 오독되므로, 모르는 값은
+ * 비워서 API 응답 자체가 미지원임을 드러낸다("모르는 것을 0으로 감추지 않는다" 원칙).
+ */
+public record SessionCostResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        @JsonProperty("user_id") UUID userId,
+        @JsonProperty("direct_variable_cost_usd") BigDecimal directVariableCostUsd,
+        @JsonProperty("unpriced_events") long unpricedEvents,
+        @JsonProperty("all_priced") boolean allPriced,
+        @JsonProperty("allocated_fixed_infra_usd_estimate") BigDecimal allocatedFixedInfraUsdEstimate,
+        @JsonProperty("total_usd") BigDecimal totalUsd
+) {
+}

--- a/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
@@ -9,8 +9,8 @@ import java.util.UUID;
  * 유저별 월간 누적 비용 조회 응답 (이슈 #434).
  *
  * <p>{@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는
- * AWS Cost Explorer 연동이 아직 없어 {@code null}이다 — #433과 같은 원칙, 0으로 채우면
- * "인프라 비용이 없다"로 오독된다.
+ * 인프라 비용 배치({@code InfraCostSyncJob})가 해당 월을 아직 캐싱하지 않았으면 {@code null}이다
+ * — #433과 같은 원칙, 0으로 채우면 "인프라 비용이 없다"로 오독된다.
  *
  * <p>{@code user_month_technical_cogs_usd}라는 이름에 "technical"을 붙인 이유: 앱스토어·결제
  * 수수료, 부가세·환율, 무료 사용량·환불, CS 비용이 빠진 <b>기술 원가 일부</b>라는 걸 명시하기

--- a/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
+++ b/src/main/java/com/mio/admin/dto/UserMonthlyCostResponse.java
@@ -1,0 +1,28 @@
+package com.mio.admin.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * 유저별 월간 누적 비용 조회 응답 (이슈 #434).
+ *
+ * <p>{@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는
+ * AWS Cost Explorer 연동이 아직 없어 {@code null}이다 — #433과 같은 원칙, 0으로 채우면
+ * "인프라 비용이 없다"로 오독된다.
+ *
+ * <p>{@code user_month_technical_cogs_usd}라는 이름에 "technical"을 붙인 이유: 앱스토어·결제
+ * 수수료, 부가세·환율, 무료 사용량·환불, CS 비용이 빠진 <b>기술 원가 일부</b>라는 걸 명시하기
+ * 위함 — 전체 수익성 지표로 오독되면 안 된다.
+ */
+public record UserMonthlyCostResponse(
+        @JsonProperty("user_id") UUID userId,
+        String month,
+        @JsonProperty("direct_variable_cost_usd") BigDecimal directVariableCostUsd,
+        @JsonProperty("unpriced_events") long unpricedEvents,
+        @JsonProperty("all_priced") boolean allPriced,
+        @JsonProperty("allocated_fixed_infra_usd_estimate") BigDecimal allocatedFixedInfraUsdEstimate,
+        @JsonProperty("user_month_technical_cogs_usd") BigDecimal userMonthTechnicalCogsUsd
+) {
+}

--- a/src/main/java/com/mio/admin/service/AdminSessionCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionCostService.java
@@ -3,21 +3,27 @@ package com.mio.admin.service;
 import com.mio.admin.dto.SessionCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
+import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
 import com.mio.session.repository.SessionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.time.YearMonth;
 import java.util.UUID;
 
 /**
- * 운영자용 세션당 비용 조회 (이슈 #433, #431의 후속).
+ * 운영자용 세션당 비용 조회 (이슈 #433, #437 — #431의 후속).
  *
- * <p>AI 비용({@code ai_cost_events} 합산)만 반영한다. 비-AI 인프라 비용 배분(AWS Cost Explorer
- * 연동, 옵션 A 시간 비례)은 별도 이슈에서 채운다 — 그 전까지 {@code allocated_fixed_infra_usd_estimate}/
- * {@code total_usd}는 {@code null}로 비워 "인프라 비용 미지원"을 명시적으로 드러낸다.
+ * <p>AI 비용({@code ai_cost_events} 합산) + 비-AI 인프라 비용 배분(옵션 A 시간 비례, 이슈 #437)을
+ * 합쳐 반환한다. 인프라 배치({@code InfraCostSyncJob})가 그 세션이 속한 달을 아직 한 번도 캐싱하지
+ * 않았으면 {@code allocated_fixed_infra_usd_estimate}/{@code total_usd}는 여전히 {@code null}이다 —
+ * 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 채워져도 과거 조회 결과와 구분이 안 된다.
  */
 @Service
 @RequiredArgsConstructor
@@ -26,23 +32,32 @@ public class AdminSessionCostService {
 
     private final SessionRepository sessionRepository;
     private final AiCostEventRepository aiCostEventRepository;
+    private final InfraCostAllocator infraCostAllocator;
 
     public SessionCostResponse getCost(UUID sessionId) {
-        var session = sessionRepository.findById(sessionId)
+        Session session = sessionRepository.findById(sessionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
 
         AiCostAggregate aggregate = aiCostEventRepository.aggregateBySessionId(sessionId);
 
-        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — 0이 아니라 null로 비운다.
-        // 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 연동해도 과거 조회 결과와 구분이 안 된다.
+        BigDecimal allocatedInfraUsd = null;
+        long durationSeconds = session.durationSeconds();
+        if (durationSeconds > 0) {
+            YearMonth sessionMonth = YearMonth.from(session.getStartedAt().atZoneSameInstant(AppConstants.ZONE));
+            allocatedInfraUsd = infraCostAllocator.allocateForSession(sessionMonth, durationSeconds);
+        }
+        BigDecimal totalUsd = allocatedInfraUsd != null
+                ? aggregate.totalCostUsd().add(allocatedInfraUsd)
+                : null;
+
         return new SessionCostResponse(
                 sessionId,
                 session.getUser().getId(),
                 aggregate.totalCostUsd(),
                 aggregate.unpricedCount(),
                 aggregate.allPriced(),
-                null,
-                null
+                allocatedInfraUsd,
+                totalUsd
         );
     }
 }

--- a/src/main/java/com/mio/admin/service/AdminSessionCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminSessionCostService.java
@@ -1,0 +1,48 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.SessionCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+/**
+ * 운영자용 세션당 비용 조회 (이슈 #433, #431의 후속).
+ *
+ * <p>AI 비용({@code ai_cost_events} 합산)만 반영한다. 비-AI 인프라 비용 배분(AWS Cost Explorer
+ * 연동, 옵션 A 시간 비례)은 별도 이슈에서 채운다 — 그 전까지 {@code allocated_fixed_infra_usd_estimate}/
+ * {@code total_usd}는 {@code null}로 비워 "인프라 비용 미지원"을 명시적으로 드러낸다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminSessionCostService {
+
+    private final SessionRepository sessionRepository;
+    private final AiCostEventRepository aiCostEventRepository;
+
+    public SessionCostResponse getCost(UUID sessionId) {
+        var session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+
+        AiCostAggregate aggregate = aiCostEventRepository.aggregateBySessionId(sessionId);
+
+        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — 0이 아니라 null로 비운다.
+        // 0으로 채우면 "인프라 비용이 없다"가 되고, 뒤늦게 연동해도 과거 조회 결과와 구분이 안 된다.
+        return new SessionCostResponse(
+                sessionId,
+                session.getUser().getId(),
+                aggregate.totalCostUsd(),
+                aggregate.unpricedCount(),
+                aggregate.allPriced(),
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/com/mio/admin/service/AdminUserCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminUserCostService.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.UserMonthlyCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -11,17 +12,20 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.time.YearMonth;
 import java.time.format.DateTimeParseException;
 import java.util.UUID;
 
 /**
- * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #433의 연장).
+ * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #437 — #433의 연장).
  *
  * <p>세션 단위였던 #433의 집계를 유저·월 단위로만 바꾼 것 — 신규 계측 없이
  * {@code AiCostEventRepository.aggregateByUserIdAndCreatedAtBetween()}만 추가로 소비한다.
- * 인프라 비용 배분은 #433과 동일하게 이번 스코프에서 뺐다.
+ * 인프라 비용 배분(옵션 A 시간 비례)은 이슈 #437에서 채웠다 — 해당 월 캐시가 아직 없으면
+ * {@code allocated_fixed_infra_usd_estimate}/{@code user_month_technical_cogs_usd}는 여전히
+ * {@code null}이다(#433과 같은 이유).
  */
 @Service
 @RequiredArgsConstructor
@@ -30,6 +34,7 @@ public class AdminUserCostService {
 
     private final UserRepository userRepository;
     private final AiCostEventRepository aiCostEventRepository;
+    private final InfraCostAllocator infraCostAllocator;
 
     public UserMonthlyCostResponse getMonthlyCost(UUID userId, String month) {
         if (!userRepository.existsById(userId)) {
@@ -41,16 +46,19 @@ public class AdminUserCostService {
         OffsetDateTime to = yearMonth.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
 
         AiCostAggregate aggregate = aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(userId, from, to);
+        BigDecimal allocatedInfraUsd = infraCostAllocator.allocateForUserMonth(userId, yearMonth);
+        BigDecimal technicalCogsUsd = allocatedInfraUsd != null
+                ? aggregate.totalCostUsd().add(allocatedInfraUsd)
+                : null;
 
-        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — #433과 같은 이유로 0이 아니라 null.
         return new UserMonthlyCostResponse(
                 userId,
                 yearMonth.toString(),
                 aggregate.totalCostUsd(),
                 aggregate.unpricedCount(),
                 aggregate.allPriced(),
-                null,
-                null
+                allocatedInfraUsd,
+                technicalCogsUsd
         );
     }
 

--- a/src/main/java/com/mio/admin/service/AdminUserCostService.java
+++ b/src/main/java/com/mio/admin/service/AdminUserCostService.java
@@ -1,0 +1,67 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.UUID;
+
+/**
+ * 운영자용 유저별 월간 누적 비용 조회 (이슈 #434, #433의 연장).
+ *
+ * <p>세션 단위였던 #433의 집계를 유저·월 단위로만 바꾼 것 — 신규 계측 없이
+ * {@code AiCostEventRepository.aggregateByUserIdAndCreatedAtBetween()}만 추가로 소비한다.
+ * 인프라 비용 배분은 #433과 동일하게 이번 스코프에서 뺐다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUserCostService {
+
+    private final UserRepository userRepository;
+    private final AiCostEventRepository aiCostEventRepository;
+
+    public UserMonthlyCostResponse getMonthlyCost(UUID userId, String month) {
+        if (!userRepository.existsById(userId)) {
+            throw new BusinessException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        YearMonth yearMonth = parseOrCurrentMonth(month);
+        OffsetDateTime from = yearMonth.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = yearMonth.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+
+        AiCostAggregate aggregate = aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(userId, from, to);
+
+        // AWS Cost Explorer 연동 전까지는 인프라 배분을 모른다 — #433과 같은 이유로 0이 아니라 null.
+        return new UserMonthlyCostResponse(
+                userId,
+                yearMonth.toString(),
+                aggregate.totalCostUsd(),
+                aggregate.unpricedCount(),
+                aggregate.allPriced(),
+                null,
+                null
+        );
+    }
+
+    private YearMonth parseOrCurrentMonth(String month) {
+        if (month == null || month.isBlank()) {
+            return YearMonth.now(AppConstants.ZONE);
+        }
+        try {
+            return YearMonth.parse(month);
+        } catch (DateTimeParseException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/AiCostAggregate.java
+++ b/src/main/java/com/mio/ai/cost/AiCostAggregate.java
@@ -1,0 +1,22 @@
+package com.mio.ai.cost;
+
+import java.math.BigDecimal;
+
+/**
+ * 세션·유저 단위 비용 집계 결과 (이슈 #431 리뷰).
+ *
+ * <p>{@code SUM(cost_usd)}는 SQL 표준상 NULL 행을 조용히 건너뛴다 — 단가 미등록으로
+ * {@code cost_usd=null}인 이벤트가 섞여 있어도 나머지 값만 합산돼 "부분 합계"가
+ * "완전한 합계"처럼 보인다. {@code unpricedCount}로 그 차이를 드러낸다.
+ *
+ * @param totalCostUsd  단가가 있는 이벤트들의 비용 합. 전부 미상이면 0
+ * @param unpricedCount cost_usd가 null인(단가 미등록) 이벤트 수
+ * @param totalCount    전체 이벤트 수
+ */
+public record AiCostAggregate(BigDecimal totalCostUsd, long unpricedCount, long totalCount) {
+
+    /** {@code totalCostUsd}가 실제로 전체 비용을 반영하는지 — 미상 이벤트가 하나라도 있으면 false */
+    public boolean allPriced() {
+        return unpricedCount == 0;
+    }
+}

--- a/src/main/java/com/mio/ai/cost/AiCostEvent.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEvent.java
@@ -1,0 +1,83 @@
+package com.mio.ai.cost;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 호출 단위 LLM/embedding 비용 원장 (이슈 #431).
+ *
+ * <p>{@code ai_policy_decisions.trace.llm_cost_usd} 는 메인 대화 생성 호출 1건만 반영한다.
+ * {@code OpenAiLlmClient.recordUsage()} 를 거치는 모든 호출부(judge·분류·추출·요약·개인화·
+ * 리포트·임베딩 등)의 비용을 이 테이블 하나로 모은다 — {@code ai_policy_decisions} 는 정책결정
+ * 로그 역할만 유지하고 비용 원장으로 겸용하지 않는다.
+ *
+ * <p>{@code userId}/{@code sessionId} 는 FK 를 걸지 않는다 — {@code audit_logs} 와 같은 이유로,
+ * 유저 하드삭제 이후에도 비용 기록 자체는 보존 정책상 남아야 할 수 있다.
+ */
+@Entity
+@Table(name = "ai_cost_events")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiCostEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "user_id")
+    private UUID userId;
+
+    @Column(name = "session_id")
+    private UUID sessionId;
+
+    @Column(name = "component", nullable = false)
+    private String component;
+
+    @Column(name = "model", nullable = false)
+    private String model;
+
+    @Column(name = "mode", nullable = false)
+    private String mode;
+
+    @Column(name = "prompt_tokens", nullable = false)
+    private long promptTokens;
+
+    @Column(name = "completion_tokens", nullable = false)
+    private long completionTokens;
+
+    @Column(name = "cached_tokens", nullable = false)
+    private long cachedTokens;
+
+    @Column(name = "cost_usd")
+    private BigDecimal costUsd;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private AiCostEvent(UUID userId, UUID sessionId, String component, String model, String mode,
+                         long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd) {
+        this.userId = userId;
+        this.sessionId = sessionId;
+        this.component = component;
+        this.model = model;
+        this.mode = mode;
+        this.promptTokens = promptTokens;
+        this.completionTokens = completionTokens;
+        this.cachedTokens = cachedTokens;
+        this.costUsd = costUsd;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/com/mio/ai/cost/AiCostEvent.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEvent.java
@@ -64,7 +64,8 @@ public class AiCostEvent {
 
     @Builder
     private AiCostEvent(UUID userId, UUID sessionId, String component, String model, String mode,
-                         long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd) {
+                         long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd,
+                         OffsetDateTime createdAt) {
         this.userId = userId;
         this.sessionId = sessionId;
         this.component = component;
@@ -74,10 +75,18 @@ public class AiCostEvent {
         this.completionTokens = completionTokens;
         this.cachedTokens = cachedTokens;
         this.costUsd = costUsd;
+        this.createdAt = createdAt;
     }
 
+    /**
+     * 호출측이 실제 사용 시각을 넘겨주지 않은 경우에만 저장 시각으로 채운다(안전망) —
+     * 정상 경로는 {@code OpenAiLlmClient.recordUsage()}가 사용 시각을 명시적으로 넘긴다.
+     * 커밋 시각에 기대면 비동기 큐 지연만큼 실제 사용 시각과 어긋난다(이슈 #431 리뷰).
+     */
     @PrePersist
     protected void onCreate() {
-        createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
     }
 }

--- a/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
@@ -13,14 +13,14 @@ public interface AiCostEventRepository extends JpaRepository<AiCostEvent, UUID> 
     // 합계만 반환하면 "일부만 더한 값"이 "전체 비용"처럼 보인다(이슈 #431 리뷰, AiCostAggregate 참고).
     @Query("SELECT new com.mio.ai.cost.AiCostAggregate("
             + "COALESCE(SUM(e.costUsd), 0), "
-            + "SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), "
+            + "COALESCE(SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), 0), "
             + "COUNT(e)) "
             + "FROM AiCostEvent e WHERE e.sessionId = :sessionId")
     AiCostAggregate aggregateBySessionId(@Param("sessionId") UUID sessionId);
 
     @Query("SELECT new com.mio.ai.cost.AiCostAggregate("
             + "COALESCE(SUM(e.costUsd), 0), "
-            + "SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), "
+            + "COALESCE(SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), 0), "
             + "COUNT(e)) "
             + "FROM AiCostEvent e WHERE e.userId = :userId AND e.createdAt >= :from AND e.createdAt < :to")
     AiCostAggregate aggregateByUserIdAndCreatedAtBetween(

--- a/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
@@ -1,0 +1,20 @@
+package com.mio.ai.cost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+public interface AiCostEventRepository extends JpaRepository<AiCostEvent, UUID> {
+
+    @Query("SELECT COALESCE(SUM(e.costUsd), 0) FROM AiCostEvent e WHERE e.sessionId = :sessionId")
+    BigDecimal sumCostBySessionId(@Param("sessionId") UUID sessionId);
+
+    @Query("SELECT COALESCE(SUM(e.costUsd), 0) FROM AiCostEvent e "
+            + "WHERE e.userId = :userId AND e.createdAt >= :from AND e.createdAt < :to")
+    BigDecimal sumCostByUserIdAndCreatedAtBetween(
+            @Param("userId") UUID userId, @Param("from") OffsetDateTime from, @Param("to") OffsetDateTime to);
+}

--- a/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEventRepository.java
@@ -4,17 +4,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.UUID;
 
 public interface AiCostEventRepository extends JpaRepository<AiCostEvent, UUID> {
 
-    @Query("SELECT COALESCE(SUM(e.costUsd), 0) FROM AiCostEvent e WHERE e.sessionId = :sessionId")
-    BigDecimal sumCostBySessionId(@Param("sessionId") UUID sessionId);
+    // SUM(e.costUsd)는 cost_usd=null(단가 미등록) 행을 조용히 건너뛴다 — unpricedCount 없이
+    // 합계만 반환하면 "일부만 더한 값"이 "전체 비용"처럼 보인다(이슈 #431 리뷰, AiCostAggregate 참고).
+    @Query("SELECT new com.mio.ai.cost.AiCostAggregate("
+            + "COALESCE(SUM(e.costUsd), 0), "
+            + "SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), "
+            + "COUNT(e)) "
+            + "FROM AiCostEvent e WHERE e.sessionId = :sessionId")
+    AiCostAggregate aggregateBySessionId(@Param("sessionId") UUID sessionId);
 
-    @Query("SELECT COALESCE(SUM(e.costUsd), 0) FROM AiCostEvent e "
-            + "WHERE e.userId = :userId AND e.createdAt >= :from AND e.createdAt < :to")
-    BigDecimal sumCostByUserIdAndCreatedAtBetween(
+    @Query("SELECT new com.mio.ai.cost.AiCostAggregate("
+            + "COALESCE(SUM(e.costUsd), 0), "
+            + "SUM(CASE WHEN e.costUsd IS NULL THEN 1 ELSE 0 END), "
+            + "COUNT(e)) "
+            + "FROM AiCostEvent e WHERE e.userId = :userId AND e.createdAt >= :from AND e.createdAt < :to")
+    AiCostAggregate aggregateByUserIdAndCreatedAtBetween(
             @Param("userId") UUID userId, @Param("from") OffsetDateTime from, @Param("to") OffsetDateTime to);
 }

--- a/src/main/java/com/mio/ai/cost/AiCostEventWriter.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEventWriter.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
 import java.util.UUID;
 
 /**
@@ -31,7 +32,8 @@ public class AiCostEventWriter {
     @Async("aiDecisionLoggerExecutor")
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void write(UUID userId, UUID sessionId, String component, String model, String mode,
-                       long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd) {
+                       long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd,
+                       OffsetDateTime occurredAt) {
         if (component == null || component.isBlank()) {
             log.debug("[AiCostEventWriter] component 없음, 스킵 model={} mode={}", model, mode);
             return;
@@ -47,6 +49,7 @@ public class AiCostEventWriter {
                     .completionTokens(completionTokens)
                     .cachedTokens(cachedTokens)
                     .costUsd(costUsd)
+                    .createdAt(occurredAt)
                     .build());
         } catch (Exception e) {
             log.warn("[AiCostEventWriter] 비용 기록 실패 component={} model={}: {}",

--- a/src/main/java/com/mio/ai/cost/AiCostEventWriter.java
+++ b/src/main/java/com/mio/ai/cost/AiCostEventWriter.java
@@ -1,0 +1,56 @@
+package com.mio.ai.cost;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * {@code OpenAiLlmClient.recordUsage()} 에서 호출되는 비용 기록 지점.
+ *
+ * <p>{@code AuditLogService} 와 같은 원칙 — 비동기·별도 트랜잭션이라 이 기록이 실패해도
+ * 실제 LLM 응답 경로(스트리밍 등)는 막지 않는다. {@code component} 가 없으면(귀속 정보를
+ * 아직 안 붙인 호출부) 조용히 스킵한다 — 절반짜리 행을 만들지 않는다.
+ *
+ * <p>{@code aiDecisionLoggerExecutor} 를 그대로 재사용한다. 이 지점이 세션당 최대 15회
+ * 호출될 수 있어 {@code AiDecisionLogger}(세션당 1회)보다 호출 빈도가 훨씬 높다 — 큐 적체가
+ * 보이면 전용 executor로 분리한다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AiCostEventWriter {
+
+    private final AiCostEventRepository repository;
+
+    @Async("aiDecisionLoggerExecutor")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void write(UUID userId, UUID sessionId, String component, String model, String mode,
+                       long promptTokens, long completionTokens, long cachedTokens, BigDecimal costUsd) {
+        if (component == null || component.isBlank()) {
+            log.debug("[AiCostEventWriter] component 없음, 스킵 model={} mode={}", model, mode);
+            return;
+        }
+        try {
+            repository.save(AiCostEvent.builder()
+                    .userId(userId)
+                    .sessionId(sessionId)
+                    .component(component)
+                    .model(model)
+                    .mode(mode)
+                    .promptTokens(promptTokens)
+                    .completionTokens(completionTokens)
+                    .cachedTokens(cachedTokens)
+                    .costUsd(costUsd)
+                    .build());
+        } catch (Exception e) {
+            log.warn("[AiCostEventWriter] 비용 기록 실패 component={} model={}: {}",
+                    component, model, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/AllocationSensitivityCalculator.java
+++ b/src/main/java/com/mio/ai/cost/AllocationSensitivityCalculator.java
@@ -1,0 +1,118 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * 옵션 A(시간비례) vs 옵션 B(요청수비례) 배분 모델 민감도 계산 (이슈 #438, 개선안 문서 §5).
+ *
+ * <p>그 달 전체 세션에 대한 합계·평균으로 A/B를 비교하면 항상 0%가 나온다 — 두 배분 방식 모두
+ * 같은 월간총청구액을 비례배분할 뿐이라, 전체 세션 합/평균은 배분 기준과 무관하게 항상 월간
+ * 총청구액(또는 총청구액/세션수)으로 수렴하는 수학적 항등이기 때문이다. 실제로 두 방식이 갈리는
+ * 지점은 세션 개별 단위 — 그래서 세션마다 A_i·B_i를 먼저 계산하고, 그 세션별 민감도
+ * ({@code |A_i-B_i|/B_i}) 의 평균을 최종 지표로 쓴다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AllocationSensitivityCalculator {
+
+    private static final int SCALE = 10;
+    private static final BigDecimal HUNDRED = BigDecimal.valueOf(100);
+    private static final BigDecimal WARN_THRESHOLD_PCT = BigDecimal.valueOf(30);
+
+    private final JdbcTemplate jdbcTemplate;
+    private final InfraCostAllocationSensitivityRepository repository;
+
+    public void computeAndSave(YearMonth month, BigDecimal totalCostUsd) {
+        if (totalCostUsd == null || totalCostUsd.signum() <= 0) {
+            log.info("[AllocationSensitivityCalculator] {}: 월간 총청구액이 0 이하라 계산 스킵", month);
+            return;
+        }
+
+        List<SessionDriver> drivers = fetchEndedSessionDrivers(month);
+        long totalDurationSeconds = drivers.stream().mapToLong(SessionDriver::durationSeconds).sum();
+        long totalMessages = drivers.stream().mapToLong(SessionDriver::messageCount).sum();
+        if (totalDurationSeconds <= 0 || totalMessages <= 0) {
+            log.info("[AllocationSensitivityCalculator] {}: 총세션-초 또는 총메시지수가 0이라 계산 스킵", month);
+            return;
+        }
+
+        BigDecimal sumA = BigDecimal.ZERO;
+        BigDecimal sumB = BigDecimal.ZERO;
+        BigDecimal sumSensitivityPct = BigDecimal.ZERO;
+        int qualifyingCount = 0;
+
+        for (SessionDriver driver : drivers) {
+            if (driver.durationSeconds() <= 0 || driver.messageCount() <= 0) {
+                continue;
+            }
+            BigDecimal a = totalCostUsd
+                    .multiply(BigDecimal.valueOf(driver.durationSeconds()))
+                    .divide(BigDecimal.valueOf(totalDurationSeconds), SCALE, RoundingMode.HALF_UP);
+            BigDecimal b = totalCostUsd
+                    .multiply(BigDecimal.valueOf(driver.messageCount()))
+                    .divide(BigDecimal.valueOf(totalMessages), SCALE, RoundingMode.HALF_UP);
+            BigDecimal sensitivityPct = a.subtract(b).abs()
+                    .divide(b, SCALE, RoundingMode.HALF_UP)
+                    .multiply(HUNDRED);
+
+            sumA = sumA.add(a);
+            sumB = sumB.add(b);
+            sumSensitivityPct = sumSensitivityPct.add(sensitivityPct);
+            qualifyingCount++;
+        }
+
+        if (qualifyingCount == 0) {
+            log.info("[AllocationSensitivityCalculator] {}: duration·message_count가 둘 다 0보다 큰 세션이 없어 계산 스킵", month);
+            return;
+        }
+
+        BigDecimal count = BigDecimal.valueOf(qualifyingCount);
+        BigDecimal avgA = sumA.divide(count, SCALE, RoundingMode.HALF_UP);
+        BigDecimal avgB = sumB.divide(count, SCALE, RoundingMode.HALF_UP);
+        BigDecimal avgSensitivityPct = sumSensitivityPct.divide(count, SCALE, RoundingMode.HALF_UP);
+
+        repository.save(InfraCostAllocationSensitivity.builder()
+                .billingPeriodStart(month.atDay(1))
+                .optionAUsd(avgA)
+                .optionBUsd(avgB)
+                .allocationSensitivityPct(avgSensitivityPct)
+                .snapshotAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build());
+
+        if (avgSensitivityPct.compareTo(WARN_THRESHOLD_PCT) > 0) {
+            log.warn("[AllocationSensitivityCalculator] {}: 배분 민감도 평균 {}%가 임계값({}%) 초과 — "
+                            + "배분 기준 재검토 근거로 참고(정확도 보증 아님)",
+                    month, avgSensitivityPct, WARN_THRESHOLD_PCT);
+        } else {
+            log.info("[AllocationSensitivityCalculator] {}: 배분 민감도 평균 {}% (세션 {}건 기준)",
+                    month, avgSensitivityPct, qualifyingCount);
+        }
+    }
+
+    private List<SessionDriver> fetchEndedSessionDrivers(YearMonth month) {
+        OffsetDateTime from = month.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        OffsetDateTime to = month.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+        return jdbcTemplate.query("""
+                SELECT EXTRACT(EPOCH FROM (ended_at - started_at))::bigint AS duration_seconds, message_count
+                FROM sessions
+                WHERE status = 'ended' AND started_at >= ? AND started_at < ?
+                """,
+                (rs, rowNum) -> new SessionDriver(rs.getLong("duration_seconds"), rs.getLong("message_count")),
+                from, to);
+    }
+
+    private record SessionDriver(long durationSeconds, long messageCount) {
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivity.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivity.java
@@ -1,0 +1,68 @@
+package com.mio.ai.cost;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * 배분 모델(옵션 A 시간비례 vs 옵션 B 요청수비례) 민감도 관찰 기록 (이슈 #438, 개선안 문서 §5).
+ *
+ * <p>둘 중 어느 쪽도 정답(ground truth)이 아니다 — {@code allocationSensitivityPct}는 "어느 쪽이
+ * 정확한지"가 아니라 "배분 기준을 바꾸면 세션별 인프라비용이 얼마나 갈리는지"를 관찰하는 값이다.
+ * 운영 중인 세션·유저 cost API({@link InfraCostAllocator})는 항상 옵션 A만 쓰고, 이 레코드는
+ * 참고용 그림자 계산일 뿐이다.
+ */
+@Entity
+@Table(name = "infra_cost_allocation_sensitivity")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InfraCostAllocationSensitivity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "billing_period_start", nullable = false)
+    private LocalDate billingPeriodStart;
+
+    @Column(name = "option_a_usd", nullable = false)
+    private BigDecimal optionAUsd;
+
+    @Column(name = "option_b_usd", nullable = false)
+    private BigDecimal optionBUsd;
+
+    @Column(name = "allocation_sensitivity_pct", nullable = false)
+    private BigDecimal allocationSensitivityPct;
+
+    @Column(name = "snapshot_at", nullable = false)
+    private OffsetDateTime snapshotAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private InfraCostAllocationSensitivity(LocalDate billingPeriodStart, BigDecimal optionAUsd,
+                                            BigDecimal optionBUsd, BigDecimal allocationSensitivityPct,
+                                            OffsetDateTime snapshotAt) {
+        this.billingPeriodStart = billingPeriodStart;
+        this.optionAUsd = optionAUsd;
+        this.optionBUsd = optionBUsd;
+        this.allocationSensitivityPct = allocationSensitivityPct;
+        this.snapshotAt = snapshotAt;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivityRepository.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocationSensitivityRepository.java
@@ -1,0 +1,9 @@
+package com.mio.ai.cost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface InfraCostAllocationSensitivityRepository
+        extends JpaRepository<InfraCostAllocationSensitivity, UUID> {
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostAllocator.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostAllocator.java
@@ -1,0 +1,99 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.UUID;
+
+/**
+ * 옵션 A(시간 비례) 인프라 비용 배분 (이슈 #437, 개선안 문서 §2.2).
+ *
+ * <p>{@code (해당 월 총청구액 / 해당 월 총세션-초) × 세션(또는 유저) duration_seconds}.
+ * 캐싱된 {@link InfraCostSnapshot}이 아직 없거나(배치 미실행) 그 달 세션-초 합이 0이면
+ * 배분할 수 없다 — 0으로 채우지 않고 {@code null}을 반환해 "배분 불가"와 "배분값 0"을 구분한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class InfraCostAllocator {
+
+    private static final int SCALE = 10;
+
+    private final InfraCostSnapshotRepository snapshotRepository;
+    private final JdbcTemplate jdbcTemplate;
+
+    /** @return 세션 1건에 배분된 인프라비용(USD). 배분 불가하면 {@code null} */
+    public BigDecimal allocateForSession(YearMonth month, long sessionDurationSeconds) {
+        if (sessionDurationSeconds <= 0) {
+            return null;
+        }
+        InfraCostSnapshot snapshot = latestSnapshot(month);
+        if (snapshot == null) {
+            return null;
+        }
+        long totalSeconds = totalSessionSecondsInMonth(month);
+        if (totalSeconds <= 0) {
+            return null;
+        }
+        return allocate(snapshot.getTotalCostUsd(), sessionDurationSeconds, totalSeconds);
+    }
+
+    /** @return 유저의 그 달 세션 전체에 배분된 인프라비용 합(USD). 배분 불가하면 {@code null} */
+    public BigDecimal allocateForUserMonth(UUID userId, YearMonth month) {
+        InfraCostSnapshot snapshot = latestSnapshot(month);
+        if (snapshot == null) {
+            return null;
+        }
+        long totalSeconds = totalSessionSecondsInMonth(month);
+        if (totalSeconds <= 0) {
+            return null;
+        }
+        long userSeconds = userSessionSecondsInMonth(userId, month);
+        if (userSeconds <= 0) {
+            return null;
+        }
+        return allocate(snapshot.getTotalCostUsd(), userSeconds, totalSeconds);
+    }
+
+    private BigDecimal allocate(BigDecimal totalCostUsd, long portionSeconds, long totalSeconds) {
+        return totalCostUsd
+                .multiply(BigDecimal.valueOf(portionSeconds))
+                .divide(BigDecimal.valueOf(totalSeconds), SCALE, RoundingMode.HALF_UP);
+    }
+
+    private InfraCostSnapshot latestSnapshot(YearMonth month) {
+        return snapshotRepository.findTopByBillingPeriodStartOrderBySnapshotAtDesc(month.atDay(1))
+                .orElse(null);
+    }
+
+    private long totalSessionSecondsInMonth(YearMonth month) {
+        OffsetDateTime from = monthStart(month);
+        OffsetDateTime to = monthStart(month.plusMonths(1));
+        Long seconds = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint
+                FROM sessions
+                WHERE status = 'ended' AND started_at >= ? AND started_at < ?
+                """, Long.class, from, to);
+        return seconds != null ? seconds : 0L;
+    }
+
+    private long userSessionSecondsInMonth(UUID userId, YearMonth month) {
+        OffsetDateTime from = monthStart(month);
+        OffsetDateTime to = monthStart(month.plusMonths(1));
+        Long seconds = jdbcTemplate.queryForObject("""
+                SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (ended_at - started_at))), 0)::bigint
+                FROM sessions
+                WHERE status = 'ended' AND user_id = ? AND started_at >= ? AND started_at < ?
+                """, Long.class, userId, from, to);
+        return seconds != null ? seconds : 0L;
+    }
+
+    private OffsetDateTime monthStart(YearMonth month) {
+        return month.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime();
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSnapshot.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSnapshot.java
@@ -1,0 +1,71 @@
+package com.mio.ai.cost;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.UUID;
+
+/**
+ * AWS CloudWatch {@code AWS/Billing EstimatedCharges} 월간 총청구액 배치 캐시 (이슈 #437).
+ *
+ * <p>{@code cloudwatch:GetMetricStatistics}는 세션 조회 시점 실시간 호출이 아니라 일 1회 배치로만
+ * 부른다 — 지표 자체가 대략 6시간 간격으로만 갱신된다. {@code isEstimated}는 지표 이름 그대로
+ * AWS 스스로도 "추정치"라 부르는 값이라는 걸 그대로 보존한다.
+ */
+@Entity
+@Table(name = "infra_cost_snapshots")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InfraCostSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    @Column(name = "billing_period_start", nullable = false)
+    private LocalDate billingPeriodStart;
+
+    @Column(name = "billing_period_end", nullable = false)
+    private LocalDate billingPeriodEnd;
+
+    @Column(name = "total_cost_usd", nullable = false)
+    private BigDecimal totalCostUsd;
+
+    @Column(name = "is_estimated", nullable = false)
+    private boolean estimated;
+
+    @Column(name = "snapshot_at", nullable = false)
+    private OffsetDateTime snapshotAt;
+
+    @Column(name = "allocation_method_version", nullable = false)
+    private String allocationMethodVersion;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private OffsetDateTime createdAt;
+
+    @Builder
+    private InfraCostSnapshot(LocalDate billingPeriodStart, LocalDate billingPeriodEnd,
+                              BigDecimal totalCostUsd, boolean estimated, OffsetDateTime snapshotAt,
+                              String allocationMethodVersion) {
+        this.billingPeriodStart = billingPeriodStart;
+        this.billingPeriodEnd = billingPeriodEnd;
+        this.totalCostUsd = totalCostUsd;
+        this.estimated = estimated;
+        this.snapshotAt = snapshotAt;
+        this.allocationMethodVersion = allocationMethodVersion;
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        if (createdAt == null) {
+            createdAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSnapshotRepository.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSnapshotRepository.java
@@ -1,0 +1,12 @@
+package com.mio.ai.cost;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.UUID;
+
+public interface InfraCostSnapshotRepository extends JpaRepository<InfraCostSnapshot, UUID> {
+
+    Optional<InfraCostSnapshot> findTopByBillingPeriodStartOrderBySnapshotAtDesc(LocalDate billingPeriodStart);
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
@@ -1,0 +1,98 @@
+package com.mio.ai.cost;
+
+import com.mio.common.AppConstants;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
+import software.amazon.awssdk.services.cloudwatch.model.Dimension;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
+import software.amazon.awssdk.services.cloudwatch.model.Statistic;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.time.ZoneOffset;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * AWS {@code AWS/Billing EstimatedCharges} 지표를 일 1회 배치로 캐싱한다 (이슈 #437).
+ *
+ * <p>처음엔 Cost Explorer({@code ce:GetCostAndUsage})로 구현했으나, 그쪽은 호출 1건당 $0.01가
+ * 과금된다 — 하루 1번 배치라도 월 $0.30. {@code cloudwatch:GetMetricStatistics}는 이 호출량에서
+ * 사실상 무료라 이쪽으로 전환했다(리뷰 반영). {@code EstimatedCharges}는 AWS 스스로도 "추정치"라고
+ * 부르는 값이라 이 원장의 {@code isEstimated=true} 원칙과도 맞는다 — 계정 결제 주기에 맞춰
+ * 월초 0으로 리셋되고 그 달 누적으로 올라가는 값이라 별도 기간 조회 없이 최신 값만 읽으면 된다.
+ *
+ * <p>실패해도 기존 캐시는 그대로 두고 다음 배치에서 재시도한다 — {@code WeeklyReflectionJob} 계열
+ * 배치와 같은 원칙으로 개별 실패가 앱 전체를 막지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class InfraCostSyncJob {
+
+    public static final String ALLOCATION_METHOD_VERSION = "v1-time-proportional";
+    private static final String NAMESPACE = "AWS/Billing";
+    private static final String METRIC_NAME = "EstimatedCharges";
+    // AWS/Billing 지표는 대략 6시간 간격으로 게시된다 — 최근 24시간을 조회하면 최소 1개는 걸린다.
+    private static final Duration LOOKBACK = Duration.ofHours(24);
+    private static final int PERIOD_SECONDS = 21_600;
+
+    private final CloudWatchClient cloudWatchClient;
+    private final InfraCostSnapshotRepository repository;
+
+    @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
+    public void sync() {
+        try {
+            Instant now = Instant.now();
+            GetMetricStatisticsRequest request = GetMetricStatisticsRequest.builder()
+                    .namespace(NAMESPACE)
+                    .metricName(METRIC_NAME)
+                    .dimensions(Dimension.builder().name("Currency").value("USD").build())
+                    .startTime(now.minus(LOOKBACK))
+                    .endTime(now)
+                    .period(PERIOD_SECONDS)
+                    .statistics(Statistic.MAXIMUM)
+                    .build();
+
+            GetMetricStatisticsResponse response = cloudWatchClient.getMetricStatistics(request);
+            List<Datapoint> datapoints = response.datapoints();
+            if (datapoints.isEmpty()) {
+                log.warn("[InfraCostSyncJob] AWS/Billing EstimatedCharges 지표에 최근 {}시간 데이터가 없음",
+                        LOOKBACK.toHours());
+                return;
+            }
+
+            Datapoint latest = datapoints.stream()
+                    .max(Comparator.comparing(Datapoint::timestamp))
+                    .orElseThrow();
+            BigDecimal totalCostUsd = BigDecimal.valueOf(latest.maximum());
+
+            YearMonth month = YearMonth.now(AppConstants.ZONE);
+            LocalDate periodStart = month.atDay(1);
+            LocalDate periodEnd = month.plusMonths(1).atDay(1);
+
+            repository.save(InfraCostSnapshot.builder()
+                    .billingPeriodStart(periodStart)
+                    .billingPeriodEnd(periodEnd)
+                    .totalCostUsd(totalCostUsd)
+                    .estimated(true) // EstimatedCharges는 AWS 스스로도 추정치라고 부르는 값이다.
+                    .snapshotAt(OffsetDateTime.now(ZoneOffset.UTC))
+                    .allocationMethodVersion(ALLOCATION_METHOD_VERSION)
+                    .build());
+
+            log.info("[InfraCostSyncJob] 캐싱 완료 period={}~{} totalCostUsd={} dataPointAt={}",
+                    periodStart, periodEnd, totalCostUsd, latest.timestamp());
+        } catch (Exception e) {
+            log.warn("[InfraCostSyncJob] CloudWatch 동기화 실패, 기존 캐시 유지: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
+++ b/src/main/java/com/mio/ai/cost/InfraCostSyncJob.java
@@ -33,6 +33,10 @@ import java.util.List;
  *
  * <p>실패해도 기존 캐시는 그대로 두고 다음 배치에서 재시도한다 — {@code WeeklyReflectionJob} 계열
  * 배치와 같은 원칙으로 개별 실패가 앱 전체를 막지 않는다.
+ *
+ * <p>스냅샷 저장 직후, 같은 배치 실행 시점에 {@link AllocationSensitivityCalculator}로 옵션 B
+ * 배분 민감도도 함께 계산한다(이슈 #438) — 이 계산은 별도 try/catch로 격리해, 실패해도 이미
+ * 성공한 스냅샷 캐싱까지 실패로 보이지 않게 한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -48,6 +52,7 @@ public class InfraCostSyncJob {
 
     private final CloudWatchClient cloudWatchClient;
     private final InfraCostSnapshotRepository repository;
+    private final AllocationSensitivityCalculator allocationSensitivityCalculator;
 
     @Scheduled(cron = "0 30 0 * * *", zone = "Asia/Seoul")
     public void sync() {
@@ -91,6 +96,13 @@ public class InfraCostSyncJob {
 
             log.info("[InfraCostSyncJob] 캐싱 완료 period={}~{} totalCostUsd={} dataPointAt={}",
                     periodStart, periodEnd, totalCostUsd, latest.timestamp());
+
+            try {
+                allocationSensitivityCalculator.computeAndSave(month, totalCostUsd);
+            } catch (Exception e) {
+                // 스냅샷 캐싱은 이미 성공했으니, 민감도 계산 실패로 위 성공까지 실패로 보이면 안 된다(이슈 #438).
+                log.warn("[InfraCostSyncJob] 배분 민감도 계산 실패, 스냅샷 캐싱에는 영향 없음: {}", e.getMessage());
+            }
         } catch (Exception e) {
             log.warn("[InfraCostSyncJob] CloudWatch 동기화 실패, 기존 캐시 유지: {}", e.getMessage());
         }

--- a/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
+++ b/src/main/java/com/mio/ai/judge/CbtMetadataClassifier.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -53,7 +54,9 @@ public class CbtMetadataClassifier {
             String assistantResponse,
             UserMessageSignal userSignal,
             int socraticQuestionsUsed,
-            boolean crisisFlowTriggered) {
+            boolean crisisFlowTriggered,
+            UUID userId,
+            UUID sessionId) {
 
         if (crisisFlowTriggered || assistantResponse == null || assistantResponse.isBlank()) {
             return CbtMetadataResult.none();
@@ -67,7 +70,8 @@ public class CbtMetadataClassifier {
                     assistantResponse,
                     userSignal,
                     socraticQuestionsUsed))
-                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS);
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                    .withAttribution("CBT_CLASSIFIER", userId, sessionId);
             String responseJson = llmClient.completeJson(request);
             return parse(responseJson, CbtInterventionState.fromWireValue(previousState), userSignal);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/judge/InputJudge.java
+++ b/src/main/java/com/mio/ai/judge/InputJudge.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -74,11 +75,13 @@ public class InputJudge {
         return combined.requiresJudge();
     }
 
-    public InputJudgeResult judge(String message, CombinedSignal combined, SafetyProfile profile) {
+    public InputJudgeResult judge(String message, CombinedSignal combined, SafetyProfile profile,
+                                   UUID userId, UUID sessionId) {
         try {
             String contextPrompt = buildContextPrompt(profile, message);
             LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, contextPrompt)
-                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS);
+                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS)
+                    .withAttribution("INPUT_JUDGE", userId, sessionId);
             String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/judge/OutputJudge.java
+++ b/src/main/java/com/mio/ai/judge/OutputJudge.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -46,11 +48,13 @@ public class OutputJudge {
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
 
-    public OutputJudgeResult judge(String aiResponse, OutputPreFilterResult preFilterResult) {
+    public OutputJudgeResult judge(String aiResponse, OutputPreFilterResult preFilterResult,
+                                    UUID userId, UUID sessionId) {
         try {
             String userContent = buildJudgePrompt(aiResponse, preFilterResult);
             LlmRequest request = LlmRequest.of(JUDGE_MODEL, SYSTEM_PROMPT, userContent)
-                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS);
+                    .withMaxCompletionTokens(JUDGE_MAX_COMPLETION_TOKENS)
+                    .withAttribution("OUTPUT_JUDGE", userId, sessionId);
             String responseJson = llmClient.completeJson(request);
             return parseJudgeResult(responseJson);
         } catch (Exception e) {

--- a/src/main/java/com/mio/ai/llm/EmbeddingClient.java
+++ b/src/main/java/com/mio/ai/llm/EmbeddingClient.java
@@ -1,7 +1,14 @@
 package com.mio.ai.llm;
 
+import java.util.UUID;
+
 /** Generates a semantic embedding for a non-blank text query. */
 public interface EmbeddingClient {
 
-    float[] embed(String text);
+    /**
+     * @param component 비용 귀속 태그(이슈 #431). null이면 {@code ai_cost_events}에 기록되지 않는다.
+     * @param userId    비용을 귀속시킬 유저(nullable)
+     * @param sessionId 비용을 귀속시킬 세션(nullable — 임베딩은 대개 세션 밖 배치 작업)
+     */
+    float[] embed(String text, String component, UUID userId, UUID sessionId);
 }

--- a/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
+++ b/src/main/java/com/mio/ai/llm/LlmCostCalculator.java
@@ -51,15 +51,25 @@ public class LlmCostCalculator {
             return null;
         }
 
+        // cachedTokens 는 promptTokens 의 부분집합(OpenAI usage.prompt_tokens_details.cached_tokens).
+        // 캐시 단가가 없는 모델(임베딩 등)은 캐시 히트분도 정가로 계산한다 — 할인을 모른다고
+        // 0 으로 치면 비용을 실제보다 더 적게 잡는 반대 방향 오류가 된다.
+        long cachedTokens = Math.min(usage.cachedTokens(), usage.promptTokens());
+        long uncachedTokens = usage.promptTokens() - cachedTokens;
+        BigDecimal cachedInputPrice = price.cachedInput() != null ? price.cachedInput() : price.input();
+
         BigDecimal inputCost = price.input()
-                .multiply(BigDecimal.valueOf(usage.promptTokens()))
+                .multiply(BigDecimal.valueOf(uncachedTokens))
+                .divide(TOKENS_PER_PRICE_UNIT, MathContext.DECIMAL64);
+        BigDecimal cachedInputCost = cachedInputPrice
+                .multiply(BigDecimal.valueOf(cachedTokens))
                 .divide(TOKENS_PER_PRICE_UNIT, MathContext.DECIMAL64);
         BigDecimal outputCost = price.output()
                 .multiply(BigDecimal.valueOf(usage.completionTokens()))
                 .divide(TOKENS_PER_PRICE_UNIT, MathContext.DECIMAL64);
 
         // stripTrailingZeros 로 0.0004500000 대신 0.00045 를 남긴다.
-        return inputCost.add(outputCost)
+        return inputCost.add(cachedInputCost).add(outputCost)
                 .setScale(COST_SCALE, RoundingMode.HALF_UP)
                 .stripTrailingZeros();
     }

--- a/src/main/java/com/mio/ai/llm/LlmPricingProperties.java
+++ b/src/main/java/com/mio/ai/llm/LlmPricingProperties.java
@@ -28,13 +28,15 @@ public class LlmPricingProperties {
     }
 
     /**
-     * @param input  입력 토큰 100만 개당 USD
-     * @param output 출력 토큰 100만 개당 USD
+     * @param input       입력 토큰 100만 개당 USD
+     * @param cachedInput 캐시 히트된 입력 토큰 100만 개당 USD. 캐시 할인이 없는 모델(임베딩 등)은 {@code null}
+     * @param output      출력 토큰 100만 개당 USD
      */
-    public record ModelPrice(BigDecimal input, BigDecimal output) {
+    public record ModelPrice(BigDecimal input, BigDecimal cachedInput, BigDecimal output) {
         public boolean isValid() {
             return input != null && output != null
-                    && input.signum() >= 0 && output.signum() >= 0;
+                    && input.signum() >= 0 && output.signum() >= 0
+                    && (cachedInput == null || cachedInput.signum() >= 0);
         }
     }
 }

--- a/src/main/java/com/mio/ai/llm/LlmRequest.java
+++ b/src/main/java/com/mio/ai/llm/LlmRequest.java
@@ -4,6 +4,7 @@ import com.mio.ai.memory.working.WorkingMessage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 /**
  * @param maxCompletionTokens 출력 토큰 상한. {@code null} 이면 상한을 보내지 않는다 —
@@ -14,11 +15,19 @@ import java.util.List;
  *                            파싱이 통째로 실패한다. 그래서 상한값은 프롬프트가 요구하는 길이 옆에
  *                            두어 둘이 함께 바뀌게 하고, 실제 절단 발생은
  *                            {@code mio.llm.truncated} 로 관측한다.
+ * @param component           비용 귀속 태그(이슈 #431). {@code null} 이면 {@code ai_cost_events}에
+ *                            기록되지 않고 조용히 스킵된다 — {@link #withAttribution}으로 채운다.
+ * @param userId              비용을 귀속시킬 유저. 세션에 안 걸리는 배치 호출도 있어 세션과
+ *                            독립적으로 둔다.
+ * @param sessionId           비용을 귀속시킬 세션. 세션 밖 호출(주간회고·리포트 등)은 null.
  */
 public record LlmRequest(
         String model,
         List<Message> messages,
-        Integer maxCompletionTokens
+        Integer maxCompletionTokens,
+        String component,
+        UUID userId,
+        UUID sessionId
 ) {
     public record Message(String role, String content) {}
 
@@ -32,14 +41,19 @@ public record LlmRequest(
 
     /** 상한을 지정한 복사본. 원본은 그대로 둔다. */
     public LlmRequest withMaxCompletionTokens(int maxCompletionTokens) {
-        return new LlmRequest(model, messages, maxCompletionTokens);
+        return new LlmRequest(model, messages, maxCompletionTokens, component, userId, sessionId);
+    }
+
+    /** 비용 귀속 정보를 붙인 복사본. 원본은 그대로 둔다 — 호출부에서 {@code .withAttribution(...)}로 체이닝. */
+    public LlmRequest withAttribution(String component, UUID userId, UUID sessionId) {
+        return new LlmRequest(model, messages, maxCompletionTokens, component, userId, sessionId);
     }
 
     public static LlmRequest of(String model, String systemPrompt, String userMessage) {
         return new LlmRequest(model, List.of(
                 new Message("system", systemPrompt),
                 new Message("user", userMessage)
-        ), null);
+        ), null, null, null, null);
     }
 
     public static LlmRequest of(String model, String systemPrompt,
@@ -52,6 +66,6 @@ public record LlmRequest(
             }
         }
         messages.add(new Message("user", userMessage));
-        return new LlmRequest(model, messages, null);
+        return new LlmRequest(model, messages, null, null, null, null);
     }
 }

--- a/src/main/java/com/mio/ai/llm/LlmUsage.java
+++ b/src/main/java/com/mio/ai/llm/LlmUsage.java
@@ -11,21 +11,29 @@ package com.mio.ai.llm;
  * @param model            요청에 사용한 모델. 응답이 실제 서빙 모델을 알려주면 그 값
  * @param promptTokens     입력 토큰. {@code resolved=false} 면 의미 없음
  * @param completionTokens 출력 토큰. {@code resolved=false} 면 의미 없음
+ * @param cachedTokens     {@code promptTokens} 중 캐시 적중분(이슈 #431). {@link LlmCostCalculator}가
+ *                         이 값만큼을 캐시 할인 단가로 계산한다. 응답에 없으면 0 —
+ *                         "캐시 안 됨"과 "몰라서 0"을 여기선 구분하지 않는다.
  * @param resolved         사용량을 실제로 받아왔는지
  */
 public record LlmUsage(
         String model,
         long promptTokens,
         long completionTokens,
+        long cachedTokens,
         boolean resolved
 ) {
     public static LlmUsage of(String model, long promptTokens, long completionTokens) {
-        return new LlmUsage(model, promptTokens, completionTokens, true);
+        return new LlmUsage(model, promptTokens, completionTokens, 0L, true);
+    }
+
+    public static LlmUsage of(String model, long promptTokens, long completionTokens, long cachedTokens) {
+        return new LlmUsage(model, promptTokens, completionTokens, cachedTokens, true);
     }
 
     /** 사용량을 받지 못했다. 모델은 알 수 있으므로 함께 남긴다. */
     public static LlmUsage unresolved(String model) {
-        return new LlmUsage(model, 0L, 0L, false);
+        return new LlmUsage(model, 0L, 0L, 0L, false);
     }
 
     public long totalTokens() {

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -14,6 +14,8 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -473,17 +475,36 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 .increment(usage.completionTokens());
 
         BigDecimal cost = costCalculator.costUsd(usage);
+        // 실제 사용 시각(응답 수신 시점)에서 뜬다 — @PrePersist로 커밋 시각을 쓰면 비동기 큐
+        // 지연만큼 실제 사용 시각과 어긋나고, 자정 근처 호출이 월간 집계에서 다음 달로 샐 수 있다.
+        OffsetDateTime occurredAt = OffsetDateTime.now(ZoneOffset.UTC);
         if (cost == null) {
             meterRegistry.counter(UNPRICED_METRIC, "model", model, "mode", mode).increment();
             // 단가 미등록이라 비용은 모르지만, 토큰량 자체는 ai_cost_events에 남긴다(cost_usd=null).
-            costEventWriter.write(userId, sessionId, component, model, mode,
-                    usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), null);
+            recordCostEvent(userId, sessionId, component, model, mode, usage, null, occurredAt);
             return;
         }
         meterRegistry.counter(COST_METRIC, "model", model, "mode", mode)
                 .increment(cost.doubleValue());
-        costEventWriter.write(userId, sessionId, component, model, mode,
-                usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), cost);
+        recordCostEvent(userId, sessionId, component, model, mode, usage, cost, occurredAt);
+    }
+
+    /**
+     * {@code @Async} 제출 자체가 큐 포화 시 {@code TaskRejectedException}을 호출 스레드에서
+     * 동기적으로 던질 수 있다(이슈 #431 리뷰) — {@code AiCostEventWriter.write()} 내부 try-catch는
+     * 이미 시작된 비동기 작업의 실패만 잡을 뿐, 제출 자체가 거부되는 경우는 못 잡는다. 이 지점이
+     * 세션당 최대 15회 호출돼 다른 비동기 로거보다 큐 포화 가능성이 높으므로, 여기서 한 번 더
+     * 막아 비용 기록 실패가 스트리밍 응답 경로까지 전파되지 않게 한다.
+     */
+    private void recordCostEvent(UUID userId, UUID sessionId, String component, String model, String mode,
+                                  LlmUsage usage, BigDecimal cost, OffsetDateTime occurredAt) {
+        try {
+            costEventWriter.write(userId, sessionId, component, model, mode,
+                    usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), cost, occurredAt);
+        } catch (Exception e) {
+            log.warn("[OpenAiLlmClient] 비용 이벤트 제출 실패 component={} model={}: {}",
+                    component, model, e.getMessage());
+        }
     }
 
     private JsonNode readChunk(String json) {

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -2,6 +2,7 @@ package com.mio.ai.llm;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.cost.AiCostEventWriter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -16,6 +17,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -52,18 +54,21 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
     private final LlmCostCalculator costCalculator;
+    private final AiCostEventWriter costEventWriter;
 
     public OpenAiLlmClient(
             @Value("${openai.api-key}") String apiKey,
             HttpClient httpClient,
             ObjectMapper objectMapper,
             MeterRegistry meterRegistry,
-            LlmCostCalculator costCalculator) {
+            LlmCostCalculator costCalculator,
+            AiCostEventWriter costEventWriter) {
         this.apiKey = apiKey;
         this.httpClient = httpClient;
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistry;
         this.costCalculator = costCalculator;
+        this.costEventWriter = costEventWriter;
     }
 
     private static final int MAX_RETRIES = 4;
@@ -104,7 +109,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                     response.body().close();
                     if (attempt >= MAX_RETRIES) {
                         recordOutcome(request.model(), MODE_STREAM, "rate_limited");
-                        recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                        recordUsage(MODE_STREAM, resolveUsage(usage, request.model()), request);
                         terminalRecorded = true;
                         throw new RuntimeException("OpenAI API error: 429 (rate limited, max retries exceeded)");
                     }
@@ -129,7 +134,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 if (response.statusCode() != 200) {
                     response.body().close();
                     recordOutcome(request.model(), MODE_STREAM, "error");
-                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()), request);
                     terminalRecorded = true;
                     throw new RuntimeException("OpenAI API error: " + response.statusCode());
                 }
@@ -164,7 +169,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 recordOutcome(request.model(), MODE_STREAM, "interrupted");
-                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()), request);
                 throw new RuntimeException("LLM streaming request interrupted", e);
             } catch (RuntimeException e) {
                 // 청크 핸들러가 던진 예외가 여기로 온다 (오케스트레이터는 SSE IOException 을
@@ -172,20 +177,20 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 // 아무것도 남지 않는다 — 실패가 "아무 일 없었던 것"이 되는 그 구조다.
                 if (!terminalRecorded) {
                     recordOutcome(request.model(), MODE_STREAM, "aborted");
-                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                    recordUsage(MODE_STREAM, resolveUsage(usage, request.model()), request);
                 }
                 throw e;
             } catch (Exception e) {
                 log.error("LLM streaming error: {}", e.getMessage());
                 recordOutcome(request.model(), MODE_STREAM, "error");
-                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()));
+                recordUsage(MODE_STREAM, resolveUsage(usage, request.model()), request);
                 throw new RuntimeException("LLM streaming failed", e);
             }
         }
 
         recordOutcome(request.model(), MODE_STREAM, "success");
         LlmUsage resolved = resolveUsage(usage, request.model());
-        recordUsage(MODE_STREAM, resolved);
+        recordUsage(MODE_STREAM, resolved, request);
 
         long ttftMs = ttft.get() > 0 ? ttft.get() : System.currentTimeMillis() - startMs;
         return new LlmStreamResult(ttftMs, resolved, truncated.get());
@@ -251,7 +256,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(request.model(), mode, "error");
-                recordUsage(mode, LlmUsage.unresolved(request.model()));
+                recordUsage(mode, LlmUsage.unresolved(request.model()), request);
                 terminalRecorded = true;
                 throw new RuntimeException("OpenAI API error: " + response.statusCode());
             }
@@ -262,25 +267,25 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             LlmUsage usage = extractUsage(root, request.model());
             recordIfTruncated(root, request.model(), mode);
             recordOutcome(request.model(), mode, "success");
-            recordUsage(mode, usage != null ? usage : LlmUsage.unresolved(request.model()));
+            recordUsage(mode, usage != null ? usage : LlmUsage.unresolved(request.model()), request);
 
             return root.path("choices").path(0).path("message").path("content").asText();
 
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             recordOutcome(request.model(), mode, "interrupted");
-            recordUsage(mode, LlmUsage.unresolved(request.model()));
+            recordUsage(mode, LlmUsage.unresolved(request.model()), request);
             throw new RuntimeException("LLM complete request interrupted", e);
         } catch (RuntimeException e) {
             if (!terminalRecorded) {
                 recordOutcome(request.model(), mode, "aborted");
-                recordUsage(mode, LlmUsage.unresolved(request.model()));
+                recordUsage(mode, LlmUsage.unresolved(request.model()), request);
             }
             throw e;
         } catch (Exception e) {
             log.error("LLM complete error: {}", e.getMessage());
             recordOutcome(request.model(), mode, "error");
-            recordUsage(mode, LlmUsage.unresolved(request.model()));
+            recordUsage(mode, LlmUsage.unresolved(request.model()), request);
             throw new RuntimeException("LLM complete failed", e);
         }
     }
@@ -302,7 +307,8 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         return objectMapper.writeValueAsString(body);
     }
 
-    public float[] embed(String text) {
+    @Override
+    public float[] embed(String text, String component, UUID userId, UUID sessionId) {
         if (text == null || text.isBlank()) {
             throw new IllegalArgumentException("embed() requires non-blank text");
         }
@@ -324,7 +330,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
 
             if (response.statusCode() != 200) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
                 terminalRecorded = true;
                 throw new RuntimeException("OpenAI Embeddings API error: " + response.statusCode());
             }
@@ -333,7 +339,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             JsonNode embeddingNode = root.path("data").path(0).path("embedding");
             if (embeddingNode.isMissingNode() || !embeddingNode.isArray()) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
                 terminalRecorded = true;
                 throw new RuntimeException("Unexpected embeddings response structure: " + response.body());
             }
@@ -345,24 +351,25 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
             // 임베딩도 과금 대상이다. 빼면 mio.llm.cost.usd 가 실제 지출보다 낮게 나온다.
             LlmUsage usage = extractUsage(root, EMBEDDING_MODEL);
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "success");
-            recordUsage(MODE_EMBED, usage != null ? usage : LlmUsage.unresolved(EMBEDDING_MODEL));
+            recordUsage(MODE_EMBED, usage != null ? usage : LlmUsage.unresolved(EMBEDDING_MODEL),
+                    component, userId, sessionId);
 
             return result;
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "interrupted");
-            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
             throw new RuntimeException("Embeddings request interrupted", e);
         } catch (RuntimeException e) {
             if (!terminalRecorded) {
                 recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "aborted");
-                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+                recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
             }
             throw e;
         } catch (Exception e) {
             log.error("Embeddings API error: {}", e.getMessage());
             recordOutcome(EMBEDDING_MODEL, MODE_EMBED, "error");
-            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL));
+            recordUsage(MODE_EMBED, LlmUsage.unresolved(EMBEDDING_MODEL), component, userId, sessionId);
             throw new RuntimeException("Embeddings request failed", e);
         }
     }
@@ -390,9 +397,12 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         if (!prompt.isNumber()) {
             return null;
         }
+        // 캐싱된 입력 토큰(이슈 #431) — prompt_tokens_details.cached_tokens. 없으면 0(임베딩
+        // 응답 등 이 필드 자체가 없는 경우 포함) — "캐시 안 됨"과 "몰라서 0"을 구분하지 않는다.
+        long cachedTokens = usage.path("prompt_tokens_details").path("cached_tokens").asLong(0L);
         // 임베딩 응답에는 completion_tokens 가 없다. 출력 토큰이 실제로 0 인 경우다.
         return LlmUsage.of(requestedModel, prompt.asLong(),
-                completion.isNumber() ? completion.asLong() : 0L);
+                completion.isNumber() ? completion.asLong() : 0L, cachedTokens);
     }
 
     /**
@@ -436,7 +446,17 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
                 .increment();
     }
 
-    private void recordUsage(String mode, LlmUsage usage) {
+    /** stream()/complete() 용 — request 에 실린 귀속 정보(component/userId/sessionId)를 그대로 넘긴다. */
+    private void recordUsage(String mode, LlmUsage usage, LlmRequest request) {
+        recordUsage(mode, usage, request.component(), request.userId(), request.sessionId());
+    }
+
+    /**
+     * 비용 계산이 실제로 모이는 단 한 곳(이슈 #431). {@code stream()}·{@code complete()}·
+     * {@code embed()} 세 진입점 전부가 여기를 거치므로, 14개 호출부를 각각 안 건드리고 이
+     * 지점 하나에만 {@code ai_cost_events} 저장을 추가하면 전부 잡힌다.
+     */
+    private void recordUsage(String mode, LlmUsage usage, String component, UUID userId, UUID sessionId) {
         String model = usage.model();
         if (!usage.resolved()) {
             // "사용량을 못 받았다" 를 별도 값으로 남긴다. 토큰 0 으로 세면 조용히 과소 계상된다.
@@ -455,10 +475,15 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         BigDecimal cost = costCalculator.costUsd(usage);
         if (cost == null) {
             meterRegistry.counter(UNPRICED_METRIC, "model", model, "mode", mode).increment();
+            // 단가 미등록이라 비용은 모르지만, 토큰량 자체는 ai_cost_events에 남긴다(cost_usd=null).
+            costEventWriter.write(userId, sessionId, component, model, mode,
+                    usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), null);
             return;
         }
         meterRegistry.counter(COST_METRIC, "model", model, "mode", mode)
                 .increment(cost.doubleValue());
+        costEventWriter.write(userId, sessionId, component, model, mode,
+                usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), cost);
     }
 
     private JsonNode readChunk(String json) {

--- a/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
+++ b/src/main/java/com/mio/ai/llm/OpenAiLlmClient.java
@@ -41,6 +41,7 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
     private static final String TOKENS_METRIC = "mio.llm.tokens";
     private static final String COST_METRIC = "mio.llm.cost.usd";
     private static final String UNPRICED_METRIC = "mio.llm.cost.unpriced";
+    private static final String COST_EVENT_METRIC = "mio.llm.cost.events";
     private static final String RETRIES_METRIC = "mio.llm.retries";
     private static final String TRUNCATED_METRIC = "mio.llm.truncated";
 
@@ -501,7 +502,9 @@ public class OpenAiLlmClient implements LlmClient, EmbeddingClient {
         try {
             costEventWriter.write(userId, sessionId, component, model, mode,
                     usage.promptTokens(), usage.completionTokens(), usage.cachedTokens(), cost, occurredAt);
+            meterRegistry.counter(COST_EVENT_METRIC, "outcome", "accepted").increment();
         } catch (Exception e) {
+            meterRegistry.counter(COST_EVENT_METRIC, "outcome", "dropped").increment();
             log.warn("[OpenAiLlmClient] 비용 이벤트 제출 실패 component={} model={}: {}",
                     component, model, e.getMessage());
         }

--- a/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ConversationCheckpointService.java
@@ -86,7 +86,7 @@ public class ConversationCheckpointService {
             List<MessageRecord> records = loadMessageRecordsSince(sessionId, since);
             if (records.isEmpty()) return;
 
-            String summaryText = generateSummary(records.stream().map(MessageRecord::line).toList());
+            String summaryText = generateSummary(records.stream().map(MessageRecord::line).toList(), userId, sessionId);
             if (summaryText == null) return;
             OffsetDateTime coveredUpTo = records.stream()
                     .map(MessageRecord::createdAt)
@@ -164,12 +164,13 @@ public class ConversationCheckpointService {
                 .toList();
     }
 
-    private String generateSummary(List<String> lines) {
+    private String generateSummary(List<String> lines, UUID userId, UUID sessionId) {
         StringBuilder sb = new StringBuilder();
         try {
             LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(CHECKPOINT_MODEL, CHECKPOINT_SYSTEM_PROMPT, String.join("\n", lines))
-                            .withMaxCompletionTokens(CHECKPOINT_MAX_COMPLETION_TOKENS),
+                            .withMaxCompletionTokens(CHECKPOINT_MAX_COMPLETION_TOKENS)
+                            .withAttribution("CHECKPOINT_SUMMARY", userId, sessionId),
                     sb::append
             );
             // 잘린 요약은 저장하지 않는다. 체크포인트는 이후 턴의 프롬프트에 그대로 실리므로,

--- a/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/EmbeddingWorker.java
@@ -68,7 +68,9 @@ public class EmbeddingWorker {
                 String summaryText = (String) row.get("summary_text");
                 int attempts = ((Number) row.get("embedding_attempts")).intValue();
                 Object claimToken = row.get("embedding_claimed_at");
-                embedOne(id, summaryText, attempts, claimToken);
+                UUID userId = row.get("user_id") != null ? UUID.fromString(row.get("user_id").toString()) : null;
+                UUID sessionId = row.get("session_id") != null ? UUID.fromString(row.get("session_id").toString()) : null;
+                embedOne(id, summaryText, attempts, claimToken, userId, sessionId);
             } catch (Exception e) {
                 log.error("EmbeddingWorker: malformed claimed row, skipping: {}", row.get("id"), e);
             }
@@ -100,7 +102,7 @@ public class EmbeddingWorker {
                     LIMIT ?
                     FOR UPDATE SKIP LOCKED
                 )
-                RETURNING id, summary_text, embedding_attempts, embedding_claimed_at
+                RETURNING id, summary_text, embedding_attempts, embedding_claimed_at, user_id, session_id
                 """,
                 MAX_ATTEMPTS, RECLAIM_AFTER_MINUTES, BATCH_SIZE
         );
@@ -125,7 +127,8 @@ public class EmbeddingWorker {
         );
     }
 
-    private void embedOne(UUID summaryId, String summaryText, int attempts, Object claimToken) {
+    private void embedOne(UUID summaryId, String summaryText, int attempts, Object claimToken,
+                           UUID userId, UUID sessionId) {
         if (summaryText == null || summaryText.isBlank()) {
             // 재시도해도 결과가 달라지지 않는다. 상한을 기다리지 않고 바로 확정한다.
             log.warn("EmbeddingWorker: summaryText is null or blank for summaryId={}, marking failed", summaryId);
@@ -133,7 +136,7 @@ public class EmbeddingWorker {
             return;
         }
         try {
-            float[] embedding = openAiLlmClient.embed(summaryText);
+            float[] embedding = openAiLlmClient.embed(summaryText, "SUMMARY_STORAGE_EMBEDDING", userId, sessionId);
             String vectorLiteral = toVectorLiteral(embedding);
 
             int updated = jdbcTemplate.update(

--- a/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/ExtractorLlmClient.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 /**
  * GPT-4o-mini를 이용해 세션 요약에서 thought/distortion/emotion/trigger를 추출.
@@ -92,7 +93,7 @@ public class ExtractorLlmClient {
     private final LlmClient llmClient;
     private final ObjectMapper objectMapper;
 
-    public ExtractorResult extract(String sessionSummary) {
+    public ExtractorResult extract(String sessionSummary, UUID userId, UUID sessionId) {
         if (sessionSummary == null || sessionSummary.isBlank()) {
             return ExtractorResult.empty();
         }
@@ -101,7 +102,8 @@ public class ExtractorLlmClient {
         try {
             LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(MODEL, SYSTEM_PROMPT, sessionSummary)
-                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                            .withAttribution("EXTRACTOR", userId, sessionId),
                     responseBuilder::append
             );
             // 잘린 응답은 파싱하지 않는다. "파싱이 실패할 테니 괜찮다"에 기댈 수 없다 —

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -172,7 +172,7 @@ public class SessionConsolidator {
         // 사용자는 (분석 톤이긴 해도) 요약을 받는다. 렌더링 실패로 요약을 잃게 두지 않는다.
         try {
             String userSummary = sessionSummaryRenderer.render(
-                    enrichInput.summaryText(), event.characterId());
+                    enrichInput.summaryText(), event.characterId(), enrichInput.userId(), enrichInput.sessionId());
             if (userSummary != null) {
                 userSummaryWriter.write(enrichInput.sessionId(), userSummary);
             }
@@ -226,14 +226,14 @@ public class SessionConsolidator {
         }
 
         // 2. 세션 요약 생성 (LLM)
-        String summaryText = generateSummary(conversationText);
+        String summaryText = generateSummary(conversationText, userId, sessionId);
 
         // 3. AES-256 암호화
         byte[] ciphertext = messageEncryptor.encrypt(summaryText.getBytes(StandardCharsets.UTF_8));
         String dekId = messageEncryptor.dekId();
 
         // 4. ExtractorLLM — thought/emotion/trigger 추출
-        ExtractorResult extracted = extractorLlmClient.extract(summaryText);
+        ExtractorResult extracted = extractorLlmClient.extract(summaryText, userId, sessionId);
 
         // 5. OntologyValidator 필터 (Phase 3-1 의존, optional)
         List<ExtractorResult.ExtractedThought> validThoughts = filterValidThoughts(extracted.thoughts());
@@ -402,11 +402,12 @@ public class SessionConsolidator {
 
     // ── 요약 생성 ────────────────────────────────────────────────
 
-    private String generateSummary(String conversationText) {
+    private String generateSummary(String conversationText, UUID userId, UUID sessionId) {
         StringBuilder sb = new StringBuilder();
         LlmStreamResult result = llmClient.stream(
                 LlmRequest.of(SUMMARY_MODEL, SUMMARY_SYSTEM_PROMPT, conversationText)
-                        .withMaxCompletionTokens(SUMMARY_MAX_COMPLETION_TOKENS),
+                        .withMaxCompletionTokens(SUMMARY_MAX_COMPLETION_TOKENS)
+                        .withAttribution("SESSION_SUMMARY", userId, sessionId),
                 sb::append
         );
         // 잘린 요약을 그대로 쓰면 암호화·저장을 거쳐 세션의 정본 기억이 되고, ExtractorLLM 이

--- a/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionSummaryRenderer.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -84,7 +85,7 @@ public class SessionSummaryRenderer {
      * @param characterId     세션에서 사용한 캐릭터. 알 수 없으면 기본 캐릭터 어조로 렌더링한다
      * @return 사용자 노출용 요약. 렌더링·계약 검사 실패 시 null
      */
-    public String render(String internalSummary, String characterId) {
+    public String render(String internalSummary, String characterId, UUID userId, UUID sessionId) {
         if (internalSummary == null || internalSummary.isBlank()) {
             return null;
         }
@@ -94,7 +95,8 @@ public class SessionSummaryRenderer {
             StringBuilder response = new StringBuilder();
             LlmStreamResult result = llmClient.stream(
                     LlmRequest.of(MODEL, buildSystemPrompt(persona), "세션 기록:\n" + internalSummary)
-                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                            .withAttribution("SUMMARY_RENDER", userId, sessionId),
                     response::append);
 
             // 잘린 텍스트를 그대로 저장하면 사용자는 문장 중간에서 끊긴 요약을 받고, 잘렸다는

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoActionPersonalizer.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.regex.Pattern;
 
 /**
@@ -85,7 +86,7 @@ public class TodoActionPersonalizer {
      *         실패 항목은 원본 {@link BehaviorTemplate#getActionTextKo()}로 채워진다.
      */
     public List<String> personalize(String sessionSummary, List<String> triggerTags,
-                                    List<BehaviorTemplate> templates) {
+                                    List<BehaviorTemplate> templates, UUID userId, UUID sessionId) {
         List<String> fallback = templates.stream().map(BehaviorTemplate::getActionTextKo).toList();
         if (templates.isEmpty() || sessionSummary == null || sessionSummary.isBlank()) {
             return fallback;
@@ -95,7 +96,8 @@ public class TodoActionPersonalizer {
             StringBuilder response = new StringBuilder();
             llmClient.stream(
                     LlmRequest.of(MODEL, SYSTEM_PROMPT, buildUserMessage(sessionSummary, triggerTags, templates))
-                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS),
+                            .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                            .withAttribution("TODO_PERSONALIZER", userId, sessionId),
                     response::append
             );
             List<String> personalized = parse(response.toString(), templates.size());

--- a/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/TodoRecommendationService.java
@@ -110,7 +110,7 @@ public class TodoRecommendationService {
 
         // LLM 개인화는 트랜잭션 밖에서 수행 (블로킹 HTTP 호출 동안 커넥션 점유 방지).
         List<String> actionTexts = actionPersonalizer.personalize(
-                input.sessionSummary(), input.triggerTags(), selected);
+                input.sessionSummary(), input.triggerTags(), selected, userId, sessionId);
 
         return persistTasks(userId, sessionId, selected, actionTexts);
     }

--- a/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/WeeklyReflectionJob.java
@@ -83,8 +83,8 @@ public class WeeklyReflectionJob {
 
         // LLM 호출 (트랜잭션 외부 — 커넥션 점유 방지)
         String context = buildContext(effectiveMap, recurringTriggers, dominantEmotions);
-        String narrative = generateText(NARRATIVE_SYSTEM, context);
-        String coachingDirection = generateText(DIRECTION_SYSTEM, context);
+        String narrative = generateText(NARRATIVE_SYSTEM, context, userId);
+        String coachingDirection = generateText(DIRECTION_SYSTEM, context, userId);
 
         // 사용자별 독립 트랜잭션으로 저장 (실패해도 다음 사용자에 영향 없음)
         updateSelfModel(userId, dominantEmotions, recurringTriggers, effectiveMap);
@@ -176,10 +176,11 @@ public class WeeklyReflectionJob {
                         .reduce((a, b) -> a + ", " + b).orElse("없음"));
     }
 
-    private String generateText(String systemPrompt, String context) {
+    private String generateText(String systemPrompt, String context, UUID userId) {
         try {
             return llmClient.completeText(LlmRequest.of("gpt-4o-mini", systemPrompt, context)
-                    .withMaxCompletionTokens(REFLECTION_MAX_COMPLETION_TOKENS));
+                    .withMaxCompletionTokens(REFLECTION_MAX_COMPLETION_TOKENS)
+                    .withAttribution("WEEKLY_REFLECTION", userId, null));
         } catch (Exception e) {
             log.warn("[WeeklyReflectionJob] LLM call failed: {}", e.getMessage());
             return null;

--- a/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractor.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 /**
  * 현재 발화의 관계 맥락을 위한 최소 구조화 추출기.
  * 결과는 WorkingMemory TTL 내 활성화에만 사용하며 신념·증거를 새로 저장하지 않는다.
@@ -35,13 +37,14 @@ public class LlmTurnOntologyExtractor implements TurnOntologyExtractor {
     private final ObjectMapper objectMapper;
 
     @Override
-    public TurnOntologySignal extract(String userMessage) {
+    public TurnOntologySignal extract(String userMessage, UUID userId, UUID sessionId) {
         if (userMessage == null || userMessage.isBlank()) {
             return TurnOntologySignal.empty();
         }
         try {
             String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
-                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                    .withAttribution("ONTOLOGY_EXTRACTOR", userId, sessionId));
             JsonNode node = objectMapper.readTree(stripCodeFence(response));
             return new TurnOntologySignal(
                     nullableText(node, "distortionCode"),

--- a/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
+++ b/src/main/java/com/mio/ai/memory/ontology/ReactiveOntologyActivator.java
@@ -68,7 +68,7 @@ public class ReactiveOntologyActivator {
             if (!isSessionActive(sessionId) || !workingMemory.tryAcquireOntologyActivation(sessionId)) {
                 return;
             }
-            TurnOntologySignal signal = turnOntologyExtractor.extract(normalizedMessage);
+            TurnOntologySignal signal = turnOntologyExtractor.extract(normalizedMessage, userId, sessionId);
             if (!isSessionActive(sessionId) || !ontologyValidator.isValidDistortionCode(signal.distortionCode())) {
                 return;
             }

--- a/src/main/java/com/mio/ai/memory/ontology/TurnOntologyExtractor.java
+++ b/src/main/java/com/mio/ai/memory/ontology/TurnOntologyExtractor.java
@@ -1,6 +1,8 @@
 package com.mio.ai.memory.ontology;
 
+import java.util.UUID;
+
 public interface TurnOntologyExtractor {
 
-    TurnOntologySignal extract(String userMessage);
+    TurnOntologySignal extract(String userMessage, UUID userId, UUID sessionId);
 }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -209,7 +209,7 @@ public class ConversationOrchestrator {
             InputJudgeResult judgeResult = null;
             boolean inputJudgeCalled = false;
             if (inputJudge.shouldCallJudge(combined, profile)) {
-                judgeResult = inputJudge.judge(normalized, combined, profile);
+                judgeResult = inputJudge.judge(normalized, combined, profile, userId, sessionId);
                 inputJudgeCalled = true;
             }
 
@@ -308,7 +308,8 @@ public class ConversationOrchestrator {
                         ? recentWorkingMessages.subList(recentWorkingMessages.size() - 10, recentWorkingMessages.size())
                         : recentWorkingMessages;
                 LlmRequest llmRequest = LlmRequest.of(LLM_MODEL, systemPrompt, historySlice, userMessage)
-                        .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS);
+                        .withMaxCompletionTokens(LLM_MAX_COMPLETION_TOKENS)
+                        .withAttribution("MAIN_GENERATION", userId, sessionId);
                 StringBuilder contentBuilder = new StringBuilder();
 
                 DeliveryMode deliveryMode = decision.deliveryMode();
@@ -328,7 +329,7 @@ public class ConversationOrchestrator {
                     OutputPreFilterResult bufferedGuardInput =
                             mergeContractViolations(preFilterResult, contractResult);
                     if (!bufferedGuardInput.passed()) {
-                        judgeActionResult = outputJudge.judge(assistantContent, bufferedGuardInput);
+                        judgeActionResult = outputJudge.judge(assistantContent, bufferedGuardInput, userId, sessionId);
                         if (judgeActionResult != null) {
                             assistantContent = resolveOutputJudgeAction(
                                     judgeActionResult, assistantContent, userMessage, l1Result, user, session, emitter,
@@ -372,7 +373,7 @@ public class ConversationOrchestrator {
                                 log.warn("OutputGuard held back unit: session={} reasons={}",
                                         sessionId, unitCheck.failReasons());
                                 earlyJudgeFutureRef.set(CompletableFuture.supplyAsync(
-                                        () -> outputJudge.judge(candidate, unitCheck), outputJudgeExecutor));
+                                        () -> outputJudge.judge(candidate, unitCheck, userId, sessionId), outputJudgeExecutor));
                                 return false;
                             },
                             unit -> sendEvent(emitter, new SseEventDto.DeltaEvent(unit, outboundMsgId)));
@@ -420,7 +421,7 @@ public class ConversationOrchestrator {
                             final String fullContent = assistantContent;
                             final OutputPreFilterResult fullFilter = streamedGuardInput;
                             judgeFuture = CompletableFuture.supplyAsync(
-                                    () -> outputJudge.judge(fullContent, fullFilter), outputJudgeExecutor);
+                                    () -> outputJudge.judge(fullContent, fullFilter, userId, sessionId), outputJudgeExecutor);
                         }
                     }
 
@@ -819,7 +820,9 @@ public class ConversationOrchestrator {
                         assistantContent,
                         userSignal,
                         sessionDelta.socraticQuestionsUsed(),
-                        isCrisisFlagged)
+                        isCrisisFlagged,
+                        userId,
+                        sessionId)
                 : CbtMetadataResult.none();
 
         UUID emotionScoreTargetId = null;

--- a/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
+++ b/src/main/java/com/mio/ai/profile/ContextPreWarmer.java
@@ -132,7 +132,7 @@ public class ContextPreWarmer {
         try {
             boolean hasHistory = checkHasHistory(userId);
             RetrievalPlan plan = memoryRetrievalPlanner.plan(combined, profile, userId, hasHistory);
-            float[] queryEmbedding = embedIfNeeded(plan, queryText);
+            float[] queryEmbedding = embedIfNeeded(plan, queryText, userId, sessionId);
             Set<String> relatedDistortionCodes = plan.sources().contains(com.mio.ai.memory.retrieval.RetrievalSource.GRAPH_DISTORTION)
                     ? ontologyRelationExpander.expandCooccurringCodes(currentDistortionCode)
                     : Set.of();
@@ -149,13 +149,13 @@ public class ContextPreWarmer {
 
     // ── 실제 병렬 retrieval (CompletableFuture) ────────────────────
 
-    private float[] embedIfNeeded(RetrievalPlan plan, String queryText) {
+    private float[] embedIfNeeded(RetrievalPlan plan, String queryText, UUID userId, UUID sessionId) {
         if (!plan.sources().contains(com.mio.ai.memory.retrieval.RetrievalSource.VECTOR_EPISODE)
                 || queryText == null || queryText.isBlank()) {
             return null;
         }
         CompletableFuture<float[]> embeddingFuture = CompletableFuture.supplyAsync(
-                () -> embeddingClient.embed(queryText), retrievalPool);
+                () -> embeddingClient.embed(queryText, "RETRIEVAL_QUERY_EMBEDDING", userId, sessionId), retrievalPool);
         try {
             long timeoutMs = Math.min(plan.budgetMs(), MAX_EMBEDDING_WAIT_MS);
             return embeddingFuture.get(timeoutMs, TimeUnit.MILLISECONDS);

--- a/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
+++ b/src/main/java/com/mio/checkin/service/CheckinAiResponseGenerator.java
@@ -37,11 +37,13 @@ public class CheckinAiResponseGenerator {
     private final JdbcTemplate jdbcTemplate;
 
     @Async
-    public void generateAndSave(UUID checkinId, String emotionType, int conditionScore, String timeOfDay) {
+    public void generateAndSave(UUID checkinId, String emotionType, int conditionScore, String timeOfDay,
+                                UUID userId) {
         try {
             String userMessage = buildPrompt(emotionType, conditionScore, timeOfDay);
             String response = llmClient.completeText(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
-                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                    .withAttribution("CHECKIN_RESPONSE", userId, null));
 
             if (response == null || response.isBlank()) {
                 log.debug("[CheckinAiResponseGenerator] no response for checkinId={}", checkinId);

--- a/src/main/java/com/mio/checkin/service/CheckinService.java
+++ b/src/main/java/com/mio/checkin/service/CheckinService.java
@@ -111,7 +111,7 @@ public class CheckinService {
                         String cacheValue = serializeResponse(response);
                         redisTemplate.opsForValue().set(cacheKey, cacheValue, IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
                     }
-                    aiResponseGenerator.generateAndSave(checkinId, emotionType, conditionScore, timeOfDay);
+                    aiResponseGenerator.generateAndSave(checkinId, emotionType, conditionScore, timeOfDay, userId);
                 }
             });
         } else {
@@ -120,7 +120,7 @@ public class CheckinService {
                 String cacheValue = serializeResponse(response);
                 redisTemplate.opsForValue().set(cacheKey, cacheValue, IDEMPOTENCY_TTL_SECONDS, TimeUnit.SECONDS);
             }
-            aiResponseGenerator.generateAndSave(checkinId, emotionType, conditionScore, timeOfDay);
+            aiResponseGenerator.generateAndSave(checkinId, emotionType, conditionScore, timeOfDay, userId);
         }
 
         return response;

--- a/src/main/java/com/mio/config/AwsConfig.java
+++ b/src/main/java/com/mio/config/AwsConfig.java
@@ -1,0 +1,28 @@
+package com.mio.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+
+/**
+ * AWS CloudWatch 클라이언트 (이슈 #437).
+ *
+ * <p>인프라 비용 배치 캐싱({@code InfraCostSyncJob})이 {@code AWS/Billing} 네임스페이스의
+ * {@code EstimatedCharges} 지표를 읽는 데 쓴다. 처음엔 Cost Explorer({@code ce:GetCostAndUsage})로
+ * 구현했으나, 그쪽은 호출 1건당 $0.01가 과금돼(하루 1번 배치라도 월 $0.30) CloudWatch 지표 조회
+ * (사실상 무료)로 전환했다 — 리뷰 반영. {@code AWS/Billing} 지표는 리전에 상관없이
+ * <b>us-east-1에만 게시</b>된다 — 앱 자체 리전(ap-northeast-2)과 무관한 AWS 고정 사양이다.
+ * 크리덴셜은 지정하지 않고 기본 체인을 쓴다 — EC2 인스턴스 역할(`mio-ec2-cloudwatch-role`,
+ * `cloudwatch:GetMetricStatistics` 인라인 정책 부여됨)을 그대로 탄다.
+ */
+@Configuration
+public class AwsConfig {
+
+    @Bean
+    public CloudWatchClient cloudWatchBillingClient() {
+        return CloudWatchClient.builder()
+                .region(Region.US_EAST_1)
+                .build();
+    }
+}

--- a/src/main/java/com/mio/report/service/ReportNarrativeService.java
+++ b/src/main/java/com/mio/report/service/ReportNarrativeService.java
@@ -9,6 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.UUID;
 
 @Component
 @RequiredArgsConstructor
@@ -40,11 +41,12 @@ public class ReportNarrativeService {
     }
 
     public NarrativeResult generate(String periodLabel, int checkinCount, Double avgEmotionScore,
-                                    List<DistortionDto> distortionTop3) {
+                                    List<DistortionDto> distortionTop3, UUID userId) {
         String userMessage = buildUserMessage(periodLabel, checkinCount, avgEmotionScore, distortionTop3);
         try {
             String response = llmClient.completeJson(LlmRequest.of(MODEL, SYSTEM_PROMPT, userMessage)
-                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS));
+                    .withMaxCompletionTokens(MAX_COMPLETION_TOKENS)
+                    .withAttribution("REPORT_NARRATIVE", userId, null));
             return parseResponse(response);
         } catch (Exception e) {
             log.warn("ReportNarrative generation failed: period={} error={}", periodLabel, e.getClass().getSimpleName());

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -106,7 +106,7 @@ public class ReportService {
 
         // DB 커넥션 반납 후 LLM 호출
         ReportNarrativeService.NarrativeResult narrative =
-                reportNarrativeService.generate("주간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3());
+                reportNarrativeService.generate("주간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3(), userId);
 
         return new WeeklyReportResponse(
                 null, data.periodStart(), data.periodEnd(), "GENERATED", false,
@@ -152,7 +152,7 @@ public class ReportService {
 
         // DB 커넥션 반납 후 LLM 호출
         ReportNarrativeService.NarrativeResult narrative =
-                reportNarrativeService.generate("월간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3());
+                reportNarrativeService.generate("월간", data.checkinCount(), data.avgEmotionScore(), data.distortionTop3(), userId);
 
         return new MonthlyReportResponse(
                 null, data.periodStart(), data.periodEnd(), "GENERATED", false,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -125,11 +125,13 @@ openai:
     models:
       "[gpt-4o]":
         input: 2.50
+        cached-input: 1.25
         output: 10.00
       "[gpt-4o-mini]":
         input: 0.15
+        cached-input: 0.075
         output: 0.60
-      # 임베딩은 출력 토큰이 없다.
+      # 임베딩은 출력 토큰과 캐시 할인이 없다.
       "[text-embedding-3-small]":
         input: 0.02
         output: 0.00

--- a/src/main/resources/db/migration/V56__create_ai_cost_events.sql
+++ b/src/main/resources/db/migration/V56__create_ai_cost_events.sql
@@ -1,0 +1,29 @@
+-- 이슈 #431 — 세션당 AI 비용 완전 집계.
+-- ai_policy_decisions.trace.llm_cost_usd 는 메인 대화 생성 호출 1건만 반영한다.
+-- OpenAiLlmClient.recordUsage() 를 거치는 모든 LLM/embedding 호출(judge, 분류, 추출, 요약,
+-- 개인화, 리포트, 임베딩 등 15개 호출부)의 비용을 여기 한 곳에 모은다.
+-- ai_policy_decisions 는 정책결정 로그 역할만 유지하고, 이 테이블이 비용 원장이다.
+
+CREATE TABLE ai_cost_events (
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id            UUID,
+    session_id         UUID,
+    component          TEXT NOT NULL,
+    model              TEXT NOT NULL,
+    mode               TEXT NOT NULL,
+    prompt_tokens      BIGINT NOT NULL DEFAULT 0,
+    completion_tokens  BIGINT NOT NULL DEFAULT 0,
+    cached_tokens      BIGINT NOT NULL DEFAULT 0,
+    cost_usd           NUMERIC(20, 10),
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 세션당 cost API: WHERE session_id = ?
+CREATE INDEX idx_ai_cost_events_session_id ON ai_cost_events (session_id) WHERE session_id IS NOT NULL;
+
+-- 유저별 월간 누적: WHERE user_id = ? AND created_at BETWEEN ...
+CREATE INDEX idx_ai_cost_events_user_id_created_at ON ai_cost_events (user_id, created_at) WHERE user_id IS NOT NULL;
+
+-- user_id 도 없는 행은 유저 누적에도 못 들어가 사실상 손실이다. FK 는 걸지 않는다
+-- (audit_logs 와 같은 이유 — 유저 하드삭제 이후에도 비용 기록 자체는 보존 정책상 남아야 할 수 있다).
+COMMENT ON TABLE ai_cost_events IS '호출 단위 LLM/embedding 비용 원장. ai_policy_decisions 와 분리 — 정책결정 로그와 비용 원장을 겸용하지 않는다.';

--- a/src/main/resources/db/migration/V57__create_infra_cost_snapshots.sql
+++ b/src/main/resources/db/migration/V57__create_infra_cost_snapshots.sql
@@ -1,0 +1,21 @@
+-- 이슈 #437 — AWS CloudWatch(AWS/Billing EstimatedCharges) 인프라 비용 배치 캐싱.
+-- 지표 자체가 대략 6시간 간격으로만 갱신돼 세션 조회 시점 실시간 호출이 아니라 배치(일 1회)로
+-- 캐싱한다. is_estimated/snapshot_at는 EstimatedCharges가 확정치가 아니라 지표 이름 그대로
+-- "추정치"라는 걸 API 응답에서도 드러내기 위함이다.
+
+CREATE TABLE infra_cost_snapshots (
+    id                         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_period_start       DATE NOT NULL,
+    billing_period_end         DATE NOT NULL,
+    total_cost_usd             NUMERIC(20, 10) NOT NULL,
+    is_estimated               BOOLEAN NOT NULL,
+    snapshot_at                TIMESTAMPTZ NOT NULL,
+    allocation_method_version  TEXT NOT NULL,
+    created_at                 TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- 특정 월의 최신 스냅샷 조회: WHERE billing_period_start = ? ORDER BY snapshot_at DESC LIMIT 1
+CREATE INDEX idx_infra_cost_snapshots_period_snapshot_at
+    ON infra_cost_snapshots (billing_period_start, snapshot_at DESC);
+
+COMMENT ON TABLE infra_cost_snapshots IS 'AWS CloudWatch(AWS/Billing) 월간 총청구액 배치 캐시. 옵션 A(시간 비례) 인프라비용 배분의 입력값.';

--- a/src/main/resources/db/migration/V58__create_infra_cost_allocation_sensitivity.sql
+++ b/src/main/resources/db/migration/V58__create_infra_cost_allocation_sensitivity.sql
@@ -1,0 +1,20 @@
+-- 이슈 #438 — 배분 모델 민감도 분석(옵션 A 시간비례 vs 옵션 B 요청수비례).
+-- 정확도 검증이 아니다 — A/B 둘 다 임의의 배분 모형이라 어느 쪽도 정답(ground truth)이 아니다.
+-- option_a_usd/option_b_usd/allocation_sensitivity_pct는 그 달 세션별 민감도(|A_i-B_i|/B_i)의
+-- 평균치다. 전체 세션 합계·평균으로 집계하면 두 배분 방식 모두 같은 월간총청구액으로 수렴해
+-- 항상 0%가 나오므로(비례배분의 수학적 항등), 반드시 세션 단위로 먼저 계산한 뒤 평균낸다.
+
+CREATE TABLE infra_cost_allocation_sensitivity (
+    id                          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    billing_period_start        DATE NOT NULL,
+    option_a_usd                NUMERIC(20, 10) NOT NULL,
+    option_b_usd                NUMERIC(20, 10) NOT NULL,
+    allocation_sensitivity_pct  NUMERIC(20, 10) NOT NULL,
+    snapshot_at                 TIMESTAMPTZ NOT NULL,
+    created_at                  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_infra_cost_allocation_sensitivity_period_snapshot_at
+    ON infra_cost_allocation_sensitivity (billing_period_start, snapshot_at DESC);
+
+COMMENT ON TABLE infra_cost_allocation_sensitivity IS '옵션 A(시간비례) vs 옵션 B(요청수비례) 배분 모델 민감도 관찰용. 운영 응답(옵션 A)에는 영향 없음 — 그림자 계산.';

--- a/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
@@ -1,0 +1,90 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.SessionCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Session;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #433 — AI 비용만 먼저 노출하고, 인프라 배분은 null로 비워 미지원을 드러내는지 검증. */
+@ExtendWith(MockitoExtension.class)
+class AdminSessionCostServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private AiCostEventRepository aiCostEventRepository;
+
+    private AdminSessionCostService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션이면 SESSION_NOT_FOUND")
+    void getCost_sessionNotFound_throws() {
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getCost(sessionId))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("전부 단가가 있으면 direct_variable_cost_usd가 채워지고 인프라·합계는 null이다")
+    void getCost_allPriced_infraStillNull() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.013"), 0L, 2L));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.sessionId()).isEqualTo(sessionId);
+        assertThat(response.userId()).isEqualTo(userId);
+        assertThat(response.directVariableCostUsd()).isEqualByComparingTo(new BigDecimal("0.013"));
+        assertThat(response.unpricedEvents()).isZero();
+        assertThat(response.allPriced()).isTrue();
+        assertThat(response.allocatedFixedInfraUsdEstimate())
+                .as("AWS Cost Explorer 연동 전까지는 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
+                .isNull();
+        assertThat(response.totalUsd()).isNull();
+    }
+
+    @Test
+    @DisplayName("단가 미등록 이벤트가 섞여 있으면 allPriced=false와 unpricedEvents가 그대로 노출된다")
+    void getCost_partiallyUnpriced_revealsIncompleteness() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.01"), 1L, 2L));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.allPriced()).isFalse();
+        assertThat(response.unpricedEvents()).isEqualTo(1L);
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminSessionCostServiceTest.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.SessionCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.session.domain.Session;
@@ -16,19 +17,23 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-/** 이슈 #433 — AI 비용만 먼저 노출하고, 인프라 배분은 null로 비워 미지원을 드러내는지 검증. */
+/** 이슈 #433/#437 — AI 비용 + 인프라 배분(캐시 있으면), 캐시 없으면 인프라·합계는 null. */
 @ExtendWith(MockitoExtension.class)
 class AdminSessionCostServiceTest {
 
     @Mock private SessionRepository sessionRepository;
     @Mock private AiCostEventRepository aiCostEventRepository;
+    @Mock private InfraCostAllocator infraCostAllocator;
 
     private AdminSessionCostService service;
 
@@ -37,7 +42,7 @@ class AdminSessionCostServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository);
+        service = new AdminSessionCostService(sessionRepository, aiCostEventRepository, infraCostAllocator);
     }
 
     @Test
@@ -68,7 +73,7 @@ class AdminSessionCostServiceTest {
         assertThat(response.unpricedEvents()).isZero();
         assertThat(response.allPriced()).isTrue();
         assertThat(response.allocatedFixedInfraUsdEstimate())
-                .as("AWS Cost Explorer 연동 전까지는 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
+                .as("인프라 비용 배치 캐시가 없으면 0이 아니라 null이어야 '인프라 비용 없음'으로 오독되지 않는다")
                 .isNull();
         assertThat(response.totalUsd()).isNull();
     }
@@ -86,5 +91,39 @@ class AdminSessionCostServiceTest {
 
         assertThat(response.allPriced()).isFalse();
         assertThat(response.unpricedEvents()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("인프라 배분 캐시가 있으면 총액을 AI비용+인프라비용으로 채운다")
+    void getCost_infraAllocationAvailable_fillsTotal() {
+        User user = User.builder().id(userId).build();
+        OffsetDateTime startedAt = OffsetDateTime.parse("2026-08-10T10:00:00+09:00");
+        OffsetDateTime endedAt = OffsetDateTime.parse("2026-08-10T10:05:00+09:00");
+        Session session = Session.builder()
+                .id(sessionId).user(user).startedAt(startedAt).endedAt(endedAt).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(new BigDecimal("0.013"), 0L, 2L));
+        when(infraCostAllocator.allocateForSession(eq(YearMonth.of(2026, 8)), eq(300L)))
+                .thenReturn(new BigDecimal("0.555"));
+
+        SessionCostResponse response = service.getCost(sessionId);
+
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isEqualByComparingTo(new BigDecimal("0.555"));
+        assertThat(response.totalUsd()).isEqualByComparingTo(new BigDecimal("0.568"));
+    }
+
+    @Test
+    @DisplayName("세션 길이가 0(진행 중이거나 미종료)이면 인프라 배분을 시도하지 않는다")
+    void getCost_zeroDuration_skipsInfraAllocation() {
+        User user = User.builder().id(userId).build();
+        Session session = Session.builder().id(sessionId).user(user).build();
+        when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        when(aiCostEventRepository.aggregateBySessionId(sessionId))
+                .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
+
+        service.getCost(sessionId);
+
+        org.mockito.Mockito.verifyNoInteractions(infraCostAllocator);
     }
 }

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -1,0 +1,117 @@
+package com.mio.admin.service;
+
+import com.mio.admin.dto.UserMonthlyCostResponse;
+import com.mio.ai.cost.AiCostAggregate;
+import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.common.AppConstants;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+/** 이슈 #434 — #433과 같은 원칙(인프라 배분 null)으로 유저·월 단위 집계만 바뀐 것 검증. */
+@ExtendWith(MockitoExtension.class)
+class AdminUserCostServiceTest {
+
+    @Mock private UserRepository userRepository;
+    @Mock private AiCostEventRepository aiCostEventRepository;
+
+    private AdminUserCostService service;
+
+    private final UUID userId = UUID.randomUUID();
+
+    @BeforeEach
+    void setUp() {
+        service = new AdminUserCostService(userRepository, aiCostEventRepository);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저면 USER_NOT_FOUND")
+    void getMonthlyCost_userNotFound_throws() {
+        when(userRepository.existsById(userId)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.getMonthlyCost(userId, "2026-08"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("잘못된 month 형식이면 INVALID_INPUT")
+    void getMonthlyCost_invalidMonthFormat_throws() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+
+        assertThatThrownBy(() -> service.getMonthlyCost(userId, "not-a-month"))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(e -> assertThat(((BusinessException) e).getErrorCode())
+                        .isEqualTo(ErrorCode.INVALID_INPUT));
+    }
+
+    @Test
+    @DisplayName("month를 지정하면 해당 월의 [1일 00:00, 다음달 1일 00:00) 범위로 집계한다")
+    void getMonthlyCost_explicitMonth_queriesCorrectRange() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("1.5"), 0L, 3L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.month()).isEqualTo("2026-08");
+        assertThat(response.directVariableCostUsd()).isEqualByComparingTo(new BigDecimal("1.5"));
+
+        ArgumentCaptor<OffsetDateTime> fromCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        ArgumentCaptor<OffsetDateTime> toCaptor = ArgumentCaptor.forClass(OffsetDateTime.class);
+        org.mockito.Mockito.verify(aiCostEventRepository)
+                .aggregateByUserIdAndCreatedAtBetween(eq(userId), fromCaptor.capture(), toCaptor.capture());
+
+        YearMonth august = YearMonth.of(2026, 8);
+        assertThat(fromCaptor.getValue())
+                .isEqualTo(august.atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime());
+        assertThat(toCaptor.getValue())
+                .isEqualTo(august.plusMonths(1).atDay(1).atStartOfDay(AppConstants.ZONE).toOffsetDateTime());
+    }
+
+    @Test
+    @DisplayName("month를 생략하면 이번 달(Asia/Seoul 기준)로 조회한다")
+    void getMonthlyCost_missingMonth_defaultsToCurrentMonth() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, null);
+
+        assertThat(response.month()).isEqualTo(YearMonth.now(AppConstants.ZONE).toString());
+    }
+
+    @Test
+    @DisplayName("인프라 배분 필드는 #433과 같은 이유로 null이다")
+    void getMonthlyCost_infraFieldsAreNull() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("2.0"), 1L, 4L));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.allPriced()).isFalse();
+        assertThat(response.unpricedEvents()).isEqualTo(1L);
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isNull();
+        assertThat(response.userMonthTechnicalCogsUsd()).isNull();
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -95,9 +95,13 @@ class AdminUserCostServiceTest {
         when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
                 .thenReturn(new AiCostAggregate(BigDecimal.ZERO, 0L, 0L));
 
+        // 서비스 호출 전후로 "지금" 월을 각각 캡처한다 — 서비스 내부와 이 어설션이 YearMonth.now()를
+        // 별도로 호출하므로, 월 경계(자정)에 걸리면 두 호출이 다른 달을 반환해 거짓 실패가 날 수 있다.
+        YearMonth before = YearMonth.now(AppConstants.ZONE);
         UserMonthlyCostResponse response = service.getMonthlyCost(userId, null);
+        YearMonth after = YearMonth.now(AppConstants.ZONE);
 
-        assertThat(response.month()).isEqualTo(YearMonth.now(AppConstants.ZONE).toString());
+        assertThat(response.month()).isIn(before.toString(), after.toString());
     }
 
     @Test

--- a/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
+++ b/src/test/java/com/mio/admin/service/AdminUserCostServiceTest.java
@@ -3,6 +3,7 @@ package com.mio.admin.service;
 import com.mio.admin.dto.UserMonthlyCostResponse;
 import com.mio.ai.cost.AiCostAggregate;
 import com.mio.ai.cost.AiCostEventRepository;
+import com.mio.ai.cost.InfraCostAllocator;
 import com.mio.common.AppConstants;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -26,12 +27,13 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-/** 이슈 #434 — #433과 같은 원칙(인프라 배분 null)으로 유저·월 단위 집계만 바뀐 것 검증. */
+/** 이슈 #434/#437 — #433과 같은 원칙(캐시 없으면 인프라 배분 null)으로 유저·월 단위 집계. */
 @ExtendWith(MockitoExtension.class)
 class AdminUserCostServiceTest {
 
     @Mock private UserRepository userRepository;
     @Mock private AiCostEventRepository aiCostEventRepository;
+    @Mock private InfraCostAllocator infraCostAllocator;
 
     private AdminUserCostService service;
 
@@ -39,7 +41,7 @@ class AdminUserCostServiceTest {
 
     @BeforeEach
     void setUp() {
-        service = new AdminUserCostService(userRepository, aiCostEventRepository);
+        service = new AdminUserCostService(userRepository, aiCostEventRepository, infraCostAllocator);
     }
 
     @Test
@@ -105,11 +107,13 @@ class AdminUserCostServiceTest {
     }
 
     @Test
-    @DisplayName("인프라 배분 필드는 #433과 같은 이유로 null이다")
-    void getMonthlyCost_infraFieldsAreNull() {
+    @DisplayName("인프라 배분 캐시가 없으면 필드는 여전히 null이다")
+    void getMonthlyCost_noInfraCache_fieldsAreNull() {
         when(userRepository.existsById(userId)).thenReturn(true);
         when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
                 .thenReturn(new AiCostAggregate(new BigDecimal("2.0"), 1L, 4L));
+        when(infraCostAllocator.allocateForUserMonth(eq(userId), eq(YearMonth.of(2026, 8))))
+                .thenReturn(null);
 
         UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
 
@@ -117,5 +121,20 @@ class AdminUserCostServiceTest {
         assertThat(response.unpricedEvents()).isEqualTo(1L);
         assertThat(response.allocatedFixedInfraUsdEstimate()).isNull();
         assertThat(response.userMonthTechnicalCogsUsd()).isNull();
+    }
+
+    @Test
+    @DisplayName("인프라 배분 캐시가 있으면 기술원가 합계를 채운다")
+    void getMonthlyCost_infraAllocationAvailable_fillsTechnicalCogs() {
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(aiCostEventRepository.aggregateByUserIdAndCreatedAtBetween(eq(userId), any(), any()))
+                .thenReturn(new AiCostAggregate(new BigDecimal("1.5"), 0L, 3L));
+        when(infraCostAllocator.allocateForUserMonth(eq(userId), eq(YearMonth.of(2026, 8))))
+                .thenReturn(new BigDecimal("0.7"));
+
+        UserMonthlyCostResponse response = service.getMonthlyCost(userId, "2026-08");
+
+        assertThat(response.allocatedFixedInfraUsdEstimate()).isEqualByComparingTo(new BigDecimal("0.7"));
+        assertThat(response.userMonthTechnicalCogsUsd()).isEqualByComparingTo(new BigDecimal("2.2"));
     }
 }

--- a/src/test/java/com/mio/ai/cost/AiCostEventRepositoryIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/AiCostEventRepositoryIntegrationTest.java
@@ -1,0 +1,102 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * SUM(cost_usd)가 단가 미등록(cost_usd=null) 이벤트를 조용히 건너뛰어 부분 합계를
+ * 완전한 합계처럼 보이게 하는 문제를 막는지 실제 DB에 대해 검증한다 (이슈 #431 리뷰).
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class AiCostEventRepositoryIntegrationTest {
+
+    @Autowired
+    private AiCostEventRepository repository;
+
+    private UUID sessionId;
+    private UUID userId;
+
+    @AfterEach
+    void tearDown() {
+        // FK가 없는 원장이라 이 세션/유저에 귀속된 행만 직접 지운다.
+        repository.findAll().stream()
+                .filter(e -> e.getSessionId() != null && e.getSessionId().equals(sessionId))
+                .forEach(e -> repository.deleteById(e.getId()));
+    }
+
+    @Test
+    @DisplayName("단가 미등록 이벤트가 섞여 있으면 unpricedCount로 드러나고, 합계는 가격 있는 이벤트만 더한다")
+    void aggregateBySessionId_revealsUnpricedEvents() {
+        sessionId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+
+        repository.save(AiCostEvent.builder()
+                .userId(userId).sessionId(sessionId)
+                .component("MAIN_GENERATION").model("gpt-4o").mode("stream")
+                .promptTokens(100).completionTokens(50).cachedTokens(0)
+                .costUsd(new BigDecimal("0.01"))
+                .createdAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build());
+        repository.save(AiCostEvent.builder()
+                .userId(userId).sessionId(sessionId)
+                .component("EXTRACTOR").model("gpt-5-future").mode("stream")
+                .promptTokens(200).completionTokens(80).cachedTokens(0)
+                .costUsd(null) // 단가 미등록 — 비용을 모른다
+                .createdAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build());
+
+        AiCostAggregate aggregate = repository.aggregateBySessionId(sessionId);
+
+        assertThat(aggregate.totalCostUsd()).isEqualByComparingTo(new BigDecimal("0.01"));
+        assertThat(aggregate.unpricedCount())
+                .as("단가 미등록 이벤트가 있으면 합계가 완전하지 않다는 걸 알 수 있어야 한다")
+                .isEqualTo(1L);
+        assertThat(aggregate.totalCount()).isEqualTo(2L);
+        assertThat(aggregate.allPriced()).isFalse();
+    }
+
+    @Test
+    @DisplayName("전부 단가가 있으면 allPriced=true")
+    void aggregateBySessionId_allPricedWhenNoUnpricedEvents() {
+        sessionId = UUID.randomUUID();
+        userId = UUID.randomUUID();
+
+        repository.save(AiCostEvent.builder()
+                .userId(userId).sessionId(sessionId)
+                .component("MAIN_GENERATION").model("gpt-4o").mode("stream")
+                .promptTokens(100).completionTokens(50).cachedTokens(0)
+                .costUsd(new BigDecimal("0.01"))
+                .createdAt(OffsetDateTime.now(ZoneOffset.UTC))
+                .build());
+
+        AiCostAggregate aggregate = repository.aggregateBySessionId(sessionId);
+
+        assertThat(aggregate.allPriced()).isTrue();
+        assertThat(aggregate.unpricedCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("이벤트가 없는 세션은 합계 0, 개수 0을 반환한다")
+    void aggregateBySessionId_emptyWhenNoEvents() {
+        sessionId = UUID.randomUUID();
+
+        AiCostAggregate aggregate = repository.aggregateBySessionId(sessionId);
+
+        assertThat(aggregate.totalCostUsd()).isEqualByComparingTo(BigDecimal.ZERO);
+        assertThat(aggregate.totalCount()).isZero();
+        assertThat(aggregate.allPriced()).isTrue();
+    }
+}

--- a/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
@@ -1,0 +1,132 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 배분 모델 민감도(옵션 A vs 옵션 B) 계산을 실제 DB로 검증한다 (이슈 #438).
+ *
+ * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
+ * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class AllocationSensitivityCalculatorIntegrationTest {
+
+    @Autowired
+    private AllocationSensitivityCalculator calculator;
+
+    @Autowired
+    private InfraCostAllocationSensitivityRepository sensitivityRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> insertedUserIds = new ArrayList<>();
+    private final List<UUID> insertedSessionIds = new ArrayList<>();
+    private final List<UUID> insertedSensitivityIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        insertedSessionIds.forEach(id -> jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", id));
+        insertedUserIds.forEach(id -> jdbcTemplate.update("DELETE FROM users WHERE id = ?", id));
+        insertedSensitivityIds.forEach(id -> sensitivityRepository.deleteById(id));
+    }
+
+    @Test
+    @DisplayName("세션별 민감도(|A_i-B_i|/B_i)의 평균을 저장한다 — 전체 합계로 계산하면 항상 0%가 되는 것과 달리 실제로 갈린다")
+    void computeAndSave_averagesPerSessionSensitivity() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        // 총세션-초 100, 총메시지 100 — 세션 A: duration 비중(0.4) > 메시지 비중(0.25) → 시간비례가 더 큼
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+        // 세션 B: duration 비중(0.6) < 메시지 비중(0.75) → 요청수비례가 더 큼
+        insertEndedSession(user, "2026-08-11T10:00:00+09:00", 60, 75);
+
+        calculator.computeAndSave(august, new BigDecimal("100"));
+
+        List<InfraCostAllocationSensitivity> saved = sensitivityRepository.findAll();
+        insertedSensitivityIds.addAll(saved.stream().map(InfraCostAllocationSensitivity::getId).toList());
+        assertThat(saved).hasSize(1);
+
+        InfraCostAllocationSensitivity result = saved.get(0);
+        // A_A=40,B_A=25(민감도60%) / A_B=60,B_B=75(민감도20%) → 평균 40%
+        assertThat(result.getAllocationSensitivityPct()).isEqualByComparingTo(new BigDecimal("40.0000000000"));
+        // sumA=100,sumB=100, count=2 → 둘 다 평균 50 (전체 합계 자체는 배분기준과 무관하게 같다는 걸 보여줌)
+        assertThat(result.getOptionAUsd()).isEqualByComparingTo(new BigDecimal("50.0000000000"));
+        assertThat(result.getOptionBUsd()).isEqualByComparingTo(new BigDecimal("50.0000000000"));
+        assertThat(result.getBillingPeriodStart()).isEqualTo(august.atDay(1));
+    }
+
+    @Test
+    @DisplayName("메시지가 0건인 세션은 개별 평균 계산에서 제외된다(0으로 나누기 방지)")
+    void computeAndSave_excludesZeroMessageSessionFromAverage_butKeepsItInTotals() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+        insertEndedSession(user, "2026-08-11T10:00:00+09:00", 60, 75);
+        // 메시지 0건 세션(duration 100s) — 총세션-초 분모(200)에는 더해지지만 개별 민감도 평균에서는
+        // 빠져야 함(0으로 나누기 회피). 총세션-초가 200으로 바뀌므로 기대값도 그에 맞춰 다시 계산함:
+        // A_A=100*40/200=20, B_A=25 → 민감도 20% / A_B=100*60/200=30, B_B=75 → 민감도 60% → 평균 40%
+        insertEndedSession(user, "2026-08-12T10:00:00+09:00", 100, 0);
+
+        calculator.computeAndSave(august, new BigDecimal("100"));
+
+        List<InfraCostAllocationSensitivity> saved = sensitivityRepository.findAll();
+        insertedSensitivityIds.addAll(saved.stream().map(InfraCostAllocationSensitivity::getId).toList());
+        assertThat(saved).hasSize(1);
+        // qualifying 세션은 여전히 2건(A,B)뿐이지만, 0건 세션의 duration이 분모에 들어가 값 자체는 바뀐다
+        assertThat(saved.get(0).getAllocationSensitivityPct()).isEqualByComparingTo(new BigDecimal("40.0000000000"));
+    }
+
+    @Test
+    @DisplayName("월간 총청구액이 0 이하면 계산을 스킵한다")
+    void computeAndSave_zeroCost_skips() {
+        YearMonth august = YearMonth.of(2026, 8);
+        UUID user = insertUser();
+        insertEndedSession(user, "2026-08-10T10:00:00+09:00", 40, 25);
+
+        calculator.computeAndSave(august, BigDecimal.ZERO);
+
+        assertThat(sensitivityRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("그 달 세션이 아예 없으면 계산을 스킵한다")
+    void computeAndSave_noSessions_skips() {
+        calculator.computeAndSave(YearMonth.of(2026, 8), new BigDecimal("100"));
+
+        assertThat(sensitivityRepository.findAll()).isEmpty();
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "allocation-sensitivity-it-" + userId);
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private void insertEndedSession(UUID userId, String startedAt, int durationSeconds, int messageCount) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at, message_count) " +
+                        "VALUES (?, ?, 'mio', 'ended', ?::timestamptz, ?::timestamptz + (? || ' seconds')::interval, ?)",
+                sessionId, userId, startedAt, startedAt, durationSeconds, messageCount);
+        insertedSessionIds.add(sessionId);
+    }
+}

--- a/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
@@ -1,0 +1,147 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.time.YearMonth;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 옵션 A(시간 비례) 배분 계산을 실제 DB로 검증한다 (이슈 #437).
+ *
+ * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
+ * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
+ */
+@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@ActiveProfiles("integration-test")
+class InfraCostAllocatorIntegrationTest {
+
+    @Autowired
+    private InfraCostAllocator allocator;
+
+    @Autowired
+    private InfraCostSnapshotRepository snapshotRepository;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    private final List<UUID> insertedUserIds = new ArrayList<>();
+    private final List<UUID> insertedSessionIds = new ArrayList<>();
+    private final List<UUID> insertedSnapshotIds = new ArrayList<>();
+
+    @AfterEach
+    void tearDown() {
+        insertedSessionIds.forEach(id -> jdbcTemplate.update("DELETE FROM sessions WHERE id = ?", id));
+        insertedUserIds.forEach(id -> jdbcTemplate.update("DELETE FROM users WHERE id = ?", id));
+        insertedSnapshotIds.forEach(id -> snapshotRepository.deleteById(id));
+    }
+
+    @Test
+    @DisplayName("캐시가 없으면 배분하지 않는다")
+    void allocateForSession_noSnapshot_returnsNull() {
+        assertThat(allocator.allocateForSession(YearMonth.of(2026, 8), 300L)).isNull();
+    }
+
+    @Test
+    @DisplayName("월 총청구액을 그 달 총세션-초 대비 세션 duration 비율로 배분한다")
+    void allocateForSession_withSnapshotAndSessions_allocatesProportionally() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID user1 = insertUser();
+        UUID user2 = insertUser();
+        // 이번 세션 300초 + 다른 세션 700초 = 그 달 총 1000초
+        insertEndedSession(user1, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertEndedSession(user2, "2026-08-11T10:00:00+09:00", "2026-08-11T10:11:40+09:00"); // 700s
+
+        // 18.5 * 300 / 1000 = 5.55
+        BigDecimal allocated = allocator.allocateForSession(august, 300L);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("5.55"));
+    }
+
+    @Test
+    @DisplayName("유저의 그 달 세션 전체(합산 시간) 기준으로 배분한다")
+    void allocateForUserMonth_sumsUserSessionsInMonth() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID targetUser = insertUser();
+        UUID otherUser = insertUser();
+        // targetUser: 300s + 200s = 500s, otherUser: 500s → 그 달 총 1000초
+        insertEndedSession(targetUser, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertEndedSession(targetUser, "2026-08-12T10:00:00+09:00", "2026-08-12T10:03:20+09:00"); // 200s
+        insertEndedSession(otherUser, "2026-08-11T10:00:00+09:00", "2026-08-11T10:08:20+09:00"); // 500s
+
+        // 18.5 * 500 / 1000 = 9.25
+        BigDecimal allocated = allocator.allocateForUserMonth(targetUser, august);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("9.25"));
+    }
+
+    @Test
+    @DisplayName("진행 중(미종료)인 세션은 총세션-초 계산에서 제외된다")
+    void allocateForSession_excludesUnendedSessions() {
+        YearMonth august = YearMonth.of(2026, 8);
+        saveSnapshot(august, new BigDecimal("18.5"));
+
+        UUID user1 = insertUser();
+        insertEndedSession(user1, "2026-08-10T10:00:00+09:00", "2026-08-10T10:05:00+09:00"); // 300s
+        insertActiveSession(user1, "2026-08-11T10:00:00+09:00"); // 미종료 — 집계 제외돼야 함
+
+        // 미종료 세션이 섞여도 총세션-초는 300초만 잡혀야 한다: 18.5 * 300 / 300 = 18.5
+        BigDecimal allocated = allocator.allocateForSession(august, 300L);
+
+        assertThat(allocated).isEqualByComparingTo(new BigDecimal("18.5"));
+    }
+
+    private void saveSnapshot(YearMonth month, BigDecimal totalCostUsd) {
+        InfraCostSnapshot snapshot = snapshotRepository.save(InfraCostSnapshot.builder()
+                .billingPeriodStart(month.atDay(1))
+                .billingPeriodEnd(month.plusMonths(1).atDay(1))
+                .totalCostUsd(totalCostUsd)
+                .estimated(true)
+                .snapshotAt(OffsetDateTime.now())
+                .allocationMethodVersion(InfraCostSyncJob.ALLOCATION_METHOD_VERSION)
+                .build());
+        insertedSnapshotIds.add(snapshot.getId());
+    }
+
+    private UUID insertUser() {
+        UUID userId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO users (id, social_provider, social_id) VALUES (?, 'kakao', ?)",
+                userId, "infra-cost-it-" + userId);
+        insertedUserIds.add(userId);
+        return userId;
+    }
+
+    private void insertEndedSession(UUID userId, String startedAt, String endedAt) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at, ended_at) " +
+                        "VALUES (?, ?, 'mio', 'ended', ?::timestamptz, ?::timestamptz)",
+                sessionId, userId, startedAt, endedAt);
+        insertedSessionIds.add(sessionId);
+    }
+
+    private void insertActiveSession(UUID userId, String startedAt) {
+        UUID sessionId = UUID.randomUUID();
+        jdbcTemplate.update(
+                "INSERT INTO sessions (id, user_id, character_id, status, started_at) " +
+                        "VALUES (?, ?, 'mio', 'active', ?::timestamptz)",
+                sessionId, userId, startedAt);
+        insertedSessionIds.add(sessionId);
+    }
+}

--- a/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
@@ -1,0 +1,70 @@
+package com.mio.ai.cost;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.CloudWatchException;
+import software.amazon.awssdk.services.cloudwatch.model.Datapoint;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRequest;
+import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsResponse;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class InfraCostSyncJobTest {
+
+    private final CloudWatchClient cloudWatchClient = mock(CloudWatchClient.class);
+    private final InfraCostSnapshotRepository repository = mock(InfraCostSnapshotRepository.class);
+    private final InfraCostSyncJob job = new InfraCostSyncJob(cloudWatchClient, repository);
+
+    @Test
+    @DisplayName("정상 응답이면 최신 데이터포인트 값을 스냅샷으로 저장한다")
+    void sync_success_savesLatestDatapoint() {
+        Datapoint older = Datapoint.builder().timestamp(Instant.parse("2026-08-15T02:38:00Z")).maximum(7.56).build();
+        Datapoint latest = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(older, latest).build());
+
+        job.sync();
+
+        ArgumentCaptor<InfraCostSnapshot> captor = ArgumentCaptor.forClass(InfraCostSnapshot.class);
+        verify(repository).save(captor.capture());
+        InfraCostSnapshot saved = captor.getValue();
+        // 두 데이터포인트 중 타임스탬프가 더 최근인 쪽(7.89)을 써야 한다 — 값이 더 큰 쪽이 아니라.
+        assertThat(saved.getTotalCostUsd()).isEqualByComparingTo(new BigDecimal("7.89"));
+        assertThat(saved.isEstimated()).isTrue();
+        assertThat(saved.getAllocationMethodVersion()).isEqualTo(InfraCostSyncJob.ALLOCATION_METHOD_VERSION);
+    }
+
+    @Test
+    @DisplayName("CloudWatch 호출이 실패해도 예외를 전파하지 않고 저장을 건너뛴다")
+    void sync_apiFailure_doesNotThrowOrSave() {
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenThrow(CloudWatchException.builder().message("access denied").build());
+
+        assertThatCode(job::sync).doesNotThrowAnyException();
+
+        verifyNoInteractions(repository);
+    }
+
+    @Test
+    @DisplayName("최근 24시간 내 데이터포인트가 없으면 저장을 건너뛴다")
+    void sync_noRecentDatapoints_skipsSave() {
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(List.of()).build());
+
+        job.sync();
+
+        verifyNoInteractions(repository);
+    }
+}

--- a/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostSyncJobTest.java
@@ -1,5 +1,6 @@
 package com.mio.ai.cost;
 
+import com.mio.common.AppConstants;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -11,11 +12,14 @@ import software.amazon.awssdk.services.cloudwatch.model.GetMetricStatisticsRespo
 
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.time.YearMonth;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -25,7 +29,10 @@ class InfraCostSyncJobTest {
 
     private final CloudWatchClient cloudWatchClient = mock(CloudWatchClient.class);
     private final InfraCostSnapshotRepository repository = mock(InfraCostSnapshotRepository.class);
-    private final InfraCostSyncJob job = new InfraCostSyncJob(cloudWatchClient, repository);
+    private final AllocationSensitivityCalculator allocationSensitivityCalculator =
+            mock(AllocationSensitivityCalculator.class);
+    private final InfraCostSyncJob job =
+            new InfraCostSyncJob(cloudWatchClient, repository, allocationSensitivityCalculator);
 
     @Test
     @DisplayName("정상 응답이면 최신 데이터포인트 값을 스냅샷으로 저장한다")
@@ -44,6 +51,39 @@ class InfraCostSyncJobTest {
         assertThat(saved.getTotalCostUsd()).isEqualByComparingTo(new BigDecimal("7.89"));
         assertThat(saved.isEstimated()).isTrue();
         assertThat(saved.getAllocationMethodVersion()).isEqualTo(InfraCostSyncJob.ALLOCATION_METHOD_VERSION);
+    }
+
+    @Test
+    @DisplayName("스냅샷 저장 성공 후 같은 배치 실행에서 배분 민감도 계산도 호출한다")
+    void sync_success_alsoTriggersAllocationSensitivityCalculation() {
+        Datapoint datapoint = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(datapoint).build());
+
+        // job.sync() 안에서 YearMonth.now()를 다시 부르므로, 실행 전후로 캡처해 월 경계(자정) 레이스를
+        // 피한다 — AdminUserCostServiceTest에서 CodeRabbit이 지적했던 것과 같은 패턴(커밋 7b0c6d3).
+        YearMonth before = YearMonth.now(AppConstants.ZONE);
+        job.sync();
+        YearMonth after = YearMonth.now(AppConstants.ZONE);
+
+        ArgumentCaptor<YearMonth> monthCaptor = ArgumentCaptor.forClass(YearMonth.class);
+        verify(allocationSensitivityCalculator)
+                .computeAndSave(monthCaptor.capture(), eq(new BigDecimal("7.89")));
+        assertThat(monthCaptor.getValue()).isIn(before, after);
+    }
+
+    @Test
+    @DisplayName("배분 민감도 계산이 실패해도 이미 성공한 스냅샷 저장에는 영향이 없다")
+    void sync_allocationSensitivityFailure_doesNotAffectSnapshotSave() {
+        Datapoint datapoint = Datapoint.builder().timestamp(Instant.parse("2026-08-15T08:38:00Z")).maximum(7.89).build();
+        when(cloudWatchClient.getMetricStatistics(any(GetMetricStatisticsRequest.class)))
+                .thenReturn(GetMetricStatisticsResponse.builder().datapoints(datapoint).build());
+        doThrow(new RuntimeException("boom")).when(allocationSensitivityCalculator)
+                .computeAndSave(any(YearMonth.class), any(BigDecimal.class));
+
+        assertThatCode(job::sync).doesNotThrowAnyException();
+
+        verify(repository).save(any(InfraCostSnapshot.class));
     }
 
     @Test

--- a/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
+++ b/src/test/java/com/mio/ai/judge/CbtMetadataClassifierTest.java
@@ -41,7 +41,9 @@ class CbtMetadataClassifierTest {
                 "그 관점을 기억해볼까요?",
                 new UserMessageSignal(45, "catastrophizing"),
                 1,
-                false
+                false,
+                null,
+                null
         );
 
         assertThat(result.state()).isEqualTo(CbtInterventionState.COMPLETED);
@@ -72,7 +74,9 @@ class CbtMetadataClassifierTest {
                 "물론이에요. 지금 떠오르는 이야기를 편하게 말해 주세요.",
                 new UserMessageSignal(45, "catastrophizing"),
                 1,
-                false
+                false,
+                null,
+                null
         );
 
         assertThat(result.state()).isEqualTo(CbtInterventionState.COMPLETED);

--- a/src/test/java/com/mio/ai/judge/InputJudgeTest.java
+++ b/src/test/java/com/mio/ai/judge/InputJudgeTest.java
@@ -91,7 +91,7 @@ class InputJudgeTest {
                 """);
 
         InputJudgeResult result = judge.judge(
-                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile());
+                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile(), null, null);
 
         assertThat(result.failed())
                 .as("CLEAN 으로 채우면 규칙이 의심한 입력을 '없는 근거'로 복구해버린다")
@@ -106,7 +106,7 @@ class InputJudgeTest {
                 """);
 
         InputJudgeResult result = judge.judge(
-                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile());
+                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile(), null, null);
 
         assertThat(result.failed()).isTrue();
     }
@@ -119,7 +119,7 @@ class InputJudgeTest {
                 """);
 
         InputJudgeResult result = judge.judge(
-                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile());
+                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile(), null, null);
 
         assertThat(result.failed()).isFalse();
         assertThat(result.security().requireOutputSecurityGuard())
@@ -137,7 +137,7 @@ class InputJudgeTest {
                 """);
 
         InputJudgeResult result = judge.judge(
-                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile());
+                "메시지", combined(SecurityLevel.SUSPICIOUS, false, false, false, true), defaultProfile(), null, null);
 
         assertThat(result.failed()).isFalse();
         assertThat(result.security().level()).isEqualTo(SecurityLevel.CLEAN);
@@ -187,7 +187,7 @@ class InputJudgeTest {
     })
     @DisplayName("risk_level 이 없거나 스키마 밖 값이면 판정 실패로 처리한다 (fail-closed)")
     void incompleteResponseIsTreatedAsFailure(String responseJson) {
-        var result = judgeReturning(responseJson).judge("죽고싶어", null, null);
+        var result = judgeReturning(responseJson).judge("죽고싶어", null, null, null, null);
 
         assertThat(result.failed())
                 .as("'%s' 는 판정 실패로 표시되어야 강등된 위기가 해제되지 않는다", responseJson)
@@ -202,7 +202,7 @@ class InputJudgeTest {
                  "risk":{"risk_level":"MEDIUM","risk_types":[],"recommended_generation_mode":"SUPPORTIVE",
                          "recommended_delivery":"CAUTIOUS_SPECULATIVE","require_output_safety_guard":false},
                  "confidence":0.8}
-                """).judge("좀 힘들어요", null, null);
+                """).judge("좀 힘들어요", null, null, null, null);
 
         assertThat(result.failed()).isFalse();
         assertThat(result.risk().riskLevel()).isEqualTo(RiskLevel.MEDIUM);

--- a/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
+++ b/src/test/java/com/mio/ai/llm/LlmCostCalculatorTest.java
@@ -14,7 +14,7 @@ class LlmCostCalculatorTest {
     @DisplayName("입력·출력 단가를 각각 적용해 합산한다")
     void computesCostFromBothTokenKinds() {
         LlmCostCalculator calculator = calculator(Map.of("gpt-4o",
-                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), new BigDecimal("10.00"))));
+                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), null, new BigDecimal("10.00"))));
 
         // 2.50*2000/1e6 + 10.00*800/1e6 = 0.005 + 0.008
         assertThat(calculator.costUsd(LlmUsage.of("gpt-4o", 2000, 800)))
@@ -22,10 +22,33 @@ class LlmCostCalculatorTest {
     }
 
     @Test
+    @DisplayName("캐시 적중 토큰은 정가가 아니라 캐시 할인 단가로 계산한다")
+    void cachedTokensUseCachedInputPrice() {
+        LlmCostCalculator calculator = calculator(Map.of("gpt-4o",
+                new LlmPricingProperties.ModelPrice(
+                        new BigDecimal("2.50"), new BigDecimal("1.25"), new BigDecimal("10.00"))));
+
+        // promptTokens=2000 중 800은 캐시 적중: (2000-800)*2.50/1e6 + 800*1.25/1e6 + 800*10.00/1e6
+        // = 0.003 + 0.001 + 0.008 = 0.012 (캐시 할인 없으면 0.013)
+        assertThat(calculator.costUsd(LlmUsage.of("gpt-4o", 2000, 800, 800)))
+                .isEqualByComparingTo(new BigDecimal("0.012"));
+    }
+
+    @Test
+    @DisplayName("캐시 단가가 등록되지 않은 모델은 캐시 적중분도 정가로 계산한다")
+    void cachedTokensFallBackToInputPriceWhenNoCachedPriceConfigured() {
+        LlmCostCalculator calculator = calculator(Map.of("text-embedding-3-small",
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), null, new BigDecimal("0.00"))));
+
+        assertThat(calculator.costUsd(LlmUsage.of("text-embedding-3-small", 1_000_000, 0, 500_000)))
+                .isEqualByComparingTo(new BigDecimal("0.02"));
+    }
+
+    @Test
     @DisplayName("사용량을 못 받았으면 0이 아니라 null")
     void unresolvedUsageHasNoCost() {
         LlmCostCalculator calculator = calculator(Map.of("gpt-4o",
-                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), new BigDecimal("10.00"))));
+                new LlmPricingProperties.ModelPrice(new BigDecimal("2.50"), null, new BigDecimal("10.00"))));
 
         assertThat(calculator.costUsd(LlmUsage.unresolved("gpt-4o"))).isNull();
         assertThat(calculator.costUsd(null)).isNull();
@@ -43,8 +66,8 @@ class LlmCostCalculatorTest {
     @DisplayName("단가 설정이 깨져 있으면(누락·음수) 계산하지 않는다")
     void invalidPriceIsTreatedAsUnknown() {
         LlmCostCalculator calculator = calculator(Map.of(
-                "half-configured", new LlmPricingProperties.ModelPrice(new BigDecimal("1.00"), null),
-                "negative", new LlmPricingProperties.ModelPrice(new BigDecimal("-1.00"), BigDecimal.ONE)));
+                "half-configured", new LlmPricingProperties.ModelPrice(new BigDecimal("1.00"), null, null),
+                "negative", new LlmPricingProperties.ModelPrice(new BigDecimal("-1.00"), null, BigDecimal.ONE)));
 
         assertThat(calculator.costUsd(LlmUsage.of("half-configured", 100, 50))).isNull();
         assertThat(calculator.costUsd(LlmUsage.of("negative", 100, 50))).isNull();
@@ -54,7 +77,7 @@ class LlmCostCalculatorTest {
     @DisplayName("출력 단가가 0인 임베딩 모델도 입력 비용은 계산한다")
     void embeddingModelCostsInputOnly() {
         LlmCostCalculator calculator = calculator(Map.of("text-embedding-3-small",
-                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), new BigDecimal("0.00"))));
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), null, new BigDecimal("0.00"))));
 
         assertThat(calculator.costUsd(LlmUsage.of("text-embedding-3-small", 1_000_000, 0)))
                 .isEqualByComparingTo(new BigDecimal("0.02"));
@@ -64,7 +87,7 @@ class LlmCostCalculatorTest {
     @DisplayName("아주 작은 비용이 0으로 반올림되지 않는다 — 반올림되면 임베딩 비용이 영원히 0으로 쌓인다")
     void tinyCostSurvivesRounding() {
         LlmCostCalculator calculator = calculator(Map.of("text-embedding-3-small",
-                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), new BigDecimal("0.00"))));
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), null, new BigDecimal("0.00"))));
 
         // 24 토큰 * $0.02/1M = 4.8e-7 — 실제 운영 스크레이프에서 0.0 으로 사라졌던 값이다.
         assertThat(calculator.costUsd(LlmUsage.of("text-embedding-3-small", 24, 0)))

--- a/src/test/java/com/mio/ai/llm/LlmRequestTest.java
+++ b/src/test/java/com/mio/ai/llm/LlmRequestTest.java
@@ -32,7 +32,24 @@ class LlmRequestTest {
     void rejectsNonPositiveLimit() {
         assertThatThrownBy(() -> LlmRequest.of("gpt-4o", "s", "u").withMaxCompletionTokens(0))
                 .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LlmRequest("gpt-4o", java.util.List.of(), -1))
+        assertThatThrownBy(() -> new LlmRequest("gpt-4o", java.util.List.of(), -1, null, null, null))
                 .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("withAttribution은 원본을 바꾸지 않고 귀속 정보가 붙은 복사본을 만든다")
+    void attributionDoesNotMutateOriginal() {
+        LlmRequest original = LlmRequest.of("gpt-4o", "system", "user");
+        java.util.UUID userId = java.util.UUID.randomUUID();
+        java.util.UUID sessionId = java.util.UUID.randomUUID();
+
+        LlmRequest attributed = original.withAttribution("MAIN_GENERATION", userId, sessionId);
+
+        assertThat(attributed.component()).isEqualTo("MAIN_GENERATION");
+        assertThat(attributed.userId()).isEqualTo(userId);
+        assertThat(attributed.sessionId()).isEqualTo(sessionId);
+        assertThat(original.component()).isNull();
+        assertThat(original.userId()).isNull();
+        assertThat(original.sessionId()).isNull();
     }
 }

--- a/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
+++ b/src/test/java/com/mio/ai/llm/OpenAiLlmClientTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.llm;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.cost.AiCostEventWriter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -38,7 +39,7 @@ class OpenAiLlmClientTest {
         meterRegistry = new SimpleMeterRegistry();
         pricing = new LlmPricingProperties();
         pricing.setModels(Map.of(MODEL, new LlmPricingProperties.ModelPrice(
-                new BigDecimal("0.15"), new BigDecimal("0.60"))));
+                new BigDecimal("0.15"), new BigDecimal("0.075"), new BigDecimal("0.60"))));
     }
 
     @Test
@@ -287,7 +288,7 @@ class OpenAiLlmClientTest {
     @DisplayName("임베딩도 토큰·비용을 계측한다 — 빼면 비용 합계가 실제 지출보다 낮다")
     void embed_recordsUsageAndCost() throws Exception {
         pricing.setModels(Map.of("text-embedding-3-small",
-                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), BigDecimal.ZERO)));
+                new LlmPricingProperties.ModelPrice(new BigDecimal("0.02"), null, BigDecimal.ZERO)));
         HttpClient httpClient = mock(HttpClient.class);
         HttpResponse<String> response = mock(HttpResponse.class);
         when(response.statusCode()).thenReturn(200);
@@ -296,7 +297,7 @@ class OpenAiLlmClientTest {
         when(httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
                 .thenReturn(response);
 
-        client(httpClient).embed("안녕하세요");
+        client(httpClient).embed("안녕하세요", "EMBEDDING", null, null);
 
         assertThat(counter("mio.llm.tokens", "mode", "embed")).isEqualTo(24.0);
         // 24 * 0.02 / 1e6 = 4.8e-7 — 6자리로 끊으면 0 이 되던 값이다.
@@ -425,7 +426,7 @@ class OpenAiLlmClientTest {
 
     private OpenAiLlmClient client(HttpClient httpClient) {
         return new OpenAiLlmClient("test-key", httpClient, new ObjectMapper(),
-                meterRegistry, new LlmCostCalculator(pricing));
+                meterRegistry, new LlmCostCalculator(pricing), mock(AiCostEventWriter.class));
     }
 
     private double total(String name) {

--- a/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
@@ -95,7 +96,7 @@ class EmbeddingWorkerIntegrationTest {
         for (int i = 0; i < EMBEDDING_DIM; i++) {
             vector[i] = 0.001f * i;
         }
-        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenReturn(vector);
 
         embeddingWorker.processPending();
 
@@ -109,7 +110,7 @@ class EmbeddingWorkerIntegrationTest {
     @DisplayName("일시적 실패는 pending으로 되돌려 다음 주기에 재시도한다")
     void processPending_transientError_returnsToPendingForRetry() {
         insertPendingSummary("임베딩 호출이 한 번 실패하는 케이스.");
-        when(openAiLlmClient.embed(anyString())).thenThrow(new RuntimeException("embedding API down"));
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenThrow(new RuntimeException("embedding API down"));
 
         embeddingWorker.processPending();
 
@@ -123,7 +124,7 @@ class EmbeddingWorkerIntegrationTest {
     @DisplayName("시도 상한에 도달하면 failed로 확정한다")
     void processPending_repeatedFailure_stopsAtAttemptCap() {
         insertPendingSummary("계속 실패하는 케이스.");
-        when(openAiLlmClient.embed(anyString())).thenThrow(new RuntimeException("embedding API down"));
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenThrow(new RuntimeException("embedding API down"));
 
         for (int i = 0; i < 5; i++) {
             embeddingWorker.processPending();
@@ -141,7 +142,7 @@ class EmbeddingWorkerIntegrationTest {
         insertStuckProcessingRow("중단된 프로세스가 남긴 행.", 40, 1);
 
         float[] vector = new float[EMBEDDING_DIM];
-        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenReturn(vector);
 
         embeddingWorker.processPending();
 
@@ -182,7 +183,7 @@ class EmbeddingWorkerIntegrationTest {
 
         // 내가 claim 을 잡고 있는 사이 다른 워커가 회수해 새 claim 을 잡은 상태를 만든다.
         float[] vector = new float[EMBEDDING_DIM];
-        when(openAiLlmClient.embed(anyString())).thenAnswer(invocation -> {
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenAnswer(invocation -> {
             jdbcTemplate.update(
                     "UPDATE session_summaries SET embedding_claimed_at = now() + interval '1 minute' WHERE id = ?",
                     summaryId);
@@ -218,7 +219,7 @@ class EmbeddingWorkerIntegrationTest {
         }
 
         float[] vector = new float[EMBEDDING_DIM];
-        when(openAiLlmClient.embed(anyString())).thenReturn(vector);
+        when(openAiLlmClient.embed(anyString(), anyString(), any(), any())).thenReturn(vector);
 
         ExecutorService pool = Executors.newFixedThreadPool(2);
         try {

--- a/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/ExtractorLlmClientTruncationTest.java
@@ -32,7 +32,7 @@ class ExtractorLlmClientTruncationTest {
         ExtractorLlmClient client = new ExtractorLlmClient(
                 stubClient(TRUNCATED_BUT_PARSEABLE, true), new ObjectMapper());
 
-        ExtractorResult result = client.extract("세션 요약 본문");
+        ExtractorResult result = client.extract("세션 요약 본문", null, null);
 
         assertThat(result.dominantEmotion())
                 .as("잘린 응답에서 읽은 감정을 저장하면 부분 분석 결과가 정본이 된다")
@@ -47,7 +47,7 @@ class ExtractorLlmClientTruncationTest {
         ExtractorLlmClient client = new ExtractorLlmClient(
                 stubClient(TRUNCATED_BUT_PARSEABLE, false), new ObjectMapper());
 
-        ExtractorResult result = client.extract("세션 요약 본문");
+        ExtractorResult result = client.extract("세션 요약 본문", null, null);
 
         assertThat(result.dominantEmotion())
                 .as("절단이 아니면 기존 동작을 바꾸지 않는다 — 이 값이 null 이면 회귀다")

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionConsolidatorTest.java
@@ -150,11 +150,11 @@ class SessionConsolidatorTest {
         when(self.getObject()).thenReturn(proxy);
         when(proxy.consolidate(sessionId, userId, "chichi", 2)).thenReturn(input);
         when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
-        when(sessionSummaryRenderer.render("내부 요약", "chichi")).thenReturn("오늘 이야기 정리해봤어요.");
+        when(sessionSummaryRenderer.render("내부 요약", "chichi", userId, sessionId)).thenReturn("오늘 이야기 정리해봤어요.");
 
         consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "chichi", 2));
 
-        verify(sessionSummaryRenderer).render("내부 요약", "chichi");
+        verify(sessionSummaryRenderer).render("내부 요약", "chichi", userId, sessionId);
         verify(userSummaryWriter).write(sessionId, "오늘 이야기 정리해봤어요.");
         verify(summaryStatusWriter).markDone(sessionId);
     }
@@ -171,7 +171,7 @@ class SessionConsolidatorTest {
         when(self.getObject()).thenReturn(proxy);
         when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
         when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
-        when(sessionSummaryRenderer.render(any(), any())).thenReturn(null);
+        when(sessionSummaryRenderer.render(any(), any(), any(), any())).thenReturn(null);
 
         consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2));
 
@@ -192,7 +192,7 @@ class SessionConsolidatorTest {
         when(self.getObject()).thenReturn(proxy);
         when(proxy.consolidate(sessionId, userId, "mio", 2)).thenReturn(input);
         when(todoRecommendationService.generateForSession(eq(userId), eq(sessionId), any())).thenReturn(3);
-        when(sessionSummaryRenderer.render(any(), any())).thenThrow(new RuntimeException("LLM down"));
+        when(sessionSummaryRenderer.render(any(), any(), any(), any())).thenThrow(new RuntimeException("LLM down"));
 
         assertThatCode(() -> consolidator.onSessionEnded(new SessionEndedEvent(sessionId, userId, "mio", 2)))
                 .doesNotThrowAnyException();

--- a/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/SessionSummaryRendererTest.java
@@ -44,7 +44,7 @@ class SessionSummaryRendererTest {
                 + "최악의 장면부터 떠올리는 마음이 보였는데, 실제 확률을 같이 따져보면서 조금 가벼워졌어요.";
         stubLlm(rendered);
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isEqualTo(rendered);
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isEqualTo(rendered);
     }
 
     @ParameterizedTest
@@ -55,7 +55,7 @@ class SessionSummaryRendererTest {
     void injectsCharacterVoiceIntoPrompt(String characterId, String displayName) {
         stubLlm("오늘 이야기 나눈 걸 정리해봤어요. 마음이 조금 정리된 것 같아요.");
 
-        renderer.render(INTERNAL_SUMMARY, characterId);
+        renderer.render(INTERNAL_SUMMARY, characterId, null, null);
 
         assertThat(capturedSystemPrompt()).contains("당신은 " + displayName + "입니다");
     }
@@ -65,7 +65,7 @@ class SessionSummaryRendererTest {
     void fallsBackToDefaultPersona() {
         stubLlm("오늘 이야기 나눈 걸 정리해봤어요. 마음이 조금 정리된 것 같아요.");
 
-        renderer.render(INTERNAL_SUMMARY, "unknown-character");
+        renderer.render(INTERNAL_SUMMARY, "unknown-character", null, null);
 
         assertThat(capturedSystemPrompt()).contains("당신은 미오입니다");
     }
@@ -93,7 +93,7 @@ class SessionSummaryRendererTest {
     void returnsNullOnContractViolation(String violating) {
         stubLlm(violating);
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isNull();
     }
 
     @Test
@@ -101,7 +101,7 @@ class SessionSummaryRendererTest {
     void returnsNullWhenTooManySentences() {
         stubLlm("오늘 이야기했어요. 걱정이 많았어요. 확률을 따져봤어요. 조금 가벼워졌어요.");
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isNull();
     }
 
     @Test
@@ -109,7 +109,7 @@ class SessionSummaryRendererTest {
     void returnsNullWhenTooLong() {
         stubLlm("오늘은 발표 걱정을 아주 많이 이야기했어요 ".repeat(12) + "그래서 조금 가벼워졌어요.");
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isNull();
     }
 
     @Test
@@ -117,7 +117,7 @@ class SessionSummaryRendererTest {
     void returnsNullOnLlmFailure() {
         doThrow(new RuntimeException("LLM down")).when(llmClient).stream(any(LlmRequest.class), any());
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isNull();
     }
 
     @Test
@@ -126,14 +126,14 @@ class SessionSummaryRendererTest {
         // 계약 검사를 통과하는 문장이라도 잘렸으면 정본으로 저장하지 않는다.
         stubLlm("오늘은 발표 걱정을 많이 이야기했어요. 확률을 같이 따져봤어요.", true);
 
-        assertThat(renderer.render(INTERNAL_SUMMARY, "mio")).isNull();
+        assertThat(renderer.render(INTERNAL_SUMMARY, "mio", null, null)).isNull();
     }
 
     @Test
     @DisplayName("내부 요약이 비면 LLM을 호출하지 않는다")
     void skipsWhenInternalSummaryBlank() {
-        assertThat(renderer.render("  ", "mio")).isNull();
-        assertThat(renderer.render(null, "mio")).isNull();
+        assertThat(renderer.render("  ", "mio", null, null)).isNull();
+        assertThat(renderer.render(null, "mio", null, null)).isNull();
 
         verify(llmClient, never()).stream(any(LlmRequest.class), any());
     }

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoActionPersonalizerTest.java
@@ -40,7 +40,7 @@ class TodoActionPersonalizerTest {
         String behaviorFirst = "4-7-8 호흡을 3회 하고, 발표 걱정이 떠오르면 다시 해보기";
         stubLlm("{\"actions\": [\"%s\"]}".formatted(behaviorFirst));
 
-        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()), null, null);
 
         assertThat(result).containsExactly(behaviorFirst);
     }
@@ -62,7 +62,7 @@ class TodoActionPersonalizerTest {
     void rejectsSituationLeadingText(String situationFirst) {
         stubLlm("{\"actions\": [\"%s\"]}".formatted(situationFirst));
 
-        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()), null, null);
 
         assertThat(result).containsExactly(TEMPLATE_TEXT);
     }
@@ -83,7 +83,7 @@ class TodoActionPersonalizerTest {
     void doesNotRejectBehaviorLeadingTextWithSituationWords(String behaviorFirst) {
         stubLlm("{\"actions\": [\"%s\"]}".formatted(behaviorFirst));
 
-        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()), null, null);
 
         assertThat(result).containsExactly(behaviorFirst);
     }
@@ -100,7 +100,7 @@ class TodoActionPersonalizerTest {
                 ]}
                 """);
 
-        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(breathing, walk));
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(breathing, walk), null, null);
 
         assertThat(result).containsExactly(
                 "4-7-8 호흡법 3회 연습하기",
@@ -112,7 +112,7 @@ class TodoActionPersonalizerTest {
     void rejectsTooLongText() {
         stubLlm("{\"actions\": [\"%s\"]}".formatted("호흡하기 ".repeat(40)));
 
-        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()));
+        List<String> result = personalizer.personalize(SUMMARY, List.of("발표"), List.of(template()), null, null);
 
         assertThat(result).containsExactly(TEMPLATE_TEXT);
     }
@@ -120,7 +120,7 @@ class TodoActionPersonalizerTest {
     @Test
     @DisplayName("세션 요약이 없으면 LLM을 호출하지 않고 템플릿 문구를 반환한다")
     void skipsWhenSummaryBlank() {
-        List<String> result = personalizer.personalize("  ", List.of("발표"), List.of(template()));
+        List<String> result = personalizer.personalize("  ", List.of("발표"), List.of(template()), null, null);
 
         assertThat(result).containsExactly(TEMPLATE_TEXT);
     }

--- a/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/TodoRecommendationServiceTest.java
@@ -70,7 +70,7 @@ class TodoRecommendationServiceTest {
         when(userRepository.findById(any())).thenReturn(Optional.of(mockUser));
         when(sessionRepository.findById(any())).thenReturn(Optional.of(mockSession));
         // 개인화기는 기본적으로 입력 템플릿 문구를 그대로 반환하도록(폴백 경로) 스텁.
-        when(actionPersonalizer.personalize(any(), any(), anyList()))
+        when(actionPersonalizer.personalize(any(), any(), anyList(), any(), any()))
                 .thenAnswer(inv -> ((List<BehaviorTemplate>) inv.getArgument(2)).stream()
                         .map(BehaviorTemplate::getActionTextKo).toList());
     }
@@ -181,7 +181,7 @@ class TodoRecommendationServiceTest {
     void usesPersonalizedActionText() {
         var t = template("bt_a", "심리_안정", "기본 호흡", "breathing", List.of(), List.of(), 1);
         when(templateRepository.findAll()).thenReturn(List.of(t));
-        when(actionPersonalizer.personalize(any(), any(), anyList()))
+        when(actionPersonalizer.personalize(any(), any(), anyList(), any(), any()))
                 .thenReturn(List.of("발표 전 긴장을 풀기 위해 4박자 호흡 5분 하기"));
 
         service.generateForSession(userId, sessionId,

--- a/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/LlmTurnOntologyExtractorTest.java
@@ -21,7 +21,7 @@ class LlmTurnOntologyExtractorTest {
                 """);
         LlmTurnOntologyExtractor extractor = new LlmTurnOntologyExtractor(llmClient, new ObjectMapper());
 
-        TurnOntologySignal signal = extractor.extract("다들 나를 싫어하는 것 같아");
+        TurnOntologySignal signal = extractor.extract("다들 나를 싫어하는 것 같아", null, null);
 
         assertThat(signal.distortionCode()).isEqualTo("mind_reading");
         assertThat(signal.beliefKind()).isNull();

--- a/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
+++ b/src/test/java/com/mio/ai/memory/ontology/ReactiveOntologyActivatorTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -62,7 +63,7 @@ class ReactiveOntologyActivatorTest {
         UserBelief otherBelief = mock(UserBelief.class);
         UUID matchingBeliefId = UUID.randomUUID();
 
-        when(turnOntologyExtractor.extract("발표에서 다들 나를 싫어하는 것 같아"))
+        when(turnOntologyExtractor.extract(eq("발표에서 다들 나를 싫어하는 것 같아"), any(), any()))
                 .thenReturn(new TurnOntologySignal("mind_reading", "core_other", "negative"));
         when(ontologyValidator.isValidDistortionCode("mind_reading")).thenReturn(true);
         when(beliefRepository.findByUser_IdAndStatus(userId, "active"))
@@ -80,7 +81,7 @@ class ReactiveOntologyActivatorTest {
 
     @Test
     void ignoresUnknownStructuredDistortionWithoutWritingWorkingMemory() {
-        when(turnOntologyExtractor.extract(anyString()))
+        when(turnOntologyExtractor.extract(anyString(), any(), any()))
                 .thenReturn(new TurnOntologySignal("invented_code", "core_self", "negative"));
         when(ontologyValidator.isValidDistortionCode("invented_code")).thenReturn(false);
 
@@ -95,7 +96,7 @@ class ReactiveOntologyActivatorTest {
     void doesNotActivateAmbiguousBeliefsThatShareKindAndPolarity() {
         UserBelief first = mock(UserBelief.class);
         UserBelief second = mock(UserBelief.class);
-        when(turnOntologyExtractor.extract("나는 아무것도 못하는 사람인 것 같아"))
+        when(turnOntologyExtractor.extract(eq("나는 아무것도 못하는 사람인 것 같아"), any(), any()))
                 .thenReturn(new TurnOntologySignal("overgeneralization", "core_self", "negative"));
         when(ontologyValidator.isValidDistortionCode("overgeneralization")).thenReturn(true);
         when(distortionRepository.findById("overgeneralization")).thenReturn(Optional.empty());
@@ -116,7 +117,7 @@ class ReactiveOntologyActivatorTest {
 
         activator.activateBeliefs(userId, sessionId, "발표에서 다들 나를 싫어하는 것 같아");
 
-        verify(turnOntologyExtractor, never()).extract(anyString());
+        verify(turnOntologyExtractor, never()).extract(anyString(), any(), any());
         verifyNoInteractions(beliefRepository, workingMemory);
     }
 }

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -406,7 +406,7 @@ class AiDecisionLoggerTest {
     private LlmPricingProperties pricedProperties() {
         LlmPricingProperties properties = new LlmPricingProperties();
         properties.setModels(Map.of("gpt-4o-mini", new LlmPricingProperties.ModelPrice(
-                new java.math.BigDecimal("0.15"), new java.math.BigDecimal("0.60"))));
+                new java.math.BigDecimal("0.15"), new java.math.BigDecimal("0.075"), new java.math.BigDecimal("0.60"))));
         return properties;
     }
 

--- a/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
+++ b/src/test/java/com/mio/ai/profile/ContextPreWarmerTest.java
@@ -74,7 +74,7 @@ class ContextPreWarmerTest {
         RetrievedItem episode = new RetrievedItem("episode-1", RetrievalSource.VECTOR_EPISODE,
                 "회의가 불안했던 날", "normal", 0.9, 1);
         when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
-        when(embeddingClient.embed("회의 때문에 불안해")).thenReturn(embedding);
+        when(embeddingClient.embed(eq("회의 때문에 불안해"), any(), any(), any())).thenReturn(embedding);
         when(vectorRetriever.retrieveEpisodes(userId, embedding, 3)).thenReturn(List.of(episode));
         when(lexicalRetriever.retrieveByKeywords(userId, "회의 때문에 불안해", 3)).thenReturn(List.of());
         when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
@@ -83,7 +83,7 @@ class ContextPreWarmerTest {
         String context = preWarmer.buildContextSync(sessionId, userId, combined, profile, "회의 때문에 불안해");
 
         assertThat(context).isEqualTo("live memory");
-        verify(embeddingClient).embed("회의 때문에 불안해");
+        verify(embeddingClient).embed(eq("회의 때문에 불안해"), any(), any(), any());
         verify(vectorRetriever).retrieveEpisodes(userId, embedding, 3);
         verify(lexicalRetriever).retrieveByKeywords(userId, "회의 때문에 불안해", 3);
     }
@@ -95,7 +95,7 @@ class ContextPreWarmerTest {
         RetrievedItem episode = new RetrievedItem("episode-2", RetrievalSource.LEXICAL_EPISODE,
                 "회의 전 긴장", "normal", 0.7, 1);
         when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
-        when(embeddingClient.embed("회의가 걱정돼")).thenThrow(new RuntimeException("timeout"));
+        when(embeddingClient.embed(eq("회의가 걱정돼"), any(), any(), any())).thenThrow(new RuntimeException("timeout"));
         when(lexicalRetriever.retrieveByKeywords(userId, "회의가 걱정돼", 3)).thenReturn(List.of(episode));
         when(fusionRanker.rank(any(), eq("normal"), eq(9))).thenReturn(List.of(episode));
         when(contextComposer.compose(any(), eq("normal"), eq(false))).thenReturn("lexical memory");
@@ -114,7 +114,7 @@ class ContextPreWarmerTest {
         RetrievedItem episode = new RetrievedItem("episode-3", RetrievalSource.LEXICAL_EPISODE,
                 "발표 전 긴장", "normal", 0.7, 1);
         when(planner.plan(combined, profile, userId, true)).thenReturn(plan);
-        when(embeddingClient.embed("발표가 걱정돼")).thenAnswer(invocation -> {
+        when(embeddingClient.embed(eq("발표가 걱정돼"), any(), any(), any())).thenAnswer(invocation -> {
             Thread.sleep(1_000);
             return new float[]{0.1f};
         });

--- a/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CbtMetadataQaTest.java
@@ -77,7 +77,9 @@ class CbtMetadataQaTest {
                 "위기 응답입니다.",
                 null,
                 0,
-                true  // crisisFlowTriggered=true
+                true,  // crisisFlowTriggered=true
+                null,
+                null
         );
 
         assertThat(result.state()).isEqualTo(CbtInterventionState.NONE);
@@ -114,7 +116,9 @@ class CbtMetadataQaTest {
                 "어떤 근거로 그렇게 생각하시나요?",
                 new UserMessageSignal(40, "catastrophizing"),
                 1,
-                false
+                false,
+                null,
+                null
         );
 
         assertThat(result.state()).isEqualTo(CbtInterventionState.SOCRATIC_ASKED);
@@ -179,7 +183,9 @@ class CbtMetadataQaTest {
                 "그렇군요! 이번에 새로운 시각을 갖게 되셨네요.",
                 new UserMessageSignal(60, "overgeneralization"),
                 1,
-                false
+                false,
+                null,
+                null
         );
 
         assertThat(result.state()).isEqualTo(CbtInterventionState.COMPLETED);

--- a/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
+++ b/src/test/java/com/mio/ai/qa/CrisisDetectionFullPathQaTest.java
@@ -5,6 +5,7 @@ import com.mio.ai.input.InputNormalizer;
 import com.mio.ai.input.SecurityRuleFilter;
 import com.mio.ai.judge.InputJudge;
 import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmPricingProperties;
 import com.mio.ai.llm.OpenAiLlmClient;
@@ -46,6 +47,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * 위기 탐지 <b>전체 경로</b> 평가 — 실제 InputJudge 판정을 포함한다 (이슈 #295).
@@ -140,7 +142,8 @@ class CrisisDetectionFullPathQaTest {
         policyEngine = new PolicyEngine(new EffectiveSecurityResolver());
         inputJudge = new InputJudge(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
-                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties())),
+                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
+                        mock(AiCostEventWriter.class)),
                 new ObjectMapper());
     }
 
@@ -207,7 +210,7 @@ class CrisisDetectionFullPathQaTest {
 
         boolean judgeCalled = inputJudge.shouldCallJudge(combined, null);
         InputJudgeResult judgeResult = judgeCalled
-                ? inputJudge.judge(normalized, combined, null)
+                ? inputJudge.judge(normalized, combined, null, null, null)
                 : null;
 
         PolicyDecision decision = policyEngine.decide(combined, judgeResult, null, null);

--- a/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorEpisodeTypeQaTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmPricingProperties;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -23,6 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 /**
  * ExtractorLLM episodeType 분류 QA 테스트 (107개 시나리오)
@@ -55,7 +57,8 @@ class ExtractorEpisodeTypeQaTest {
         );
         extractor = new ExtractorLlmClient(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
-                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties())),
+                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
+                        mock(AiCostEventWriter.class)),
                 new ObjectMapper()
         );
     }
@@ -78,7 +81,7 @@ class ExtractorEpisodeTypeQaTest {
     @MethodSource("scenarios")
     @DisplayName("episodeType 분류")
     void classifyEpisodeType(String id, String expectedType, String description, String summary) {
-        ExtractorResult result = extractor.extract(summary);
+        ExtractorResult result = extractor.extract(summary, null, null);
         System.out.printf("[%s] expected=%-14s actual=%-14s emotion=%-10s score=%s thoughts=%d  — %s%n",
                 id, expectedType, result.episodeType(), result.dominantEmotion(),
                 result.emotionScore(), result.thoughts().size(), description);

--- a/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
+++ b/src/test/java/com/mio/ai/qa/ExtractorLlmScaleTest.java
@@ -1,6 +1,7 @@
 package com.mio.ai.qa;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.cost.AiCostEventWriter;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmPricingProperties;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -14,6 +15,8 @@ import java.net.http.HttpClient;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
+
+import static org.mockito.Mockito.mock;
 
 @DisplayName("[QA] ExtractorLLM episodeType 스케일 테스트 (~1000 시나리오)")
 @Tag("llm-integration")
@@ -36,7 +39,8 @@ class ExtractorLlmScaleTest {
                 "OPENAI_API_KEY 미설정 또는 placeholder — LLM 통합 테스트 skip");
         extractor = new ExtractorLlmClient(
                 new OpenAiLlmClient(apiKey, HttpClient.newHttpClient(), new ObjectMapper(),
-                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties())),
+                        new SimpleMeterRegistry(), new LlmCostCalculator(new LlmPricingProperties()),
+                        mock(AiCostEventWriter.class)),
                 new ObjectMapper()
         );
     }
@@ -109,7 +113,7 @@ class ExtractorLlmScaleTest {
 
     private Result runCase(Case c) {
         try {
-            ExtractorResult r = extractor.extract(c.summary());
+            ExtractorResult r = extractor.extract(c.summary(), null, null);
             String actual = r.episodeType() != null ? r.episodeType() : "null";
             return new Result(c.id(), c.expected(), actual, c.expected().equals(actual), c.cat());
         } catch (Exception e) {

--- a/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
@@ -3,10 +3,12 @@ package com.mio.checkin.service;
 import com.mio.ai.llm.LlmClient;
 import com.mio.ai.llm.LlmRequest;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 import java.util.UUID;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -20,12 +22,18 @@ class CheckinAiResponseGeneratorTest {
         LlmClient llmClient = mock(LlmClient.class);
         JdbcTemplate jdbcTemplate = mock(JdbcTemplate.class);
         UUID checkinId = UUID.randomUUID();
+        UUID userId = UUID.randomUUID();
         when(llmClient.completeText(any(LlmRequest.class))).thenReturn("오늘도 잘 버텼어요.");
         CheckinAiResponseGenerator generator = new CheckinAiResponseGenerator(llmClient, jdbcTemplate);
 
-        generator.generateAndSave(checkinId, "anxious", 3, "morning", UUID.randomUUID());
+        generator.generateAndSave(checkinId, "anxious", 3, "morning", userId);
 
-        verify(llmClient).completeText(any(LlmRequest.class));
+        ArgumentCaptor<LlmRequest> requestCaptor = ArgumentCaptor.forClass(LlmRequest.class);
+        verify(llmClient).completeText(requestCaptor.capture());
+        LlmRequest sentRequest = requestCaptor.getValue();
+        assertThat(sentRequest.component()).isEqualTo("CHECKIN_RESPONSE");
+        assertThat(sentRequest.userId()).isEqualTo(userId);
+        assertThat(sentRequest.sessionId()).isNull();
         verify(jdbcTemplate).update(eq("UPDATE checkins SET ai_response = ? WHERE id = ?"),
                 eq("오늘도 잘 버텼어요."), eq(checkinId));
     }

--- a/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
+++ b/src/test/java/com/mio/checkin/service/CheckinAiResponseGeneratorTest.java
@@ -23,7 +23,7 @@ class CheckinAiResponseGeneratorTest {
         when(llmClient.completeText(any(LlmRequest.class))).thenReturn("오늘도 잘 버텼어요.");
         CheckinAiResponseGenerator generator = new CheckinAiResponseGenerator(llmClient, jdbcTemplate);
 
-        generator.generateAndSave(checkinId, "anxious", 3, "morning");
+        generator.generateAndSave(checkinId, "anxious", 3, "morning", UUID.randomUUID());
 
         verify(llmClient).completeText(any(LlmRequest.class));
         verify(jdbcTemplate).update(eq("UPDATE checkins SET ai_response = ? WHERE id = ?"),

--- a/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
+++ b/src/test/java/com/mio/report/service/ReportNarrativeServiceTest.java
@@ -22,7 +22,7 @@ class ReportNarrativeServiceTest {
                 .thenReturn("{\"narrative\":\"이번 주도 잘 해냈어요.\",\"coaching_direction\":\"작은 휴식을 이어가요.\"}");
         ReportNarrativeService service = new ReportNarrativeService(llmClient, new ObjectMapper());
 
-        ReportNarrativeService.NarrativeResult result = service.generate("이번 주", 2, 42.0, List.of());
+        ReportNarrativeService.NarrativeResult result = service.generate("이번 주", 2, 42.0, List.of(), null);
 
         assertThat(result.narrative()).isEqualTo("이번 주도 잘 해냈어요.");
         assertThat(result.coachingDirection()).isEqualTo("작은 휴식을 이어가요.");


### PR DESCRIPTION
## 요약

develop 에 쌓여 있는 1.1 작업 전체를 배포하지 않고, **AI 비용 원장·조회 API 파트만** 프로덕션에 먼저 올린다.
`origin/main` 에서 분기해 해당 파트 9 커밋만 cherry-pick 했다.

현재 프로덕션은 세션당 AI 원가를 알 수 없다 — `ai_policy_decisions` 에 메인 대화 생성 1건만 남아
실제 원가가 과소계상된다. 이 PR 이 `ai_cost_events` 원장을 단일 진실 공급원으로 세우고
세션별·사용자 월별 조회 API 를 연다.

## 관련 이슈

- Closes #431
- Closes #433
- Closes #434
- Closes #437
- Closes #438

## 변경 사항

- `OpenAiLlmClient.recordUsage()` 단일 지점에서 15개 LLM/임베딩 호출부의 비용을 `ai_cost_events` 에 기록 (#431)
  - `LlmRequest` 에 component / userId / sessionId 귀속 추가
  - `cached_tokens` 파싱해 캐시 적중분을 할인 단가로 계산 — 없으면 캐시 히트가 많은 세션이 과대계상된다
- `GET /v1/admin/sessions/{id}/cost` — 세션별 직접 AI 변동비 (#433)
- `GET /v1/admin/users/{id}/cost-monthly` — 사용자 월간 직접 AI 변동비 (#434)
  - 둘 다 `unpriced_events` / `all_priced` 로 부분합 여부를 노출한다
- CloudWatch `AWS/Billing` `EstimatedCharges` 기반 인프라 비용 배치 캐싱 (#437)
  - Cost Explorer(`ce:GetCostAndUsage`, 건당 $0.01)에서 CloudWatch 지표(사실상 무료)로 전환
- 배분 모델(옵션 A 시간 비례 vs 옵션 B) 민감도 그림자 계산 (#438)
- 비용 원장 결함 수정: 시각 정확도·부분합계·예외 전파, 빈 결과셋 NPE, 비용 이벤트 큐 거부 메트릭

## 영향 범위

- [x] API 스펙 또는 응답 형식이 변경됩니다. — 운영자 전용 엔드포인트 2종 신설 (사용자 API 무변경)
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다. — V56 / V57 / V58
- [x] 환경 변수 또는 외부 설정 변경이 필요합니다. — `application.yml` 모델 단가에 `cached-input` 추가
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. — `InfraCostSyncJob` 매일 00:30 KST 신설, 비용 이벤트 비동기 기록
- [x] 로깅 / 모니터링 포인트가 변경됩니다. — 비용 이벤트 큐 거부 메트릭 추가
- [ ] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

> 안전 판정 경로 체크는 하지 않았다. `InputJudge` / `OutputJudge` 파일이 diff 에 포함되지만
> **판정 로직은 그대로**이고 `LlmRequest` 에 귀속 메타(component/userId/sessionId)를 넘기는
> 호출 규약 변경만 있다. 동일 커밋이 develop 에서 이미 Crisis Eval 게이트를 통과했다.

## 테스트

### 실행 커맨드

```bash
./gradlew build   # CI 에서 수행
```

### 확인 내용

- 이 9 커밋은 develop 에 머지될 때 CI 를 이미 통과한 것과 **동일한 diff** 다.
- `origin/main` 위 cherry-pick 충돌 0, `compileJava` + `compileTestJava` 통과를 사전 검증했다.
- Flyway 번호 연속성 확인: main 은 V55 가 마지막이고 이 PR 이 V56 / V57 / V58 을 붙여 **갭이 없다.**
  develop 의 세션 반응 API(V76)를 함께 올리지 않은 이유가 이것이다 — V59~V75 를 건너뛰면
  다음 develop 배포에서 Flyway out-of-order 로 실패한다.

## 중점 리뷰 포인트

- **배포 표면이 관리자 API 만이 아니다.** `8fdba1e` 가 `OpenAiLlmClient.recordUsage()` 와 15개 호출부,
  `ConversationOrchestrator` / `SessionConsolidator` / `ReportService` 까지 52 파일을 건드린다.
  대화 경로 회귀를 중점적으로 봐 주면 좋겠다.
- `InfraCostSyncJob` 은 EC2 인스턴스 역할(`mio-ec2-cloudwatch-role`, `cloudwatch:GetMetricStatistics`)
  기본 크리덴셜 체인을 탄다. 배포 전 해당 IAM 이 실제로 붙어 있는지 확인이 필요하다.
  `AWS/Billing` 지표는 리전 무관하게 us-east-1 에만 게시되므로 클라이언트 리전이 거기로 고정돼 있다.

## 배포 / 롤백

- **Rollout:** main 머지 → CD 자동 배포. 기동 시 V56 / V57 / V58 적용.
  `InfraCostSyncJob` 은 다음 00:30 KST 에 첫 실행되며, 그 전까지 인프라 배분 필드는 `null` 이다
  (0 이 아니라 `null` 인 이유는 "비용 없음" 으로 오독되지 않게 하기 위해서다).
- **Rollback:** 직전 이미지로 되돌린다. V56~V58 은 신규 테이블·컬럼 추가만이라 기존 코드와 공존한다 —
  스키마 롤백 없이 앱만 되돌려도 동작한다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [x] (hotfix 인 경우) 같은 수정을 develop 에도 반영했습니다 — **이 PR 은 develop 에서 cherry-pick 한
      것이라 develop 이 원본이다.** 머지 후 `git merge -s ours` 로 main 을 develop 에 역흡수해
      다음 정기 배포에서 merge-base 가 어긋나지 않게 한다.
