### PR TITLE
fix: 위기 답변 파서가 한국어 부정을 긍정으로 읽지 않게 한다

### DIFF
--- a/src/main/java/com/mio/ai/crisis/CrisisAnswerParser.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisAnswerParser.java
@@ -12,6 +12,11 @@ import java.util.Locale;
  * "아니, 이미 정했어"가 NO 로 확정된다 — 후자는 준비 완료 진술을 지우는 방향의 오류다.
  * 긍정·부정 마커가 함께 있으면 확정하지 않고 UNKNOWN 을 반환하며, 상태기계가 UNKNOWN 을
  * 고정 handoff 로 fail-closed 처리한다.
+ *
+ * <p>마커 스캔보다 먼저 보는 것이 하나 있다 — 부정 보조용언 {@code -지 않다}
+ * ({@link #NEGATION_AUXILIARIES}). 한국어 부정은 어미에 후치하므로 서술어 어간만 읽으면
+ * 부정문이 긍정으로 확정된다. 이 표지가 있으면 극성을 해소하지 않고 UNKNOWN 으로 닫는다
+ * (이슈 #504).
  */
 @Component
 public class CrisisAnswerParser {
@@ -23,9 +28,13 @@ public class CrisisAnswerParser {
      * <p>"있"/"없" 은 어간만으로 매칭하지 않는다. 한국어에서 매우 흔한 음절이라
      * "있잖아요"·"상관없이" 같은 무관한 발화까지 확정 답변으로 분류됐다. 서술어 어미가
      * 붙은 형태만 인정해, 답이 아닌 문장은 UNKNOWN 으로 남아 handoff 로 닫히게 한다.
+     *
+     * <p><b>{@code 있지}·{@code 없지} 는 제외한다 (이슈 #504).</b> 다른 항목과 달리 {@code -지}
+     * 는 종결어미가 아니라 부정 보조용언 {@code 않다} 를 이끄는 보조적 연결어미이기도 하다.
+     * 마커로 두면 {@code "있지 않아요"}(= 없다)가 긍정으로 확정된다.
      */
     private static final List<String> YES_MARKERS = List.of(
-            "있어", "있습", "있다", "있음", "있네", "있죠", "있지", "있는데",
+            "있어", "있습", "있다", "있음", "있네", "있죠", "있는데",
             "그래", "맞아", "정했", "준비", "구했", "yes");
 
     /** 한 음절 인정어. 다른 단어의 일부로 흔히 나타나서(반응·언니네) 서두에서만 인정한다. */
@@ -33,7 +42,7 @@ public class CrisisAnswerParser {
 
     /** 문장 어디에 있어도 부정으로 보는 마커. 종결형만 인정한다 (YES 쪽 "있"/"없" 과 같은 이유). */
     private static final List<String> NO_MARKERS = List.of(
-            "없어", "없습", "없다", "없음", "없네", "없죠", "없지", "없는데",
+            "없어", "없습", "없다", "없음", "없네", "없죠", "없는데",
             "아니요", "아니에요", "아니야", "아닙니다", "아닌데", "no");
 
     /**
@@ -48,6 +57,24 @@ public class CrisisAnswerParser {
      */
     private static final List<String> NO_PREFIXES = List.of("아니");
 
+    /**
+     * 부정 보조용언 {@code 않다} 를 이끄는 연결어미 (이슈 #504). 비한글 제거 후 형태다.
+     *
+     * <p>한국어 부정은 어미에 후치한다 — {@code -지 않다}. 그래서 {@code -지} 는 종결어미가
+     * 아니라 뒤따르는 {@code 않다} 에 극성을 넘기는 자리이고, {@code 있지}·{@code 없지} 를
+     * 종결형 마커로 읽으면 {@code "있지 않아요"}(= 없다)가 긍정으로 확정된다.
+     * {@code IMMEDIATE_SUPPORT} 단계에서 그 오판독은 곁에 아무도 없다고 답한 사용자를
+     * {@code COMPLETED} 로 종결시키고 "그 사람에게 연락하라"고 안내한다 — 안전의 반대 방향이다.
+     *
+     * <p><b>해소하지 않고 UNKNOWN 으로 닫는다.</b> 이중부정({@code "없지 않아요"} = 있다)까지
+     * 정확히 풀려면 선행 서술어를 읽어야 하는데, 그 판단을 위기 경로에 넣기 전에 임상·언어
+     * 검토가 필요하다. UNKNOWN 은 상태기계가 고정 handoff 로 처리하고,
+     * {@code IMMEDIATE_SUPPORT} 에서는 NO 와 도착지가 같아 손실이 없다. 나머지 세 단계에서는
+     * 핫라인 우선 연결로 한 단계 보수화되는 방향이다.
+     */
+    private static final List<String> NEGATION_AUXILIARIES = List.of(
+            "지않", "진않", "지는않", "지가않", "지도않", "질않");
+
     public CrisisAnswer parse(String raw) {
         if (raw == null || raw.isBlank()) {
             return CrisisAnswer.UNKNOWN;
@@ -55,6 +82,13 @@ public class CrisisAnswerParser {
 
         String normalized = raw.toLowerCase(Locale.ROOT)
                 .replaceAll("[^가-힣a-z]", "");
+
+        // 극성이 뒤집히는 자리이므로 마커 스캔보다 먼저 본다. 마커를 먼저 읽으면
+        // 부정문 안의 서술어 어간이 그 문장의 답으로 확정된다.
+        if (containsAny(normalized, NEGATION_AUXILIARIES)) {
+            return CrisisAnswer.UNKNOWN;
+        }
+
         boolean yes = containsAny(normalized, YES_MARKERS)
                 || startsWithAny(normalized, YES_PREFIXES);
         boolean no = containsAny(normalized, NO_MARKERS)

--- a/src/main/java/com/mio/ai/crisis/CrisisAnswerParser.java
+++ b/src/main/java/com/mio/ai/crisis/CrisisAnswerParser.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Pattern;
 
 /**
  * 예·아니오 고정 질문의 명시적 답만 구조화한다. 자유 서술을 위험 판단으로 추론하지 않는다.
@@ -13,10 +14,10 @@ import java.util.Locale;
  * 긍정·부정 마커가 함께 있으면 확정하지 않고 UNKNOWN 을 반환하며, 상태기계가 UNKNOWN 을
  * 고정 handoff 로 fail-closed 처리한다.
  *
- * <p>마커 스캔보다 먼저 보는 것이 하나 있다 — 부정 보조용언 {@code -지 않다}
- * ({@link #NEGATION_AUXILIARIES}). 한국어 부정은 어미에 후치하므로 서술어 어간만 읽으면
- * 부정문이 긍정으로 확정된다. 이 표지가 있으면 극성을 해소하지 않고 UNKNOWN 으로 닫는다
- * (이슈 #504).
+ * <p>마커 스캔보다 먼저 보는 것이 하나 있다 — 존재 서술어 어간에 {@code -지} 계열 어미가
+ * 붙은 형태({@link #EXISTENCE_POLARITY_BLOCKERS}). 한국어 부정은 어미에 후치하므로
+ * ({@code -지 않다}) 어간만 읽으면 부정문이 긍정으로 확정된다. 이 형태가 있으면 극성을
+ * 해소하지 않고 UNKNOWN 으로 닫는다 (이슈 #504).
  */
 @Component
 public class CrisisAnswerParser {
@@ -29,12 +30,13 @@ public class CrisisAnswerParser {
      * "있잖아요"·"상관없이" 같은 무관한 발화까지 확정 답변으로 분류됐다. 서술어 어미가
      * 붙은 형태만 인정해, 답이 아닌 문장은 UNKNOWN 으로 남아 handoff 로 닫히게 한다.
      *
-     * <p><b>{@code 있지}·{@code 없지} 는 제외한다 (이슈 #504).</b> 다른 항목과 달리 {@code -지}
-     * 는 종결어미가 아니라 부정 보조용언 {@code 않다} 를 이끄는 보조적 연결어미이기도 하다.
-     * 마커로 두면 {@code "있지 않아요"}(= 없다)가 긍정으로 확정된다.
+     * <p>{@code 있지}·{@code 없지} 는 그대로 둔다. {@code -지} 가 부정 보조용언 {@code 않다} 를
+     * 이끄는 자리이기도 하지만, 그 충돌은 {@link #EXISTENCE_POLARITY_BLOCKERS} 가 마커 스캔보다
+     * 먼저 걸러낸다 (이슈 #504). 마커를 지우면 {@code "있지"}·{@code "있지요"} 같은 평범한 구어
+     * 긍정을 잃고, {@code "없지만"} 이 부정 증거를 통째로 잃어 YES 로 뒤집힌다.
      */
     private static final List<String> YES_MARKERS = List.of(
-            "있어", "있습", "있다", "있음", "있네", "있죠", "있는데",
+            "있어", "있습", "있다", "있음", "있네", "있죠", "있지", "있는데",
             "그래", "맞아", "정했", "준비", "구했", "yes");
 
     /** 한 음절 인정어. 다른 단어의 일부로 흔히 나타나서(반응·언니네) 서두에서만 인정한다. */
@@ -42,7 +44,7 @@ public class CrisisAnswerParser {
 
     /** 문장 어디에 있어도 부정으로 보는 마커. 종결형만 인정한다 (YES 쪽 "있"/"없" 과 같은 이유). */
     private static final List<String> NO_MARKERS = List.of(
-            "없어", "없습", "없다", "없음", "없네", "없죠", "없는데",
+            "없어", "없습", "없다", "없음", "없네", "없죠", "없지", "없는데",
             "아니요", "아니에요", "아니야", "아닙니다", "아닌데", "no");
 
     /**
@@ -57,35 +59,58 @@ public class CrisisAnswerParser {
      */
     private static final List<String> NO_PREFIXES = List.of("아니");
 
+    /** 존재 서술어 어간. {@code -지} 계열 어미와 결합할 때 극성이 모호해지는 두 형태다. */
+    private static final List<String> EXISTENCE_STEMS = List.of("있", "없");
+
     /**
-     * 부정 보조용언 {@code 않다} 를 이끄는 연결어미 (이슈 #504). 비한글 제거 후 형태다.
+     * {@code -지} 계열 어미 — 앞의 존재 서술어를 <b>답으로 확정할 수 없게</b> 만드는 형태.
      *
-     * <p>한국어 부정은 어미에 후치한다 — {@code -지 않다}. 그래서 {@code -지} 는 종결어미가
-     * 아니라 뒤따르는 {@code 않다} 에 극성을 넘기는 자리이고, {@code 있지}·{@code 없지} 를
-     * 종결형 마커로 읽으면 {@code "있지 않아요"}(= 없다)가 긍정으로 확정된다.
-     * {@code IMMEDIATE_SUPPORT} 단계에서 그 오판독은 곁에 아무도 없다고 답한 사용자를
+     * <p>{@code -지 않다}(부정 보조용언)와 {@code -지만}(양보 연결어미) 둘 다 포함한다.
+     * 종류는 다르지만 결과가 같다 — 어느 쪽이든 {@code 있지}·{@code 없지} 를 종결형 답변으로
+     * 읽으면 문장의 뜻과 반대가 된다.
+     */
+    private static final List<String> POLARITY_SUFFIXES = List.of(
+            "지않", "진않", "지는않", "지가않", "지도않", "질않", "지를않", "지아니", "지만");
+
+    /**
+     * 존재 서술어 어간에 {@code -지} 계열 어미가 붙은 형태 (이슈 #504).
+     *
+     * <p>한국어 부정은 어미에 후치한다({@code -지 않다}). 그래서 서술어 어간만 읽으면
+     * {@code "있지 않아요"}(= 없다)가 긍정으로, {@code "없지만 …"}(= 없다)이 부정 증거 없이
+     * 남는다. {@code IMMEDIATE_SUPPORT} 단계에서 그 오판독은 곁에 아무도 없다고 답한 사용자를
      * {@code COMPLETED} 로 종결시키고 "그 사람에게 연락하라"고 안내한다 — 안전의 반대 방향이다.
      *
-     * <p><b>해소하지 않고 UNKNOWN 으로 닫는다.</b> 이중부정({@code "없지 않아요"} = 있다)까지
-     * 정확히 풀려면 선행 서술어를 읽어야 하는데, 그 판단을 위기 경로에 넣기 전에 임상·언어
-     * 검토가 필요하다. UNKNOWN 은 상태기계가 고정 handoff 로 처리하고,
-     * {@code IMMEDIATE_SUPPORT} 에서는 NO 와 도착지가 같아 손실이 없다. 나머지 세 단계에서는
-     * 핫라인 우선 연결로 한 단계 보수화되는 방향이다.
+     * <p><b>어간에 붙은 형태만 본다.</b> {@code -지 않} 전체를 차단하면
+     * {@code "계획은 세우지 않았지만 도구는 구했어요"} 처럼 <b>다른</b> 서술어가 부정되고 준비
+     * 완료 진술이 따라오는 문장까지 삼켜, 이 클래스가 명시한 규율(준비 행동 동사는 부정 서두
+     * 뒤에 나와도 긍정 증거다)을 깨뜨린다. 충돌은 {@code 있}·{@code 없} 어간에만 있으므로
+     * 그 자리만 막는다.
+     *
+     * <p><b>극성을 해소하지 않고 UNKNOWN 으로 닫는다.</b> 이중부정
+     * ({@code "없지 않아요"} = 있다)까지 정확히 풀려면 선행 서술어를 읽어야 하고, 그 판단을
+     * 위기 경로에 넣기 전에 임상·언어 검토가 필요하다. UNKNOWN 은 상태기계가 고정 handoff 로
+     * 처리하며 {@code IMMEDIATE_SUPPORT} 에서는 NO 와 도착지가 같다. 나머지 단계에서는
+     * 핫라인 우선으로 보수화되는 방향이다 — 단 {@code MEANS_ACCESS} 는 YES·NO 도착지가 같아
+     * (둘 다 {@code IMMEDIATE_SUPPORT}) UNKNOWN 이 지원 인물 확인 단계를 건너뛰게 만든다.
      */
-    private static final List<String> NEGATION_AUXILIARIES = List.of(
-            "지않", "진않", "지는않", "지가않", "지도않", "질않");
+    private static final List<String> EXISTENCE_POLARITY_BLOCKERS = EXISTENCE_STEMS.stream()
+            .flatMap(stem -> POLARITY_SUFFIXES.stream().map(suffix -> stem + suffix))
+            .toList();
+
+    /** 매 턴 호출되는 경로라 정규식을 미리 컴파일한다. */
+    private static final Pattern NON_ANSWER_CHARS = Pattern.compile("[^가-힣a-z]");
 
     public CrisisAnswer parse(String raw) {
         if (raw == null || raw.isBlank()) {
             return CrisisAnswer.UNKNOWN;
         }
 
-        String normalized = raw.toLowerCase(Locale.ROOT)
-                .replaceAll("[^가-힣a-z]", "");
+        String normalized = NON_ANSWER_CHARS
+                .matcher(raw.toLowerCase(Locale.ROOT)).replaceAll("");
 
         // 극성이 뒤집히는 자리이므로 마커 스캔보다 먼저 본다. 마커를 먼저 읽으면
         // 부정문 안의 서술어 어간이 그 문장의 답으로 확정된다.
-        if (containsAny(normalized, NEGATION_AUXILIARIES)) {
+        if (containsAny(normalized, EXISTENCE_POLARITY_BLOCKERS)) {
             return CrisisAnswer.UNKNOWN;
         }
 
@@ -100,7 +125,7 @@ public class CrisisAnswerParser {
         return yes ? CrisisAnswer.YES : CrisisAnswer.NO;
     }
 
-    private boolean containsAny(String value, List<String> markers) {
+    private static boolean containsAny(String value, List<String> markers) {
         for (String marker : markers) {
             if (value.contains(marker)) {
                 return true;
@@ -109,7 +134,7 @@ public class CrisisAnswerParser {
         return false;
     }
 
-    private boolean startsWithAny(String value, List<String> prefixes) {
+    private static boolean startsWithAny(String value, List<String> prefixes) {
         for (String prefix : prefixes) {
             if (value.startsWith(prefix)) {
                 return true;

--- a/src/test/java/com/mio/ai/crisis/CrisisAnswerParserTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisAnswerParserTest.java
@@ -82,4 +82,61 @@ class CrisisAnswerParserTest {
         // 서두의 "아니"만 부정으로 인정한다. 문장 중간 사용은 답변이 아니라 정정·부연이 많다.
         assertThat(parser.parse("그건 아니고 그냥 지쳤어요")).isEqualTo(CrisisAnswer.UNKNOWN);
     }
+
+    /**
+     * 부정 보조용언 {@code 않다} 를 이끄는 연결어미 {@code -지} 의 커버리지 축 (이슈 #504).
+     *
+     * <p>이 케이스들은 마커 목록에서 복사한 것이 아니라 <b>목록이 놓치는 형태</b>다.
+     * 한국어 부정은 어미에 후치하므로({@code -지 않다}) 위험 어휘와 부정 표지의 순서·거리가
+     * 판별 정보를 가진다. {@code 있지} 를 종결형 긍정 마커로 읽으면
+     * {@code "있지 않아요"}(= 없다)가 YES 로 확정되고, {@code IMMEDIATE_SUPPORT} 단계에서
+     * <b>곁에 아무도 없다고 답한 사용자가 COMPLETED 로 종결</b>된다.
+     *
+     * <p>확정 대신 UNKNOWN 인 이유: 이중부정({@code "없지 않아요"} = 있다)까지 정확히 풀려면
+     * 선행 서술어를 읽어야 하는데 그 판단은 임상·언어 검토 대상이다. UNKNOWN 은 handoff 로
+     * fail-closed 되고, {@code IMMEDIATE_SUPPORT} 에서는 NO 와 도착지가 같다.
+     */
+    @Test
+    @DisplayName("부정 보조용언 '-지 않다'가 붙은 답변을 긍정으로 확정하지 않는다")
+    void negationAuxiliaryIsNeverReadAsAffirmative() {
+        for (String answer : new String[]{
+                "있지 않아요",
+                "믿을 만한 사람이 있지 않아요",
+                "그런 사람은 있지 않습니다",
+                "딱히 있지 않네요",
+                "지금은 있지 않아요",
+                "연락할 사람이 있지가 않아요",
+                "있지는 않습니다",
+                "있진 않아요",
+                "계획은 세우지 않았어요",
+                "정해두지 않았어요",
+                "떠오르지 않아요"}) {
+            assertThat(parser.parse(answer))
+                    .as("'%s' 는 부정이다 — 긍정으로 확정하면 위기 플로우가 잘못 종결된다", answer)
+                    .isNotEqualTo(CrisisAnswer.YES);
+        }
+    }
+
+    /**
+     * 이중부정은 의미상 긍정이지만 선행 서술어를 읽어야 풀린다. 현재는 확정하지 않는 쪽이
+     * 안전하다 — {@code IMMEDIATE_SUPPORT} 에서 UNKNOWN 은 handoff 로 닫히고,
+     * 지원 인물이 있는 사용자를 핫라인으로 한 번 더 안내하는 것은 되돌릴 수 있는 비용이다.
+     */
+    @Test
+    @DisplayName("이중부정은 긍정으로 확정하지 않는다")
+    void doubleNegationIsNotResolvedToAffirmative() {
+        assertThat(parser.parse("연락할 사람이 없지 않아요")).isNotEqualTo(CrisisAnswer.YES);
+    }
+
+    /** 부정 표지 검사가 정상 긍정·부정 답변을 삼키지 않아야 한다 (회귀 방지). */
+    @Test
+    @DisplayName("부정 표지가 없는 평범한 답변은 그대로 확정한다")
+    void plainAnswersAreUnaffectedByNegationHandling() {
+        assertThat(parser.parse("네 있어요")).isEqualTo(CrisisAnswer.YES);
+        assertThat(parser.parse("한 명 있어요")).isEqualTo(CrisisAnswer.YES);
+        assertThat(parser.parse("이미 정했어요")).isEqualTo(CrisisAnswer.YES);
+        assertThat(parser.parse("도구는 벌써 구했어")).isEqualTo(CrisisAnswer.YES);
+        assertThat(parser.parse("아무도 없어요")).isEqualTo(CrisisAnswer.NO);
+        assertThat(parser.parse("아니에요")).isEqualTo(CrisisAnswer.NO);
+    }
 }

--- a/src/test/java/com/mio/ai/crisis/CrisisAnswerParserTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisAnswerParserTest.java
@@ -2,6 +2,8 @@ package com.mio.ai.crisis;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -84,59 +86,111 @@ class CrisisAnswerParserTest {
     }
 
     /**
-     * 부정 보조용언 {@code 않다} 를 이끄는 연결어미 {@code -지} 의 커버리지 축 (이슈 #504).
+     * 존재 서술어 어간 + {@code -지} 계열 어미의 커버리지 축 (이슈 #504).
      *
      * <p>이 케이스들은 마커 목록에서 복사한 것이 아니라 <b>목록이 놓치는 형태</b>다.
-     * 한국어 부정은 어미에 후치하므로({@code -지 않다}) 위험 어휘와 부정 표지의 순서·거리가
-     * 판별 정보를 가진다. {@code 있지} 를 종결형 긍정 마커로 읽으면
-     * {@code "있지 않아요"}(= 없다)가 YES 로 확정되고, {@code IMMEDIATE_SUPPORT} 단계에서
-     * <b>곁에 아무도 없다고 답한 사용자가 COMPLETED 로 종결</b>된다.
+     * 한국어 부정은 어미에 후치하므로({@code -지 않다}) 어간만 읽으면 {@code "있지 않아요"}
+     * (= 없다)가 긍정으로 확정되고, {@code IMMEDIATE_SUPPORT} 단계에서 곁에 아무도 없다고 답한
+     * 사용자가 {@code COMPLETED} 로 종결된다.
      *
-     * <p>확정 대신 UNKNOWN 인 이유: 이중부정({@code "없지 않아요"} = 있다)까지 정확히 풀려면
-     * 선행 서술어를 읽어야 하는데 그 판단은 임상·언어 검토 대상이다. UNKNOWN 은 handoff 로
-     * fail-closed 되고, {@code IMMEDIATE_SUPPORT} 에서는 NO 와 도착지가 같다.
+     * <p>단정을 {@code UNKNOWN} 으로 고정한다. {@code isNotEqualTo(YES)} 로 두면 구현이 실수로
+     * {@code NO} 를 반환해도 통과하는데, {@code NO} 는 이중부정({@code "없지 않아요"} = 있다)을
+     * 잘못 확정하는 값이다 — 이 클래스가 피하려는 바로 그 오판독이다.
      */
-    @Test
-    @DisplayName("부정 보조용언 '-지 않다'가 붙은 답변을 긍정으로 확정하지 않는다")
-    void negationAuxiliaryIsNeverReadAsAffirmative() {
-        for (String answer : new String[]{
-                "있지 않아요",
-                "믿을 만한 사람이 있지 않아요",
-                "그런 사람은 있지 않습니다",
-                "딱히 있지 않네요",
-                "지금은 있지 않아요",
-                "연락할 사람이 있지가 않아요",
-                "있지는 않습니다",
-                "있진 않아요",
-                "계획은 세우지 않았어요",
-                "정해두지 않았어요",
-                "떠오르지 않아요"}) {
-            assertThat(parser.parse(answer))
-                    .as("'%s' 는 부정이다 — 긍정으로 확정하면 위기 플로우가 잘못 종결된다", answer)
-                    .isNotEqualTo(CrisisAnswer.YES);
-        }
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+            "있지 않아요",
+            "믿을 만한 사람이 있지 않아요",
+            "그런 사람은 있지 않습니다",
+            "딱히 있지 않네요",
+            "지금은 있지 않아요",
+            "연락할 사람이 있지가 않아요",
+            "있지는 않습니다",
+            "있진 않아요",
+            "있지도 않아요",
+            "있질 않아요",
+            "있지를 않아요",
+            "있지 아니합니다",
+            "없지 않아요",
+            "없지는 않습니다"})
+    @DisplayName("존재 서술어에 붙은 '-지 않다'는 어느 쪽으로도 확정하지 않는다")
+    void negatedExistenceIsNeverResolved(String answer) {
+        assertThat(parser.parse(answer))
+                .as("'%s' 를 확정하면 위기 플로우가 잘못 라우팅된다", answer)
+                .isEqualTo(CrisisAnswer.UNKNOWN);
     }
 
     /**
-     * 이중부정은 의미상 긍정이지만 선행 서술어를 읽어야 풀린다. 현재는 확정하지 않는 쪽이
-     * 안전하다 — {@code IMMEDIATE_SUPPORT} 에서 UNKNOWN 은 handoff 로 닫히고,
-     * 지원 인물이 있는 사용자를 핫라인으로 한 번 더 안내하는 것은 되돌릴 수 있는 비용이다.
+     * 양보 연결어미 {@code -지만} 도 같은 자리다. 부정 보조용언은 아니지만 결과가 같다 —
+     * {@code "없지만 …"} 은 뜻이 부정인데 뒤에 긍정 마커가 오면 YES 로 뒤집히고,
+     * {@code "있지만 연락은 안 해요"} 는 뜻이 부정인데 {@code 있지} 때문에 YES 가 된다.
+     */
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+            "믿을 만한 사람은 없지만 그래도 괜찮아요",
+            "그런 사람 없지만 준비는 됐어요",
+            "아무도 없지만 맞아요 견딜 수 있어요",
+            "있지만 연락은 안 해요",
+            "있지만 지금은 어려워요"})
+    @DisplayName("존재 서술어에 붙은 '-지만'도 확정하지 않는다")
+    void concessiveExistenceIsNeverResolved(String answer) {
+        assertThat(parser.parse(answer)).isEqualTo(CrisisAnswer.UNKNOWN);
+    }
+
+    /**
+     * 차단은 <b>존재 서술어 어간에 붙은 형태만</b> 본다. {@code -지 않} 전체를 차단하면
+     * 다른 서술어가 부정되고 준비 완료 진술이 따라오는 문장까지 삼켜, 이 클래스가 명시한
+     * 규율(준비 행동 동사는 부정 서두 뒤에 나와도 긍정 증거다)이 깨진다.
+     *
+     * <p>위기 triage 에서 이 손실은 안전 문제가 아니라 <b>기록</b> 문제다 —
+     * {@code handoff} 는 핫라인을 주지만 {@code "도구는 구했어요"} 라고 명확히 말한 턴이
+     * {@code ambiguous_answer} 로 영구 기록되고 후속 단계 평가 기회가 사라진다.
      */
     @Test
-    @DisplayName("이중부정은 긍정으로 확정하지 않는다")
-    void doubleNegationIsNotResolvedToAffirmative() {
-        assertThat(parser.parse("연락할 사람이 없지 않아요")).isNotEqualTo(CrisisAnswer.YES);
+    @DisplayName("다른 서술어의 부정은 준비 완료 진술을 지우지 않는다")
+    void negationOfOtherPredicatesDoesNotEraseReadinessStatement() {
+        assertThat(parser.parse("계획은 세우지 않았지만 도구는 구했어요"))
+                .isEqualTo(CrisisAnswer.YES);
+        assertThat(parser.parse("아직 정하지 않았지만 준비는 했어요"))
+                .isEqualTo(CrisisAnswer.YES);
+    }
+
+    /** 평범한 구어 긍정. 어간+{@code -지} 를 마커에서 빼면 이것들이 UNKNOWN 으로 떨어진다. */
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {"있지", "있지요", "그런 사람 있지", "한 명 있지"})
+    @DisplayName("종결형 '있지'는 평범한 긍정으로 확정한다")
+    void bareExistenceEndingStillResolvesToYes(String answer) {
+        assertThat(parser.parse(answer)).isEqualTo(CrisisAnswer.YES);
     }
 
     /** 부정 표지 검사가 정상 긍정·부정 답변을 삼키지 않아야 한다 (회귀 방지). */
     @Test
-    @DisplayName("부정 표지가 없는 평범한 답변은 그대로 확정한다")
-    void plainAnswersAreUnaffectedByNegationHandling() {
+    @DisplayName("차단 형태가 없는 평범한 답변은 그대로 확정한다")
+    void plainAnswersAreUnaffectedByBlockers() {
         assertThat(parser.parse("네 있어요")).isEqualTo(CrisisAnswer.YES);
         assertThat(parser.parse("한 명 있어요")).isEqualTo(CrisisAnswer.YES);
         assertThat(parser.parse("이미 정했어요")).isEqualTo(CrisisAnswer.YES);
         assertThat(parser.parse("도구는 벌써 구했어")).isEqualTo(CrisisAnswer.YES);
         assertThat(parser.parse("아무도 없어요")).isEqualTo(CrisisAnswer.NO);
         assertThat(parser.parse("아니에요")).isEqualTo(CrisisAnswer.NO);
+    }
+
+    /**
+     * 차단 목록 밖의 부정 형태 — 현재 동작을 고정한다. 전부 마커가 없어 UNKNOWN 이지만,
+     * 그건 목록이 덮어서가 아니라 <b>매칭할 마커가 우연히 없어서</b>다. 마커 목록이 넓어지면
+     * 이 축이 먼저 깨지므로 회귀 감지 지점으로 남겨 둔다.
+     */
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+            "계시지 않아요",
+            "안 계세요",
+            "없으십니다",
+            "그런 생각 안 들어요",
+            "떠오르지 않아요",
+            "계획은 세우지 않았어요",
+            "정해두지 않았어요"})
+    @DisplayName("목록 밖 부정 형태는 현재 확정되지 않는다 — 회귀 감지 지점")
+    void outOfListNegationsCurrentlyResolveToUnknown(String answer) {
+        assertThat(parser.parse(answer)).isEqualTo(CrisisAnswer.UNKNOWN);
     }
 }

--- a/src/test/java/com/mio/ai/crisis/CrisisNegationRoutingTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisNegationRoutingTest.java
@@ -1,0 +1,90 @@
+package com.mio.ai.crisis;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 부정 답변이 위기 플로우를 잘못 종결시키지 않는지 검증한다 (이슈 #504).
+ *
+ * <p>{@link CrisisAnswerParserTest} 는 판독 결과만 본다. 그런데 실제로 지켜야 하는 성질은
+ * 판독값이 아니라 <b>라우팅</b>이다 — 같은 오판독이 단계에 따라 전혀 다른 결과를 낸다.
+ * {@code IMMEDIATE_SUPPORT} 에서 부정을 긍정으로 읽으면
+ * {@code COMPLETED} + {@code "지금 바로 그 사람에게 연락하고…"} 가 나가는데,
+ * 이건 곁에 아무도 없다고 답한 사용자에게 그 사람에게 연락하라고 말하는 것이다.
+ * 올바른 도착지는 {@code HANDOFF} (핫라인 우선 연결)다.
+ *
+ * <p>그래서 두 단위를 함께 통과시키는 축을 따로 둔다. 파서만 고치고 라우팅을 확인하지 않으면
+ * 다음 사람이 마커를 다시 넣었을 때 이 성질이 조용히 깨진다.
+ */
+class CrisisNegationRoutingTest {
+
+    private final CrisisAnswerParser parser = new CrisisAnswerParser();
+    private final CrisisFlowStateMachine machine = new CrisisFlowStateMachine();
+
+    /** {@code IMMEDIATE_SUPPORT} 질문: "지금 곁에 있거나 바로 연락할 수 있는 믿을 만한 사람이 있나요?" */
+    private static final String[] NO_SUPPORT_ANSWERS = {
+            "있지 않아요",
+            "믿을 만한 사람이 있지 않아요",
+            "그런 사람은 있지 않습니다",
+            "딱히 있지 않네요",
+            "지금은 있지 않아요",
+            "연락할 사람이 있지가 않아요",
+            "있지는 않습니다",
+            "있진 않아요",
+            "없어요",
+            "아니요",
+            "아무도 없어요"
+    };
+
+    @Test
+    @DisplayName("지원 인물이 없다는 답변은 어떤 표현이든 COMPLETED로 종결되지 않는다")
+    void absentSupportNeverCompletesTheFlow() {
+        for (String answer : NO_SUPPORT_ANSWERS) {
+            CrisisFlowTransition transition =
+                    machine.next(CrisisFlowStage.IMMEDIATE_SUPPORT, parser.parse(answer));
+
+            assertThat(transition.status())
+                    .as("'%s' 로 플로우가 종결되면 곁에 아무도 없는 사용자에게 "
+                            + "'그 사람에게 연락하라'고 안내하게 된다", answer)
+                    .isNotEqualTo(CrisisFlowStatus.COMPLETED);
+            assertThat(transition.nextStage())
+                    .as("'%s' 는 핫라인 우선 연결(HANDOFF)로 닫혀야 한다", answer)
+                    .isEqualTo(CrisisFlowStage.HANDOFF);
+        }
+    }
+
+    @Test
+    @DisplayName("현재성·계획·수단 단계의 부정 답변도 위험을 지우지 않는다")
+    void negationInEarlyStagesDoesNotEscalateIntoDetailQuestions() {
+        // 부정을 긍정으로 읽으면 실제로는 계획·수단이 없는 사용자에게 수단 질문이 이어진다.
+        // 확정하지 못하면 handoff 로 닫는 것이 이 상태기계의 기존 규율이다.
+        assertThat(machine.next(CrisisFlowStage.CURRENT_INTENT, parser.parse("죽고 싶은 생각이 있지 않아요"))
+                .nextStage())
+                .as("자·타해 생각이 없다는 답변이 계획 질문으로 이어지면 안 된다")
+                .isNotEqualTo(CrisisFlowStage.PLAN);
+        assertThat(machine.next(CrisisFlowStage.PLAN, parser.parse("계획은 세우지 않았어요"))
+                .nextStage())
+                .as("계획이 없다는 답변이 수단 질문으로 이어지면 안 된다")
+                .isNotEqualTo(CrisisFlowStage.MEANS);
+        assertThat(machine.next(CrisisFlowStage.MEANS, parser.parse("정해두지 않았어요"))
+                .nextStage())
+                .as("수단을 정하지 않았다는 답변이 접근성 질문으로 이어지면 안 된다")
+                .isNotEqualTo(CrisisFlowStage.MEANS_ACCESS);
+    }
+
+    @Test
+    @DisplayName("긍정 답변의 triage 경로는 그대로 유지된다")
+    void affirmativePathIsUnchanged() {
+        assertThat(machine.next(CrisisFlowStage.CURRENT_INTENT, parser.parse("네 있어요")).nextStage())
+                .isEqualTo(CrisisFlowStage.PLAN);
+        assertThat(machine.next(CrisisFlowStage.PLAN, parser.parse("이미 정했어요")).nextStage())
+                .isEqualTo(CrisisFlowStage.MEANS);
+        assertThat(machine.next(CrisisFlowStage.MEANS, parser.parse("도구는 벌써 구했어")).nextStage())
+                .isEqualTo(CrisisFlowStage.MEANS_ACCESS);
+        assertThat(machine.next(CrisisFlowStage.IMMEDIATE_SUPPORT, parser.parse("한 명 있어요")).status())
+                .as("지원 인물이 있다고 답하면 종결까지 가야 한다 — 과잉 handoff 는 경험 퇴행이다")
+                .isEqualTo(CrisisFlowStatus.COMPLETED);
+    }
+}

--- a/src/test/java/com/mio/ai/crisis/CrisisNegationRoutingTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisNegationRoutingTest.java
@@ -2,6 +2,8 @@ package com.mio.ai.crisis;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,8 +25,14 @@ class CrisisNegationRoutingTest {
     private final CrisisAnswerParser parser = new CrisisAnswerParser();
     private final CrisisFlowStateMachine machine = new CrisisFlowStateMachine();
 
+    private CrisisFlowTransition route(CrisisFlowStage stage, String answer) {
+        return machine.next(stage, parser.parse(answer));
+    }
+
     /** {@code IMMEDIATE_SUPPORT} 질문: "지금 곁에 있거나 바로 연락할 수 있는 믿을 만한 사람이 있나요?" */
-    private static final String[] NO_SUPPORT_ANSWERS = {
+    @ParameterizedTest(name = "[{index}] {0}")
+    @ValueSource(strings = {
+            // 어간 + 부정 보조용언
             "있지 않아요",
             "믿을 만한 사람이 있지 않아요",
             "그런 사람은 있지 않습니다",
@@ -33,58 +41,92 @@ class CrisisNegationRoutingTest {
             "연락할 사람이 있지가 않아요",
             "있지는 않습니다",
             "있진 않아요",
+            "있지를 않아요",
+            // 어간 + 양보 연결어미. 부정 증거가 사라져 뒤따르는 긍정 마커에 뒤집히던 형태다.
+            "믿을 만한 사람은 없지만 그래도 괜찮아요",
+            "그런 사람 없지만 준비는 됐어요",
+            "아무도 없지만 맞아요 견딜 수 있어요",
+            "있지만 연락은 안 해요",
+            // 표준 부정
             "없어요",
             "아니요",
-            "아무도 없어요"
-    };
-
-    @Test
+            "아무도 없어요"})
     @DisplayName("지원 인물이 없다는 답변은 어떤 표현이든 COMPLETED로 종결되지 않는다")
-    void absentSupportNeverCompletesTheFlow() {
-        for (String answer : NO_SUPPORT_ANSWERS) {
-            CrisisFlowTransition transition =
-                    machine.next(CrisisFlowStage.IMMEDIATE_SUPPORT, parser.parse(answer));
+    void absentSupportNeverCompletesTheFlow(String answer) {
+        CrisisFlowTransition transition = route(CrisisFlowStage.IMMEDIATE_SUPPORT, answer);
 
-            assertThat(transition.status())
-                    .as("'%s' 로 플로우가 종결되면 곁에 아무도 없는 사용자에게 "
-                            + "'그 사람에게 연락하라'고 안내하게 된다", answer)
-                    .isNotEqualTo(CrisisFlowStatus.COMPLETED);
-            assertThat(transition.nextStage())
-                    .as("'%s' 는 핫라인 우선 연결(HANDOFF)로 닫혀야 한다", answer)
-                    .isEqualTo(CrisisFlowStage.HANDOFF);
-        }
+        assertThat(transition.status())
+                .as("'%s' 로 플로우가 종결되면 곁에 아무도 없는 사용자에게 "
+                        + "'그 사람에게 연락하라'고 안내하게 된다", answer)
+                .isNotEqualTo(CrisisFlowStatus.COMPLETED);
+        assertThat(transition.nextStage())
+                .as("'%s' 는 핫라인 우선 연결(HANDOFF)로 닫혀야 한다", answer)
+                .isEqualTo(CrisisFlowStage.HANDOFF);
     }
 
     @Test
-    @DisplayName("현재성·계획·수단 단계의 부정 답변도 위험을 지우지 않는다")
+    @DisplayName("현재성·계획·수단 단계의 부정 답변은 상세 질문으로 이어지지 않는다")
     void negationInEarlyStagesDoesNotEscalateIntoDetailQuestions() {
-        // 부정을 긍정으로 읽으면 실제로는 계획·수단이 없는 사용자에게 수단 질문이 이어진다.
-        // 확정하지 못하면 handoff 로 닫는 것이 이 상태기계의 기존 규율이다.
-        assertThat(machine.next(CrisisFlowStage.CURRENT_INTENT, parser.parse("죽고 싶은 생각이 있지 않아요"))
-                .nextStage())
+        assertThat(route(CrisisFlowStage.CURRENT_INTENT, "그런 생각이 있지 않아요").nextStage())
                 .as("자·타해 생각이 없다는 답변이 계획 질문으로 이어지면 안 된다")
-                .isNotEqualTo(CrisisFlowStage.PLAN);
-        assertThat(machine.next(CrisisFlowStage.PLAN, parser.parse("계획은 세우지 않았어요"))
-                .nextStage())
+                .isEqualTo(CrisisFlowStage.HANDOFF);
+        assertThat(route(CrisisFlowStage.PLAN, "계획이 있지 않아요").nextStage())
                 .as("계획이 없다는 답변이 수단 질문으로 이어지면 안 된다")
-                .isNotEqualTo(CrisisFlowStage.MEANS);
-        assertThat(machine.next(CrisisFlowStage.MEANS, parser.parse("정해두지 않았어요"))
-                .nextStage())
+                .isEqualTo(CrisisFlowStage.HANDOFF);
+        assertThat(route(CrisisFlowStage.MEANS, "정해둔 게 있지 않아요").nextStage())
                 .as("수단을 정하지 않았다는 답변이 접근성 질문으로 이어지면 안 된다")
-                .isNotEqualTo(CrisisFlowStage.MEANS_ACCESS);
+                .isEqualTo(CrisisFlowStage.HANDOFF);
+    }
+
+    /**
+     * {@code MEANS_ACCESS} 는 YES·NO 도착지가 같다({@code IMMEDIATE_SUPPORT}). UNKNOWN 만
+     * {@code HANDOFF} 다. 즉 원래 버그는 이 단계에서 아무 영향이 없었지만, <b>수정은 영향을
+     * 만든다</b> — 수단 접근성에 답한 사용자가 지원 인물 확인 질문을 받지 못하고 종결된다.
+     *
+     * <p>핫라인은 나가므로 안전 방향 역전은 아니지만 손실이 0인 것도 아니다. 이 축을 고정해
+     * 두는 이유는 그 손실이 의도된 것임을 다음 사람이 알 수 있게 하기 위해서다.
+     */
+    @Test
+    @DisplayName("수단 접근성 단계에서는 UNKNOWN이 지원 인물 확인을 건너뛴다 — 의도된 손실")
+    void meansAccessLosesSupportCheckOnUnknown() {
+        assertThat(machine.next(CrisisFlowStage.MEANS_ACCESS, CrisisAnswer.YES).nextStage())
+                .isEqualTo(CrisisFlowStage.IMMEDIATE_SUPPORT);
+        assertThat(machine.next(CrisisFlowStage.MEANS_ACCESS, CrisisAnswer.NO).nextStage())
+                .as("이 단계는 YES·NO 도착지가 같다 — 원래 버그의 영향이 없던 자리다")
+                .isEqualTo(CrisisFlowStage.IMMEDIATE_SUPPORT);
+        assertThat(route(CrisisFlowStage.MEANS_ACCESS, "가지고 있지 않아요").nextStage())
+                .as("수정으로 이 단계는 handoff 로 닫힌다 — 지원 인물 확인을 잃는다")
+                .isEqualTo(CrisisFlowStage.HANDOFF);
     }
 
     @Test
     @DisplayName("긍정 답변의 triage 경로는 그대로 유지된다")
     void affirmativePathIsUnchanged() {
-        assertThat(machine.next(CrisisFlowStage.CURRENT_INTENT, parser.parse("네 있어요")).nextStage())
+        assertThat(route(CrisisFlowStage.CURRENT_INTENT, "네 있어요").nextStage())
                 .isEqualTo(CrisisFlowStage.PLAN);
-        assertThat(machine.next(CrisisFlowStage.PLAN, parser.parse("이미 정했어요")).nextStage())
+        assertThat(route(CrisisFlowStage.PLAN, "이미 정했어요").nextStage())
                 .isEqualTo(CrisisFlowStage.MEANS);
-        assertThat(machine.next(CrisisFlowStage.MEANS, parser.parse("도구는 벌써 구했어")).nextStage())
+        assertThat(route(CrisisFlowStage.MEANS, "도구는 벌써 구했어").nextStage())
                 .isEqualTo(CrisisFlowStage.MEANS_ACCESS);
-        assertThat(machine.next(CrisisFlowStage.IMMEDIATE_SUPPORT, parser.parse("한 명 있어요")).status())
+        assertThat(route(CrisisFlowStage.IMMEDIATE_SUPPORT, "한 명 있어요").status())
                 .as("지원 인물이 있다고 답하면 종결까지 가야 한다 — 과잉 handoff 는 경험 퇴행이다")
                 .isEqualTo(CrisisFlowStatus.COMPLETED);
+        assertThat(route(CrisisFlowStage.IMMEDIATE_SUPPORT, "있지").status())
+                .as("종결형 '있지' 는 평범한 구어 긍정이다")
+                .isEqualTo(CrisisFlowStatus.COMPLETED);
+    }
+
+    /**
+     * 다른 서술어가 부정되고 준비 완료 진술이 따라오는 문장. 차단을 존재 서술어 어간으로
+     * 한정했기 때문에 이 진술이 살아남는다 — 명시적 준비 완료를 {@code ambiguous_answer} 로
+     * 지우면 그 사용자의 위험 기록 자체가 사라진다.
+     */
+    @Test
+    @DisplayName("다른 서술어의 부정은 수단 확보 진술을 지우지 않는다")
+    void negationOfOtherPredicatesKeepsMeansSecuredAnswer() {
+        assertThat(route(CrisisFlowStage.MEANS, "계획은 세우지 않았지만 도구는 구했어요").nextStage())
+                .isEqualTo(CrisisFlowStage.MEANS_ACCESS);
+        assertThat(route(CrisisFlowStage.MEANS, "아직 정하지 않았지만 준비는 했어요").nextStage())
+                .isEqualTo(CrisisFlowStage.MEANS_ACCESS);
     }
 }


### PR DESCRIPTION
## 요약
위기 고정 플로우의 답변 파서가 한국어 부정 `-지 않다` 를 **긍정으로 판독**했습니다.
`IMMEDIATE_SUPPORT` 단계에서 `"믿을 만한 사람이 있지 않아요"`(= 곁에 아무도 없다)가 `YES` 로
읽혀 `COMPLETED` 로 종결되고, 사용자는 `"지금 바로 그 사람에게 연락하고, 연결될 때까지
가능하면 혼자 있지 말아주세요"` 를 받았습니다. 올바른 도착지는 `handoff()` — 핫라인 우선 연결입니다.

공격자가 필요 없고, 결정론적이라 100% 재현되며, **실패 방향이 안전의 반대**였습니다.

## 관련 이슈
- Closes #504
- 범위 밖 기존 결함은 #509 로 분리

## 변경 사항
차단 대상을 **존재 서술어 어간에 붙은 형태로 한정**합니다 —
`{있, 없} × {지않, 진않, 지는않, 지가않, 지도않, 질않, 지를않, 지아니, 지만}` 18형태.
이 형태가 있으면 극성을 해소하지 않고 `UNKNOWN` 으로 닫고, 상태기계가 고정 handoff 로 처리합니다.

`있지`·`없지` 마커는 **그대로 둡니다.** 차단 검사가 마커 스캔보다 먼저 돌기 때문에
제거해도 원래 버그 수정에 기여하지 않고, 제거하면 손해만 납니다(아래 "리뷰 반영" 참조).

### 왜 어간으로 한정하는가
`-지 않` 전체를 차단하면 **다른** 서술어가 부정되고 준비 완료 진술이 따라오는 문장까지 삼켜,
이 클래스가 명시한 규율(*"준비 행동 동사는 부정 서두 뒤에 나와도 긍정 증거다"*)이 깨집니다.
`"계획은 세우지 않았지만 도구는 구했어요"` 가 `UNKNOWN` 이 되면 명시적 수단 확보 진술이
`ambiguous_answer` 로 영구 기록되고, `handoff` 는 종결 상태라 후속 단계 평가 기회까지 사라집니다.
충돌은 `있`·`없` 어간에만 있으므로 그 자리만 막으면 예외 규칙이 필요 없습니다.

### 왜 극성을 해소하지 않고 UNKNOWN 인가
이중부정(`"없지 않아요"` = 있다)까지 정확히 풀려면 선행 서술어를 읽어야 하고,
그 판단을 위기 경로에 넣기 전에 임상·언어 검토가 필요합니다.

| 단계 | 정답이 NO일 때 도착지 | UNKNOWN 도착지 | 차이 |
|---|---|---|---|
| `IMMEDIATE_SUPPORT` | `handoff()` | `handoff()` | **동일** |
| `CURRENT_INTENT` / `PLAN` / `MEANS` | `IMMEDIATE_SUPPORT` | `handoff()` | 핫라인 우선으로 보수화 |
| **`MEANS_ACCESS`** | `IMMEDIATE_SUPPORT` | `handoff()` | **YES·NO 도착지가 같은 단계** — UNKNOWN 이 지원 인물 확인을 건너뛴다 |

마지막 행이 손실입니다. 원래 버그는 이 단계에서 아무 영향이 없었지만 **수정은 영향을 만듭니다** —
수단 접근성에 답한 사용자가 지원 인물 확인 질문을 받지 못하고 종결됩니다.
핫라인은 나가므로 안전 방향 역전은 아니지만 **손실이 0은 아닙니다.**
그 손실이 의도된 것임을 `CrisisNegationRoutingTest` 로 고정했습니다.

### 범위 한정
질문 문구와 고정 응답은 건드리지 않았습니다 (로드맵 방침상 전문가·법무 검토 대상).

## 리뷰 반영 — 첫 버전의 결함 셋
적대적 리뷰가 실행으로 셋을 잡았고 전부 고쳤습니다.

1. **`있지`·`없지` 제거가 새 안전 역전을 만들었다.** `-지` 는 부정 보조용언 자리이기만 한 게
   아니라 양보 연결어미 `-지만` 자리이기도 합니다. `없지만` 은 첫 차단 목록에 걸리지 않는데
   `없지` 가 사라져 부정 증거가 0이 되고, YES 마커가 하나라도 있으면 YES 로 확정됐습니다 —
   `"믿을 만한 사람은 없지만 그래도 괜찮아요"` → `COMPLETED`. **고치려던 것과 같은 실패입니다.**
2. **그 제거는 원래 버그 수정에 기여하지 않는다.** 차단이 먼저 돌기 때문입니다.
   제거는 `있지`·`있지요` 같은 평범한 구어 긍정만 잃었습니다.
3. **`-지 않` 전체 차단이 준비 완료 진술을 삼켰다** (위 "왜 어간으로 한정하는가").

세 결함의 원인이 하나였습니다 — **차단 범위가 넓었습니다.** 어간 한정 + 마커 복구로 셋이 함께 사라집니다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [x] **안전 판정 경로**가 바뀝니다.
- [ ] Breaking change 가 있습니다.

> 안전 판정 경로 중 **위기 고정 플로우 답변 판독**만 바뀝니다.
> `SafetyL1`·`InputJudge`·`PolicyEngine`·`OutputPreFilter`·`OutputJudge` 는 건드리지 않았습니다.
>
> **`handoff` 종결 비율이 오릅니다.** `-지 않아요` 는 `-있나요?` 질문에 대한 자연스러운 부정
> 응답 형태이므로 한계적 증가가 아닙니다. 배포 후 `mio.crisis.fixed.flow` 를 단계별로 실측해
> 임계를 정하는 것을 권합니다.
>
> **API 계약 불변**: `State_공통상태값정의.md §23` 이 위기 플로우 상태를 FE 미노출로 명시하고,
> FE 가 보는 것은 SSE `crisis` 이벤트와 `finished_reason=crisis_flow` 뿐입니다.
> `§23-3` 이 이미 `unknown → handoff` fail-closed 를 문서화하고 있어 **계약 준수 방향**입니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.ai.crisis.*"
./gradlew test
```

### 확인 내용
**TDD** — 테스트를 먼저 추가해 RED 3건을 확인한 뒤 구현했습니다.

**정직한 측정** (develop 기준선 파서와 나란히 컴파일해 실제 `CrisisFlowStateMachine` 에 통과, 34건):

| 그룹 | n | develop 역전 | 이 PR 역전 |
|---|---:|---:|---:|
| 원래 버그 (`있`+`-지 않` 9형태) | 10 | 9 | **0** |
| 양보 어미 (`없지만`·`있지만`) | 4 | 1 | **0** |
| 준비 완료 진술 보존 | 2 | 0 | **0** |
| 구어 긍정 (`있지`·`있지요`) | 3 | 0 | **0** |
| 정상 긍정·부정 | 8 | 0 | **0** |
| **이 PR 범위 소계** | **27** | **10** | **0** |
| 기존 결함 — `없어` 부분일치 (#509) | 3 | 3 | 3 |
| 기존 결함 — 경계 없는 마커 (#509) | 4 | 4 | 4 |
| **전체** | **34** | **17** | **7** |

**남은 역전 7건은 전부 이 PR 범위 밖의 기존 결함**이고 #509 로 등록했습니다.
`없어지고 싶어요` → NO, `그래도 혼자예요` → YES 계열입니다. 이 PR 로 나빠지지도 좋아지지도 않습니다.

> 첫 PR 본문의 *"위험 역전 6건 → 0건"*, *"어느 단계에서도 위험 역전이 발생하지 않습니다"* 는
> **과장이었습니다.** 18건 표본이 `있 + -지 않 + 종결어미` 로만 구성돼 교정 대상 패턴만
> 측정했고, 회귀는 정의상 표본 밖에 있었습니다. 위 표로 정정합니다.

**돌연변이 검증** (테스트가 계약을 실제로 고정하는지):

| 돌연변이 | 이전 테스트 | 현재 테스트 |
|---|---|---|
| 차단 목록에서 `지도않`·`질않` 제거 | 생존 (BUILD SUCCESSFUL) | **1건 실패** |
| 차단 시 `UNKNOWN` 대신 `NO` 반환 | 생존 | **19건 실패** |

`isNotEqualTo(YES)` 는 구현이 실수로 `NO` 를 반환해도 통과하는데, `NO` 는 이중부정을
잘못 확정하는 값입니다 — `isEqualTo(UNKNOWN)` 으로 바꿨습니다.
`@ParameterizedTest` 로 실패 케이스가 개별 식별되게 하고, 차단 목록 밖 형태(경어 `계시지 않아요`,
전치 부정 `안 계세요`)를 **회귀 감지 지점**으로 고정했습니다.

**전체 스위트 1,646건 중 이 PR 로 인한 실패 0건.** 남는 2건은 로컬 환경 전용
(`LockedEvalContaminationGuardTest` 가 로컬 `docs/` 를 훑음; `docs/` 는 git 미추적이라
깨끗한 worktree 에서는 통과). **CI 통과.**

## 중점 리뷰 포인트
1. **차단 목록의 완결성.** `{있,없} × 9어미` 로 잡았습니다. 빠진 형태가 있는지 봐주세요.
   확인한 것: `지를않`·`지아니`·`지도않`·`질않` 포함, `안 계세요`·`계시지 않아요` 같은 경어는
   **미포함**(마커가 없어 우연히 UNKNOWN 이고, 회귀 감지 테스트로 고정).
2. **`MEANS_ACCESS` 손실을 수용할지.** 위 표 마지막 행. 이 단계만 YES·NO 도착지가 같아
   UNKNOWN 이 지원 인물 확인을 건너뜁니다.
3. **`handoff` 증가 규모.** 한계적이지 않을 수 있습니다. 배포 후 실측 계획이 필요합니다.
4. **커버리지 케이스의 독립성.** 차단 목록에서 복사하지 않은 형태로 구성했는지 확인해 주세요.
   목록 밖 축(경어·전치 부정)을 별도 테스트로 뒀습니다.

## 배포 / 롤백
- Rollout: `develop` 머지 후 **Crisis Eval (full path)** 수동 실행. 평가 코드는 항상 신뢰 브랜치
  (`develop`)를 checkout 하므로 머지 후에 게이트를 돌립니다.
- Rollback: 파서 단일 파일 되돌리기. 상태·스키마·계약 변경이 없어 데이터 정리가 필요 없습니다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
      — 변경 없음. `docs/` 가 git 미추적이라 이 PR 에 담을 수 없으나,
      `State_공통상태값정의.md §23-3` 의 판독 규칙 서술에 `-지` 계열 처리를 덧붙여야 합니다
      (이슈 #460 의 서술형 답변 정책과 함께). 클래스 javadoc 의
      *"답이 아닌 문장은 UNKNOWN 으로 남는다"* 서술은 #509 계열에서 거짓이므로 그 이슈에서 정정합니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [ ] (hotfix 인 경우) — hotfix 아님.
