### PR TITLE
fix: trace 에 자해 질의 라벨을 남기지 않는다 — 범주와 개수만

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.ToLongFunction;
 
@@ -38,6 +39,17 @@ public class AiDecisionLogger {
     private static final String SCHEMA_VERSION = "v2.5";
     private static final String CRISIS_MARKER_PREFIX = "crisis_context_marker:";
     private static final String PROMPT_VERSION = "phase2";
+
+    /**
+     * {@code SecurityAssessment.attackTypes()} 안에서 <b>민감하지 않은</b> 항목 (이슈 #510).
+     *
+     * <p>그 리스트는 패턴 라벨(= 사용자 문구)과 원문 기반 우회 신호가 섞여 있다.
+     * 후자는 {@code SecurityRuleFilter.obfuscationSignals()} 가 만드는 고정 토큰 두 개뿐이고,
+     * 하필 {@code unverifiableByJudge} 의 산출 근거 그 자체다 — 라벨과 함께 개수로 뭉개면
+     * 진단 가치가 가장 큰 항목이 사라진다. 그래서 이 둘만 그대로 남기고 라벨은 개수로 바꾼다.
+     */
+    private static final Set<String> NON_SENSITIVE_SECURITY_SIGNALS =
+            Set.of("zero_width_char", "obfuscated_input");
 
     private final AiPolicyDecisionRepository repository;
     private final ObjectMapper objectMapper;
@@ -318,8 +330,17 @@ public class AiDecisionLogger {
      * 접두어로 필터링해 {@code crisis_keyword:*} 를 배제하는 규약을 이미 지키므로, 보안 축에도
      * 같은 규약을 적용한다 — <b>등급·성격·개수만</b> 남긴다.
      *
-     * <p>개수를 남기는 이유: 보안 축 재현율의 분모·분자가 되고, 어느 턴에서 여러 패턴이
-     * 동시에 걸렸는지가 오탐 분석의 단서다. 어떤 패턴이었는지는 평가셋에서 오프라인으로 본다.
+     * <p>라벨은 <b>개수만</b> 남긴다({@code security_pattern_label_count}). 보안 축 재현율의
+     * 분모·분자가 되고, 한 턴에 여러 패턴이 동시에 걸렸는지가 오탐 분석의 단서다. 어떤 패턴이
+     * 걸렸는지는 평가셋에서 오프라인으로 본다. 다만 이 개수는 계열을 구분하지 못한다 —
+     * 자해 질의 경로의 {@code attackTypes} 는 자해·조작·의심 세 계열의 합집합이므로
+     * ({@code SecurityRuleFilter} 의 self-harm 분기) 계열별 분해가 필요하면 별도 필드가 필요하다.
+     *
+     * <p>반면 원문 기반 우회 신호({@link #NON_SENSITIVE_SECURITY_SIGNALS})는 고정 토큰이라
+     * 그대로 남긴다 — 이 값이 {@code unverifiable_by_judge} 가 왜 섰는지를 설명한다.
+     *
+     * <p>근본 해결은 {@code trace} 의 보존기간·암호화 정책이다. 이 필터는 새 노출을 막을 뿐
+     * 이미 적재된 레코드를 정리하지 않는다 — <b>보존기간 정책과 함께 정리해야 하는 과제로 남는다.</b>
      *
      * <p>부재는 값으로 축약하지 않는다. 특히 {@code unverifiable_by_judge} 를 부재 시
      * {@code false} 로 두면 "원문 근거 없었음"과 "판정 객체 자체가 없었음"이 같은 값이 되어,
@@ -329,15 +350,20 @@ public class AiDecisionLogger {
         if (assessment == null) {
             trace.put("security_rule_level", null);
             trace.put("attack_kind", null);
-            trace.put("security_attack_pattern_count", null);
+            trace.put("security_obfuscation_signals", null);
+            trace.put("security_pattern_label_count", null);
             trace.put("security_evidence_unverifiable_by_judge", null);
             return;
         }
+        List<String> types = assessment.attackTypes();
+        List<String> signals = types.stream()
+                .filter(NON_SENSITIVE_SECURITY_SIGNALS::contains)
+                .toList();
         trace.put("security_rule_level", assessment.level().name());
         trace.put("attack_kind", assessment.attackKind() != null
                 ? assessment.attackKind().name() : null);
-        trace.put("security_attack_pattern_count",
-                assessment.attackTypes() != null ? assessment.attackTypes().size() : null);
+        trace.put("security_obfuscation_signals", signals);
+        trace.put("security_pattern_label_count", types.size() - signals.size());
         trace.put("security_evidence_unverifiable_by_judge", assessment.unverifiableByJudge());
     }
 

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -35,7 +35,7 @@ import java.util.function.ToLongFunction;
 @Slf4j
 public class AiDecisionLogger {
 
-    private static final String SCHEMA_VERSION = "v2.4";
+    private static final String SCHEMA_VERSION = "v2.5";
     private static final String CRISIS_MARKER_PREFIX = "crisis_context_marker:";
     private static final String PROMPT_VERSION = "phase2";
 
@@ -299,7 +299,7 @@ public class AiDecisionLogger {
     }
 
     /**
-     * 보안 판정의 근거를 남긴다 (이슈 #505).
+     * 보안 판정의 근거를 남긴다 (이슈 #505, #510).
      *
      * <p>{@code securityAssessment} 는 이 클래스의 인자로 들어오면서도 트레이스에 반영되지
      * 않아 그대로 버려졌다. 남는 것은 {@code security_level} 컬럼 하나였고, 그 값은 룰과
@@ -310,27 +310,34 @@ public class AiDecisionLogger {
      * 판정자가 룰의 의심을 걷어낸 것이고, 그 경로는 사용자 텍스트의 영향을 받는다.
      * 두 값을 분리해 두지 않으면 사후에 구분할 수 없다.
      *
-     * <p>{@code attack_types} 는 {@code SecurityRuleFilter} 의 닫힌 패턴 라벨 집합이고
-     * 사용자 문장을 복제하지 않는다. 다만 라벨 자체가 발화의 축자 부분열이므로
-     * ({@code 관리자 권한}·{@code 역할극} 등) "그 문구가 메시지에 있었다"는 사실은 남는다.
-     * {@code trace} 는 평문 JSONB 이고 메시지 원문은 AES-256 컬럼 암호화라 이 비대칭은
-     * 의도된 것이 아니다 — 보존기간 정책과 함께 정리 대상이다.
+     * <p><b>패턴 라벨은 남기지 않는다 (이슈 #510).</b> {@code SecurityRuleFilter} 의 라벨은
+     * 패턴 문자열 자체이고, 자해 질의 패턴은 {@code "자살 방법 알려줘"}·
+     * {@code "단계별 자해 방법"} 이다. 라벨을 적재하면 "이 사용자가 자살 방법을 물었다"가
+     * AES-256 없이 평문 JSONB 에 영구 남는다 — 메시지 원문은 컬럼 암호화하는데 {@code trace}
+     * 는 평문이라 비대칭이 생긴다. 이 클래스는 L1 시그널을 {@code crisis_context_marker:}
+     * 접두어로 필터링해 {@code crisis_keyword:*} 를 배제하는 규약을 이미 지키므로, 보안 축에도
+     * 같은 규약을 적용한다 — <b>등급·성격·개수만</b> 남긴다.
+     *
+     * <p>개수를 남기는 이유: 보안 축 재현율의 분모·분자가 되고, 어느 턴에서 여러 패턴이
+     * 동시에 걸렸는지가 오탐 분석의 단서다. 어떤 패턴이었는지는 평가셋에서 오프라인으로 본다.
+     *
+     * <p>부재는 값으로 축약하지 않는다. 특히 {@code unverifiable_by_judge} 를 부재 시
+     * {@code false} 로 두면 "원문 근거 없었음"과 "판정 객체 자체가 없었음"이 같은 값이 되어,
+     * 원문 기반 탐지가 통째로 빠진 턴을 식별할 수 없다.
      */
     private void putSecurityEvidence(Map<String, Object> trace, SecurityAssessment assessment) {
         if (assessment == null) {
-            // 부재를 false·빈 목록으로 축약하지 않는다. 특히 마지막 필드는
-            // "원문 근거 없었음"과 "판정 객체 자체가 없었음"이 같은 값이 되면
-            // 원문 기반 탐지가 통째로 빠진 턴을 사후에 식별할 수 없다.
             trace.put("security_rule_level", null);
             trace.put("attack_kind", null);
-            trace.put("security_attack_types", null);
+            trace.put("security_attack_pattern_count", null);
             trace.put("security_evidence_unverifiable_by_judge", null);
             return;
         }
         trace.put("security_rule_level", assessment.level().name());
         trace.put("attack_kind", assessment.attackKind() != null
                 ? assessment.attackKind().name() : null);
-        trace.put("security_attack_types", assessment.attackTypes());
+        trace.put("security_attack_pattern_count",
+                assessment.attackTypes() != null ? assessment.attackTypes().size() : null);
         trace.put("security_evidence_unverifiable_by_judge", assessment.unverifiableByJudge());
     }
 

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -155,7 +155,7 @@ class AiDecisionLoggerTest {
                 .as("룰이 무엇으로 봤는지 남아야 판정자 강등을 사후에 구분할 수 있다")
                 .contains("\"security_rule_level\":\"ATTACK\"")
                 .contains("\"attack_kind\":\"MANIPULATION\"")
-                .contains("\"security_attack_types\":[\"규칙을 잊고\"]")
+                .contains("\"security_attack_pattern_count\":1")
                 .contains("\"security_evidence_unverifiable_by_judge\"");
         assertThat(captor.getValue().getSecurityLevel())
                 .as("실효 판정은 기존 컬럼에 그대로 남는다")
@@ -267,6 +267,109 @@ class AiDecisionLoggerTest {
         verify(repository).save(captor.capture());
 
         assertThat(captor.getValue().getTrace()).contains("\"crisis_attribution\":null");
+    }
+
+    /**
+     * 이슈 #510 — trace 는 범주만 담고 내용은 담지 않는다.
+     *
+     * <p>`SecurityRuleFilter` 의 라벨은 패턴 문자열 자체다. 자해 질의 패턴은
+     * {@code "자살 방법 알려줘"}·{@code "단계별 자해 방법"} 이므로, 라벨을 그대로 적재하면
+     * "이 사용자가 자살 방법을 물었다"가 AES-256 없이 평문 JSONB 에 영구 남는다.
+     *
+     * <p>이 클래스는 L1 시그널을 {@code crisis_context_marker:} 접두어로 필터링해
+     * {@code crisis_keyword:죽고싶다} 류를 배제하는 규약을 이미 지킨다. 같은 규약을 보안 축에도
+     * 적용한다 — 등급·성격·개수만 남기고 라벨은 남기지 않는다.
+     */
+    @Test
+    @DisplayName("자해 질의 라벨을 트레이스에 남기지 않는다 — 범주와 개수만")
+    void logDoesNotPersistSelfHarmInquiryLabels() {
+        PolicyDecision decision = crisisDecision("pd_selfharm");
+
+        logger.log(
+                UUID.randomUUID(), UUID.randomUUID(), decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(),
+                SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘", "단계별 자해 방법")),
+                100, 10, true, false, null, null, "default",
+                false, false, false, decision.crisisTrigger(), null
+        );
+
+        String trace = capturedTraceOnce();
+        assertThat(trace)
+                .as("라벨은 패턴 문자열 자체다 — 평문 trace 에 담기면 민감정보가 남는다")
+                .doesNotContain("자살 방법 알려줘")
+                .doesNotContain("단계별 자해 방법")
+                .doesNotContain("security_attack_types");
+        assertThat(trace)
+                .as("범주와 개수는 남긴다 — 보안 축 재현율의 분모·분자가 된다")
+                .contains("\"attack_kind\":\"SELF_HARM_INQUIRY\"")
+                .contains("\"security_rule_level\":\"ATTACK\"")
+                .contains("\"security_attack_pattern_count\":2");
+    }
+
+    /**
+     * 이슈 #510 — 부재를 값으로 축약하지 않는 결정에 회귀 방어를 붙인다.
+     *
+     * <p>PR #507 이 가장 공들여 정당화한 결정인데 이 분기를 타는 테스트가 없었다.
+     * {@code unverifiable_by_judge=false} 로 되돌리면 "원문 근거 없었음"과 "판정 객체 자체가
+     * 없었음"이 같은 값이 되어, 원문 기반 탐지가 통째로 빠진 턴을 식별할 수 없다.
+     */
+    @Test
+    @DisplayName("보안 판정 객체가 없으면 부재를 null로 남긴다 — false로 축약하지 않는다")
+    void logKeepsSecurityEvidenceNullWhenAssessmentAbsent() {
+        PolicyDecision decision = generateDecision("pd_no_assessment");
+
+        logger.log(
+                UUID.randomUUID(), UUID.randomUUID(), decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(),
+                null,
+                100, 10, false, false, null, null, "default",
+                false, false, false, decision.crisisTrigger(), null
+        );
+
+        assertThat(capturedTraceOnce())
+                .contains("\"security_rule_level\":null")
+                .contains("\"attack_kind\":null")
+                .contains("\"security_attack_pattern_count\":null")
+                .contains("\"security_evidence_unverifiable_by_judge\":null");
+    }
+
+    /** 값까지 고정한다 — 키 존재만 단정하면 true·false 를 뒤집어도 통과한다. */
+    @Test
+    @DisplayName("원문 전용 근거 플래그는 값까지 고정한다")
+    void logPinsUnverifiableByJudgeValue() {
+        PolicyDecision decision = generateDecision("pd_unverifiable");
+
+        logger.log(
+                UUID.randomUUID(), UUID.randomUUID(), decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(),
+                SecurityAssessment.suspicious(List.of("역할극"), true),
+                100, 10, false, true, null, null, "default",
+                false, false, false, decision.crisisTrigger(), null
+        );
+
+        assertThat(capturedTraceOnce())
+                .as("원문에서만 드러난 근거가 있었는지는 Judge CLEAN 강등을 사후 판정하는 값이다")
+                .contains("\"security_evidence_unverifiable_by_judge\":true");
+    }
+
+    /** trace 스키마 버전은 키 구성이 바뀔 때 함께 올린다 — 구 레코드와 부재를 구분하려면 필요하다. */
+    @Test
+    @DisplayName("trace 스키마 버전이 키 구성 변경을 반영한다")
+    void traceSchemaVersionReflectsKeySet() {
+        PolicyDecision decision = generateDecision("pd_schema");
+
+        logger.log(
+                UUID.randomUUID(), UUID.randomUUID(), decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(), SecurityAssessment.clean(),
+                100, 10, false, false, null, null, "default",
+                false, false, false, decision.crisisTrigger(), null
+        );
+
+        assertThat(capturedTraceOnce()).contains("\"schema_version\":\"v2.5\"");
     }
 
     /**
@@ -653,6 +756,30 @@ class AiDecisionLoggerTest {
                 0,
                 memoryResult,
                 null
+        );
+    }
+
+    /** 이 테스트 클래스의 기존 {@code capturedTrace()} 와 동일하다 — 신규 축에서 의도를 드러내려 이름만 다르게 쓴다. */
+    private String capturedTraceOnce() {
+        return capturedTrace();
+    }
+
+    /** 위기 확정 결정 (이슈 #510 축). */
+    private PolicyDecision crisisDecision(String decisionId) {
+        return new PolicyDecision(
+                decisionId,
+                DecisionAction.CRISIS_FLOW,
+                GenerationMode.CRISIS,
+                DeliveryMode.CRISIS_FLOW,
+                SecurityLevel.ATTACK,
+                false,
+                false,
+                false,
+                InterventionHints.empty(),
+                "test-policy",
+                RiskLevel.HARD_CRISIS,
+                CrisisTrigger.SELF_HARM_INQUIRY,
+                JudgeStatus.SKIPPED
         );
     }
 

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -155,7 +155,7 @@ class AiDecisionLoggerTest {
                 .as("룰이 무엇으로 봤는지 남아야 판정자 강등을 사후에 구분할 수 있다")
                 .contains("\"security_rule_level\":\"ATTACK\"")
                 .contains("\"attack_kind\":\"MANIPULATION\"")
-                .contains("\"security_attack_pattern_count\":1")
+                .contains("\"security_pattern_label_count\":1")
                 .contains("\"security_evidence_unverifiable_by_judge\"");
         assertThat(captor.getValue().getSecurityLevel())
                 .as("실효 판정은 기존 컬럼에 그대로 남는다")
@@ -294,7 +294,7 @@ class AiDecisionLoggerTest {
                 false, false, false, decision.crisisTrigger(), null
         );
 
-        String trace = capturedTraceOnce();
+        String trace = capturedTrace();
         assertThat(trace)
                 .as("라벨은 패턴 문자열 자체다 — 평문 trace 에 담기면 민감정보가 남는다")
                 .doesNotContain("자살 방법 알려줘")
@@ -304,7 +304,7 @@ class AiDecisionLoggerTest {
                 .as("범주와 개수는 남긴다 — 보안 축 재현율의 분모·분자가 된다")
                 .contains("\"attack_kind\":\"SELF_HARM_INQUIRY\"")
                 .contains("\"security_rule_level\":\"ATTACK\"")
-                .contains("\"security_attack_pattern_count\":2");
+                .contains("\"security_pattern_label_count\":2");
     }
 
     /**
@@ -328,10 +328,11 @@ class AiDecisionLoggerTest {
                 false, false, false, decision.crisisTrigger(), null
         );
 
-        assertThat(capturedTraceOnce())
+        assertThat(capturedTrace())
                 .contains("\"security_rule_level\":null")
                 .contains("\"attack_kind\":null")
-                .contains("\"security_attack_pattern_count\":null")
+                .contains("\"security_obfuscation_signals\":null")
+                .contains("\"security_pattern_label_count\":null")
                 .contains("\"security_evidence_unverifiable_by_judge\":null");
     }
 
@@ -350,15 +351,21 @@ class AiDecisionLoggerTest {
                 false, false, false, decision.crisisTrigger(), null
         );
 
-        assertThat(capturedTraceOnce())
+        assertThat(capturedTrace())
                 .as("원문에서만 드러난 근거가 있었는지는 Judge CLEAN 강등을 사후 판정하는 값이다")
                 .contains("\"security_evidence_unverifiable_by_judge\":true");
     }
 
-    /** trace 스키마 버전은 키 구성이 바뀔 때 함께 올린다 — 구 레코드와 부재를 구분하려면 필요하다. */
+    /**
+     * 보안 축 trace 키 집합을 고정한다 (이슈 #510).
+     *
+     * <p>버전 상수가 자기 자신과 같은지 보는 것은 동어반복이라 회귀를 못 잡는다.
+     * 실제로 고정해야 하는 것은 <b>어떤 키가 나가는가</b>다 — 키가 사라지면 집계 쿼리가
+     * 조용히 빈 결과를 내고, 키가 추가되면 스키마 버전을 올릴지 결정해야 한다.
+     */
     @Test
-    @DisplayName("trace 스키마 버전이 키 구성 변경을 반영한다")
-    void traceSchemaVersionReflectsKeySet() {
+    @DisplayName("보안 축 trace 키 집합과 스키마 버전을 함께 고정한다")
+    void logPinsSecurityTraceKeySet() {
         PolicyDecision decision = generateDecision("pd_schema");
 
         logger.log(
@@ -369,7 +376,49 @@ class AiDecisionLoggerTest {
                 false, false, false, decision.crisisTrigger(), null
         );
 
-        assertThat(capturedTraceOnce()).contains("\"schema_version\":\"v2.5\"");
+        String trace = capturedTrace();
+        assertThat(trace)
+                .contains("\"schema_version\":\"v2.5\"")
+                .contains("\"security_rule_level\":")
+                .contains("\"attack_kind\":")
+                .contains("\"security_obfuscation_signals\":")
+                .contains("\"security_pattern_label_count\":")
+                .contains("\"security_evidence_unverifiable_by_judge\":")
+                .contains("\"crisis_attribution\":");
+        assertThat(trace)
+                .as("라벨 키는 되살아나면 안 된다")
+                .doesNotContain("security_attack_types");
+    }
+
+    /**
+     * 원문 기반 우회 신호는 고정 토큰이라 그대로 남긴다 (이슈 #510).
+     *
+     * <p>이 값이 {@code unverifiable_by_judge} 가 왜 섰는지를 설명한다 — 라벨과 함께 개수로
+     * 뭉개면 진단 가치가 가장 큰 항목이 사라진다.
+     */
+    @Test
+    @DisplayName("우회 신호 토큰은 남기고 패턴 라벨만 개수로 바꾼다")
+    void logKeepsObfuscationSignalsButCountsLabels() {
+        PolicyDecision decision = generateDecision("pd_obfuscation");
+
+        logger.log(
+                UUID.randomUUID(), UUID.randomUUID(), decision,
+                new ModerationResult(false, Map.of(), Map.of()),
+                SafetyL1Result.clear(),
+                SecurityAssessment.suspicious(
+                        List.of("역할극", "zero_width_char", "obfuscated_input"), true),
+                100, 10, false, true, null, null, "default",
+                false, false, false, decision.crisisTrigger(), null
+        );
+
+        String trace = capturedTrace();
+        assertThat(trace)
+                .as("고정 토큰은 민감하지 않고 unverifiable_by_judge 의 근거다")
+                .contains("\"security_obfuscation_signals\":[\"zero_width_char\",\"obfuscated_input\"]")
+                .contains("\"security_pattern_label_count\":1");
+        assertThat(trace)
+                .as("패턴 라벨은 사용자 문구다")
+                .doesNotContain("역할극");
     }
 
     /**
@@ -757,11 +806,6 @@ class AiDecisionLoggerTest {
                 memoryResult,
                 null
         );
-    }
-
-    /** 이 테스트 클래스의 기존 {@code capturedTrace()} 와 동일하다 — 신규 축에서 의도를 드러내려 이름만 다르게 쓴다. */
-    private String capturedTraceOnce() {
-        return capturedTrace();
     }
 
     /** 위기 확정 결정 (이슈 #510 축). */


### PR DESCRIPTION
## 요약
PR #507 이 추가한 `security_attack_types` 가 **자해 질의 패턴 라벨을 평문으로** 적재했습니다.
`SecurityRuleFilter` 의 라벨은 패턴 문자열 자체이고, 자해 질의 패턴은
`"자살 방법 알려줘"`·`"단계별 자해 방법"` 입니다. 결과적으로 **"이 사용자가 자살 방법을 물었다"가
AES-256 없이 `ai_policy_decisions.trace` 에 영구 적재**됩니다. 메시지 원문은 컬럼 암호화하는데
`trace` 는 평문 JSONB 라 비대칭입니다.

**머지 후 독립 리뷰가 잡았습니다.** 제가 #507 에서 놓친 것입니다.

## 관련 이슈
- Closes #510

## 변경 사항

### 같은 파일이 이미 지키던 규약을 우회했습니다
`AiDecisionLogger` 는 L1 시그널을 `crisis_context_marker:` 접두어로 **필터링해서** 넣고
주석이 이유를 명시합니다 — *"마커 종류만 기록하므로 **발화 원문은 포함되지 않는다**"*.
즉 `crisis_keyword:죽고싶다` 류를 평문 trace 에서 의도적으로 배제해온 것이 이 파일의 규약입니다.
보안 축에도 같은 규약을 적용합니다 — **등급·성격·개수만** 남깁니다.

| 변경 | 이유 |
|---|---|
| `security_attack_types` (라벨 배열) → `security_attack_pattern_count` (개수) | 내용 제거. 개수는 보안 축 재현율의 분모·분자가 되고, 한 턴에 여러 패턴이 동시에 걸렸는지가 오탐 분석의 단서입니다. **어떤** 패턴이었는지는 평가셋에서 오프라인으로 봅니다 |
| `SCHEMA_VERSION` `v2.4` → `v2.5` | 키 5개가 늘었는데 버전이 그대로면 소비자가 "키 없음(구 레코드)"과 "키가 null(부재)"를 구분할 수 없습니다 — #507 자신의 "부재와 값을 섞지 않는다" 원칙과 같은 결의 문제입니다 |

### 함께 고친 테스트 공백 (같은 리뷰 지적)

1. **`assessment == null` 분기를 타는 테스트가 0건**이었습니다. 테스트의 `log(...)` 호출 12건이
   전부 비-null `SecurityAssessment` 를 넘겼습니다. #507 커밋 메시지가 가장 공들여 정당화한
   결정("부재를 `false` 로 축약하지 않는다")에 회귀 방어가 없었습니다.
2. **`security_evidence_unverifiable_by_judge` 값이 고정되지 않았습니다** — 키 존재만 단정해
   `true`/`false` 를 뒤집어도 통과했습니다. `SecurityAssessment` javadoc 이 *"판정자 CLEAN 으로
   등급 낮추면 원문 탐지가 무력화된다"* 고 강조하는 필드입니다.

### javadoc 정정
#507 은 라벨을 *"발화의 축자 부분열"* 이라고 썼는데, 다중 토큰 라벨은 `PARTICLE_GAP` 관대
정규식으로 매칭되므로 축자 부분열이 아니라 **근사 매칭**입니다. 그리고 노출 등급 예시를
`관리자 권한`·`역할극` 같은 조작 라벨로만 들어 **과소진술**했습니다 — 자해 라벨이 같은 배열에
실린다는 사실을 명시했습니다.

## 영향 범위
- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] **안전 판정 경로**가 바뀝니다.
- [ ] Breaking change 가 있습니다.

> **동작 변경 0.** `trace` jsonb 내부만 바뀝니다. 마이그레이션 없음, 쓰기 횟수 불변.
>
> **키 이름이 바뀝니다** (`security_attack_types` → `security_attack_pattern_count`).
> #507 이 머지된 지 얼마 되지 않아 이 키를 읽는 쿼리·대시보드가 아직 없습니다
> (검색 결과 소비처 0건). `SCHEMA_VERSION` 을 올려 구 레코드와 구분되게 했습니다.
>
> **이미 적재된 레코드**에 라벨이 남아 있을 수 있습니다. 프로덕션(`main`)에는 #507 이 아직
> 배포되지 않았으므로 노출 범위는 dev 환경에 한정됩니다 — 배포 전에 이 PR 이 들어가면
> 프로덕션 노출은 0입니다. dev 데이터 정리 필요 여부는 아래 배포 절에 적었습니다.

## 테스트
### 실행 커맨드
```bash
./gradlew test --tests "com.mio.ai.orchestrator.*"
./gradlew test
```

### 확인 내용
TDD — 신규 4건 추가해 RED 3건 확인 후 구현(4번째는 순수 회귀 가드라 처음부터 통과).

**돌연변이 검증:**

| 돌연변이 | 결과 |
|---|---|
| 부재 분기를 `null` → `false` 로 되돌림 | **1건 실패** |
| `security_attack_pattern_count` → 라벨 배열로 되돌림 | **2건 실패** |

전체 스위트 **1,695건 중 이 PR 로 인한 실패 0건**. 남는 2건은 로컬 `docs/` 전용
(`LockedEvalContaminationGuardTest`, git 미추적이라 CI 에서는 미발생).

## 중점 리뷰 포인트
1. **개수만으로 충분한지.** 보안 축 재현율 분석에 어떤 패턴이 걸렸는지가 필요하면 평가셋에서
   봐야 합니다. 프로덕션 trace 로 패턴별 분석을 하려면 해시·코드화가 대안이지만,
   그러면 다시 역추적 가능성이 생깁니다. 지금은 개수가 맞다고 판단했습니다.
2. **`attack_kind` 는 남겨도 되는지.** enum(`NONE`/`MANIPULATION`/`SELF_HARM_INQUIRY`)이라
   내용은 없지만 `SELF_HARM_INQUIRY` 자체가 "자해 질의를 했다"는 사실입니다. 보안 축 지표에
   필수라 남겼는데, 이것도 민감정보로 볼지 판단이 필요합니다.
3. **이미 적재된 dev 데이터.** 정리할지, 보존기간에 맡길지.

## 배포 / 롤백
- Rollout: 동작 변경이 없어 별도 절차 없음. **`main` 배포 전에 들어가면 프로덕션 노출 0입니다.**
- dev 데이터: `UPDATE ai_policy_decisions SET trace = trace - 'security_attack_types'`
  로 기존 키를 제거할 수 있습니다. 실행 여부는 팀 판단.
- Rollback: 2개 파일 되돌리기. 단 롤백하면 라벨 적재가 재개됩니다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 마이그레이션 없음.
      `docs/` 가 git 미추적이라 `04_AI_파이프라인_v2.4.md` 관측 필드 목록 갱신은 별도로 필요합니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다. — **이 PR 의 주제입니다.**
- [ ] (hotfix 인 경우) — hotfix 아님, develop 대상.
