### PR TITLE
hotfix: 리포트 인지왜곡 집계를 세션요약 기준으로 바꾼다

### DIFF
--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -15,6 +15,7 @@ import com.mio.report.dto.WeeklyReportResponse;
 import com.mio.session.domain.Session;
 import com.mio.session.repository.MessageRepository;
 import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.todo.domain.TaskStatus;
 import com.mio.todo.repository.BehaviorTaskRepository;
 import com.mio.user.repository.UserRepository;
@@ -50,6 +51,7 @@ public class ReportService {
 
     private final CheckinRepository checkinRepository;
     private final MessageRepository messageRepository;
+    private final SessionSummaryRepository sessionSummaryRepository;
     private final SessionRepository sessionRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
     private final UserRepository userRepository;
@@ -199,7 +201,7 @@ public class ReportService {
     // ── 공통 집계 ─────────────────────────────────────────────────
 
     private List<DistortionDto> buildDistortionTop3(UUID userId, OffsetDateTime start, OffsetDateTime end) {
-        List<Object[]> rows = messageRepository.findBiasTypeDistribution(userId, start, end);
+        List<Object[]> rows = sessionSummaryRepository.findBiasTypeDistribution(userId, start, end);
         List<DistortionDto> result = new ArrayList<>();
         for (int i = 0; i < Math.min(3, rows.size()); i++) {
             String type = (String) rows.get(i)[0];

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -18,11 +18,6 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
                                @Param("start") OffsetDateTime start,
                                @Param("end") OffsetDateTime end);
 
-    @Query("SELECT m.biasType, COUNT(m) FROM Message m WHERE m.user.id = :userId AND m.createdAt >= :start AND m.createdAt < :end AND m.biasType IS NOT NULL GROUP BY m.biasType ORDER BY COUNT(m) DESC")
-    List<Object[]> findBiasTypeDistribution(@Param("userId") UUID userId,
-                                            @Param("start") OffsetDateTime start,
-                                            @Param("end") OffsetDateTime end);
-
     @Query("SELECT m FROM Message m WHERE m.session.id = :sessionId AND m.role = :role ORDER BY m.createdAt DESC")
     List<Message> findRecentBySessionAndRole(@Param("sessionId") UUID sessionId,
                                              @Param("role") MessageRole role,

--- a/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionSummaryRepository.java
@@ -6,11 +6,33 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface SessionSummaryRepository extends JpaRepository<SessionSummary, UUID> {
     Optional<SessionSummary> findBySession_Id(UUID sessionId);
+
+    /**
+     * 리포트용 인지왜곡 분포 (이슈 #502).
+     *
+     * <p>{@code messages.bias_type} 은 실시간 위기감지(SafetyL1)용 경량 신호라 커버리지가
+     * 낮다 — 정식 인지왜곡 분석은 {@code SessionConsolidator} 가 ExtractorLLM 으로 세션 종료
+     * 후 만드는 이 컬럼({@code bias_types_detected})에 있다. JSONB 배열이라 네이티브 쿼리로만
+     * 펼칠 수 있다.
+     */
+    @Query(value = """
+            SELECT bt.bias_type AS biasType, COUNT(*) AS cnt
+            FROM session_summaries s
+            CROSS JOIN LATERAL jsonb_array_elements_text(s.bias_types_detected) AS bt(bias_type)
+            WHERE s.user_id = :userId AND s.created_at >= :start AND s.created_at < :end
+            GROUP BY bt.bias_type
+            ORDER BY cnt DESC
+            """, nativeQuery = true)
+    List<Object[]> findBiasTypeDistribution(@Param("userId") UUID userId,
+                                            @Param("start") OffsetDateTime start,
+                                            @Param("end") OffsetDateTime end);
 
     /**
      * 사용자 노출용 요약을 채운다 (이슈 #339).


### PR DESCRIPTION
## 요약
#503(develop에 이미 머지됨)의 수정을 main에도 핫픽스로 반영합니다. develop이 그 사이 263커밋 더 앞서있어서 develop→main 승격 대신, 이 수정 하나만 cherry-pick했습니다.

## 관련 이슈
- Closes #502

## 변경 사항
- develop 커밋 cf3682d를 cherry-pick (#503과 동일한 코드 변경)
- `ReportServiceWeeklyReadTest.java`는 이 hotfix에서 제외했습니다 — main이 아직 이슈 #419(내러티브 배치화) 리팩터 전이라 develop의 테스트 구조(생성자 시그니처 등)가 그대로 안 옮겨집니다. 프로덕션 코드 수정(3개 파일)만 포함했고, 회귀 테스트는 develop에 이미 있습니다.

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (distortion_top3 값의 출처만 바뀌고 필드 형식은 동일)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava`
### 확인 내용
main 코드베이스 기준으로 컴파일 성공 확인. 기능 회귀 테스트는 develop의 #503에서 이미 통과 확인됨(동일 코드 변경).

## 중점 리뷰 포인트
- cherry-pick이 main의 구버전 ReportService(아직 #419 리팩터 전, reportNarrativeService 필드 존재)와 충돌 없이 잘 붙었는지

## 배포 / 롤백
- Rollout: 코드 배포만으로 즉시 적용, 별도 마이그레이션·피처플래그 불필요
- Rollback: 이전 이미지로 롤백하면 즉시 원복 (스키마 변경 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.