### PR TITLE
fix: 리포트 인지왜곡 집계를 세션요약 기준으로 바꾼다

### DIFF
--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -18,6 +18,7 @@ import com.mio.report.dto.WeeklyReportResponse;
 import com.mio.session.domain.Session;
 import com.mio.session.repository.MessageRepository;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.repository.UserRepository;
@@ -68,6 +69,7 @@ public class ReportService {
     // LLM 을 무한정 태우는 경로가 다시 열린다. 되돌리려면 생성자를 바꿔야 하도록 둔다.
     private final CheckinRepository checkinRepository;
     private final MessageRepository messageRepository;
+    private final SessionSummaryRepository sessionSummaryRepository;
     private final SessionRepository sessionRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
     private final UserRepository userRepository;
@@ -333,7 +335,7 @@ public class ReportService {
     // ── 공통 집계 ─────────────────────────────────────────────────
 
     private List<DistortionDto> buildDistortionTop3(UUID userId, OffsetDateTime start, OffsetDateTime end) {
-        List<Object[]> rows = messageRepository.findBiasTypeDistribution(userId, start, end);
+        List<Object[]> rows = sessionSummaryRepository.findBiasTypeDistribution(userId, start, end);
         List<DistortionDto> result = new ArrayList<>();
         for (int i = 0; i < Math.min(3, rows.size()); i++) {
             String type = (String) rows.get(i)[0];

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -18,11 +18,6 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
                                @Param("start") OffsetDateTime start,
                                @Param("end") OffsetDateTime end);
 
-    @Query("SELECT m.biasType, COUNT(m) FROM Message m WHERE m.user.id = :userId AND m.createdAt >= :start AND m.createdAt < :end AND m.biasType IS NOT NULL GROUP BY m.biasType ORDER BY COUNT(m) DESC")
-    List<Object[]> findBiasTypeDistribution(@Param("userId") UUID userId,
-                                            @Param("start") OffsetDateTime start,
-                                            @Param("end") OffsetDateTime end);
-
     @Query("SELECT m FROM Message m WHERE m.session.id = :sessionId AND m.role = :role ORDER BY m.createdAt DESC")
     List<Message> findRecentBySessionAndRole(@Param("sessionId") UUID sessionId,
                                              @Param("role") MessageRole role,

--- a/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
@@ -6,11 +6,33 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface SessionSummaryRepository extends JpaRepository<SessionSummary, UUID> {
     Optional<SessionSummary> findBySession_Id(UUID sessionId);
+
+    /**
+     * 리포트용 인지왜곡 분포 (이슈 #502).
+     *
+     * <p>{@code messages.bias_type} 은 실시간 위기감지(SafetyL1)용 경량 신호라 커버리지가
+     * 낮다 — 정식 인지왜곡 분석은 {@code SessionConsolidator} 가 ExtractorLLM 으로 세션 종료
+     * 후 만드는 이 컬럼({@code bias_types_detected})에 있다. JSONB 배열이라 네이티브 쿼리로만
+     * 펼칠 수 있다.
+     */
+    @Query(value = """
+            SELECT bt.bias_type AS biasType, COUNT(*) AS cnt
+            FROM session_summaries s
+            CROSS JOIN LATERAL jsonb_array_elements_text(s.bias_types_detected) AS bt(bias_type)
+            WHERE s.user_id = :userId AND s.created_at >= :start AND s.created_at < :end
+            GROUP BY bt.bias_type
+            ORDER BY cnt DESC
+            """, nativeQuery = true)
+    List<Object[]> findBiasTypeDistribution(@Param("userId") UUID userId,
+                                            @Param("start") OffsetDateTime start,
+                                            @Param("end") OffsetDateTime end);
 
     /**
      * 사용자 노출용 요약을 채운다 (이슈 #339).

--- a/src/test/java/com/mio/report/service/ReportServiceWeeklyReadTest.java
+++ b/src/test/java/com/mio/report/service/ReportServiceWeeklyReadTest.java
@@ -12,6 +12,7 @@ import com.mio.report.dto.WeeklyReportResponse;
 import com.mio.report.repository.WeeklyReportRepository;
 import com.mio.session.repository.MessageRepository;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -62,6 +63,7 @@ class ReportServiceWeeklyReadTest {
 
     @Mock private CheckinRepository checkinRepository;
     @Mock private MessageRepository messageRepository;
+    @Mock private SessionSummaryRepository sessionSummaryRepository;
     @Mock private SessionRepository sessionRepository;
     @Mock private BehaviorTaskRepository behaviorTaskRepository;
     @Mock private UserRepository userRepository;
@@ -79,8 +81,8 @@ class ReportServiceWeeklyReadTest {
         lastWeekStart = ReportWeek.lastWeekStartFrom(LocalDate.now(AppConstants.ZONE));
         lastMonthStart = LocalDate.now(AppConstants.ZONE).minusMonths(1).withDayOfMonth(1);
 
-        service = new ReportService(checkinRepository, messageRepository, sessionRepository,
-                behaviorTaskRepository, userRepository, weeklyReportRepository, txManager);
+        service = new ReportService(checkinRepository, messageRepository, sessionSummaryRepository,
+                sessionRepository, behaviorTaskRepository, userRepository, weeklyReportRepository, txManager);
 
         // @PostConstruct 가 만드는 readOnlyTx 를 콜백 실행만 하는 스텁으로 대체한다.
         TransactionTemplate tx = mock(TransactionTemplate.class);
@@ -286,6 +288,37 @@ class ReportServiceWeeklyReadTest {
             MonthlyReportResponse response = service.getMonthlyReport(userId, lastMonthStart.plusDays(15));
 
             assertThat(response.monthStart()).isEqualTo(lastMonthStart);
+        }
+    }
+
+    @Nested
+    @DisplayName("인지왜곡 집계 — session_summaries 기준 (#502)")
+    class DistortionSource {
+
+        @Test
+        void 세션요약에만_있고_메시지에는_없어도_리포트에_반영된다() {
+            when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), any()))
+                    .thenReturn(Optional.empty());
+            when(sessionSummaryRepository.findBiasTypeDistribution(eq(userId), any(), any()))
+                    .thenReturn(java.util.Collections.singletonList(new Object[]{"overgeneralization", 2L}));
+
+            WeeklyReportResponse response = service.getWeeklyReport(userId, lastWeekStart);
+
+            assertThat(response.distortionTop3()).hasSize(1);
+            assertThat(response.distortionTop3().get(0).type()).isEqualTo("overgeneralization");
+            assertThat(response.distortionTop3().get(0).label()).isEqualTo("과일반화");
+            assertThat(response.distortionTop3().get(0).count()).isEqualTo(2L);
+        }
+
+        @Test
+        void 세션요약_저장소를_유저와_기간으로_조회한다() {
+            when(weeklyReportRepository.findByUser_IdAndWeekStart(eq(userId), any()))
+                    .thenReturn(Optional.empty());
+
+            service.getWeeklyReport(userId, lastWeekStart);
+
+            org.mockito.Mockito.verify(sessionSummaryRepository)
+                    .findBiasTypeDistribution(eq(userId), any(), any());
         }
     }
 


### PR DESCRIPTION
## 요약
리포트의 `distortion_top3`가 실시간 위기감지용 경량 신호(`messages.bias_type`)를 집계하고 있어서, 채팅 세션 요약엔 인지왜곡이 뜨는데 리포트엔 "없음"으로 나오는 불일치가 있었습니다. 정식 인지왜곡 분석 결과가 있는 `session_summaries.bias_types_detected`를 집계하도록 바꿨습니다.

## 관련 이슈
- Closes #502

## 변경 사항
- `SessionSummaryRepository`에 `bias_types_detected`(JSONB) 집계 네이티브 쿼리 추가
- `ReportService.buildDistortionTop3()`가 새 쿼리를 쓰도록 교체
- 더 이상 쓰이지 않는 `MessageRepository.findBiasTypeDistribution` 제거 (`messages.bias_type` 컬럼 자체는 SafetyL1 위기감지용으로 계속 사용되므로 남겨둠)
- Notion `Report — 구현 문서` §4 스펙을 새 쿼리 기준으로 갱신 (스펙 자체가 원래 `messages.bias_type` 기준으로 작성돼 있던 게 이 버그의 근본 원인)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (`distortion_top3` 값의 출처만 바뀌고 필드 형식은 동일)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew test`
### 확인 내용
전체 1636건 중 10건 실패, 전부 이 변경과 무관함을 확인:
- `MioApplicationTests` 2건: 로컬 개발 DB의 기존 flyway 체크섬 드리프트 (문서화된 기존 이슈, 코드 무관)
- `AllocationSensitivityCalculatorIntegrationTest`/`InfraCostAllocatorIntegrationTest` 7건: 로컬 개발 DB의 `sessions`/`infra_cost_snapshots`에 이전 로컬 데모 작업에서 남은 목데이터가 섞여 있어 집계 값이 어긋남 — 이 브랜치가 건드리지 않는 파일들이고, 신선한 DB(CI)에서는 재현 안 됨
- `LockedEvalContaminationGuardTest` 1건: base 브랜치에서도 실패하는 기존 이슈
`com.mio.report.*`, `com.mio.session.repository.*` 관련 테스트는 전부 통과 (신규 회귀 테스트 2건 포함).

## 중점 리뷰 포인트
- 네이티브 쿼리(`jsonb_array_elements_text` + `LATERAL`)가 의도대로 동작하는지
- `messages.bias_type`/`findBiasTypeDistribution` 제거가 다른 곳에 영향 없는지 (grep으로 리포트 외 사용처 없음 확인함)

## 배포 / 롤백
- Rollout: 코드 배포만으로 즉시 적용, 별도 마이그레이션·피처플래그 불필요
- Rollback: 이전 이미지로 롤백하면 즉시 원복 (스키마 변경 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion 스펙 갱신)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.