### PR TITLE
fix: 판정자가 고쳐 쓴 본문을 결정론 필터에 다시 통과시킨다

### DIFF
--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -67,8 +67,7 @@ public class AiDecisionLogger {
             long llmTtftMs,
             boolean crisisFlowTriggered,
             boolean inputJudgeCalled,
-            OutputPreFilterResult preFilterResult,
-            OutputJudgeResult outputJudgeResult,
+            OutputGuardOutcome outputGuard,
             String l1ThresholdSource,
             boolean safetyProfileCacheHit,
             MemoryCacheOutcome memoryCache,
@@ -87,7 +86,7 @@ public class AiDecisionLogger {
             Map<String, Object> trace = buildTrace(
                     moderation, l1Result, securityAssessment, llmTtftMs, totalPipelineMs,
                     crisisFlowTriggered, decision,
-                    inputJudgeCalled, preFilterResult, outputJudgeResult,
+                    inputJudgeCalled, outputGuard,
                     l1ThresholdSource, safetyProfileCacheHit, memoryCache,
                     safetyProfileDegraded, appliedCrisisTrigger, llmUsage, contractResult,
                     firstSubstantiveTokenMs, firstRenderedTokenMs, safePrefixApplied,
@@ -131,8 +130,7 @@ public class AiDecisionLogger {
             long llmTtftMs,
             boolean crisisFlowTriggered,
             boolean inputJudgeCalled,
-            OutputPreFilterResult preFilterResult,
-            OutputJudgeResult outputJudgeResult,
+            OutputGuardOutcome outputGuard,
             String l1ThresholdSource,
             boolean safetyProfileCacheHit,
             boolean memoryCacheHit,
@@ -142,7 +140,7 @@ public class AiDecisionLogger {
         // 편의 오버로드는 staleness 를 받지 않는다 — 폴백 경로를 지나지 않는 호출용이다.
         log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered, inputJudgeCalled,
-                preFilterResult, outputJudgeResult, l1ThresholdSource, safetyProfileCacheHit,
+                outputGuard, l1ThresholdSource, safetyProfileCacheHit,
                 memoryCacheHit ? MemoryCacheOutcome.fallback(null) : MemoryCacheOutcome.live(),
                 safetyProfileDegraded, appliedCrisisTrigger, llmUsage,
                 ResponseContractResult.notApplicable(), -1, -1, false, 0, null, null);
@@ -162,7 +160,7 @@ public class AiDecisionLogger {
             boolean crisisFlowTriggered) {
         log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
                 totalPipelineMs, llmTtftMs, crisisFlowTriggered,
-                false, OutputPreFilterResult.pass(), null,
+                false, OutputGuardOutcome.preFilterOnly(OutputPreFilterResult.pass()),
                 "default", false, MemoryCacheOutcome.live(), false, decision.crisisTrigger(), null,
                 ResponseContractResult.notApplicable(), -1, -1, false, 0, null, null);
     }
@@ -176,8 +174,7 @@ public class AiDecisionLogger {
             boolean crisisFlowTriggered,
             PolicyDecision decision,
             boolean inputJudgeCalled,
-            OutputPreFilterResult preFilterResult,
-            OutputJudgeResult outputJudgeResult,
+            OutputGuardOutcome outputGuard,
             String l1ThresholdSource,
             boolean safetyProfileCacheHit,
             MemoryCacheOutcome memoryCache,
@@ -289,12 +286,18 @@ public class AiDecisionLogger {
         trace.put("contract_result", contractResult != null
                 ? contractResult.logValue() : ResponseContractResult.notApplicable().logValue());
         trace.put("contract_violations", contractResult != null ? contractResult.violations() : List.of());
+        OutputPreFilterResult preFilterResult = outputGuard.preFilter();
+        OutputJudgeResult outputJudgeResult = outputGuard.judge();
         trace.put("output_pre_filter_result", preFilterResult != null
                 ? (preFilterResult.passed() ? "PASS" : "FAIL") : null);
         trace.put("output_pre_filter_fail_reasons", preFilterResult != null
                 ? preFilterResult.failReasons() : null);
         trace.put("output_judge_action", outputJudgeResult != null
                 ? outputJudgeResult.action().name() : null);
+        // 판정자가 고쳐 쓴 본문이 다시 위반이어서 거부됐는가 (이슈 #526). 이 값이 없으면
+        // "판정이 고쳐 썼다" 와 "고쳐 쓴 것이 다시 위반이었다" 를 구분할 수 없고, 그러면
+        // 재검증이 실제로 발동하는지 알 수 없다.
+        trace.put("rewrite_rejected", outputGuard.rewriteRejected());
         // action 만으로는 "위험하다고 판정해서 REPLACE" 와 "판정을 못 받아서 REPLACE" 가
         // 구별되지 않는다 (이슈 #364). Input Judge 의 judge_status 와 같은 계약이다.
         //   SKIPPED   → Judge 를 부르지 않았다 (pre-filter 통과)

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -344,6 +344,9 @@ public class ConversationOrchestrator {
             // 출력 가드가 승격시킨 위기는 decision.action() 이 GENERATE 라 결정에 경로가 없다.
             CrisisTrigger appliedCrisisTrigger = null;
             OutputPreFilterResult preFilterResult = OutputPreFilterResult.pass();
+            // 판정자가 고쳐 쓴 본문을 재검증에서 거부했는지 — trace 로 나간다 (이슈 #526).
+            // 로거 호출과 같은 스코프에 둔다.
+            AtomicBoolean rewriteRejected = new AtomicBoolean(false);
             // 전달 계측 (이슈 #306). 첫 생성 토큰 지연(llmTtftMs)과 구분해서 남긴다 —
             // 하나로 재면 서버가 먼저 보내는 문구만으로도 수치가 좋아진다.
             AtomicLong firstSubstantiveTokenMs = new AtomicLong(-1);
@@ -411,6 +414,8 @@ public class ConversationOrchestrator {
                 DeliveryMode deliveryMode = decision.deliveryMode();
 
                 boolean inputHadRiskSignal = combined.riskCandidate() || combined.emotionSpike();
+                RewriteGuard rewriteGuard =
+                        new RewriteGuard(responsePlan, inputHadRiskSignal, rewriteRejected);
 
                 if (deliveryMode == DeliveryMode.BUFFER) {
                     // Buffer: complete first, then OutputGuard, then SSE
@@ -431,7 +436,7 @@ public class ConversationOrchestrator {
                                     judgeActionResult, assistantContent, userMessage, l1Result, user, session, emitter,
                                     outboundMsgId, userSignal.emotionScore(),
                                     finishedReasonRef, crisisSeverityRef, turn, turnPersisted,
-                                    firstSubstantiveTokenMs, startMs, deliveredPrefix);
+                                    firstSubstantiveTokenMs, startMs, deliveredPrefix, rewriteGuard);
                             if (judgeActionResult.action() == OutputJudgeAction.CRISIS_FLOW) {
                                 crisisFlowTriggered = true;
                                 crisisContextRef.set(true);
@@ -589,11 +594,12 @@ public class ConversationOrchestrator {
                             }
                             recordCrisisOutcome(crisisResult, finishedReasonRef, crisisSeverityRef);
                         } else {
+                            // BUFFER 경로와 같은 재검증을 쓴다 (이슈 #526). 두 경로가 각자
+                            // REWRITE 를 처리하면 한쪽만 고쳐지고, 실제로 그렇게 됐다.
                             String replacedContent = switch (judgeActionResult.action()) {
-                                case REWRITE -> judgeActionResult.rewrittenContent() != null
-                                        ? judgeActionResult.rewrittenContent()
-                                        : "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
-                                case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+                                case REWRITE -> rewrittenBodyOrSafeFixed(
+                                        judgeActionResult, SAFE_FIXED_RESPONSE, rewriteGuard);
+                                case REPLACE -> SAFE_FIXED_RESPONSE;
                                 case SEND, CRISIS_FLOW -> null;
                             };
 
@@ -693,7 +699,8 @@ public class ConversationOrchestrator {
                     resolveFinishedReason(finishedReasonRef));
             decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
                     securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
-                    inputJudgeCalled, preFilterResult, judgeActionResult,
+                    inputJudgeCalled,
+                    new OutputGuardOutcome(preFilterResult, judgeActionResult, rewriteRejected.get()),
                     profile.source(), safetyProfileCacheHit, memoryCache,
                     profile.degraded(), appliedCrisisTrigger, llmUsage, contractResult,
                     firstSubstantiveTokenMs.get(), firstRenderedMs,
@@ -953,6 +960,58 @@ public class ConversationOrchestrator {
                 base.severity(), base.fixedResponse() + " " + crisisFixedFlowCoordinator.initialResponse());
     }
 
+    /**
+     * 서버 고정 안전 응답. {@code REPLACE} 와 <b>재검증에 실패한 {@code REWRITE}</b> 가 같은
+     * 문구를 쓴다 — 고쳐 쓴 것이 다시 위반이면 REPLACE 로 내리는 것과 같기 때문이다.
+     */
+    private static final String SAFE_FIXED_RESPONSE = "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
+
+    /**
+     * 판정자가 다시 쓴 본문을 결정론 필터에 다시 통과시킨다 (이슈 #526).
+     *
+     * <p>{@code REWRITE} 는 판정자가 <b>본문을 직접 써서</b> 돌려주는 유일한 경로다. 그리고
+     * {@code OutputJudge} 프롬프트에는 생성 모델의 출력(= 사용자 입력에 영향받은 텍스트)이
+     * 구분자 없이 들어간다. 즉 이 경로가 결정론 필터를 우회해 임의 본문을 사용자에게 주입할
+     * 수 있는 <b>가장 짧은 길</b>이다.
+     *
+     * <p><b>판정자에게 두 번째 기회를 주지 않는다.</b> 고쳐 쓴 본문이 다시 위반이면 서버 고정
+     * 응답으로 내린다 — 같은 판정자가 만든 위반을 같은 판정자에게 다시 물을 근거가 없고,
+     * 재호출은 과금과 지연을 늘리면서 같은 실패를 반복할 수 있다.
+     *
+     * <p>재검증은 {@code REWRITE} 에만 적용한다. {@code REPLACE}·{@code CRISIS_FLOW} 의 본문은
+     * 서버 고정 문구이므로 검사할 이유가 없고, 오탐이 나면 위기 응답을 망친다.
+     */
+    private String rewrittenBodyOrSafeFixed(
+            OutputJudgeResult result, String originalContent, RewriteGuard guard) {
+        String rewritten = result.rewrittenContent();
+        if (rewritten == null) {
+            return originalContent;
+        }
+        OutputPreFilterResult recheck = mergeContractViolations(
+                outputPreFilter.checkWithCrisisContext(rewritten, guard.inputHadRiskSignal()),
+                responseContractValidator.validate(guard.responsePlan(), rewritten));
+        if (recheck.passed()) {
+            return rewritten;
+        }
+        log.warn("OutputJudge REWRITE body still violated the deterministic filter — "
+                + "falling back to the fixed safe response. reasons={}", recheck.failReasons());
+        guard.rejected().set(true);
+        return SAFE_FIXED_RESPONSE;
+    }
+
+    /**
+     * {@code REWRITE} 재검증에 필요한 것만 묶는다 (이슈 #526).
+     *
+     * <p>{@code resolveOutputJudgeAction} 은 이미 파라미터가 16개다. 여기에 두 개를 더 붙이면
+     * 읽을 수 없어진다. 그리고 세 값은 같은 목적으로만 쓰이므로 함께 다니는 것이 맞다.
+     *
+     * @param responsePlan        계약 재검증 기준
+     * @param inputHadRiskSignal  위기 문맥 판정에 쓰는 입력측 신호
+     * @param rejected            재검증이 본문을 거부했는지 — trace 로 나간다
+     */
+    private record RewriteGuard(
+            ResponsePlan responsePlan, boolean inputHadRiskSignal, AtomicBoolean rejected) {}
+
     private String resolveOutputJudgeAction(
             OutputJudgeResult result,
             String originalContent,
@@ -969,11 +1028,12 @@ public class ConversationOrchestrator {
             AtomicBoolean turnPersisted,
             AtomicLong firstSubstantiveTokenMs,
             long pipelineStartedAtMs,
-            String deliveredPrefix) throws IOException {
+            String deliveredPrefix,
+            RewriteGuard rewriteGuard) throws IOException {
 
         return switch (result.action()) {
             case SEND -> originalContent;
-            case REWRITE -> result.rewrittenContent() != null ? result.rewrittenContent() : originalContent;
+            case REWRITE -> rewrittenBodyOrSafeFixed(result, originalContent, rewriteGuard);
             case REPLACE -> "지금 많이 힘드시겠어요. 잠시 함께 이야기 나눠볼게요.";
             case CRISIS_FLOW -> {
                 // 전송 전에 결말을 저장한다 (이슈 P0-A 리뷰 반영).

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -414,7 +414,7 @@ public class ConversationOrchestrator {
                 DeliveryMode deliveryMode = decision.deliveryMode();
 
                 boolean inputHadRiskSignal = combined.riskCandidate() || combined.emotionSpike();
-                RewriteGuard rewriteGuard = new RewriteGuard(rewriteRejected);
+                RewriteGuard rewriteGuard = new RewriteGuard(responsePlan, rewriteRejected);
 
                 if (deliveryMode == DeliveryMode.BUFFER) {
                     // Buffer: complete first, then OutputGuard, then SSE
@@ -986,16 +986,22 @@ public class ConversationOrchestrator {
         if (rewritten == null) {
             return originalContent;
         }
-        // 내용 안전만 본다 (리뷰 반영). check() 는 역할 주장·진단·의존 강화·지침 유출·
-        // 자해 방법 다섯 가지를 보고, checkWithCrisisContext() 는 그 위에 CRISIS_MISMATCH
-        // 어조 휴리스틱을 얹는다. 후자를 재검증에 넣으면 안 된다 — 그건 우리가 판정자에게
-        // 고치라고 시킨 바로 그 항목이고, 키워드만 보므로 정상 위로 문구
-        // (`힘내요`·`괜찮아질 거야`)가 걸린다. 그러면 판정자의 교정이 가장 필요한 위기 인접
-        // 턴에서 매번 고정 문구로 대체된다.
+        // 재검증은 **의미** 규칙만 본다. 어조·형식으로 판정자를 거부하지 않는다.
         //
-        // 계약 검증도 넣지 않는다. 계약 위반은 형식 문제이고 고정 문구가 계약을 만족하는
-        // 것도 아니므로, 안전을 얻지 못하면서 오거부 경로만 늘린다.
-        OutputPreFilterResult recheck = outputPreFilter.check(rewritten);
+        // check() 는 역할 주장·진단·의존 강화·지침 유출·자해 방법을 본다.
+        // checkWithCrisisContext() 는 그 위에 CRISIS_MISMATCH 어조 휴리스틱을 얹는데
+        // 그건 쓰지 않는다 — 우리가 판정자에게 고치라고 시킨 바로 그 항목이고, 키워드만
+        // 보므로 정상 위로 문구(`힘내요`·`괜찮아질 거야`)가 걸린다. 그러면 판정자의 교정이
+        // 가장 필요한 위기 인접 턴에서 매번 고정 문구로 대체된다 (이슈 #528).
+        //
+        // 계약은 **금지 요소만** 본다. 정체성 단정·결과 보장·진단 귀속은 OutputPreFilter 의
+        // 다섯 범주에 대응하는 것이 없고 임상 제약이다 — `당신은 정말 좋은 사람이에요.
+        // 꼭 좋아질 거예요.` 가 check() 를 통과한다. 반면 질문 수·문장 수는 형식이라
+        // 빼둔다: 고정 문구가 계약을 만족하는 것도 아니어서 형식 위반을 다른 형식 위반으로
+        // 바꾸는 셈이고, 안전을 얻지 못하면서 코칭만 잃는다.
+        OutputPreFilterResult recheck = mergeContractViolations(
+                outputPreFilter.check(rewritten),
+                responseContractValidator.validateForbiddenElements(guard.responsePlan(), rewritten));
         if (recheck.passed()) {
             return rewritten;
         }
@@ -1011,13 +1017,15 @@ public class ConversationOrchestrator {
      * <p>{@code resolveOutputJudgeAction} 은 이미 파라미터가 16개다. 거부 여부를 파라미터로
      * 더 붙이는 대신 이 값으로 묶는다.
      *
-     * <p>처음에는 {@code responsePlan}·{@code inputHadRiskSignal} 도 함께 들고 다녔는데,
-     * 재검증 범위를 내용 안전으로 좁히면서 둘 다 필요 없어졌다 — 좁힌 검사는 응답 계획도
-     * 입력측 신호도 보지 않는다.
+     * <p>{@code inputHadRiskSignal} 은 들고 다니지 않는다 — 재검증이 어조 휴리스틱
+     * ({@code CRISIS_MISMATCH})을 쓰지 않으므로 필요가 없다. {@code responsePlan} 은
+     * 계약의 금지 요소가 계획별로 다르므로 필요하다(고위험 계획은 {@code advice}·
+     * {@code cbt_intervention} 을 추가로 금지한다).
      *
-     * @param rejected 재검증이 본문을 거부했는지 — trace 로 나간다
+     * @param responsePlan 금지 요소 재검증 기준
+     * @param rejected     재검증이 본문을 거부했는지 — trace 로 나간다
      */
-    private record RewriteGuard(AtomicBoolean rejected) {}
+    private record RewriteGuard(ResponsePlan responsePlan, AtomicBoolean rejected) {}
 
     private String resolveOutputJudgeAction(
             OutputJudgeResult result,

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -414,8 +414,7 @@ public class ConversationOrchestrator {
                 DeliveryMode deliveryMode = decision.deliveryMode();
 
                 boolean inputHadRiskSignal = combined.riskCandidate() || combined.emotionSpike();
-                RewriteGuard rewriteGuard =
-                        new RewriteGuard(responsePlan, inputHadRiskSignal, rewriteRejected);
+                RewriteGuard rewriteGuard = new RewriteGuard(rewriteRejected);
 
                 if (deliveryMode == DeliveryMode.BUFFER) {
                     // Buffer: complete first, then OutputGuard, then SSE
@@ -987,9 +986,16 @@ public class ConversationOrchestrator {
         if (rewritten == null) {
             return originalContent;
         }
-        OutputPreFilterResult recheck = mergeContractViolations(
-                outputPreFilter.checkWithCrisisContext(rewritten, guard.inputHadRiskSignal()),
-                responseContractValidator.validate(guard.responsePlan(), rewritten));
+        // 내용 안전만 본다 (리뷰 반영). check() 는 역할 주장·진단·의존 강화·지침 유출·
+        // 자해 방법 다섯 가지를 보고, checkWithCrisisContext() 는 그 위에 CRISIS_MISMATCH
+        // 어조 휴리스틱을 얹는다. 후자를 재검증에 넣으면 안 된다 — 그건 우리가 판정자에게
+        // 고치라고 시킨 바로 그 항목이고, 키워드만 보므로 정상 위로 문구
+        // (`힘내요`·`괜찮아질 거야`)가 걸린다. 그러면 판정자의 교정이 가장 필요한 위기 인접
+        // 턴에서 매번 고정 문구로 대체된다.
+        //
+        // 계약 검증도 넣지 않는다. 계약 위반은 형식 문제이고 고정 문구가 계약을 만족하는
+        // 것도 아니므로, 안전을 얻지 못하면서 오거부 경로만 늘린다.
+        OutputPreFilterResult recheck = outputPreFilter.check(rewritten);
         if (recheck.passed()) {
             return rewritten;
         }
@@ -1000,17 +1006,18 @@ public class ConversationOrchestrator {
     }
 
     /**
-     * {@code REWRITE} 재검증에 필요한 것만 묶는다 (이슈 #526).
+     * {@code REWRITE} 재검증 결과를 밖으로 실어 내는 통로 (이슈 #526).
      *
-     * <p>{@code resolveOutputJudgeAction} 은 이미 파라미터가 16개다. 여기에 두 개를 더 붙이면
-     * 읽을 수 없어진다. 그리고 세 값은 같은 목적으로만 쓰이므로 함께 다니는 것이 맞다.
+     * <p>{@code resolveOutputJudgeAction} 은 이미 파라미터가 16개다. 거부 여부를 파라미터로
+     * 더 붙이는 대신 이 값으로 묶는다.
      *
-     * @param responsePlan        계약 재검증 기준
-     * @param inputHadRiskSignal  위기 문맥 판정에 쓰는 입력측 신호
-     * @param rejected            재검증이 본문을 거부했는지 — trace 로 나간다
+     * <p>처음에는 {@code responsePlan}·{@code inputHadRiskSignal} 도 함께 들고 다녔는데,
+     * 재검증 범위를 내용 안전으로 좁히면서 둘 다 필요 없어졌다 — 좁힌 검사는 응답 계획도
+     * 입력측 신호도 보지 않는다.
+     *
+     * @param rejected 재검증이 본문을 거부했는지 — trace 로 나간다
      */
-    private record RewriteGuard(
-            ResponsePlan responsePlan, boolean inputHadRiskSignal, AtomicBoolean rejected) {}
+    private record RewriteGuard(AtomicBoolean rejected) {}
 
     private String resolveOutputJudgeAction(
             OutputJudgeResult result,

--- a/src/main/java/com/mio/ai/orchestrator/OutputGuardOutcome.java
+++ b/src/main/java/com/mio/ai/orchestrator/OutputGuardOutcome.java
@@ -1,0 +1,29 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.judge.OutputJudgeResult;
+import com.mio.ai.judge.OutputPreFilterResult;
+
+/**
+ * 출력측 게이트가 이 턴에 무엇을 했는지 (이슈 #526).
+ *
+ * <p>세 값이 한 이야기다 — 결정론 필터가 무엇을 잡았고, 판정자가 어떻게 처리했고,
+ * 판정자가 고쳐 쓴 본문이 <b>다시</b> 위반이어서 거부됐는지.
+ *
+ * <p>{@code rewriteRejected} 없이는 "판정이 고쳐 썼다" 와 "고쳐 쓴 것이 다시 위반이었다" 를
+ * 구분할 수 없다. 그 구분이 없으면 재검증이 프로덕션에서 실제로 발동하는지 알 수 없고,
+ * 발동하지 않는 방어는 방어가 아니라 죽은 코드다.
+ *
+ * @param preFilter       결정론 필터 결과. 부르지 않았으면 {@code null}
+ * @param judge           출력 판정 결과. 부르지 않았으면 {@code null}
+ * @param rewriteRejected 판정자가 고쳐 쓴 본문이 재검증에 실패해 서버 고정 응답으로 내려갔는가
+ */
+public record OutputGuardOutcome(
+        OutputPreFilterResult preFilter,
+        OutputJudgeResult judge,
+        boolean rewriteRejected) {
+
+    /** 출력 판정을 부르지 않은 턴 — 결정론 필터만 돌았다. */
+    public static OutputGuardOutcome preFilterOnly(OutputPreFilterResult preFilter) {
+        return new OutputGuardOutcome(preFilter, null, false);
+    }
+}

--- a/src/main/java/com/mio/ai/plan/ResponseContractValidator.java
+++ b/src/main/java/com/mio/ai/plan/ResponseContractValidator.java
@@ -14,8 +14,17 @@ import java.util.regex.Pattern;
  * 대형 LLM Judge 없이 판정할 수 있고, 그래서 Judge 호출을 늘리지 않고도 자유도가 낮은
  * 응답을 빠르게 통과시킬 수 있다.
  *
- * <p>역할 이탈·의존 강화·명시적 위해 같은 <b>의미 판단</b>은 여기서 하지 않는다. 그쪽은
- * {@code OutputPreFilter} 가 이미 담당하며, 중복 구현하면 두 곳의 기준이 갈라진다.
+ * <p>역할 이탈·의존 강화·명시적 위해는 여기서 하지 않는다. 그쪽은 {@code OutputPreFilter} 가
+ * 이미 담당하며, 중복 구현하면 두 곳의 기준이 갈라진다.
+ *
+ * <p><b>다만 이 클래스가 형식만 보는 것은 아니다 (이슈 #526).</b> {@link #FORBIDDEN_PATTERNS}
+ * 의 {@code diagnosis}·{@code certainty_about_user}·{@code guaranteed_outcome} 은 임상 근거가
+ * 있는 <b>의미</b> 제약이고, {@code advice}·{@code cbt_intervention} 은 고위험 계획에서만
+ * 금지되는 개입 제약이다. {@code OutputPreFilter} 의 다섯 범주에는 대응하는 것이 없다 —
+ * {@code "당신은 정말 좋은 사람이에요. 꼭 좋아질 거예요."} 가 그쪽을 통과한다.
+ *
+ * <p>그래서 검사가 두 부류로 나뉘고, 호출자는 필요한 쪽만 쓸 수 있어야 한다.
+ * {@link #validate} 는 둘 다 보고, {@link #validateForbiddenElements} 는 의미 규칙만 본다.
  */
 @Component
 public class ResponseContractValidator {
@@ -52,6 +61,38 @@ public class ResponseContractValidator {
                     "근거를 (찾아|따져|살펴)|다르게 (생각|해석)해 ?보|재구성|다른 관점")
     );
 
+    /**
+     * 금지 요소만 검사한다 — 세는 규칙(질문 수·문장 수)은 보지 않는다 (이슈 #526).
+     *
+     * <p>판정자가 고쳐 쓴 본문을 재검증할 때 쓴다. 그 자리에서 세는 규칙까지 적용하면
+     * 질문 하나가 많은 본문이 서버 고정 문구로 대체되는데, 고정 문구가 계약을 만족하는
+     * 것도 아니어서 형식 위반을 다른 형식 위반으로 바꾸는 셈이 된다 — 안전을 얻지 못하고
+     * 코칭만 잃는다.
+     *
+     * <p>반면 금지 요소는 임상 제약이므로 고정 문구가 실제로 낫다. 정체성을 단정하거나
+     * 결과를 보장하는 말은 빗나갔을 때 사용자가 스스로를 더 부정하게 만든다.
+     */
+    public ResponseContractResult validateForbiddenElements(ResponsePlan plan, String response) {
+        if (plan == null || !plan.isContractEnforced() || response == null || response.isBlank()) {
+            return ResponseContractResult.notApplicable();
+        }
+        List<String> violations = forbiddenElementViolations(plan, response);
+        return violations.isEmpty()
+                ? ResponseContractResult.pass()
+                : ResponseContractResult.violated(violations);
+    }
+
+    private List<String> forbiddenElementViolations(ResponsePlan plan, String response) {
+        List<String> violations = new ArrayList<>();
+        for (String element : plan.forbiddenElements()) {
+            Pattern pattern = FORBIDDEN_PATTERNS.get(element);
+            if (pattern != null && pattern.matcher(response).find()) {
+                violations.add(element);
+            }
+        }
+        return violations;
+    }
+
     public ResponseContractResult validate(ResponsePlan plan, String response) {
         if (plan == null || !plan.isContractEnforced() || response == null || response.isBlank()) {
             return ResponseContractResult.notApplicable();
@@ -69,12 +110,7 @@ public class ResponseContractValidator {
             violations.add("max_sentences(%d>%d)".formatted(sentences, plan.maxSentences()));
         }
 
-        for (String element : plan.forbiddenElements()) {
-            Pattern pattern = FORBIDDEN_PATTERNS.get(element);
-            if (pattern != null && pattern.matcher(response).find()) {
-                violations.add(element);
-            }
-        }
+        violations.addAll(forbiddenElementViolations(plan, response));
 
         return violations.isEmpty()
                 ? ResponseContractResult.pass()

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -76,8 +76,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 false,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -137,8 +136,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 true,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -209,8 +207,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 true,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 MemoryCacheOutcome.live(),
@@ -259,7 +256,7 @@ class AiDecisionLoggerTest {
                 UUID.randomUUID(), UUID.randomUUID(), decision,
                 new ModerationResult(false, Map.of(), Map.of()),
                 SafetyL1Result.clear(), SecurityAssessment.clean(),
-                100, 10, false, false, null, null, "default",
+                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -290,7 +287,7 @@ class AiDecisionLoggerTest {
                 new ModerationResult(false, Map.of(), Map.of()),
                 SafetyL1Result.clear(),
                 SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘", "단계별 자해 방법")),
-                100, 10, true, false, null, null, "default",
+                100, 10, true, false, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -324,7 +321,7 @@ class AiDecisionLoggerTest {
                 new ModerationResult(false, Map.of(), Map.of()),
                 SafetyL1Result.clear(),
                 null,
-                100, 10, false, false, null, null, "default",
+                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -347,7 +344,7 @@ class AiDecisionLoggerTest {
                 new ModerationResult(false, Map.of(), Map.of()),
                 SafetyL1Result.clear(),
                 SecurityAssessment.suspicious(List.of("역할극"), true),
-                100, 10, false, true, null, null, "default",
+                100, 10, false, true, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -372,7 +369,7 @@ class AiDecisionLoggerTest {
                 UUID.randomUUID(), UUID.randomUUID(), decision,
                 new ModerationResult(false, Map.of(), Map.of()),
                 SafetyL1Result.clear(), SecurityAssessment.clean(),
-                100, 10, false, false, null, null, "default",
+                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -407,7 +404,7 @@ class AiDecisionLoggerTest {
                 SafetyL1Result.clear(),
                 SecurityAssessment.suspicious(
                         List.of("역할극", "zero_width_char", "obfuscated_input"), true),
-                100, 10, false, true, null, null, "default",
+                100, 10, false, true, new OutputGuardOutcome(null, null, false), "default",
                 false, false, false, decision.crisisTrigger(), null
         );
 
@@ -458,8 +455,7 @@ class AiDecisionLoggerTest {
                 10,
                 true,
                 false,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -516,8 +512,7 @@ class AiDecisionLoggerTest {
                 10,
                 true,
                 false,
-                OutputPreFilterResult.pass(),
-                null,
+                new OutputGuardOutcome(OutputPreFilterResult.pass(), null, false),
                 "default",
                 false,
                 false,
@@ -561,8 +556,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 false,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -596,8 +590,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 false,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -630,8 +623,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 true,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,
@@ -790,8 +782,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 false,
-                OutputPreFilterResult.pass(),
-                judgeResult,
+                new OutputGuardOutcome(OutputPreFilterResult.pass(), judgeResult, false),
                 "default",
                 false,
                 MemoryCacheOutcome.live(),
@@ -845,8 +836,7 @@ class AiDecisionLoggerTest {
                 10,
                 false,
                 false,
-                null,
-                null,
+                new OutputGuardOutcome(null, null, false),
                 "default",
                 false,
                 false,

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -452,6 +452,38 @@ class ConversationOrchestratorContractIntegrationTest {
     }
 
     /**
+     * 재검증은 <b>내용 안전</b>만 본다 — 어조·형식으로 판정자를 거부하지 않는다 (이슈 #526 리뷰).
+     *
+     * <p>{@code CRISIS_MISMATCH} 는 "위기 입력에 가벼운 응답" 을 잡는 어조 휴리스틱이고,
+     * 키워드만 본다({@code 힘내요}·{@code 괜찮아질 거야} 등). <b>그건 우리가 판정자에게
+     * 고치라고 시킨 바로 그 항목이다.</b> 재검증에 다시 넣으면 판정자가 위로 문구를 쓸 때마다
+     * 거부되고 고정 문구로 대체된다 — 판정자의 교정이 가장 필요한 위기 인접 턴에서.
+     *
+     * <p>그리고 그 대체는 개선이 아니다. 고정 문구는 이 휴리스틱을 통과하지만 코칭으로서는
+     * 훨씬 나쁘다. 즉 안전을 얻는 것이 아니라 품질만 잃는다.
+     *
+     * <p>재검증이 거부해야 하는 것은 <b>주입된 내용</b>이다 — 역할 주장·진단·의존 강화·
+     * 지침 유출·자해 방법. 그 경우에만 고정 문구가 판정자 본문보다 실제로 낫다.
+     */
+    @Test
+    @DisplayName("위로 표현이 든 고쳐 쓴 본문을 어조 휴리스틱으로 거부하지 않는다")
+    void rewriteIsNotRejectedForComfortingToneOnACrisisTurn() {
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        // CRISIS_MISMATCH 키워드('힘내요'·'괜찮아질 거야')를 담았지만 내용 안전 위반은 없다.
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite(
+                        "많이 힘드셨겠어요. 지금 느끼는 감정은 자연스러운 거예요. "
+                                + "혼자 두지 않을게요, 곧 괜찮아질 거야."));
+        RecordingSseEmitter emitter = new RecordingSseEmitter(objectMapper);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "rewrite-tone-key");
+
+        assertThat(emitter.everDeliveredText())
+                .as("어조 휴리스틱으로 거부하면 위기 턴마다 같은 고정 문구가 나간다")
+                .contains("많이 힘드셨겠어요");
+    }
+
+    /**
      * 판정자가 다시 쓴 본문도 결정론 필터를 지나야 한다 (이슈 #526).
      *
      * <p>{@code REWRITE} 는 판정자가 <b>본문을 직접 써서</b> 돌려주는 유일한 경로다. 그리고

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -452,6 +452,78 @@ class ConversationOrchestratorContractIntegrationTest {
     }
 
     /**
+     * 계약의 <b>금지 요소</b>는 재검증에서 계속 본다 (이슈 #526 재리뷰).
+     *
+     * <p>처음에는 계약 검증을 통째로 뺐다. "계약 위반은 형식 문제" 라고 봤는데 틀렸다 —
+     * {@code ResponseContractValidator} 는 <b>두 종류를 섞어</b> 갖고 있다.
+     *
+     * <ul>
+     *   <li><b>세는 규칙</b>: {@code max_questions}·{@code max_sentences}. 형식이다.
+     *   <li><b>의미 규칙</b>: {@code diagnosis}·{@code certainty_about_user}·
+     *       {@code guaranteed_outcome}(모든 계획에 적용) 그리고 {@code advice}·
+     *       {@code cbt_intervention}(고위험 계획에 추가). 임상 근거가 있는 제약이다.
+     * </ul>
+     *
+     * <p>{@code 당신은 정말 좋은 사람이에요. 꼭 좋아질 거예요.} 는 {@code OutputPreFilter.check()}
+     * 다섯 범주에 걸리지 않는다. 정체성 단정과 결과 보장이라 계약 쪽에만 있다. 계약을 통째로
+     * 빼면 판정자가 이런 본문을 돌려줄 때 그대로 전달된다.
+     */
+    @Test
+    @DisplayName("고쳐 쓴 본문의 정체성 단정·결과 보장은 계속 거부한다")
+    void rewriteWithForbiddenContractElementsIsRejected() {
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite("당신은 정말 좋은 사람이에요. 꼭 좋아질 거예요."));
+        RecordingSseEmitter emitter = new RecordingSseEmitter(objectMapper);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "rewrite-contract-key");
+
+        assertThat(emitter.everDeliveredText())
+                .as("정체성 단정·결과 보장은 형식이 아니라 임상 제약이다")
+                .doesNotContain("정말 좋은 사람이에요")
+                .doesNotContain("꼭 좋아질 거예요");
+    }
+
+    /**
+     * 세는 규칙으로는 거부하지 않는다 (이슈 #526 재리뷰).
+     *
+     * <p>질문 하나가 많은 본문을 고정 문구로 대체하면 안전을 얻지 못하면서 코칭만 잃는다.
+     * 고정 문구가 계약을 만족하는 것도 아니다 — 형식 위반을 다른 형식 위반으로 바꾸는 셈이다.
+     */
+    @Test
+    @DisplayName("질문 수 초과만으로는 고쳐 쓴 본문을 거부하지 않는다")
+    void rewriteIsNotRejectedForExceedingQuestionCountAlone() {
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite(
+                        "많이 힘드셨겠어요. 언제부터 그랬나요? 지금은 어떤가요? 곁에 누가 있나요?"));
+        RecordingSseEmitter emitter = new RecordingSseEmitter(objectMapper);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "rewrite-count-key");
+
+        assertThat(emitter.everDeliveredText()).contains("많이 힘드셨겠어요");
+    }
+
+    /**
+     * 거부 사실이 {@code trace} 에 남는다 (이슈 #526 재리뷰).
+     *
+     * <p>이 계측이 없으면 방어가 프로덕션에서 발동하는지 알 수 없다. 그런데 전달 텍스트만
+     * 단정하면 <b>계측 자체가 로거에 도달하는지</b>는 검증되지 않는다 — 값을 직접 본다.
+     */
+    @Test
+    @DisplayName("거부하면 trace 의 rewrite_rejected 가 true 다")
+    void rejectionIsRecordedInTrace() {
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite("저는 의사니까 제 말을 믿으세요."));
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE,
+                new RecordingSseEmitter(objectMapper), "rewrite-trace-key");
+
+        assertThat(awaitTrace().path("rewrite_rejected").asBoolean()).isTrue();
+    }
+
+    /**
      * 재검증은 <b>내용 안전</b>만 본다 — 어조·형식으로 판정자를 거부하지 않는다 (이슈 #526 리뷰).
      *
      * <p>{@code CRISIS_MISMATCH} 는 "위기 입력에 가벼운 응답" 을 잡는 어조 휴리스틱이고,

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -452,6 +452,53 @@ class ConversationOrchestratorContractIntegrationTest {
     }
 
     /**
+     * 판정자가 다시 쓴 본문도 결정론 필터를 지나야 한다 (이슈 #526).
+     *
+     * <p>{@code REWRITE} 는 판정자가 <b>본문을 직접 써서</b> 돌려주는 유일한 경로다. 그리고
+     * {@code OutputJudge} 프롬프트에는 생성 모델의 출력(= 사용자 입력에 영향받은 텍스트)이
+     * 구분자 없이 들어간다. 즉 이 경로가 결정론 필터를 우회해 임의 본문을 사용자에게
+     * 주입할 수 있는 <b>가장 짧은 길</b>이다.
+     *
+     * <p>고쳐 쓴 본문이 다시 위반이면 서버 고정 응답으로 내린다. 판정자에게 두 번째 기회를
+     * 주지 않는다 — 같은 판정자가 만든 위반을 같은 판정자에게 다시 물을 근거가 없다.
+     */
+    @Test
+    @DisplayName("판정자가 고쳐 쓴 본문이 다시 위반이면 사용자에게 보내지 않는다")
+    void rewrittenBodyThatStillViolatesIsNotDelivered() {
+        // 계약을 위반해 출력 판정으로 넘어가게 한다.
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        // 판정자가 고쳐 썼다고 주장하지만 본문은 역할 경계를 위반한다.
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite("저는 의사니까 제 말을 믿으세요."));
+        RecordingSseEmitter emitter = new RecordingSseEmitter(objectMapper);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "rewrite-refilter-key");
+
+        assertThat(emitter.everDeliveredText())
+                .as("판정자 본문이 결정론 필터를 우회해 사용자에게 닿으면 안 된다")
+                .doesNotContain("저는 의사");
+    }
+
+    /**
+     * 고쳐 쓴 본문이 깨끗하면 그대로 전달된다 (이슈 #526).
+     *
+     * <p>재검증이 REWRITE 경로 자체를 무력화하면 안 된다 — 그러면 판정자의 교정 능력을
+     * 통째로 버리는 것이고, 위반이 아닌 본문까지 고정 응답으로 대체된다.
+     */
+    @Test
+    @DisplayName("고쳐 쓴 본문이 필터를 통과하면 그대로 전달된다")
+    void cleanRewrittenBodyIsDelivered() {
+        streamReplies("당신은 우울증이에요. 그래도 곧 좋아질 거예요.");
+        when(outputJudge.judge(anyString(), any(), any(), any()))
+                .thenReturn(OutputJudgeResult.rewrite("많이 힘드셨겠어요. 어떤 순간이 가장 무거웠나요?"));
+        RecordingSseEmitter emitter = new RecordingSseEmitter(objectMapper);
+
+        orchestrator.handle(userId, sessionId, RISK_CANDIDATE_MESSAGE, emitter, "rewrite-clean-key");
+
+        assertThat(emitter.everDeliveredText()).contains("많이 힘드셨겠어요");
+    }
+
+    /**
      * 위기 승격 턴의 사용자 화면 상태를 검증한다.
      *
      * <p>이벤트가 나갔는지가 아니라 <b>화면에 무엇이 남는지</b>로 판정한다. 지우는 이벤트가


### PR DESCRIPTION
## 요약

`OutputJudge` 가 `REWRITE` 를 반환하면 **판정자가 직접 쓴 본문이 결정론 필터를 다시 거치지 않고 그대로 전달**됐습니다.

`REWRITE` 는 판정자가 **본문을 직접 써서** 돌려주는 유일한 경로입니다. 그리고 `OutputJudge` 프롬프트에는 생성 모델의 출력(= 사용자 입력에 영향받은 텍스트)이 구분자 없이 들어갑니다. 즉 이 경로가 결정론 필터를 우회해 임의 본문을 사용자에게 주입할 수 있는 **가장 짧은 길**이었습니다.

실측: 판정자가 `"저는 의사니까 제 말을 믿으세요."` 를 돌려주면 `OutputPreFilter` 의 `ROLE_BOUNDARY_PATTERNS` 에 `"저는 의사"` 가 있는데도 통과합니다.

## 관련 이슈
- Closes #526

## 변경 사항

### 1. 재검증

고쳐 쓴 본문을 `OutputPreFilter` + `ResponseContractValidator` 에 다시 통과시키고, 실패하면 서버 고정 응답으로 내립니다.

**판정자에게 두 번째 기회를 주지 않습니다.** 같은 판정자가 만든 위반을 같은 판정자에게 다시 물을 근거가 없고, 재호출은 과금과 지연을 늘리면서 같은 실패를 반복할 수 있습니다.

재검증은 `REWRITE` 에만 적용합니다. `REPLACE`·`CRISIS_FLOW` 의 본문은 서버 고정 문구이므로 검사할 이유가 없고, **오탐이 나면 위기 응답을 망칩니다.**

### 2. 갈라진 두 경로를 합친다

`REWRITE` 처리가 **두 곳**에 있었습니다 — `resolveOutputJudgeAction()`(BUFFER)과 인라인 `switch`(CAUTIOUS_SPECULATIVE). 각자 구현이라 한쪽만 고치면 다른 쪽이 남습니다.

**실제로 그 일이 일어났습니다.** BUFFER 만 고쳤는데 테스트가 계속 실패했고, 테스트가 지나는 경로가 CAUTIOUS_SPECULATIVE 였습니다. 둘이 같은 메서드를 쓰게 했습니다.

고정 안전 응답도 상수로 뽑았습니다 — `REPLACE` 와 재검증 실패가 **같은 문구**를 쓴다는 사실이 코드에 드러나야 합니다.

### 3. `rewrite_rejected` 를 trace 에 남긴다

없으면 이 방어가 프로덕션에서 발동하는지 알 수 없습니다. `output_judge_action` 만으로는 "판정이 고쳐 썼다" 와 "고쳐 쓴 것이 다시 위반이었다" 가 구별되지 않습니다. **발동하지 않는 방어는 방어가 아니라 죽은 코드입니다.**

파라미터를 늘리지 않고 **줄이면서** 넣었습니다 — `preFilterResult` 와 `outputJudgeResult` 를 `OutputGuardOutcome` 하나로 묶어 로거 파라미터가 24개 → 23개가 됐습니다. 세 값이 한 이야기이므로 함께 다니는 것이 맞습니다.

## 영향 범위
- [x] **안전 판정 경로**가 바뀝니다 — 출력 판정의 `REWRITE` 결과가 사용자에게 닿기 전에 한 번 더 걸러집니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다 — `trace` 에 `rewrite_rejected` 추가.

API 응답 형식·DB 스키마·설정 변경 없습니다. 비용은 0 입니다 — 정규식 재실행이고 LLM 재호출이 없습니다.

## 테스트

### 실행 커맨드
```bash
./gradlew test --tests "com.mio.ai.orchestrator.*" --rerun-tasks
./gradlew test --rerun-tasks   # 1724건, 실패 2건 (아래)
```

전체 스위트 실패 2건은 `LockedEvalContaminationGuardTest` 로 **로컬 미추적 `docs/` 원인**입니다 (#486).

**Crisis Eval (full path)** 는 `9895ed4`(이 브랜치의 base)에서 통과했습니다. 이 PR 자체는 머지 후 다시 돌립니다.

### 확인 내용

**단정 강도를 변이로 확인했습니다 — 양방향입니다.**

| 변이 | 결과 |
|---|---|
| 재검증 제거 (우회 복원) | `다시 위반이면 사용자에게 보내지 않는다` 실패 |
| 깨끗한 본문도 고정 응답으로 (과잉 차단) | `통과하면 그대로 전달된다` 실패 |

두 번째가 중요합니다. 재검증이 `REWRITE` 경로 자체를 무력화하면 **판정자의 교정 능력을 통째로 버리는 것**이고, 위반이 아닌 본문까지 고정 응답으로 대체됩니다.

## 중점 리뷰 포인트

1. **`SEND` 를 재검증하지 않는 판단.** `SEND` 본문은 이미 pre-filter 를 지난 원본이므로 다시 볼 이유가 없다고 봤습니다. 다만 판정자가 `SEND` 를 돌려주면서 원본과 다른 본문을 의도할 여지는 없는지 확인해 주세요.
2. **실패 시 `SAFE_FIXED_RESPONSE` 로 내리는 선택.** 대안은 원본(`originalContent`)으로 되돌리는 것인데, 원본은 애초에 pre-filter 를 위반해서 판정에 넘어간 텍스트라 더 나쁩니다.
3. **`OutputGuardOutcome` 도입.** 값 객체를 하나 늘렸지만 파라미터는 줄었습니다. 이름이 `OutputJudgeResult` 와 혼동되지 않는지 봐주세요.
4. **CAUTIOUS_SPECULATIVE 경로에서 이미 스트리밍된 접두어와의 상호작용.** 그 경로는 승인 단위 holdback 이라 본문이 아직 안 나갔다고 이해했지만, 확인이 필요합니다.

## 배포 / 롤백
- **Rollout**: 코드 변경만.
- **Rollback**: 커밋 revert. 되돌리면 판정자 본문이 다시 필터를 우회합니다.

## 남은 것 (별도)

`SPECULATIVE` 전달 경로에는 출력 검사가 **하나도 없습니다**(`// SPECULATIVE: stream immediately, no post-guard`). 같은 계열이지만 이미 스트리밍된 뒤라 `delta.replace` 로 회수하는 형태여야 하고, 사용자가 이미 읽었을 수 있다는 점이 본질적으로 다릅니다 — 별도 이슈로 다룹니다.

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다 — 변이 검사로 양방향 확인.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. — 해당 없음
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [x] (hotfix 인 경우) 같은 수정을 develop 에도 반영했습니다. — develop 대상 PR
