### PR TITLE
feat: 신규 세션 선제 인사와 세션 대화 이력 조회 API

### DIFF
--- a/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
+++ b/src/main/java/com/mio/ai/memory/consolidation/SessionConsolidator.java
@@ -218,6 +218,20 @@ public class SessionConsolidator {
             return null;
         }
 
+        // 0. 사용자 발화 존재 게이트 (이슈 #530)
+        //
+        // 선제 인사가 도입되면서 "메시지 0건" 이 더 이상 "대화 없음" 과 같지 않다. 오프닝만
+        // 저장된 세션은 conversationText 가 비어 있지 않으므로 아래 isBlank 가드를 통과하고,
+        // 검수된 인사 한 문장으로 요약·감정·인지 왜곡·Todo 를 만들어 낸다. 사용자가 하지 않은
+        // 말에서 CBT 패턴을 뽑는 셈이다.
+        //
+        // 그래서 요약 가능 여부를 message_count 가 아니라 사용자 메시지 존재 여부로 판단한다.
+        // 종결 상태는 기존 메시지 0건 세션과 동일하게 호출자가 failed 로 마감한다.
+        if (!hasUserMessage(sessionId)) {
+            log.info("SessionConsolidator: no user message, skipping consolidation sessionId={}", sessionId);
+            return null;
+        }
+
         // 1. 대화 컨텍스트 구성 (체크포인트 요약 + 잔여 메시지)
         String conversationText = buildConversationContext(sessionId);
         if (conversationText.isBlank()) {
@@ -337,6 +351,25 @@ public class SessionConsolidator {
      * 체크포인트 요약 + 마지막 체크포인트 이후 잔여 메시지를 합쳐 반환한다.
      * 체크포인트가 없으면 전체 메시지를 그대로 반환한다 (기존 동작).
      */
+    /**
+     * 세션에 사용자 발화가 하나라도 있는지 (이슈 #530).
+     *
+     * <p>조회가 실패하면 {@code false} 로 본다. 판단 근거를 얻지 못한 상태에서 요약을 진행하면
+     * 최악의 경우 인사 한 줄로 LLM 을 돌려 없는 패턴을 만들어 내므로, 만들지 않는 쪽으로
+     * fail-closed 한다.
+     */
+    private boolean hasUserMessage(UUID sessionId) {
+        try {
+            Boolean exists = jdbcTemplate.queryForObject(
+                    "SELECT EXISTS(SELECT 1 FROM messages WHERE session_id = ? AND role = 'user')",
+                    Boolean.class, sessionId);
+            return Boolean.TRUE.equals(exists);
+        } catch (Exception e) {
+            log.warn("SessionConsolidator: user message check failed, skipping sessionId={}", sessionId, e);
+            return false;
+        }
+    }
+
     private String buildConversationContext(UUID sessionId) {
         List<SessionCheckpoint> checkpoints =
                 checkpointRepository.findBySession_IdOrderByCheckpointSeqAsc(sessionId);

--- a/src/main/java/com/mio/character/domain/OpeningMessageCatalog.java
+++ b/src/main/java/com/mio/character/domain/OpeningMessageCatalog.java
@@ -1,0 +1,182 @@
+package com.mio.character.domain;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 캐릭터별 인사 카피의 단일 출처 (이슈 #530, 원본 추적 #428).
+ *
+ * <p>인사말은 세션 개시(선제 인사)와 캐릭터 변경 응답 두 곳에서 쓰인다. 서비스마다 상수를
+ * 따로 두면 같은 캐릭터가 화면마다 다른 말투로 인사하게 되므로 여기 하나만 둔다.
+ *
+ * <p>LLM 을 쓰지 않는다. 사용자 발화 전에는 안전·CBT 추론을 실행할 근거가 없어서, 모델이
+ * 감정이나 과거를 추정하면 사용자가 하지 않은 말을 사실처럼 꺼내게 된다.
+ *
+ * <p><b>두 가지 모드</b> — 처음 만나는 사용자에게는 자기소개를 하고("난 미오야"), 다시 온
+ * 사용자에게는 닉네임을 부른다("안녕 민석!"). 매번 자기를 소개하면 계속 처음 만난 사이처럼
+ * 느껴지고, 첫 만남에 이름부터 부르면 소개 없이 아는 척하는 셈이 된다.
+ *
+ * <p>문구 계약 — 1~2문장, 질문 최대 1개, 진단·위기 단정·과거 기억 단정 금지, 의존성을
+ * 강화하는 표현("항상 곁에 있다") 금지, 행동 과제·Todo·CBT 재구성 금지. 캐릭터 차이는
+ * 어조에만 두고 안전 기준은 동일하다.
+ *
+ * <p>모드별로 캐릭터당 3종을 두는 이유: 1종이면 사용자가 새 채팅마다 완전히 같은 문장을 본다.
+ */
+public final class OpeningMessageCatalog {
+
+    /** 카탈로그에 없는 캐릭터가 들어왔을 때 쓰는 폴백. 인사가 안 나가는 것보다 낫다. */
+    public static final String FALLBACK_CHARACTER_ID = "mio";
+
+    /** 닉네임 치환 슬롯. */
+    public static final String NICKNAME_PLACEHOLDER = "{nickname}";
+
+    /**
+     * 캐릭터 노출 순서. {@code Map.copyOf} 는 반복 순서를 보장하지 않아 별도로 둔다 —
+     * 카탈로그 순서가 실행마다 흔들리면 검증·문서 대조가 재현되지 않는다.
+     */
+    private static final List<String> CHARACTER_ORDER = List.of("mio", "bau", "rumi", "momo", "chichi");
+
+    private static final Map<String, Map<OpeningAudience, List<OpeningMessage>>> BY_CHARACTER;
+
+    static {
+        Map<String, Map<OpeningAudience, List<OpeningMessage>>> map = new LinkedHashMap<>();
+        map.put("mio", sets(
+                List.of(
+                        new OpeningMessage("mio_intro_01", "안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?"),
+                        new OpeningMessage("mio_intro_02", "반가워, 난 미오야 🐧 지금 기분은 어때?"),
+                        new OpeningMessage("mio_intro_03", "안녕! 난 미오야 🐧 편하게 아무 얘기부터 시작해도 돼.")
+                ),
+                List.of(
+                        new OpeningMessage("mio_back_01", "안녕 {nickname}! 🐧 오늘 어떤 하루를 보냈어?"),
+                        new OpeningMessage("mio_back_02", "{nickname}, 왔네! 🐧 지금 기분은 어때?"),
+                        new OpeningMessage("mio_back_03", "안녕 {nickname}! 🐧 오늘은 무슨 얘기부터 해볼까?")
+                )));
+        map.put("bau", sets(
+                List.of(
+                        new OpeningMessage("bau_intro_01", "안녕! 난 바우야 🐕 오늘 뭘 해봤어?"),
+                        new OpeningMessage("bau_intro_02", "반가워! 난 바우야 🐕 오늘은 어떻게 지냈어?"),
+                        new OpeningMessage("bau_intro_03", "안녕! 난 바우야 🐕 오늘 이야기 하나만 들려줘.")
+                ),
+                List.of(
+                        new OpeningMessage("bau_back_01", "안녕 {nickname}! 🐕 오늘 뭘 해봤어?"),
+                        new OpeningMessage("bau_back_02", "{nickname}, 왔구나! 🐕 오늘은 어떻게 지냈어?"),
+                        new OpeningMessage("bau_back_03", "안녕 {nickname}! 🐕 오늘 이야기 하나만 들려줘.")
+                )));
+        map.put("rumi", sets(
+                List.of(
+                        new OpeningMessage("rumi_intro_01", "안녕, 난 루미야 🦉 무엇이 너를 괴롭히고 있어?"),
+                        new OpeningMessage("rumi_intro_02", "안녕, 난 루미야 🦉 지금 가장 많이 떠오르는 건 뭐야?"),
+                        new OpeningMessage("rumi_intro_03", "안녕, 난 루미야 🦉 순서는 상관없어. 떠오르는 것부터 말해 줘.")
+                ),
+                List.of(
+                        new OpeningMessage("rumi_back_01", "안녕 {nickname} 🦉 무엇이 너를 괴롭히고 있어?"),
+                        new OpeningMessage("rumi_back_02", "{nickname}, 왔네 🦉 지금 가장 많이 떠오르는 건 뭐야?"),
+                        new OpeningMessage("rumi_back_03", "안녕 {nickname} 🦉 순서는 상관없어. 떠오르는 것부터 말해 줘.")
+                )));
+        map.put("momo", sets(
+                List.of(
+                        new OpeningMessage("momo_intro_01", "안녕... 난 모모야 🐻 오늘 어떤 하루였어?"),
+                        new OpeningMessage("momo_intro_02", "반가워... 난 모모야 🐻 지금 마음은 어때?"),
+                        new OpeningMessage("momo_intro_03", "안녕... 난 모모야 🐻 말하고 싶은 만큼만 말해도 괜찮아.")
+                ),
+                List.of(
+                        new OpeningMessage("momo_back_01", "안녕 {nickname}... 🐻 오늘 어떤 하루였어?"),
+                        new OpeningMessage("momo_back_02", "{nickname}, 왔구나... 🐻 지금 마음은 어때?"),
+                        new OpeningMessage("momo_back_03", "안녕 {nickname}... 🐻 말하고 싶은 만큼만 말해도 괜찮아.")
+                )));
+        map.put("chichi", sets(
+                List.of(
+                        new OpeningMessage("chichi_intro_01", "안녕, 난 치치야 😺 뭐가 문제야, 말해봐."),
+                        new OpeningMessage("chichi_intro_02", "난 치치야 😺 오늘 제일 걸리는 게 뭐야?"),
+                        new OpeningMessage("chichi_intro_03", "난 치치야 😺 하나만 골라서 말해봐. 거기서 시작하자.")
+                ),
+                List.of(
+                        new OpeningMessage("chichi_back_01", "{nickname}, 뭐가 문제야 😺 말해봐."),
+                        new OpeningMessage("chichi_back_02", "어서 와 {nickname} 😺 오늘 제일 걸리는 게 뭐야?"),
+                        new OpeningMessage("chichi_back_03", "{nickname}, 하나만 골라서 말해봐 😺 거기서 시작하자.")
+                )));
+        BY_CHARACTER = Map.copyOf(map);
+    }
+
+    private OpeningMessageCatalog() {
+    }
+
+    /**
+     * 해당 캐릭터·모드의 문구 후보 전체. 알 수 없는 캐릭터면 {@code mio} 세트로 폴백한다.
+     *
+     * <p>{@code character_id} 유효성은 이미 세션·캐릭터 서비스가 앞단에서 검증한다. 여기서
+     * 예외를 던지면 배포 결함(카피 누락) 하나가 세션 생성 전체를 막는다.
+     */
+    public static List<OpeningMessage> messagesFor(String characterId, OpeningAudience audience) {
+        Map<OpeningAudience, List<OpeningMessage>> sets = BY_CHARACTER.get(characterId);
+        if (sets == null) {
+            sets = BY_CHARACTER.get(FALLBACK_CHARACTER_ID);
+        }
+        return sets.get(audience);
+    }
+
+    /**
+     * 캐릭터 대표 문구 — 캐릭터 변경 응답의 {@code greeting_message} 가 쓴다.
+     *
+     * <p>자기소개 세트의 첫 문구를 쓴다. 이 엔드포인트는 닉네임을 다루지 않고, 로테이션도
+     * 적용하지 않는다 — 호출마다 값이 달라지면 기존 API 의 동작이 바뀐다.
+     */
+    public static String representativeMessage(String characterId) {
+        return messagesFor(characterId, OpeningAudience.FIRST_SESSION).get(0).content();
+    }
+
+    /** 카탈로그가 문구를 가진 캐릭터 ID 목록 (노출 순서). 테스트·검증용. */
+    public static List<String> characterIds() {
+        return CHARACTER_ORDER;
+    }
+
+    private static Map<OpeningAudience, List<OpeningMessage>> sets(List<OpeningMessage> firstSession,
+                                                                   List<OpeningMessage> returning) {
+        return Map.of(
+                OpeningAudience.FIRST_SESSION, firstSession,
+                OpeningAudience.RETURNING, returning);
+    }
+
+    /** 인사 대상. 사용자가 이 캐릭터 서비스를 처음 쓰는지 여부로 갈린다. */
+    public enum OpeningAudience {
+
+        /** 첫 세션 — 자기소개를 한다. 닉네임을 쓰지 않으므로 닉네임이 없어도 안전하다. */
+        FIRST_SESSION,
+
+        /** 재방문 — 닉네임을 부른다. 유효한 닉네임이 있을 때만 선택한다. */
+        RETURNING
+    }
+
+    /**
+     * 검수된 인사 문구 한 건.
+     *
+     * @param variant 로테이션 식별자 {@code {characterId}_{intro|back}_NN}. DB 와 지표에만 쓰고
+     *                API 로 노출하지 않는다 — 노출하면 클라이언트가 문구로 분기할 여지가 생긴다.
+     * @param content 슬롯이 치환되지 않은 원본 템플릿
+     */
+    public record OpeningMessage(String variant, String content) {
+
+        /** 닉네임 슬롯을 가진 문구인지. */
+        public boolean requiresNickname() {
+            return content.contains(NICKNAME_PLACEHOLDER);
+        }
+
+        /**
+         * 닉네임을 넣어 렌더링한다.
+         *
+         * <p>슬롯이 있는 문구에 닉네임이 없으면 슬롯이 그대로 사용자에게 보이게 되므로
+         * 예외로 막는다. 선택 단계에서 닉네임 없는 사용자에게는 자기소개 세트를 주도록
+         * 되어 있어, 이 예외는 그 규칙이 깨졌다는 신호다.
+         */
+        public String render(String nickname) {
+            if (!requiresNickname()) {
+                return content;
+            }
+            if (nickname == null || nickname.isBlank()) {
+                throw new IllegalArgumentException("Nickname required for opening variant: " + variant);
+            }
+            return content.replace(NICKNAME_PLACEHOLDER, nickname);
+        }
+    }
+}

--- a/src/main/java/com/mio/character/service/CharacterService.java
+++ b/src/main/java/com/mio/character/service/CharacterService.java
@@ -1,6 +1,7 @@
 package com.mio.character.service;
 
 import com.mio.character.domain.CharacterPersona;
+import com.mio.character.domain.OpeningMessageCatalog;
 import com.mio.character.dto.*;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
@@ -36,13 +37,9 @@ public class CharacterService {
         CATALOG_MAP = Collections.unmodifiableMap(map);
     }
 
-    private static final Map<String, String> GREETINGS = Map.of(
-            "mio",   "안녕! 나 미오야 🐧 오늘 어떤 하루를 보냈어?",
-            "bau",   "안녕! 나 바우야 🐕 오늘 뭘 해봤어?",
-            "rumi",  "안녕, 나 루미야 🦉 무엇이 너를 괴롭히고 있어?",
-            "momo",  "안녕... 나 모모야 🐻 오늘 어떤 하루였어?",
-            "chichi","안녕, 치치야 😺 뭐가 문제야, 말해봐."
-    );
+    // 인사 카피는 OpeningMessageCatalog 가 단일 출처다 (이슈 #530). 세션 선제 인사와 같은
+    // 문구를 쓰기 위해 이관했고, 이 엔드포인트는 계속 대표 문구 1종만 고정 반환한다 —
+    // 로테이션을 여기 적용하면 기존 API 의 동작이 바뀐다.
 
     private final UserRepository userRepository;
 
@@ -80,7 +77,7 @@ public class CharacterService {
                 request.characterId(),
                 c.name(),
                 changed,
-                GREETINGS.get(request.characterId())
+                OpeningMessageCatalog.representativeMessage(request.characterId())
         );
     }
 

--- a/src/main/java/com/mio/session/controller/SessionController.java
+++ b/src/main/java/com/mio/session/controller/SessionController.java
@@ -2,6 +2,7 @@ package com.mio.session.controller;
 
 import com.mio.common.response.ApiResponse;
 import com.mio.session.dto.*;
+import com.mio.session.service.SessionMessageHistoryService;
 import com.mio.session.service.SessionService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -23,6 +24,24 @@ import com.mio.common.error.ErrorCode;
 public class SessionController {
 
     private final SessionService sessionService;
+    private final SessionMessageHistoryService sessionMessageHistoryService;
+
+    /**
+     * 세션 대화 이력 조회 (이슈 #531).
+     *
+     * <p>앱 재진입 시 진행 중이던 대화를 화면에 되살리는 경로다. 오래된 순서로 반환하며
+     * {@code cursor} 로 이어 받는다.
+     */
+    @GetMapping("/{sessionId}/messages")
+    public ResponseEntity<ApiResponse<SessionMessagesResponse>> getSessionMessages(
+            @PathVariable UUID sessionId,
+            @RequestParam(required = false) String cursor,
+            @RequestParam(required = false) Integer limit,
+            Principal principal) {
+        UUID userId = resolveUserId(principal);
+        return ResponseEntity.ok(ApiResponse.ok(
+                sessionMessageHistoryService.getHistory(userId, sessionId, cursor, limit)));
+    }
 
     @GetMapping("/active")
     public ResponseEntity<ApiResponse<ActiveSessionResponse>> getActiveSession(

--- a/src/main/java/com/mio/session/domain/Message.java
+++ b/src/main/java/com/mio/session/domain/Message.java
@@ -59,6 +59,25 @@ public class Message {
     @Column(name = "is_crisis_flagged", nullable = false)
     private boolean isCrisisFlagged;
 
+    /**
+     * 일반 대화와 선제 인사를 구분한다 (이슈 #530).
+     *
+     * <p>기본값을 두는 이유: 기존 저장 경로는 이 필드를 지정하지 않으므로, 빌더에서 빠지면
+     * null 이 되어 NOT NULL 컬럼 위반으로 대화 저장이 실패한다.
+     */
+    @Builder.Default
+    @Column(name = "message_kind", nullable = false)
+    private MessageKind messageKind = MessageKind.CONVERSATION;
+
+    /**
+     * 선제 인사의 로테이션 문구 식별자. 일반 대화에서는 null 이다.
+     *
+     * <p>본문은 암호화돼 있어 직전 문구를 비교하려면 복호화가 필요하다. 코드로 남겨
+     * 복호화 없이 제외 대상을 찾고, 지표를 문구별로 나눈다.
+     */
+    @Column(name = "opening_variant")
+    private String openingVariant;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private OffsetDateTime createdAt;
 

--- a/src/main/java/com/mio/session/domain/MessageKind.java
+++ b/src/main/java/com/mio/session/domain/MessageKind.java
@@ -1,0 +1,36 @@
+package com.mio.session.domain;
+
+import java.util.Arrays;
+
+/**
+ * 메시지 종류 (이슈 #530).
+ *
+ * <p>선제 인사는 사용자 발화에 대한 응답이 아니라 세션 개시 시 서버가 저장하는 고정 문구다.
+ * 일반 대화와 섞이면 (1) 세션당 1건 제약을 걸 수 없고, (2) 사용자 발화 없이 오프닝만 있는
+ * 세션을 정상 대화로 오인해 한 문장으로 요약·Todo 를 만들게 된다.
+ */
+public enum MessageKind {
+
+    /** 일반 대화 — 사용자 발화와 그에 대한 AI 응답. */
+    CONVERSATION("conversation"),
+
+    /** 세션 생성 시 저장하는 선제 인사. {@code role=assistant} 만 허용, 세션당 최대 1건. */
+    SESSION_OPENING("session_opening");
+
+    private final String value;
+
+    MessageKind(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public static MessageKind fromValue(String value) {
+        return Arrays.stream(values())
+                .filter(kind -> kind.value.equals(value))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Unknown message kind: " + value));
+    }
+}

--- a/src/main/java/com/mio/session/domain/MessageKindConverter.java
+++ b/src/main/java/com/mio/session/domain/MessageKindConverter.java
@@ -1,0 +1,18 @@
+package com.mio.session.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class MessageKindConverter implements AttributeConverter<MessageKind, String> {
+
+    @Override
+    public String convertToDatabaseColumn(MessageKind attribute) {
+        return attribute == null ? null : attribute.value();
+    }
+
+    @Override
+    public MessageKind convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : MessageKind.fromValue(dbData);
+    }
+}

--- a/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
+++ b/src/main/java/com/mio/session/dto/ActiveSessionResponse.java
@@ -14,9 +14,15 @@ public record ActiveSessionResponse(
         @JsonProperty("last_message_at") OffsetDateTime lastMessageAt,
         @JsonProperty("message_count") Integer messageCount,
         @JsonProperty("last_summary_status") String lastSummaryStatus,
-        @JsonProperty("last_ended_session_id") UUID lastEndedSessionId
+        @JsonProperty("last_ended_session_id") UUID lastEndedSessionId,
+        /**
+         * 이 세션의 선제 인사 (이슈 #530). {@code null} 일 수 있다 — 이 기능 배포 이전에
+         * 이미 열려 있던 세션에는 인사가 없고, 소급 생성하지 않는다.
+         */
+        @JsonProperty("initial_message") InitialAssistantMessageResponse initialMessage
 ) {
-    public static ActiveSessionResponse fromActive(Session session) {
+    public static ActiveSessionResponse fromActive(Session session,
+                                                   InitialAssistantMessageResponse initialMessage) {
         return new ActiveSessionResponse(
                 session.getId(),
                 session.getCharacterId(),
@@ -25,7 +31,8 @@ public record ActiveSessionResponse(
                 session.getLastMessageAt(),
                 session.getMessageCount(),
                 null,
-                null
+                null,
+                initialMessage
         );
     }
 
@@ -33,7 +40,8 @@ public record ActiveSessionResponse(
         return new ActiveSessionResponse(
                 null, null, null, null, null, null,
                 lastEndedSession == null ? null : lastEndedSession.getSummaryStatus().value(),
-                lastEndedSession == null ? null : lastEndedSession.getId()
+                lastEndedSession == null ? null : lastEndedSession.getId(),
+                null
         );
     }
 }

--- a/src/main/java/com/mio/session/dto/InitialAssistantMessageResponse.java
+++ b/src/main/java/com/mio/session/dto/InitialAssistantMessageResponse.java
@@ -1,0 +1,36 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mio.session.domain.Message;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+
+/**
+ * 세션 선제 인사 응답 (이슈 #530).
+ *
+ * <p>{@code opening_variant} 는 담지 않는다. 내부 관측 값이고, 노출하면 클라이언트가 문구로
+ * 분기 처리할 여지가 생긴다. FE 는 {@code message_id} 로 중복을 제거하고 {@code content} 를
+ * 그대로 렌더링한다.
+ */
+public record InitialAssistantMessageResponse(
+        @JsonProperty("message_id") UUID messageId,
+        String role,
+        String kind,
+        String content,
+        @JsonProperty("created_at") OffsetDateTime createdAt
+) {
+    /**
+     * @param message   저장된 선제 인사 메시지
+     * @param plainText 복호화된 본문. 엔티티는 암호문만 들고 있어 호출자가 평문을 넘긴다
+     */
+    public static InitialAssistantMessageResponse from(Message message, String plainText) {
+        return new InitialAssistantMessageResponse(
+                message.getId(),
+                message.getRole().value(),
+                message.getMessageKind().value(),
+                plainText,
+                message.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/mio/session/dto/SessionMessagesResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionMessagesResponse.java
@@ -1,0 +1,40 @@
+package com.mio.session.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 세션 대화 이력 조회 응답 (이슈 #531).
+ *
+ * <p>앱을 다시 켰을 때 진행 중이던 대화를 화면에 되살리기 위한 계약이다. 지금까지 대화 원문은
+ * {@code messages} 에 저장되기만 하고 사용자용 조회 경로가 없었다.
+ */
+public record SessionMessagesResponse(
+        @JsonProperty("session_id") UUID sessionId,
+        List<SessionMessageItem> messages,
+        /** 다음 페이지 커서. 더 받을 것이 없으면 null. */
+        @JsonProperty("next_cursor") String nextCursor,
+        @JsonProperty("has_next") boolean hasNext
+) {
+    public SessionMessagesResponse {
+        messages = messages == null ? List.of() : List.copyOf(messages);
+    }
+
+    /**
+     * 대화 메시지 한 건.
+     *
+     * @param content 복호화된 본문
+     * @param kind    {@code conversation} / {@code session_opening}
+     */
+    public record SessionMessageItem(
+            @JsonProperty("message_id") UUID messageId,
+            String role,
+            String kind,
+            String content,
+            @JsonProperty("created_at") OffsetDateTime createdAt
+    ) {
+    }
+}

--- a/src/main/java/com/mio/session/dto/SessionResponse.java
+++ b/src/main/java/com/mio/session/dto/SessionResponse.java
@@ -10,14 +10,17 @@ public record SessionResponse(
         @JsonProperty("session_id") UUID sessionId,
         @JsonProperty("character_id") String characterId,
         String status,
-        @JsonProperty("started_at") OffsetDateTime startedAt
+        @JsonProperty("started_at") OffsetDateTime startedAt,
+        /** 선제 인사 (이슈 #530). 신규 세션 생성 응답에는 항상 존재한다. */
+        @JsonProperty("initial_message") InitialAssistantMessageResponse initialMessage
 ) {
-    public static SessionResponse from(Session session) {
+    public static SessionResponse from(Session session, InitialAssistantMessageResponse initialMessage) {
         return new SessionResponse(
                 session.getId(),
                 session.getCharacterId(),
                 session.getStatus().value(),
-                session.getStartedAt()
+                session.getStartedAt(),
+                initialMessage
         );
     }
 }

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -1,6 +1,7 @@
 package com.mio.session.repository;
 
 import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageKind;
 import com.mio.session.domain.MessageRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +10,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MessageRepository extends JpaRepository<Message, UUID> {
@@ -24,4 +26,41 @@ public interface MessageRepository extends JpaRepository<Message, UUID> {
                                              Pageable pageable);
 
     List<Message> findBySession_IdOrderByCreatedAtAsc(UUID sessionId);
+
+    /** 세션의 선제 인사. 재진입 복구에 쓴다 — 세션당 1건이 DB 제약으로 보장된다 (이슈 #530). */
+    Optional<Message> findBySession_IdAndMessageKind(UUID sessionId, MessageKind messageKind);
+
+    /**
+     * 사용자의 최근 선제 인사 문구 식별자 (이슈 #530).
+     *
+     * <p>직전에 쓴 문구를 로테이션 후보에서 빼기 위한 조회다. 본문이 아니라 코드만 읽어
+     * 복호화 비용을 들이지 않는다. {@code Pageable} 로 1건만 가져온다.
+     */
+    @Query("SELECT m.openingVariant FROM Message m "
+            + "WHERE m.user.id = :userId AND m.messageKind = :messageKind "
+            + "ORDER BY m.createdAt DESC")
+    List<String> findRecentOpeningVariants(@Param("userId") UUID userId,
+                                           @Param("messageKind") MessageKind messageKind,
+                                           Pageable pageable);
+
+    /** 세션 대화 이력 첫 페이지 — 오래된 순 (이슈 #531). */
+    @Query("SELECT m FROM Message m WHERE m.session.id = :sessionId "
+            + "ORDER BY m.createdAt ASC, m.id ASC")
+    List<Message> findHistoryFirstPage(@Param("sessionId") UUID sessionId, Pageable pageable);
+
+    /**
+     * 세션 대화 이력 다음 페이지 — keyset 페이지네이션 (이슈 #531).
+     *
+     * <p>offset 이 아니라 {@code (created_at, id)} 기준으로 이어 받는다. offset 은 조회 중 새
+     * 메시지가 들어오면 경계가 밀려 중복·누락이 생긴다. {@code created_at} 만으로는 같은
+     * 시각에 저장된 메시지에서 순서가 흔들리므로 {@code id} 를 tie-break 로 둔다.
+     */
+    @Query("SELECT m FROM Message m WHERE m.session.id = :sessionId "
+            + "AND (m.createdAt > :afterCreatedAt "
+            + "     OR (m.createdAt = :afterCreatedAt AND m.id > :afterId)) "
+            + "ORDER BY m.createdAt ASC, m.id ASC")
+    List<Message> findHistoryAfter(@Param("sessionId") UUID sessionId,
+                                   @Param("afterCreatedAt") OffsetDateTime afterCreatedAt,
+                                   @Param("afterId") UUID afterId,
+                                   Pageable pageable);
 }

--- a/src/main/java/com/mio/session/repository/SessionRepository.java
+++ b/src/main/java/com/mio/session/repository/SessionRepository.java
@@ -53,6 +53,14 @@ public interface SessionRepository extends JpaRepository<Session, UUID> {
 
     boolean existsByUser_IdAndStatus(UUID userId, SessionStatus status);
 
+    /**
+     * 이 사용자에게 방금 만든 세션 외에 다른 세션이 있는지 (이슈 #530).
+     *
+     * <p>선제 인사가 자기소개("난 미오야")를 할지 닉네임을 부를지 가른다. 세션 저장 뒤에
+     * 판정하므로 현재 세션을 제외해야 한다 — 안 그러면 모든 사용자가 재방문으로 보인다.
+     */
+    boolean existsByUser_IdAndIdNot(UUID userId, UUID excludedSessionId);
+
     boolean existsByIdAndStatus(UUID id, SessionStatus status);
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)

--- a/src/main/java/com/mio/session/service/SessionMessageHistoryService.java
+++ b/src/main/java/com/mio/session/service/SessionMessageHistoryService.java
@@ -1,0 +1,150 @@
+package com.mio.session.service;
+
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.SessionMessagesResponse;
+import com.mio.session.dto.SessionMessagesResponse.SessionMessageItem;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 세션 대화 이력 조회 (이슈 #531).
+ *
+ * <p>대화 원문은 계속 {@code messages} 에 저장돼 왔지만 사용자용 조회 경로가 없어서, 앱을 다시
+ * 켜면 진행 중이던 대화를 화면에 되살릴 방법이 없었다. 선제 인사(#530)가 세션의 첫 메시지로
+ * 저장되면서 이 공백이 더 분명해졌다.
+ *
+ * <p>대화 원문을 반환하는 경로이므로 소유자 검증이 유일한 방어선이다. 조회 전용이며 어떤
+ * 상태도 바꾸지 않는다.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SessionMessageHistoryService {
+
+    static final int DEFAULT_LIMIT = 50;
+    static final int MAX_LIMIT = 100;
+
+    /** 커서 구분자. UUID·ISO 시각 어디에도 나타나지 않는 문자를 쓴다. */
+    private static final String CURSOR_DELIMITER = "|";
+
+    private final SessionRepository sessionRepository;
+    private final MessageRepository messageRepository;
+    private final MessageEncryptor messageEncryptor;
+
+    /**
+     * 세션의 대화를 오래된 순으로 반환한다.
+     *
+     * @param cursor 이전 응답의 {@code next_cursor}. null 이면 가장 오래된 메시지부터
+     * @param limit  1~{@value #MAX_LIMIT}. null 이면 {@value #DEFAULT_LIMIT}
+     */
+    @Transactional(readOnly = true)
+    public SessionMessagesResponse getHistory(UUID userId, UUID sessionId, String cursor, Integer limit) {
+        Session session = sessionRepository.findById(sessionId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SESSION_NOT_FOUND));
+        if (!session.belongsTo(userId)) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        int pageSize = resolveLimit(limit);
+        // 한 건 더 읽어 다음 페이지 존재 여부를 판단한다. 별도 count 쿼리를 돌리면 페이지마다
+        // 전체 스캔이 한 번 더 붙는다.
+        PageRequest page = PageRequest.of(0, pageSize + 1);
+
+        List<Message> rows = cursor == null || cursor.isBlank()
+                ? messageRepository.findHistoryFirstPage(sessionId, page)
+                : findAfterCursor(sessionId, cursor, page);
+
+        boolean hasNext = rows.size() > pageSize;
+        List<Message> pageRows = hasNext ? rows.subList(0, pageSize) : rows;
+
+        List<SessionMessageItem> items = new ArrayList<>(pageRows.size());
+        for (Message message : pageRows) {
+            decrypt(message).ifPresent(content -> items.add(new SessionMessageItem(
+                    message.getId(),
+                    message.getRole().value(),
+                    message.getMessageKind().value(),
+                    content,
+                    message.getCreatedAt())));
+        }
+
+        // 커서는 복호화 성공 여부와 무관하게 실제로 읽은 마지막 행을 기준으로 만든다.
+        // 복호화에 실패한 행을 기준에서 빼면 다음 페이지가 그 행부터 다시 시작해 무한히 맴돈다.
+        String nextCursor = hasNext ? encodeCursor(pageRows.get(pageRows.size() - 1)) : null;
+
+        return new SessionMessagesResponse(sessionId, items, nextCursor, hasNext);
+    }
+
+    private int resolveLimit(Integer limit) {
+        if (limit == null) {
+            return DEFAULT_LIMIT;
+        }
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+        return limit;
+    }
+
+    private List<Message> findAfterCursor(UUID sessionId, String cursor, PageRequest page) {
+        Cursor decoded = decodeCursor(cursor);
+        return messageRepository.findHistoryAfter(sessionId, decoded.createdAt(), decoded.id(), page);
+    }
+
+    /**
+     * 복호화한 본문. 실패하면 빈 값을 반환하고 그 메시지를 건너뛴다.
+     *
+     * <p>한 건의 복호화 실패로 이력 전체가 500 이 되면 사용자는 대화로 돌아갈 수 없다.
+     * 원문은 로그에 남기지 않는다.
+     */
+    private Optional<String> decrypt(Message message) {
+        try {
+            return Optional.of(
+                    new String(messageEncryptor.decrypt(message.getContentCiphertext()), StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            log.warn("Skipping undecryptable message in history: messageId={}", message.getId(), e);
+            return Optional.empty();
+        }
+    }
+
+    private String encodeCursor(Message last) {
+        String raw = last.getCreatedAt() + CURSOR_DELIMITER + last.getId();
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(raw.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Cursor decodeCursor(String cursor) {
+        try {
+            String raw = new String(Base64.getUrlDecoder().decode(cursor), StandardCharsets.UTF_8);
+            int separator = raw.lastIndexOf(CURSOR_DELIMITER);
+            if (separator < 0) {
+                throw new IllegalArgumentException("missing delimiter");
+            }
+            return new Cursor(
+                    OffsetDateTime.parse(raw.substring(0, separator)),
+                    UUID.fromString(raw.substring(separator + 1)));
+        } catch (IllegalArgumentException | DateTimeParseException e) {
+            // 커서는 서버가 만든 opaque 값이다. 깨진 값이 오면 클라이언트가 형식을 조립했거나
+            // 잘라 보낸 것이므로, 조용히 첫 페이지로 되돌리지 않고 잘못된 입력으로 알린다.
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private record Cursor(OffsetDateTime createdAt, UUID id) {
+    }
+}

--- a/src/main/java/com/mio/session/service/SessionOpeningService.java
+++ b/src/main/java/com/mio/session/service/SessionOpeningService.java
@@ -1,0 +1,214 @@
+package com.mio.session.service;
+
+import com.mio.character.domain.OpeningMessageCatalog;
+import com.mio.character.domain.OpeningMessageCatalog.OpeningAudience;
+import com.mio.character.domain.OpeningMessageCatalog.OpeningMessage;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageKind;
+import com.mio.session.domain.MessageRole;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.InitialAssistantMessageResponse;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * 세션 선제 인사 저장·조회 (이슈 #530, 원본 추적 #428).
+ *
+ * <p>인사는 화면 표시와 대화 이력이 갈라지지 않도록 일반 메시지와 동일하게 암호화 저장한다.
+ * 표시 전용으로 두면 서버는 인사를 모르는데 사용자 화면에는 있는 이중 상태가 된다.
+ *
+ * <p>{@link SessionService} 에서 분리한 이유는 세션 생성 메서드가 인사 선택·저장·복호화까지
+ * 안게 되면 한 메서드가 여러 책임을 갖게 되기 때문이다. 트랜잭션은 호출자의 것을 그대로
+ * 쓴다 — 세션만 있고 인사가 없는 중간 상태를 만들지 않기 위해 같은 트랜잭션이어야 한다.
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SessionOpeningService {
+
+    /** 오프닝 생성 결과. 카피 누락·캐릭터별 분포 감시. */
+    private static final String CREATED_METRIC = "mio.session.opening.created";
+
+    /** 직전과 같은 문구가 나간 횟수. 0 에 수렴해야 로테이션이 동작하는 것이다. */
+    private static final String REPEAT_METRIC = "mio.session.opening.variant.repeat";
+
+    /** 직전 variant 조회 실패 — fail-open 경로를 탄 빈도. */
+    private static final String LOOKUP_FAILED_METRIC = "mio.session.opening.variant.lookup_failed";
+
+    /** 재방문 판정 조회 실패 — 자기소개로 폴백한 빈도. */
+    private static final String AUDIENCE_LOOKUP_FAILED_METRIC = "mio.session.opening.audience.lookup_failed";
+
+    /** 가입 계약({@code SignupCompleteRequest})과 같은 닉네임 길이 범위. */
+    private static final int NICKNAME_MIN_LENGTH = 2;
+    private static final int NICKNAME_MAX_LENGTH = 13;
+
+    private final MessageRepository messageRepository;
+    private final SessionRepository sessionRepository;
+    private final MessageEncryptor messageEncryptor;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * 세션의 선제 인사를 저장하고 응답 DTO 를 만든다.
+     *
+     * <p>호출자(세션 생성)의 트랜잭션 안에서 실행된다. 세션당 1건은
+     * {@code uq_messages_session_opening} 이 최종 보장한다.
+     */
+    public InitialAssistantMessageResponse createOpening(Session session, User user) {
+        OpeningAudience audience = resolveAudience(session, user);
+        OpeningMessage selected = select(user.getId(), session.getCharacterId(), audience);
+        String rendered = selected.render(usableNickname(user));
+
+        byte[] ciphertext = messageEncryptor.encrypt(rendered.getBytes(StandardCharsets.UTF_8));
+        Message saved = messageRepository.save(Message.builder()
+                .session(session)
+                .user(user)
+                .role(MessageRole.ASSISTANT)
+                .messageKind(MessageKind.SESSION_OPENING)
+                .openingVariant(selected.variant())
+                .contentCiphertext(ciphertext)
+                .contentDekId(messageEncryptor.dekId())
+                .isCrisisFlagged(false)
+                .build());
+
+        meterRegistry.counter(CREATED_METRIC,
+                "character", session.getCharacterId(),
+                "audience", audience.name().toLowerCase(),
+                "variant", selected.variant()).increment();
+
+        return InitialAssistantMessageResponse.from(saved, rendered);
+    }
+
+    /**
+     * 자기소개를 할지 닉네임을 부를지 정한다 (이슈 #530).
+     *
+     * <p>재방문 판정은 <b>이 사용자의 다른 세션 존재 여부</b>다. 오프닝 이력으로 판정하면 이
+     * 기능 배포 이전부터 쓰던 사용자가 모두 "처음 온 사람" 이 되어 자기소개를 다시 받는다.
+     *
+     * <p>닉네임이 없거나 형식이 어긋나면 재방문이어도 자기소개 세트를 쓴다. 그 세트는 이름을
+     * 부르지 않으므로 빈 이름이 문장에 노출될 경로가 없다.
+     */
+    private OpeningAudience resolveAudience(Session session, User user) {
+        if (usableNickname(user) == null) {
+            return OpeningAudience.FIRST_SESSION;
+        }
+        return hasPreviousSession(session, user)
+                ? OpeningAudience.RETURNING
+                : OpeningAudience.FIRST_SESSION;
+    }
+
+    /**
+     * 방금 만든 세션을 제외한 이전 세션이 있는지. 조회가 실패하면 첫 세션으로 본다 —
+     * 처음 온 사람에게 자기소개를 하는 쪽이, 처음 온 사람의 이름을 부르는 쪽보다 안전하다.
+     */
+    private boolean hasPreviousSession(Session session, User user) {
+        try {
+            return sessionRepository.existsByUser_IdAndIdNot(user.getId(), session.getId());
+        } catch (Exception e) {
+            meterRegistry.counter(AUDIENCE_LOOKUP_FAILED_METRIC).increment();
+            log.warn("Failed to check previous sessions, treating as first session: userId={}",
+                    user.getId(), e);
+            return false;
+        }
+    }
+
+    /**
+     * 인사말에 넣을 수 있는 닉네임. 없으면 {@code null}.
+     *
+     * <p>가입 계약(2~13자)을 벗어난 값은 쓰지 않는다. 한 글자나 비정상적으로 긴 값이
+     * 문장에 들어가면 인사가 깨진 것처럼 보인다.
+     */
+    private String usableNickname(User user) {
+        String nickname = user.getNickname();
+        if (nickname == null || nickname.isBlank()) {
+            return null;
+        }
+        String trimmed = nickname.trim();
+        if (trimmed.length() < NICKNAME_MIN_LENGTH || trimmed.length() > NICKNAME_MAX_LENGTH) {
+            return null;
+        }
+        return trimmed;
+    }
+
+    /**
+     * 저장된 선제 인사를 복구한다 (재진입·응답 유실 후 active 조회).
+     *
+     * <p>새로 만들지 않는다. 없으면 {@code Optional.empty()} — 이 기능 배포 이전에 이미 열려
+     * 있던 세션에는 인사가 존재하지 않고, 대화가 진행된 세션 중간에 소급 생성하면
+     * {@code created_at} 순서가 첫 사용자 발화보다 뒤로 가서 이력이 어긋난다.
+     *
+     * <p>복호화가 실패해도 예외를 전파하지 않는다. 인사 한 줄 때문에 활성 세션 조회 전체가
+     * 실패하면 사용자는 진행 중인 대화로 돌아갈 수 없다.
+     */
+    @Transactional(readOnly = true)
+    public Optional<InitialAssistantMessageResponse> findOpening(UUID sessionId) {
+        return messageRepository.findBySession_IdAndMessageKind(sessionId, MessageKind.SESSION_OPENING)
+                .flatMap(message -> {
+                    try {
+                        String plainText = new String(
+                                messageEncryptor.decrypt(message.getContentCiphertext()),
+                                StandardCharsets.UTF_8);
+                        return Optional.of(InitialAssistantMessageResponse.from(message, plainText));
+                    } catch (Exception e) {
+                        log.warn("Failed to decrypt session opening, omitting it: sessionId={}", sessionId, e);
+                        return Optional.empty();
+                    }
+                });
+    }
+
+    /**
+     * 직전에 쓴 문구를 뺀 뒤 균등 무작위로 고른다.
+     *
+     * <p>사용자·세션 ID 해시로 고르지 않는 이유: 같은 사용자가 매번 같은 문구를 받게 되어
+     * 로테이션의 목적을 잃는다.
+     */
+    private OpeningMessage select(UUID userId, String characterId, OpeningAudience audience) {
+        List<OpeningMessage> candidates = OpeningMessageCatalog.messagesFor(characterId, audience);
+        String previousVariant = findPreviousVariant(userId);
+
+        List<OpeningMessage> pool = new ArrayList<>(candidates);
+        if (previousVariant != null && pool.size() > 1) {
+            pool.removeIf(message -> message.variant().equals(previousVariant));
+        }
+
+        OpeningMessage selected = pool.get(ThreadLocalRandom.current().nextInt(pool.size()));
+        if (selected.variant().equals(previousVariant)) {
+            // 후보가 1종뿐인 캐릭터에서만 발생한다. 로테이션이 실제로 도는지 보려면
+            // "직전과 같았다" 를 세는 지표가 필요하다.
+            meterRegistry.counter(REPEAT_METRIC, "character", characterId).increment();
+        }
+        return selected;
+    }
+
+    /**
+     * 직전 오프닝 variant. 없거나 조회가 실패하면 {@code null} 을 반환한다 (fail-open).
+     *
+     * <p>인사 문구를 고르는 보조 조회가 세션 생성을 막아서는 안 된다. 최악의 경우 같은
+     * 문구가 한 번 더 나오는 것이고, 그건 인사가 아예 없는 것보다 낫다.
+     */
+    private String findPreviousVariant(UUID userId) {
+        try {
+            List<String> recent = messageRepository.findRecentOpeningVariants(
+                    userId, MessageKind.SESSION_OPENING, PageRequest.of(0, 1));
+            return recent.isEmpty() ? null : recent.get(0);
+        } catch (Exception e) {
+            meterRegistry.counter(LOOKUP_FAILED_METRIC).increment();
+            log.warn("Failed to load previous opening variant, selecting from full set: userId={}", userId, e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/mio/session/service/SessionOpeningService.java
+++ b/src/main/java/com/mio/session/service/SessionOpeningService.java
@@ -15,8 +15,11 @@ import com.mio.user.domain.User;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.nio.charset.StandardCharsets;
@@ -25,6 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
 
 /**
  * 세션 선제 인사 저장·조회 (이슈 #530, 원본 추적 #428).
@@ -57,6 +61,15 @@ public class SessionOpeningService {
     private static final int NICKNAME_MIN_LENGTH = 2;
     private static final int NICKNAME_MAX_LENGTH = 13;
 
+    /**
+     * 인사말에 넣을 닉네임에서 제거하는 문자 — 글자·숫자·공백·{@code _ - .} 이외 전부.
+     *
+     * <p>줄바꿈·콜론·괄호처럼 대화 구조를 흉내낼 수 있는 문자를 지운다. 자세한 이유는
+     * {@link #usableNickname(User)} 주석에 있다.
+     */
+    private static final Pattern DISALLOWED_IN_NICKNAME =
+            Pattern.compile("[^\\p{IsAlphabetic}\\p{IsDigit} _.-]");
+
     private final MessageRepository messageRepository;
     private final SessionRepository sessionRepository;
     private final MessageEncryptor messageEncryptor;
@@ -67,11 +80,17 @@ public class SessionOpeningService {
      *
      * <p>호출자(세션 생성)의 트랜잭션 안에서 실행된다. 세션당 1건은
      * {@code uq_messages_session_opening} 이 최종 보장한다.
+     *
+     * <p>{@code MANDATORY} 로 못박은 이유: 트랜잭션 없이 호출되면 세션과 인사가 각각 다른
+     * 트랜잭션에서 커밋되어, 이 클래스가 막으려던 "세션만 있고 인사가 없는 상태" 가 조용히
+     * 생긴다. 주석으로만 남기면 나중에 배치·재시도 경로에서 깨져도 아무 신호가 없다.
      */
+    @Transactional(propagation = Propagation.MANDATORY)
     public InitialAssistantMessageResponse createOpening(Session session, User user) {
-        OpeningAudience audience = resolveAudience(session, user);
+        String nickname = usableNickname(user);
+        OpeningAudience audience = resolveAudience(session, user, nickname);
         OpeningMessage selected = select(user.getId(), session.getCharacterId(), audience);
-        String rendered = selected.render(usableNickname(user));
+        String rendered = selected.render(nickname);
 
         byte[] ciphertext = messageEncryptor.encrypt(rendered.getBytes(StandardCharsets.UTF_8));
         Message saved = messageRepository.save(Message.builder()
@@ -101,9 +120,11 @@ public class SessionOpeningService {
      *
      * <p>닉네임이 없거나 형식이 어긋나면 재방문이어도 자기소개 세트를 쓴다. 그 세트는 이름을
      * 부르지 않으므로 빈 이름이 문장에 노출될 경로가 없다.
+     *
+     * @param nickname {@link #usableNickname(User)} 결과. 쓸 수 없으면 null
      */
-    private OpeningAudience resolveAudience(Session session, User user) {
-        if (usableNickname(user) == null) {
+    private OpeningAudience resolveAudience(Session session, User user, String nickname) {
+        if (nickname == null) {
             return OpeningAudience.FIRST_SESSION;
         }
         return hasPreviousSession(session, user)
@@ -118,7 +139,12 @@ public class SessionOpeningService {
     private boolean hasPreviousSession(Session session, User user) {
         try {
             return sessionRepository.existsByUser_IdAndIdNot(user.getId(), session.getId());
-        } catch (Exception e) {
+        } catch (DataIntegrityViolationException e) {
+            // 이 조회는 대기 중인 세션 INSERT 를 auto-flush 시킬 수 있다. 그때 나는 활성 세션
+            // unique 위반은 "조회 실패" 가 아니라 세션 생성 경합이므로, 삼키면 호출부가 409 로
+            // 변환할 기회를 잃고 abort 된 트랜잭션이 500 으로 끝난다.
+            throw e;
+        } catch (DataAccessException e) {
             meterRegistry.counter(AUDIENCE_LOOKUP_FAILED_METRIC).increment();
             log.warn("Failed to check previous sessions, treating as first session: userId={}",
                     user.getId(), e);
@@ -127,21 +153,30 @@ public class SessionOpeningService {
     }
 
     /**
-     * 인사말에 넣을 수 있는 닉네임. 없으면 {@code null}.
+     * 인사말에 넣을 수 있는 닉네임. 쓸 수 없으면 {@code null} (자기소개 세트로 폴백된다).
      *
-     * <p>가입 계약(2~13자)을 벗어난 값은 쓰지 않는다. 한 글자나 비정상적으로 긴 값이
-     * 문장에 들어가면 인사가 깨진 것처럼 보인다.
+     * <p>가입 계약(2~13자)을 벗어난 값은 쓰지 않는다. 한 글자나 비정상적으로 긴 값이 문장에
+     * 들어가면 인사가 깨진 것처럼 보인다.
+     *
+     * <p><b>왜 문자 종류까지 제한하는가</b> — 이 인사말은 저장 후 {@code role=assistant} 로
+     * WorkingMemory 에 적재되어 다음 턴 프롬프트의 대화 이력에 들어간다. 즉 닉네임은 사용자
+     * 입력 중 유일하게 <b>모델이 "자기가 한 말"로 보는 자리</b>에 들어가는 값이고, 이 경로는
+     * 설계상 SafetyL1·InputJudge·SecurityRuleFilter 를 타지 않는다(LLM 을 부르지 않으므로).
+     *
+     * <p>13자로는 긴 지시문을 넣을 수 없지만 {@code \n} 이나 {@code System:} 같은 <b>구조</b>를
+     * 끼워 넣기에는 충분하다. 그래서 이름에 쓰일 법한 문자만 남기고 나머지는 제거한다. 제거 후
+     * 길이 계약을 못 지키면 이름을 부르지 않는다.
      */
     private String usableNickname(User user) {
         String nickname = user.getNickname();
         if (nickname == null || nickname.isBlank()) {
             return null;
         }
-        String trimmed = nickname.trim();
-        if (trimmed.length() < NICKNAME_MIN_LENGTH || trimmed.length() > NICKNAME_MAX_LENGTH) {
+        String sanitized = DISALLOWED_IN_NICKNAME.matcher(nickname).replaceAll("").trim();
+        if (sanitized.length() < NICKNAME_MIN_LENGTH || sanitized.length() > NICKNAME_MAX_LENGTH) {
             return null;
         }
-        return trimmed;
+        return sanitized;
     }
 
     /**
@@ -205,7 +240,10 @@ public class SessionOpeningService {
             List<String> recent = messageRepository.findRecentOpeningVariants(
                     userId, MessageKind.SESSION_OPENING, PageRequest.of(0, 1));
             return recent.isEmpty() ? null : recent.get(0);
-        } catch (Exception e) {
+        } catch (DataIntegrityViolationException e) {
+            // 위와 같은 이유 — 무결성 위반은 폴백 대상이 아니다.
+            throw e;
+        } catch (DataAccessException e) {
             meterRegistry.counter(LOOKUP_FAILED_METRIC).increment();
             log.warn("Failed to load previous opening variant, selecting from full set: userId={}", userId, e);
             return null;

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -92,7 +92,13 @@ public class SessionService {
                 .build();
 
         try {
-            Session saved = sessionRepository.save(session);
+            // saveAndFlush 인 이유: 아래 선제 인사 생성이 sessions 를 조회하므로 Hibernate 가
+            // 그 시점에 이 INSERT 를 자동 flush 한다. 그러면 활성 세션 unique 위반이 조회
+            // 호출부에서 터지고, 그 호출부가 조회 실패를 폴백 처리하면서 위반을 삼킨다.
+            // 그 뒤 트랜잭션은 이미 abort 상태라 후속 문장이 전부 실패하고, 아래 catch 가
+            // 잡지 못하는 예외로 끝나 409 대신 500 이 나간다. 여기서 명시적으로 flush 해서
+            // 경합을 이 try 안에서 확정한다.
+            Session saved = sessionRepository.saveAndFlush(session);
 
             // 선제 인사는 세션과 같은 트랜잭션에서 저장한다 (이슈 #530). 세션만 있고 인사가
             // 없는 중간 상태를 만들지 않기 위해서다. LLM 은 호출하지 않는다 — 사용자 발화

--- a/src/main/java/com/mio/session/service/SessionService.java
+++ b/src/main/java/com/mio/session/service/SessionService.java
@@ -6,6 +6,7 @@ import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.ai.profile.ContextPreWarmer;
 import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.MessageRole;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SessionStatus;
 import com.mio.session.domain.SummaryStatus;
@@ -63,6 +64,7 @@ public class SessionService {
     private final ApplicationEventPublisher eventPublisher;
     private final ContextPreWarmer contextPreWarmer;
     private final StringRedisTemplate redisTemplate;
+    private final SessionOpeningService sessionOpeningService;
 
     @Transactional
     public SessionResponse createSession(UUID userId, CreateSessionRequest request) {
@@ -91,24 +93,48 @@ public class SessionService {
 
         try {
             Session saved = sessionRepository.save(session);
+
+            // 선제 인사는 세션과 같은 트랜잭션에서 저장한다 (이슈 #530). 세션만 있고 인사가
+            // 없는 중간 상태를 만들지 않기 위해서다. LLM 은 호출하지 않는다 — 사용자 발화
+            // 전에는 안전·CBT 추론을 실행할 근거가 없다.
+            InitialAssistantMessageResponse initialMessage =
+                    sessionOpeningService.createOpening(saved, user);
+
             // pre-warming은 커밋 후 실행 — 트랜잭션 롤백 시 고아 캐시 방지
             UUID savedSessionId = saved.getId();
             if (TransactionSynchronizationManager.isSynchronizationActive()) {
                 TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                     @Override
                     public void afterCommit() {
+                        appendOpeningToWorkingMemory(savedSessionId, initialMessage);
                         contextPreWarmer.preWarm(savedSessionId, userId);
                     }
                 });
             } else {
+                appendOpeningToWorkingMemory(savedSessionId, initialMessage);
                 contextPreWarmer.preWarm(savedSessionId, userId);
             }
-            return SessionResponse.from(saved);
+            return SessionResponse.from(saved, initialMessage);
         } catch (DataIntegrityViolationException e) {
             if (isActiveSessionUniqueViolation(e)) {
                 throw new BusinessException(ErrorCode.SESSION_ALREADY_ACTIVE);
             }
             throw e;
+        }
+    }
+
+    /**
+     * 오프닝을 세션 버퍼에 넣어 첫 턴 history 앞에 놓는다 (이슈 #530).
+     *
+     * <p>커밋 후에 실행한다 — 롤백된 세션의 발화가 Redis 에 남으면 다음 턴 프롬프트가 존재하지
+     * 않는 대화를 참조한다. 실패해도 예외를 전파하지 않는다. 이미 커밋된 세션·인사를
+     * 사용자에게 돌려주지 못하게 만드는 대가가, 첫 턴 문맥에서 인사 한 줄이 빠지는 것보다 크다.
+     */
+    private void appendOpeningToWorkingMemory(UUID sessionId, InitialAssistantMessageResponse opening) {
+        try {
+            workingMemory.appendMessage(sessionId, MessageRole.ASSISTANT.value(), opening.content());
+        } catch (Exception e) {
+            log.warn("Failed to append session opening to working memory: sessionId={}", sessionId, e);
         }
     }
 
@@ -119,7 +145,11 @@ public class SessionService {
             throw new BusinessException(ErrorCode.ONBOARDING_REQUIRED);
         }
         return sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE)
-                .map(ActiveSessionResponse::fromActive)
+                .map(active -> ActiveSessionResponse.fromActive(
+                        active,
+                        // 저장된 인사를 그대로 돌려준다. 새로 만들지 않는다 — 재진입마다
+                        // 인사가 늘어나면 대화창에 같은 말풍선이 쌓인다 (이슈 #530).
+                        sessionOpeningService.findOpening(active.getId()).orElse(null)))
                 .orElseGet(() -> {
                     Session lastEnded = sessionRepository
                             .findTopByUser_IdAndStatusOrderByEndedAtDesc(userId, SessionStatus.ENDED)

--- a/src/main/resources/db/migration/V58_1__add_message_kind_to_messages.sql
+++ b/src/main/resources/db/migration/V58_1__add_message_kind_to_messages.sql
@@ -24,9 +24,11 @@ ALTER TABLE messages
     -- 선제 인사는 캐릭터의 발화다. user 역할로는 존재할 수 없다.
     ADD CONSTRAINT ck_messages_opening_role
         CHECK (message_kind <> 'session_opening' OR role = 'assistant'),
-    -- variant 는 선제 인사에만 존재한다. 일반 대화에 값이 남으면 지표가 오염된다.
+    -- variant 는 선제 인사에만, 그리고 선제 인사에는 반드시 존재한다. 한쪽만 걸면 일반
+    -- 대화에 값이 남아 지표가 오염되거나, variant 없는 인사가 들어와 로테이션에서 직전
+    -- 문구를 제외할 수 없게 된다.
     ADD CONSTRAINT ck_messages_opening_variant
-        CHECK (message_kind = 'session_opening' OR opening_variant IS NULL);
+        CHECK ((message_kind = 'session_opening') = (opening_variant IS NOT NULL));
 
 -- 세션당 선제 인사 1건. 애플리케이션의 exists 검사만으로는 동시 요청을 막을 수 없으므로
 -- 최종 방어는 DB 가 맡는다.

--- a/src/main/resources/db/migration/V58_1__add_message_kind_to_messages.sql
+++ b/src/main/resources/db/migration/V58_1__add_message_kind_to_messages.sql
@@ -1,0 +1,40 @@
+-- 신규 세션 선제 인사 (이슈 #530, 원본 추적 #428)
+--
+-- 채팅에 들어가면 캐릭터가 먼저 말을 걸어야 하는데, 지금은 세션과 컨텍스트 pre-warm 만
+-- 만들고 최초 assistant 메시지 계약이 없어 사용자가 빈 화면을 본다. 인사를 화면에만
+-- 띄우면 서버 대화 이력과 갈라지므로, 일반 메시지와 같은 방식으로 암호화 저장하되
+-- 종류를 구분한다.
+--
+-- 버전 번호가 58.1 인 이유:
+--   프로덕션 flyway_schema_history 최대 = 58, develop = 76.
+--   V59 는 add_data_deletion_requests 와 중복이고, V77 은 이 핫픽스가 프로덕션에 먼저
+--   적용된 뒤 develop 승격 때 V59~V76 이 out-of-order 가 되어 기동이 실패한다
+--   (out-of-order 기본값 false). 58 < 58.1 < 59 자리에 넣으면 프로덕션은 58 → 58.1 → 59…
+--   순서로, 빈 DB(CI)는 1 → … → 58 → 58.1 → 59 → … → 76 순서로 모두 정상 적용된다.
+
+ALTER TABLE messages
+    ADD COLUMN message_kind    TEXT NOT NULL DEFAULT 'conversation',
+    -- 로테이션 문구 식별자. 본문을 복호화해 비교하지 않고 이 코드로 직전 문구를 판정한다.
+    -- API 로 노출하지 않는 내부 관측 값이다.
+    ADD COLUMN opening_variant TEXT;
+
+ALTER TABLE messages
+    ADD CONSTRAINT ck_messages_message_kind
+        CHECK (message_kind IN ('conversation', 'session_opening')),
+    -- 선제 인사는 캐릭터의 발화다. user 역할로는 존재할 수 없다.
+    ADD CONSTRAINT ck_messages_opening_role
+        CHECK (message_kind <> 'session_opening' OR role = 'assistant'),
+    -- variant 는 선제 인사에만 존재한다. 일반 대화에 값이 남으면 지표가 오염된다.
+    ADD CONSTRAINT ck_messages_opening_variant
+        CHECK (message_kind = 'session_opening' OR opening_variant IS NULL);
+
+-- 세션당 선제 인사 1건. 애플리케이션의 exists 검사만으로는 동시 요청을 막을 수 없으므로
+-- 최종 방어는 DB 가 맡는다.
+CREATE UNIQUE INDEX uq_messages_session_opening
+    ON messages (session_id)
+    WHERE message_kind = 'session_opening';
+
+-- 직전 인사 문구 조회 (같은 문구가 연속으로 노출되지 않게 제외 대상을 찾는다).
+CREATE INDEX idx_messages_user_opening
+    ON messages (user_id, created_at DESC)
+    WHERE message_kind = 'session_opening';

--- a/src/test/java/com/mio/character/domain/OpeningMessageCatalogTest.java
+++ b/src/test/java/com/mio/character/domain/OpeningMessageCatalogTest.java
@@ -1,0 +1,253 @@
+package com.mio.character.domain;
+
+import com.mio.character.domain.OpeningMessageCatalog.OpeningAudience;
+import com.mio.character.domain.OpeningMessageCatalog.OpeningMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 선제 인사 문구 계약 (이슈 #530).
+ *
+ * <p>문구는 사용자에게 그대로 노출되는 제품 카피이고 LLM 검증을 거치지 않는다. 그래서
+ * 안전 계약(진단·단정·의존성 강화 금지)과 닉네임 슬롯 규칙을 코드에서 고정한다.
+ */
+class OpeningMessageCatalogTest {
+
+    private static final Pattern VARIANT = Pattern.compile("^[a-z]+_(intro|back)_\\d{2}$");
+
+    /** 로테이션을 체감하려면 모드별로 최소 2종이 필요하다. 확정 세트는 3종이다. */
+    private static final int EXPECTED_VARIANTS_PER_SET = 3;
+
+    /** 가입 계약 상한(13자)을 채운 닉네임. 렌더링 길이 검증에 쓴다. */
+    private static final String LONGEST_NICKNAME = "가나다라마바사아자차카타파";
+
+    private static final List<String> CHARACTER_IDS = List.of("mio", "bau", "rumi", "momo", "chichi");
+
+    /**
+     * 캐릭터 변경 API 가 반환하는 대표 문구. 세트의 첫 자기소개 문구와 같아야 한다.
+     * "나 X야" → "난 X야" 어조 정정을 포함한다.
+     */
+    private static final List<String> REPRESENTATIVE_MESSAGES = List.of(
+            "안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?",
+            "안녕! 난 바우야 🐕 오늘 뭘 해봤어?",
+            "안녕, 난 루미야 🦉 무엇이 너를 괴롭히고 있어?",
+            "안녕... 난 모모야 🐻 오늘 어떤 하루였어?",
+            "안녕, 난 치치야 😺 뭐가 문제야, 말해봐."
+    );
+
+    static List<String> characterIds() {
+        return CHARACTER_IDS;
+    }
+
+    @Test
+    @DisplayName("캐릭터 5종이 모두 카탈로그에 있다")
+    void catalog_coversAllCharacters() {
+        assertThat(OpeningMessageCatalog.characterIds()).containsExactlyElementsOf(CHARACTER_IDS);
+    }
+
+    @ParameterizedTest
+    @MethodSource("characterIds")
+    @DisplayName("캐릭터별로 모드마다 3종씩 있고 모두 비어 있지 않다")
+    void messagesFor_hasThreeNonBlankVariantsPerAudience(String characterId) {
+        for (OpeningAudience audience : OpeningAudience.values()) {
+            List<OpeningMessage> messages = OpeningMessageCatalog.messagesFor(characterId, audience);
+
+            assertThat(messages).hasSize(EXPECTED_VARIANTS_PER_SET);
+            assertThat(messages).allSatisfy(message -> {
+                assertThat(message.content()).isNotBlank();
+                assertThat(message.variant()).matches(VARIANT);
+                assertThat(message.variant()).startsWith(characterId + "_");
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("첫 세션 문구는 닉네임 슬롯을 쓰지 않는다 — 닉네임이 없어도 안전해야 한다")
+    void firstSessionMessages_haveNoNicknameSlot() {
+        assertThat(messagesOf(OpeningAudience.FIRST_SESSION)).allSatisfy(message -> {
+            assertThat(message.requiresNickname()).isFalse();
+            assertThat(message.render(null)).isEqualTo(message.content());
+        });
+    }
+
+    @Test
+    @DisplayName("재방문 문구는 모두 닉네임 슬롯을 정확히 1개 가진다")
+    void returningMessages_haveExactlyOneNicknameSlot() {
+        assertThat(messagesOf(OpeningAudience.RETURNING)).allSatisfy(message -> {
+            assertThat(message.requiresNickname()).isTrue();
+            assertThat(occurrences(message.content(), OpeningMessageCatalog.NICKNAME_PLACEHOLDER))
+                    .as("%s 에 슬롯이 2개 이상이면 이름이 중복 노출된다", message.variant())
+                    .isEqualTo(1);
+        });
+    }
+
+    @Test
+    @DisplayName("재방문 문구는 닉네임을 넣으면 슬롯이 남지 않는다")
+    void returningMessages_renderWithoutLeftoverSlot() {
+        assertThat(messagesOf(OpeningAudience.RETURNING)).allSatisfy(message -> {
+            String rendered = message.render("민석");
+            assertThat(rendered).contains("민석");
+            assertThat(rendered).doesNotContain("{", "}");
+        });
+    }
+
+    @Test
+    @DisplayName("닉네임 없이 재방문 문구를 렌더링하면 예외 — 슬롯이 그대로 노출되지 않는다")
+    void returningMessage_renderWithoutNickname_throws() {
+        OpeningMessage message = OpeningMessageCatalog
+                .messagesFor("mio", OpeningAudience.RETURNING).get(0);
+
+        assertThatThrownBy(() -> message.render(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining(message.variant());
+    }
+
+    @Test
+    @DisplayName("variant 코드는 전체에서 유일하다")
+    void variants_areGloballyUnique() {
+        List<String> variants = allMessages().stream().map(OpeningMessage::variant).toList();
+
+        assertThat(Set.copyOf(variants))
+                .as("variant 가 겹치면 직전 문구 제외가 다른 문구까지 지운다")
+                .hasSameSizeAs(variants);
+    }
+
+    @ParameterizedTest
+    @MethodSource("characterIds")
+    @DisplayName("같은 캐릭터·모드 안에서 문구 본문이 중복되지 않는다")
+    void contents_areDistinctWithinSet(String characterId) {
+        for (OpeningAudience audience : OpeningAudience.values()) {
+            List<String> contents = OpeningMessageCatalog.messagesFor(characterId, audience).stream()
+                    .map(OpeningMessage::content)
+                    .toList();
+
+            assertThat(Set.copyOf(contents))
+                    .as("%s/%s 문구가 중복되면 로테이션이 무의미하다", characterId, audience)
+                    .hasSameSizeAs(contents);
+        }
+    }
+
+    @Test
+    @DisplayName("문구는 질문을 최대 1개만 포함한다")
+    void contents_haveAtMostOneQuestion() {
+        assertThat(allMessages()).allSatisfy(message ->
+                assertThat(countQuestionMarks(message.content()))
+                        .as("%s 문구에 질문이 2개 이상이다: %s", message.variant(), message.content())
+                        .isLessThanOrEqualTo(1));
+    }
+
+    @Test
+    @DisplayName("가장 긴 닉네임을 넣어도 문구 길이가 상한을 넘지 않는다")
+    void contents_areShortEvenWithLongestNickname() {
+        assertThat(allMessages()).allSatisfy(message -> {
+            String rendered = message.requiresNickname()
+                    ? message.render(LONGEST_NICKNAME)
+                    : message.content();
+            assertThat(rendered.length())
+                    .as("%s 문구가 너무 길다: %s", message.variant(), rendered)
+                    .isLessThanOrEqualTo(60);
+        });
+    }
+
+    @Test
+    @DisplayName("금지 표현이 없다 — 진단·위기 단정·의존성 강화·과제 지시")
+    void contents_avoidForbiddenExpressions() {
+        List<String> forbidden = List.of(
+                "우울증", "불안장애", "진단", "장애", "치료",
+                "항상 곁에", "언제나 곁에", "나만 믿어", "나밖에",
+                "죽", "자살", "위기",
+                "숙제", "과제", "미션", "해야 해", "해야 돼"
+        );
+
+        assertThat(allMessages()).allSatisfy(message ->
+                assertThat(forbidden)
+                        .as("%s 문구에 금지 표현이 있다: %s", message.variant(), message.content())
+                        .noneSatisfy(word -> assertThat(message.content()).contains(word)));
+    }
+
+    @Test
+    @DisplayName("자기소개 문구는 캐릭터 이름을 밝힌다")
+    void firstSessionMessages_introduceCharacterName() {
+        List<String> names = List.of("미오", "바우", "루미", "모모", "치치");
+
+        for (int i = 0; i < CHARACTER_IDS.size(); i++) {
+            String name = names.get(i);
+            assertThat(OpeningMessageCatalog.messagesFor(CHARACTER_IDS.get(i), OpeningAudience.FIRST_SESSION))
+                    .as("첫 세션인데 자기소개가 없으면 사용자는 상대가 누구인지 모른다")
+                    .allSatisfy(message -> assertThat(message.content()).contains("난 " + name + "야"));
+        }
+    }
+
+    @Test
+    @DisplayName("재방문 문구는 캐릭터 자기소개를 반복하지 않는다")
+    void returningMessages_doNotReintroduce() {
+        List<String> introductions = List.of("난 미오야", "난 바우야", "난 루미야", "난 모모야", "난 치치야");
+
+        assertThat(messagesOf(OpeningAudience.RETURNING)).allSatisfy(message ->
+                assertThat(introductions)
+                        .as("%s 가 자기소개를 반복한다: %s", message.variant(), message.content())
+                        .noneSatisfy(intro -> assertThat(message.content()).contains(intro)));
+    }
+
+    @Test
+    @DisplayName("대표 문구는 자기소개 세트의 첫 문구다")
+    void representativeMessage_isFirstIntroduction() {
+        List<String> representatives = CHARACTER_IDS.stream()
+                .map(OpeningMessageCatalog::representativeMessage)
+                .toList();
+
+        assertThat(representatives).containsExactlyElementsOf(REPRESENTATIVE_MESSAGES);
+        assertThat(representatives)
+                .as("캐릭터 변경 응답은 닉네임을 다루지 않으므로 슬롯이 없어야 한다")
+                .allSatisfy(message -> assertThat(message).doesNotContain("{"));
+    }
+
+    @Test
+    @DisplayName("알 수 없는 캐릭터는 mio 세트로 폴백한다")
+    void messagesFor_unknownCharacter_fallsBackToMio() {
+        for (OpeningAudience audience : OpeningAudience.values()) {
+            assertThat(OpeningMessageCatalog.messagesFor("unknown-character", audience))
+                    .as("카피 누락 하나가 세션 생성 전체를 막지 않아야 한다")
+                    .isEqualTo(OpeningMessageCatalog.messagesFor(
+                            OpeningMessageCatalog.FALLBACK_CHARACTER_ID, audience));
+        }
+    }
+
+    private static List<OpeningMessage> messagesOf(OpeningAudience audience) {
+        List<OpeningMessage> messages = new ArrayList<>();
+        CHARACTER_IDS.forEach(id -> messages.addAll(OpeningMessageCatalog.messagesFor(id, audience)));
+        return messages;
+    }
+
+    private static List<OpeningMessage> allMessages() {
+        List<OpeningMessage> messages = new ArrayList<>();
+        for (OpeningAudience audience : OpeningAudience.values()) {
+            messages.addAll(messagesOf(audience));
+        }
+        return messages;
+    }
+
+    private static long countQuestionMarks(String content) {
+        return content.chars().filter(c -> c == '?' || c == '？').count();
+    }
+
+    private static int occurrences(String content, String token) {
+        int count = 0;
+        int index = content.indexOf(token);
+        while (index >= 0) {
+            count++;
+            index = content.indexOf(token, index + token.length());
+        }
+        return count;
+    }
+}

--- a/src/test/java/com/mio/config/FlywayMigrationOrderTest.java
+++ b/src/test/java/com/mio/config/FlywayMigrationOrderTest.java
@@ -1,0 +1,80 @@
+package com.mio.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flyway 버전 중복과 순서를 기동 전에 잡는다 (이슈 #530).
+ *
+ * <p>이 핫픽스는 점 버전 {@code V58_1}(= 58.1)을 쓴다. 프로덕션은 V58, develop 은 V76 이라
+ * V59 는 중복이고 V77 은 승격 시 V59~V76 이 out-of-order 가 되어 기동이 실패한다.
+ * 58 &lt; 58.1 &lt; 59 라는 전제가 깨지면 프로덕션 배포가 막히므로 테스트로 고정한다.
+ */
+class FlywayMigrationOrderTest {
+
+    /** 버전부는 숫자와 {@code _}(= 점) 조합이고, 설명과의 경계는 {@code __} 두 개다. */
+    private static final Pattern VERSION = Pattern.compile("^V(\\d+(?:_\\d+)*)__.*\\.sql$");
+
+    private static final Path MIGRATIONS = Path.of("src/main/resources/db/migration");
+
+    @Test
+    @DisplayName("모든 versioned migration은 서로 다른 버전을 가진다")
+    void versionedMigrations_doNotShareAVersion() throws IOException {
+        Map<String, List<String>> duplicates = versions().entrySet().stream()
+                .filter(entry -> entry.getValue().size() > 1)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        assertThat(duplicates)
+                .as("같은 Flyway 버전 파일이 둘이면 깨끗한 DB 기동이 실패한다")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("선제 인사 마이그레이션은 58과 59 사이에 놓인다")
+    void sessionOpeningMigration_sortsBetween58And59() throws IOException {
+        assertThat(versions()).containsKey("58_1");
+
+        Comparator<String> byVersion = Comparator.comparing(FlywayMigrationOrderTest::toComparable);
+
+        assertThat(byVersion.compare("58", "58_1"))
+                .as("58 < 58.1 이어야 프로덕션(V58 적용 완료)이 이 마이그레이션을 실행한다")
+                .isNegative();
+        assertThat(byVersion.compare("58_1", "59"))
+                .as("58.1 < 59 여야 develop 승격 때 V59~V76 이 out-of-order 가 되지 않는다")
+                .isNegative();
+    }
+
+    /** 파일 이름의 버전부 → 파일 목록. */
+    private Map<String, List<String>> versions() throws IOException {
+        try (Stream<Path> paths = Files.list(MIGRATIONS)) {
+            return paths
+                    .map(path -> path.getFileName().toString())
+                    .map(VERSION::matcher)
+                    .filter(Matcher::matches)
+                    .collect(Collectors.groupingBy(
+                            matcher -> matcher.group(1),
+                            Collectors.mapping(matcher -> matcher.group(0), Collectors.toList())
+                    ));
+        }
+    }
+
+    /** Flyway 와 같은 규칙으로 버전을 비교 가능한 문자열로 정규화한다 (각 파트를 0-패딩). */
+    private static String toComparable(String version) {
+        return Stream.of(version.split("_"))
+                .map(part -> String.format("%010d", Integer.parseInt(part)))
+                .collect(Collectors.joining("."));
+    }
+}

--- a/src/test/java/com/mio/session/controller/SessionControllerTest.java
+++ b/src/test/java/com/mio/session/controller/SessionControllerTest.java
@@ -7,6 +7,7 @@ import com.mio.common.error.GlobalExceptionHandler;
 import com.mio.session.dto.*;
 import com.mio.auth.filter.JwtAuthenticationFilter;
 import com.mio.config.SecurityConfig;
+import com.mio.session.service.SessionMessageHistoryService;
 import com.mio.session.service.SessionService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -31,6 +32,7 @@ import static org.mockito.Mockito.inOrder;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -49,9 +51,67 @@ class SessionControllerTest {
     @Autowired private MockMvc mockMvc;
     @Autowired private ObjectMapper objectMapper;
     @MockBean private SessionService sessionService;
+    @MockBean private SessionMessageHistoryService sessionMessageHistoryService;
 
     private static final UUID TEST_USER_ID = UUID.randomUUID();
     private static final UUID TEST_SESSION_ID = UUID.randomUUID();
+
+    /** 선제 인사 응답 픽스처 (이슈 #530). */
+    private static final InitialAssistantMessageResponse OPENING = new InitialAssistantMessageResponse(
+            UUID.randomUUID(), "assistant", "session_opening",
+            "안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?",
+            OffsetDateTime.now());
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/messages - 대화 이력을 오래된 순으로 반환")
+    void getSessionMessages_returnsHistory() throws Exception {
+        var opening = new SessionMessagesResponse.SessionMessageItem(
+                UUID.randomUUID(), "assistant", "session_opening",
+                "안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?", OffsetDateTime.now());
+        var userTurn = new SessionMessagesResponse.SessionMessageItem(
+                UUID.randomUUID(), "user", "conversation", "오늘 발표가 있었어", OffsetDateTime.now());
+        when(sessionMessageHistoryService.getHistory(eq(TEST_USER_ID), eq(TEST_SESSION_ID), any(), any()))
+                .thenReturn(new SessionMessagesResponse(
+                        TEST_SESSION_ID, List.of(opening, userTurn), "next-cursor", true));
+
+        mockMvc.perform(get("/v1/sessions/{sessionId}/messages", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
+                .andExpect(jsonPath("$.data.messages.length()").value(2))
+                .andExpect(jsonPath("$.data.messages[0].kind").value("session_opening"))
+                .andExpect(jsonPath("$.data.messages[1].role").value("user"))
+                .andExpect(jsonPath("$.data.next_cursor").value("next-cursor"))
+                .andExpect(jsonPath("$.data.has_next").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/messages - cursor·limit 쿼리 파라미터를 서비스로 전달")
+    void getSessionMessages_passesQueryParams() throws Exception {
+        when(sessionMessageHistoryService.getHistory(any(), any(), any(), any()))
+                .thenReturn(new SessionMessagesResponse(TEST_SESSION_ID, List.of(), null, false));
+
+        mockMvc.perform(get("/v1/sessions/{sessionId}/messages", TEST_SESSION_ID)
+                        .param("cursor", "abc123")
+                        .param("limit", "20")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.messages").isArray())
+                .andExpect(jsonPath("$.data.next_cursor").doesNotExist());
+
+        verify(sessionMessageHistoryService).getHistory(TEST_USER_ID, TEST_SESSION_ID, "abc123", 20);
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/{id}/messages - 남의 세션이면 403")
+    void getSessionMessages_forbidden() throws Exception {
+        when(sessionMessageHistoryService.getHistory(any(), any(), any(), any()))
+                .thenThrow(new BusinessException(ErrorCode.FORBIDDEN));
+
+        mockMvc.perform(get("/v1/sessions/{sessionId}/messages", TEST_SESSION_ID)
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isForbidden());
+    }
 
     @Test
     @DisplayName("GET /v1/sessions/active - 활성 세션 없고 이전 종료 세션도 없으면 session_id: null 반환")
@@ -70,7 +130,8 @@ class SessionControllerTest {
     @DisplayName("GET /v1/sessions/active - 활성 세션 있으면 세션 정보 반환")
     void getActiveSession_hasSession_returnsSession() throws Exception {
         ActiveSessionResponse response = new ActiveSessionResponse(
-                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 0, null, null
+                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 1, null, null,
+                OPENING
         );
         when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
 
@@ -79,14 +140,32 @@ class SessionControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
                 .andExpect(jsonPath("$.data.character_id").value("mio"))
-                .andExpect(jsonPath("$.data.status").value("active"));
+                .andExpect(jsonPath("$.data.status").value("active"))
+                .andExpect(jsonPath("$.data.initial_message.message_id").value(OPENING.messageId().toString()))
+                .andExpect(jsonPath("$.data.initial_message.kind").value("session_opening"))
+                .andExpect(jsonPath("$.data.initial_message.content").value(OPENING.content()));
+    }
+
+    @Test
+    @DisplayName("GET /v1/sessions/active - 인사 없는 기존 세션은 initial_message 를 내려보내지 않는다")
+    void getActiveSession_legacySession_omitsInitialMessage() throws Exception {
+        ActiveSessionResponse response = new ActiveSessionResponse(
+                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), null, 4, null, null, null
+        );
+        when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
+
+        mockMvc.perform(get("/v1/sessions/active")
+                        .principal(() -> TEST_USER_ID.toString()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
+                .andExpect(jsonPath("$.data.initial_message").doesNotExist());
     }
 
     @Test
     @DisplayName("GET /v1/sessions/active - 활성 세션 없고 마지막 종료 세션 요약이 done 이면 last_summary_status 반환")
     void getActiveSession_noActiveSession_returnsLastSummaryStatus() throws Exception {
         ActiveSessionResponse response = new ActiveSessionResponse(
-                null, null, null, null, null, null, "done", TEST_SESSION_ID
+                null, null, null, null, null, null, "done", TEST_SESSION_ID, null
         );
         when(sessionService.getActiveSession(TEST_USER_ID)).thenReturn(response);
 
@@ -101,7 +180,8 @@ class SessionControllerTest {
     @Test
     @DisplayName("POST /v1/sessions - 세션 생성 성공 시 201 반환")
     void createSession_success_returns201() throws Exception {
-        SessionResponse response = new SessionResponse(TEST_SESSION_ID, "mio", "active", OffsetDateTime.now());
+        SessionResponse response = new SessionResponse(
+                TEST_SESSION_ID, "mio", "active", OffsetDateTime.now(), OPENING);
         when(sessionService.createSession(eq(TEST_USER_ID), any())).thenReturn(response);
 
         mockMvc.perform(post("/v1/sessions")
@@ -110,7 +190,13 @@ class SessionControllerTest {
                         .content("{\"character_id\":\"mio\"}"))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.data.session_id").value(TEST_SESSION_ID.toString()))
-                .andExpect(jsonPath("$.data.status").value("active"));
+                .andExpect(jsonPath("$.data.status").value("active"))
+                .andExpect(jsonPath("$.data.initial_message.role").value("assistant"))
+                .andExpect(jsonPath("$.data.initial_message.kind").value("session_opening"))
+                .andExpect(jsonPath("$.data.initial_message.content").value(OPENING.content()))
+                // opening_variant 는 내부 관측 값이라 응답에 담지 않는다 (이슈 #530)
+                .andExpect(jsonPath("$.data.initial_message.opening_variant").doesNotExist())
+                .andExpect(jsonPath("$.data.initial_message.variant").doesNotExist());
     }
 
     @Test

--- a/src/test/java/com/mio/session/service/SessionMessageHistoryServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionMessageHistoryServiceTest.java
@@ -1,0 +1,281 @@
+package com.mio.session.service;
+
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.common.error.BusinessException;
+import com.mio.common.error.ErrorCode;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageKind;
+import com.mio.session.domain.MessageRole;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.SessionMessagesResponse;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 세션 대화 이력 조회 (이슈 #531).
+ */
+@ExtendWith(MockitoExtension.class)
+class SessionMessageHistoryServiceTest {
+
+    @Mock private SessionRepository sessionRepository;
+    @Mock private MessageRepository messageRepository;
+    @Mock private MessageEncryptor messageEncryptor;
+
+    private SessionMessageHistoryService historyService;
+    private UUID userId;
+    private User user;
+    private Session session;
+    private UUID sessionId;
+
+    @BeforeEach
+    void setUp() {
+        historyService = new SessionMessageHistoryService(
+                sessionRepository, messageRepository, messageEncryptor);
+
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-id")
+                .privacyConsent(true)
+                .build();
+        user.completeOnboarding("mio");
+        ReflectionTestUtils.setField(user, "id", userId);
+
+        session = Session.builder().user(user).characterId("mio").build();
+        sessionId = UUID.randomUUID();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+
+        lenient().when(sessionRepository.findById(sessionId)).thenReturn(Optional.of(session));
+        // 테스트에서는 암호화를 항등 함수로 둔다 — 검증 대상은 페이지네이션과 권한이다.
+        lenient().when(messageEncryptor.decrypt(any()))
+                .thenAnswer(inv -> inv.getArgument(0));
+    }
+
+    @Test
+    @DisplayName("오래된 순서로 반환하고 선제 인사가 첫 항목이다")
+    void getHistory_returnsOldestFirstWithOpeningAtTop() {
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any())).thenReturn(List.of(
+                opening("안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?", base),
+                conversation(MessageRole.USER, "오늘 발표가 있었어", base.plusSeconds(30)),
+                conversation(MessageRole.ASSISTANT, "발표가 마음에 남았구나", base.plusSeconds(35))));
+
+        SessionMessagesResponse response = historyService.getHistory(userId, sessionId, null, null);
+
+        assertThat(response.sessionId()).isEqualTo(sessionId);
+        assertThat(response.messages()).hasSize(3);
+        assertThat(response.messages().get(0).kind()).isEqualTo("session_opening");
+        assertThat(response.messages().get(0).role()).isEqualTo("assistant");
+        assertThat(response.messages().get(1).role()).isEqualTo("user");
+        assertThat(response.messages().get(2).kind()).isEqualTo("conversation");
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("limit 보다 많으면 has_next 와 next_cursor 를 준다")
+    void getHistory_moreThanLimit_returnsCursor() {
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        List<Message> rows = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            rows.add(conversation(MessageRole.USER, "메시지 " + i, base.plusSeconds(i)));
+        }
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any())).thenReturn(rows);
+
+        SessionMessagesResponse response = historyService.getHistory(userId, sessionId, null, 2);
+
+        assertThat(response.messages()).hasSize(2);
+        assertThat(response.hasNext()).isTrue();
+        assertThat(response.nextCursor()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("다음 페이지 조회는 limit+1 건을 요청한다 — 별도 count 쿼리 없이 has_next 판정")
+    void getHistory_requestsOneExtraRow() {
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any())).thenReturn(List.of());
+
+        historyService.getHistory(userId, sessionId, null, 10);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(messageRepository).findHistoryFirstPage(eq(sessionId), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(11);
+    }
+
+    @Test
+    @DisplayName("발급한 커서로 이어 받으면 그 지점 이후를 조회한다")
+    void getHistory_withCursor_continuesAfterLastRow() {
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        Message first = conversation(MessageRole.USER, "첫 번째", base);
+        Message second = conversation(MessageRole.ASSISTANT, "두 번째", base.plusSeconds(5));
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any()))
+                .thenReturn(List.of(first, second));
+
+        String cursor = historyService.getHistory(userId, sessionId, null, 1).nextCursor();
+
+        when(messageRepository.findHistoryAfter(eq(sessionId), any(), any(), any()))
+                .thenReturn(List.of(second));
+        SessionMessagesResponse page2 = historyService.getHistory(userId, sessionId, cursor, 1);
+
+        verify(messageRepository).findHistoryAfter(
+                eq(sessionId), eq(first.getCreatedAt()), eq(first.getId()), any());
+        assertThat(page2.messages()).hasSize(1);
+        assertThat(page2.messages().get(0).messageId()).isEqualTo(second.getId());
+        assertThat(page2.hasNext()).isFalse();
+    }
+
+    @Test
+    @DisplayName("복호화에 실패한 메시지는 건너뛰고 나머지를 돌려준다")
+    void getHistory_undecryptableMessage_isSkipped() {
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        Message broken = conversation(MessageRole.USER, "깨진 메시지", base);
+        Message healthy = conversation(MessageRole.ASSISTANT, "정상 메시지", base.plusSeconds(5));
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any()))
+                .thenReturn(List.of(broken, healthy));
+        when(messageEncryptor.decrypt(broken.getContentCiphertext()))
+                .thenThrow(new IllegalStateException("bad dek"));
+        when(messageEncryptor.decrypt(healthy.getContentCiphertext()))
+                .thenReturn("정상 메시지".getBytes(StandardCharsets.UTF_8));
+
+        SessionMessagesResponse response = historyService.getHistory(userId, sessionId, null, null);
+
+        assertThat(response.messages()).hasSize(1);
+        assertThat(response.messages().get(0).content()).isEqualTo("정상 메시지");
+    }
+
+    @Test
+    @DisplayName("복호화 실패 행도 커서 기준에 포함된다 — 같은 페이지를 무한 반복하지 않게")
+    void getHistory_cursorAdvancesPastUndecryptableRow() {
+        OffsetDateTime base = OffsetDateTime.now(ZoneOffset.UTC);
+        Message healthy = conversation(MessageRole.USER, "정상", base);
+        Message broken = conversation(MessageRole.ASSISTANT, "깨짐", base.plusSeconds(5));
+        Message beyond = conversation(MessageRole.USER, "다음 페이지", base.plusSeconds(10));
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any()))
+                .thenReturn(List.of(healthy, broken, beyond));
+        when(messageEncryptor.decrypt(broken.getContentCiphertext()))
+                .thenThrow(new IllegalStateException("bad dek"));
+
+        SessionMessagesResponse response = historyService.getHistory(userId, sessionId, null, 2);
+
+        assertThat(response.messages()).hasSize(1);
+        assertThat(response.hasNext()).isTrue();
+
+        when(messageRepository.findHistoryAfter(eq(sessionId), any(), any(), any()))
+                .thenReturn(List.of(beyond));
+        historyService.getHistory(userId, sessionId, response.nextCursor(), 2);
+
+        // 커서는 깨진 행(마지막으로 읽은 행) 기준이어야 한다.
+        verify(messageRepository).findHistoryAfter(
+                eq(sessionId), eq(broken.getCreatedAt()), eq(broken.getId()), any());
+    }
+
+    @Test
+    @DisplayName("메시지가 없으면 빈 배열을 준다")
+    void getHistory_emptySession_returnsEmptyList() {
+        when(messageRepository.findHistoryFirstPage(eq(sessionId), any())).thenReturn(List.of());
+
+        SessionMessagesResponse response = historyService.getHistory(userId, sessionId, null, null);
+
+        assertThat(response.messages()).isEmpty();
+        assertThat(response.hasNext()).isFalse();
+        assertThat(response.nextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("남의 세션은 FORBIDDEN — 대화 원문을 반환하는 경로의 유일한 방어선")
+    void getHistory_otherUsersSession_throwsForbidden() {
+        assertThatThrownBy(() -> historyService.getHistory(UUID.randomUUID(), sessionId, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.FORBIDDEN);
+
+        verify(messageRepository, never()).findHistoryFirstPage(any(), any());
+    }
+
+    @Test
+    @DisplayName("없는 세션은 SESSION_NOT_FOUND")
+    void getHistory_unknownSession_throwsNotFound() {
+        UUID unknown = UUID.randomUUID();
+        when(sessionRepository.findById(unknown)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> historyService.getHistory(userId, unknown, null, null))
+                .isInstanceOf(BusinessException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.SESSION_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("limit 범위를 벗어나면 INVALID_INPUT")
+    void getHistory_limitOutOfRange_throws() {
+        for (int invalid : new int[]{0, -1, 101}) {
+            assertThatThrownBy(() -> historyService.getHistory(userId, sessionId, null, invalid))
+                    .as("limit=%d", invalid)
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    @Test
+    @DisplayName("깨진 커서는 INVALID_INPUT — 조용히 첫 페이지로 되돌리지 않는다")
+    void getHistory_malformedCursor_throws() {
+        for (String invalid : List.of("!!!not-base64!!!", "bm8tZGVsaW1pdGVy")) {
+            assertThatThrownBy(() -> historyService.getHistory(userId, sessionId, invalid, null))
+                    .as("cursor=%s", invalid)
+                    .isInstanceOf(BusinessException.class)
+                    .extracting("errorCode")
+                    .isEqualTo(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    private Message opening(String content, OffsetDateTime createdAt) {
+        return message(MessageRole.ASSISTANT, MessageKind.SESSION_OPENING, "mio_intro_01", content, createdAt);
+    }
+
+    private Message conversation(MessageRole role, String content, OffsetDateTime createdAt) {
+        return message(role, MessageKind.CONVERSATION, null, content, createdAt);
+    }
+
+    private Message message(MessageRole role, MessageKind kind, String variant,
+                            String content, OffsetDateTime createdAt) {
+        Message message = Message.builder()
+                .session(session)
+                .user(user)
+                .role(role)
+                .messageKind(kind)
+                .openingVariant(variant)
+                .contentCiphertext(content.getBytes(StandardCharsets.UTF_8))
+                .contentDekId("dek-1")
+                .isCrisisFlagged(false)
+                .build();
+        ReflectionTestUtils.setField(message, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(message, "createdAt", createdAt);
+        return message;
+    }
+}

--- a/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.QueryTimeoutException;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -29,6 +31,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
@@ -181,10 +184,85 @@ class SessionOpeningServiceTest {
     }
 
     @Test
+    @DisplayName("닉네임의 대화 구조 흉내 문자는 제거한다 — assistant 역할로 프롬프트에 들어가는 자리다")
+    void createOpening_sanitizesNicknameStructureCharacters() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId())).thenReturn(true);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        // 13자 제한으로 긴 지시문은 못 넣지만 줄바꿈·콜론 같은 구조는 넣을 수 있다.
+        ReflectionTestUtils.setField(user, "nickname", "민석\nSystem:");
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("민석");
+        assertThat(response.content()).doesNotContain("\n");
+        assertThat(response.content()).doesNotContain("System:");
+        assertThat(response.content()).doesNotContain(":");
+    }
+
+    @Test
+    @DisplayName("문자를 제거하고 나면 길이 계약을 못 지키는 닉네임은 부르지 않는다")
+    void createOpening_nicknameFullyStripped_fallsBackToIntroduction() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        // 제거 후 "가" 한 글자만 남아 최소 길이(2)를 못 채운다.
+        ReflectionTestUtils.setField(user, "nickname", "가:{}");
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("난 미오야");
+        assertThat(response.content()).doesNotContain("가");
+    }
+
+    @Test
+    @DisplayName("이름에 쓰일 법한 문자는 그대로 남긴다")
+    void createOpening_keepsOrdinaryNicknameCharacters() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId())).thenReturn(true);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        for (String ordinary : List.of("민석", "Alex", "김민석", "min_seok", "user-01", "J.K")) {
+            ReflectionTestUtils.setField(user, "nickname", ordinary);
+
+            InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+            assertThat(response.content())
+                    .as("닉네임 '%s' 가 그대로 쓰여야 한다", ordinary)
+                    .contains(ordinary);
+        }
+    }
+
+    @Test
+    @DisplayName("세션 생성 경합의 무결성 위반은 삼키지 않고 그대로 올린다 — 호출부가 409로 바꿔야 한다")
+    void createOpening_integrityViolationDuringAudienceLookup_propagates() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId()))
+                .thenThrow(new DataIntegrityViolationException("uq_sessions_one_active_per_user"));
+
+        assertThatThrownBy(() -> sessionOpeningService.createOpening(session, user))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        verify(messageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("직전 문구 조회의 무결성 위반도 삼키지 않는다")
+    void createOpening_integrityViolationDuringVariantLookup_propagates() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenThrow(new DataIntegrityViolationException("uq_sessions_one_active_per_user"));
+
+        assertThatThrownBy(() -> sessionOpeningService.createOpening(session, user))
+                .isInstanceOf(DataIntegrityViolationException.class);
+
+        verify(messageRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("재방문 판정 조회가 실패하면 자기소개로 폴백한다")
     void createOpening_audienceLookupFails_fallsBackToIntroduction() {
         when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId()))
-                .thenThrow(new IllegalStateException("db down"));
+                .thenThrow(new QueryTimeoutException("statement timeout"));
         when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
                 .thenReturn(List.of());
 
@@ -212,7 +290,7 @@ class SessionOpeningServiceTest {
     @DisplayName("직전 문구 조회가 실패해도 인사는 생성된다")
     void createOpening_lookupFails_stillCreatesOpening() {
         when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
-                .thenThrow(new IllegalStateException("db down"));
+                .thenThrow(new QueryTimeoutException("statement timeout"));
 
         InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
 

--- a/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
@@ -212,8 +212,15 @@ class SessionOpeningServiceTest {
 
         InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
 
-        assertThat(response.content()).contains("난 미오야");
-        assertThat(response.content()).doesNotContain("가");
+        // 자기소개 세트의 문구와 정확히 일치해야 한다. 특정 음절의 부재로 단언하면
+        // ("반가워, 난 미오야…" 처럼) 문구가 그 음절을 품고 있을 때 무작위 선택에 따라
+        // 통과·실패가 갈리는 flaky 테스트가 된다.
+        List<String> introductions = OpeningMessageCatalog
+                .messagesFor("mio", OpeningAudience.FIRST_SESSION).stream()
+                .map(OpeningMessage::content)
+                .toList();
+        assertThat(introductions).contains(response.content());
+        assertThat(response.content()).doesNotContain(":", "{", "}");
     }
 
     @Test

--- a/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionOpeningServiceTest.java
@@ -1,0 +1,291 @@
+package com.mio.session.service;
+
+import com.mio.character.domain.OpeningMessageCatalog;
+import com.mio.character.domain.OpeningMessageCatalog.OpeningAudience;
+import com.mio.character.domain.OpeningMessageCatalog.OpeningMessage;
+import com.mio.common.crypto.MessageEncryptor;
+import com.mio.session.domain.Message;
+import com.mio.session.domain.MessageKind;
+import com.mio.session.domain.MessageRole;
+import com.mio.session.domain.Session;
+import com.mio.session.dto.InitialAssistantMessageResponse;
+import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.user.domain.User;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 선제 인사 저장·로테이션 (이슈 #530).
+ */
+@ExtendWith(MockitoExtension.class)
+class SessionOpeningServiceTest {
+
+    @Mock private MessageRepository messageRepository;
+    @Mock private SessionRepository sessionRepository;
+    @Mock private MessageEncryptor messageEncryptor;
+
+    private SessionOpeningService sessionOpeningService;
+    private User user;
+    private UUID userId;
+    private Session session;
+
+    @BeforeEach
+    void setUp() {
+        sessionOpeningService = new SessionOpeningService(
+                messageRepository, sessionRepository, messageEncryptor, new SimpleMeterRegistry());
+
+        userId = UUID.randomUUID();
+        user = User.builder()
+                .socialProvider("kakao")
+                .socialId("test-id")
+                .privacyConsent(true)
+                .build();
+        user.completeOnboarding("mio");
+        ReflectionTestUtils.setField(user, "id", userId);
+        ReflectionTestUtils.setField(user, "nickname", "민석");
+
+        session = Session.builder().user(user).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+
+        // 기본은 첫 세션. 재방문 케이스만 개별 테스트에서 true 로 바꾼다.
+        lenient().when(sessionRepository.existsByUser_IdAndIdNot(any(), any())).thenReturn(false);
+        lenient().when(messageEncryptor.encrypt(any())).thenAnswer(inv -> inv.getArgument(0));
+        lenient().when(messageEncryptor.dekId()).thenReturn("dek-1");
+        lenient().when(messageRepository.save(any())).thenAnswer(inv -> {
+            Message message = inv.getArgument(0);
+            ReflectionTestUtils.setField(message, "id", UUID.randomUUID());
+            return message;
+        });
+    }
+
+    @Test
+    @DisplayName("선제 인사를 assistant/session_opening 메시지로 저장한다")
+    void createOpening_savesAssistantOpeningMessage() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        ArgumentCaptor<Message> captor = ArgumentCaptor.forClass(Message.class);
+        verify(messageRepository).save(captor.capture());
+        Message saved = captor.getValue();
+
+        assertThat(saved.getRole()).isEqualTo(MessageRole.ASSISTANT);
+        assertThat(saved.getMessageKind()).isEqualTo(MessageKind.SESSION_OPENING);
+        assertThat(saved.getOpeningVariant()).startsWith("mio_");
+        assertThat(saved.getEmotionScore()).isNull();
+        assertThat(saved.isCrisisFlagged()).isFalse();
+
+        assertThat(response.role()).isEqualTo("assistant");
+        assertThat(response.kind()).isEqualTo("session_opening");
+        assertThat(response.messageId()).isEqualTo(saved.getId());
+        assertThat(response.content()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("응답 본문은 해당 캐릭터의 검수 문구 중 하나다")
+    void createOpening_usesCuratedCopyForCharacter() {
+        Session chichiSession = Session.builder().user(user).characterId("chichi").build();
+        ReflectionTestUtils.setField(chichiSession, "id", UUID.randomUUID());
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(chichiSession, user);
+
+        List<String> curated = OpeningMessageCatalog
+                .messagesFor("chichi", OpeningAudience.FIRST_SESSION).stream()
+                .map(OpeningMessage::content)
+                .toList();
+        assertThat(curated).contains(response.content());
+    }
+
+    @Test
+    @DisplayName("첫 세션에는 자기소개를 한다 — 닉네임을 부르지 않는다")
+    void createOpening_firstSession_introducesItself() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId())).thenReturn(false);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("난 미오야");
+        assertThat(response.content()).doesNotContain("민석");
+    }
+
+    @Test
+    @DisplayName("재방문에는 닉네임을 부르고 자기소개를 반복하지 않는다")
+    void createOpening_returningUser_greetsByNickname() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId())).thenReturn(true);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("민석");
+        assertThat(response.content()).doesNotContain("난 미오야");
+        assertThat(response.content()).doesNotContain("{nickname}");
+    }
+
+    @Test
+    @DisplayName("닉네임이 없으면 재방문이어도 자기소개 세트를 쓴다 — 빈 이름을 노출하지 않는다")
+    void createOpening_returningWithoutNickname_fallsBackToIntroduction() {
+        ReflectionTestUtils.setField(user, "nickname", null);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("난 미오야");
+        assertThat(response.content()).doesNotContain("{nickname}");
+        // 닉네임이 없으면 재방문 판정 자체가 불필요하다 — 어차피 자기소개 세트다.
+        verify(sessionRepository, never()).existsByUser_IdAndIdNot(any(), any());
+    }
+
+    @Test
+    @DisplayName("닉네임이 가입 계약(2~13자)을 벗어나면 자기소개 세트를 쓴다")
+    void createOpening_nicknameOutOfContract_fallsBackToIntroduction() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        for (String invalid : List.of("가", "   ", "가나다라마바사아자차카타파하")) {
+            ReflectionTestUtils.setField(user, "nickname", invalid);
+
+            InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+            assertThat(response.content())
+                    .as("닉네임 '%s' 는 문장에 넣지 않아야 한다", invalid)
+                    .contains("난 미오야");
+        }
+    }
+
+    @Test
+    @DisplayName("재방문 판정 조회가 실패하면 자기소개로 폴백한다")
+    void createOpening_audienceLookupFails_fallsBackToIntroduction() {
+        when(sessionRepository.existsByUser_IdAndIdNot(userId, session.getId()))
+                .thenThrow(new IllegalStateException("db down"));
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).contains("난 미오야");
+    }
+
+    @Test
+    @DisplayName("직전에 쓴 문구는 다시 선택하지 않는다")
+    void createOpening_neverRepeatsPreviousVariant() {
+        OpeningMessage previous = OpeningMessageCatalog
+                .messagesFor("mio", OpeningAudience.FIRST_SESSION).get(0);
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of(previous.variant()));
+
+        // 무작위 선택이므로 반복 실행해 확률적 회귀까지 잡는다.
+        for (int i = 0; i < 50; i++) {
+            InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+            assertThat(response.content()).isNotEqualTo(previous.content());
+        }
+    }
+
+    @Test
+    @DisplayName("직전 문구 조회가 실패해도 인사는 생성된다")
+    void createOpening_lookupFails_stillCreatesOpening() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenThrow(new IllegalStateException("db down"));
+
+        InitialAssistantMessageResponse response = sessionOpeningService.createOpening(session, user);
+
+        assertThat(response.content()).isNotBlank();
+        verify(messageRepository).save(any());
+    }
+
+    @Test
+    @DisplayName("직전 문구 조회는 최신 1건만 읽는다")
+    void createOpening_readsOnlyLatestVariant() {
+        when(messageRepository.findRecentOpeningVariants(eq(userId), eq(MessageKind.SESSION_OPENING), any()))
+                .thenReturn(List.of());
+
+        sessionOpeningService.createOpening(session, user);
+
+        ArgumentCaptor<Pageable> captor = ArgumentCaptor.forClass(Pageable.class);
+        verify(messageRepository).findRecentOpeningVariants(
+                eq(userId), eq(MessageKind.SESSION_OPENING), captor.capture());
+        assertThat(captor.getValue().getPageSize()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("저장된 인사를 복호화해 반환한다")
+    void findOpening_returnsStoredOpening() {
+        UUID sessionId = session.getId();
+        String content = "안녕! 나 미오야 🐧 오늘 어떤 하루를 보냈어?";
+        Message stored = openingMessage(content);
+        when(messageRepository.findBySession_IdAndMessageKind(sessionId, MessageKind.SESSION_OPENING))
+                .thenReturn(Optional.of(stored));
+        when(messageEncryptor.decrypt(any())).thenReturn(content.getBytes(StandardCharsets.UTF_8));
+
+        Optional<InitialAssistantMessageResponse> response = sessionOpeningService.findOpening(sessionId);
+
+        assertThat(response).isPresent();
+        assertThat(response.get().content()).isEqualTo(content);
+        assertThat(response.get().messageId()).isEqualTo(stored.getId());
+        verify(messageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("인사가 없는 기존 세션은 빈 값을 돌려주고 새로 만들지 않는다")
+    void findOpening_missing_returnsEmptyWithoutCreating() {
+        UUID sessionId = session.getId();
+        when(messageRepository.findBySession_IdAndMessageKind(sessionId, MessageKind.SESSION_OPENING))
+                .thenReturn(Optional.empty());
+
+        assertThat(sessionOpeningService.findOpening(sessionId)).isEmpty();
+        verify(messageRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("복호화가 실패하면 인사를 생략하고 예외를 전파하지 않는다")
+    void findOpening_decryptFails_returnsEmpty() {
+        UUID sessionId = session.getId();
+        when(messageRepository.findBySession_IdAndMessageKind(sessionId, MessageKind.SESSION_OPENING))
+                .thenReturn(Optional.of(openingMessage("whatever")));
+        when(messageEncryptor.decrypt(any())).thenThrow(new IllegalStateException("bad dek"));
+
+        assertThat(sessionOpeningService.findOpening(sessionId)).isEmpty();
+    }
+
+    private Message openingMessage(String content) {
+        Message message = Message.builder()
+                .session(session)
+                .user(user)
+                .role(MessageRole.ASSISTANT)
+                .messageKind(MessageKind.SESSION_OPENING)
+                .openingVariant("mio_01")
+                .contentCiphertext(content.getBytes(StandardCharsets.UTF_8))
+                .contentDekId("dek-1")
+                .isCrisisFlagged(false)
+                .build();
+        ReflectionTestUtils.setField(message, "id", UUID.randomUUID());
+        return message;
+    }
+}

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -75,7 +75,7 @@ class SessionServiceTest {
 
     private final InitialAssistantMessageResponse openingResponse = new InitialAssistantMessageResponse(
             UUID.randomUUID(), "assistant", "session_opening",
-            "안녕! 나 미오야 🐧 오늘 어떤 하루를 보냈어?",
+            "안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?",
             OffsetDateTime.now(ZoneOffset.UTC));
 
     @BeforeEach
@@ -110,7 +110,7 @@ class SessionServiceTest {
                 .user(mockUser)
                 .characterId("mio")
                 .build();
-        when(sessionRepository.save(any())).thenReturn(session);
+        when(sessionRepository.saveAndFlush(any())).thenReturn(session);
 
         SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest("mio"));
 
@@ -127,7 +127,7 @@ class SessionServiceTest {
                 .user(mockUser)
                 .characterId("mio")
                 .build();
-        when(sessionRepository.save(any())).thenReturn(session);
+        when(sessionRepository.saveAndFlush(any())).thenReturn(session);
 
         SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest(null));
 
@@ -167,7 +167,7 @@ class SessionServiceTest {
     void createSession_uniqueViolation_throwsBusinessException() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
-        when(sessionRepository.save(any()))
+        when(sessionRepository.saveAndFlush(any()))
                 .thenThrow(new DataIntegrityViolationException("save failed", new RuntimeException("uq_sessions_one_active_per_user")));
 
         assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
@@ -181,7 +181,7 @@ class SessionServiceTest {
     void createSession_otherIntegrityViolation_propagates() {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
-        when(sessionRepository.save(any()))
+        when(sessionRepository.saveAndFlush(any()))
                 .thenThrow(new DataIntegrityViolationException("save failed", new RuntimeException("other_constraint")));
 
         assertThatThrownBy(() -> sessionService.createSession(userId, new CreateSessionRequest("mio")))
@@ -224,7 +224,7 @@ class SessionServiceTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
         when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
         Session session = Session.builder().user(mockUser).characterId("mio").build();
-        when(sessionRepository.save(any())).thenReturn(session);
+        when(sessionRepository.saveAndFlush(any())).thenReturn(session);
 
         SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest("mio"));
 
@@ -239,7 +239,7 @@ class SessionServiceTest {
         when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
         Session session = Session.builder().user(mockUser).characterId("mio").build();
         ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
-        when(sessionRepository.save(any())).thenReturn(session);
+        when(sessionRepository.saveAndFlush(any())).thenReturn(session);
 
         sessionService.createSession(userId, new CreateSessionRequest("mio"));
 
@@ -253,7 +253,7 @@ class SessionServiceTest {
         when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
         Session session = Session.builder().user(mockUser).characterId("mio").build();
         ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
-        when(sessionRepository.save(any())).thenReturn(session);
+        when(sessionRepository.saveAndFlush(any())).thenReturn(session);
         doThrow(new IllegalStateException("redis down"))
                 .when(workingMemory).appendMessage(any(), anyString(), anyString());
 

--- a/src/test/java/com/mio/session/service/SessionServiceTest.java
+++ b/src/test/java/com/mio/session/service/SessionServiceTest.java
@@ -14,6 +14,7 @@ import com.mio.session.dto.ActiveSessionResponse;
 import com.mio.session.dto.CreateSessionRequest;
 import com.mio.session.dto.EmotionScoreRequest;
 import com.mio.session.dto.EmotionScoreResponse;
+import com.mio.session.dto.InitialAssistantMessageResponse;
 import com.mio.session.dto.SendMessageRequest;
 import com.mio.session.dto.SessionResponse;
 import com.mio.session.repository.SessionRepository;
@@ -66,10 +67,16 @@ class SessionServiceTest {
     @Mock private StringRedisTemplate redisTemplate;
     @Mock private SessionMessageLock sessionMessageLock;
     @Mock private ValueOperations<String, String> valueOps;
+    @Mock private SessionOpeningService sessionOpeningService;
 
     private SessionService sessionService;
     private UUID userId;
     private User mockUser;
+
+    private final InitialAssistantMessageResponse openingResponse = new InitialAssistantMessageResponse(
+            UUID.randomUUID(), "assistant", "session_opening",
+            "안녕! 나 미오야 🐧 오늘 어떤 하루를 보냈어?",
+            OffsetDateTime.now(ZoneOffset.UTC));
 
     @BeforeEach
     void setUp() {
@@ -77,8 +84,13 @@ class SessionServiceTest {
         sessionService = new SessionService(
                 sessionRepository, sessionSummaryRepository, behaviorTaskRepository, userRepository,
                 sessionMessagePersistenceService, conversationOrchestrator, sessionMessageLock,
-                workingMemory, eventPublisher, contextPreWarmer, redisTemplate
+                workingMemory, eventPublisher, contextPreWarmer, redisTemplate, sessionOpeningService
         );
+        // 선제 인사는 세션 생성 경로의 일부다 (이슈 #530). 스텁이 없으면 null 이 흘러
+        // 오프닝 적재에서 NPE 가 나므로, 실제 계약대로 응답 객체를 돌려준다.
+        lenient().when(sessionOpeningService.createOpening(any(), any())).thenReturn(openingResponse);
+        lenient().when(sessionOpeningService.findOpening(any())).thenReturn(Optional.empty());
+
         userId = UUID.randomUUID();
         mockUser = User.builder()
                 .socialProvider("kakao")
@@ -204,6 +216,83 @@ class SessionServiceTest {
 
         assertThat(response.characterId()).isEqualTo("mio");
         assertThat(response.status()).isEqualTo("active");
+    }
+
+    @Test
+    @DisplayName("세션 생성 응답에 선제 인사가 포함된다")
+    void createSession_includesInitialMessage() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        when(sessionRepository.save(any())).thenReturn(session);
+
+        SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest("mio"));
+
+        assertThat(response.initialMessage()).isEqualTo(openingResponse);
+        verify(sessionOpeningService).createOpening(session, mockUser);
+    }
+
+    @Test
+    @DisplayName("선제 인사는 커밋 후 WorkingMemory에 적재된다 — 첫 턴 history 앞에 놓기 위해")
+    void createSession_appendsOpeningToWorkingMemory() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+        when(sessionRepository.save(any())).thenReturn(session);
+
+        sessionService.createSession(userId, new CreateSessionRequest("mio"));
+
+        verify(workingMemory).appendMessage(session.getId(), "assistant", openingResponse.content());
+    }
+
+    @Test
+    @DisplayName("WorkingMemory 적재가 실패해도 세션 생성은 성공한다")
+    void createSession_workingMemoryFails_stillReturnsSession() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        when(sessionRepository.existsByUser_IdAndStatus(userId, SessionStatus.ACTIVE)).thenReturn(false);
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+        when(sessionRepository.save(any())).thenReturn(session);
+        doThrow(new IllegalStateException("redis down"))
+                .when(workingMemory).appendMessage(any(), anyString(), anyString());
+
+        SessionResponse response = sessionService.createSession(userId, new CreateSessionRequest("mio"));
+
+        assertThat(response.initialMessage()).isEqualTo(openingResponse);
+    }
+
+    @Test
+    @DisplayName("활성 세션 재진입은 저장된 인사를 그대로 반환한다 — 새로 만들지 않는다")
+    void getActiveSession_returnsStoredOpening() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+        when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE))
+                .thenReturn(Optional.of(session));
+        when(sessionOpeningService.findOpening(session.getId())).thenReturn(Optional.of(openingResponse));
+
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+
+        assertThat(response.initialMessage()).isEqualTo(openingResponse);
+        verify(sessionOpeningService, never()).createOpening(any(), any());
+    }
+
+    @Test
+    @DisplayName("배포 이전에 열린 세션은 initial_message가 null이다 — 소급 생성하지 않는다")
+    void getActiveSession_legacySession_returnsNullInitialMessage() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(mockUser));
+        Session session = Session.builder().user(mockUser).characterId("mio").build();
+        ReflectionTestUtils.setField(session, "id", UUID.randomUUID());
+        when(sessionRepository.findByUser_IdAndStatus(userId, SessionStatus.ACTIVE))
+                .thenReturn(Optional.of(session));
+        when(sessionOpeningService.findOpening(session.getId())).thenReturn(Optional.empty());
+
+        ActiveSessionResponse response = sessionService.getActiveSession(userId);
+
+        assertThat(response.sessionId()).isEqualTo(session.getId());
+        assertThat(response.initialMessage()).isNull();
+        verify(sessionOpeningService, never()).createOpening(any(), any());
     }
 
     @Test


### PR DESCRIPTION
## 요약

채팅에 들어가면 캐릭터가 먼저 말을 걸게 한다. 지금은 `POST /v1/sessions` 가 세션과 컨텍스트
pre-warm 만 만들고 최초 assistant 메시지 계약이 없어 사용자가 빈 화면을 본다. 생성 모델 품질
문제가 아니라 세션 API 계약 누락이다.

같은 파일을 건드리므로 **세션 대화 이력 조회 API** 도 함께 넣는다. 대화 원문은 `messages` 에
전량 저장되고 있었지만 사용자용 조회 경로가 없어서, 앱을 다시 켜면 진행 중이던 대화를 화면에
되살릴 방법이 없었다. 선제 인사가 세션의 첫 메시지로 저장되면서 이 공백이 명시적으로 드러났다.

`develop` 승격을 기다리지 않고 `main` 핫픽스로 먼저 배포한다 — `develop` 에는 FE 변경이 필요한
항목이 다수 대기 중이고, 이 기능은 P0 하네스와 P1-1~P1-7 어디에도 코드 의존성이 없다
(LLM 을 호출하지 않으므로 파이프라인을 우회한다).

## 관련 이슈

- Closes #530
- Closes #531
- 원본 추적: #428 (알림 맥락형 인사는 그 이슈에 남긴다)

## 변경 사항

**선제 인사 (#530)**

- `V58_1__add_message_kind_to_messages.sql` — `message_kind` / `opening_variant` 컬럼, CHECK 3종,
  세션당 오프닝 1건 partial unique index, 직전 문구 조회 인덱스
- `MessageKind` + 컨버터, `Message` 엔티티 필드 추가
- `OpeningMessageCatalog` — 캐릭터별 인사 카피의 단일 출처. `CharacterService.GREETINGS` 이관
- `SessionOpeningService` — 모드 판정 + 로테이션 선택 + 닉네임 치환 + 저장/복구
- `SessionService.createSession()` — 세션과 오프닝을 한 트랜잭션에서 저장, 커밋 후 WorkingMemory 적재
- `SessionService.getActiveSession()` — 저장된 오프닝을 그대로 반환 (새로 만들지 않음)
- `InitialAssistantMessageResponse` 추가, `SessionResponse` / `ActiveSessionResponse` 확장
- `SessionConsolidator` — 사용자 발화 0건 세션 조기 종료
- 지표: `mio.session.opening.created{character,audience,variant}`,
  `...variant.repeat`, `...variant.lookup_failed`, `...audience.lookup_failed`

**대화 이력 조회 (#531)**

- `GET /v1/sessions/{sessionId}/messages` — 커서 페이지네이션, 오래된 순
- `SessionMessageHistoryService`, `SessionMessagesResponse`
- keyset 쿼리 2종 (`findHistoryFirstPage`, `findHistoryAfter`)

**테스트**

- `OpeningMessageCatalogTest` — 문구 30종 계약(길이·질문 수·금지 표현·슬롯 규칙·대표 문구)
- `SessionOpeningServiceTest` — 모드 판정, 닉네임 폴백, 로테이션(50회 반복), 복구, 복호화 실패
- `SessionMessageHistoryServiceTest` — 정렬·커서 연속성·권한·limit 검증·복호화 실패 처리
- `SessionServiceTest` / `SessionControllerTest` 확장
- `FlywayMigrationOrderTest` — 버전 중복 + `58 < 58.1 < 59` 고정

## 인사 문구 정책

| 모드 | 조건 | 예시 |
|---|---|---|
| 자기소개 | 이 사용자의 **첫 세션** | `안녕! 난 미오야 🐧 오늘 어떤 하루를 보냈어?` |
| 닉네임 호출 | **이전 세션 있음** + 닉네임 유효(2~13자) | `안녕 민석! 🐧 오늘 어떤 하루를 보냈어?` |

- 모드별 캐릭터당 3종, 총 30종. 직전 노출 문구를 제외한 뒤 균등 무작위 선택
- 닉네임 없음·계약 위반·판정 조회 실패 → **자기소개 세트로 폴백** (이름 없는 문장이라 안전)
- LLM 호출 0. 기억·감정·알림 맥락 반영 없음
- 기존 운영 문구의 `나 X야` → `난 X야` 어조 정정 —
  `POST /v1/user/character` 의 `greeting_message` **값도 함께 바뀐다** (필드·타입은 불변)

## 마이그레이션 번호를 `V58_1` 로 한 이유

프로덕션 `flyway_schema_history` 실측 최대 = **58**, `develop` = **76**.

| 후보 | 결과 |
|---|---|
| `V59` | `add_data_deletion_requests` 와 버전 중복 → 기동 실패 |
| `V77` | 프로덕션이 77 을 적용한 뒤 승격 시 V59~V76 이 out-of-order → 기동 실패 (`out-of-order` 기본값 false) |
| **`V58_1`** | `58 < 58.1 < 59` → 플래그 없이 양쪽 순서대로 적용 |

## 영향 범위

- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [x] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

안전 판정 경로는 건드리지 않는다. 선제 인사는 LLM·판정기를 호출하지 않고 검수된 고정 문구를
저장하는 경로이며, 대화 턴 처리(`POST /{id}/messages`)는 변경하지 않았다. 따라서 Crisis Eval
게이트 실행은 필요하지 않다.

**API 변경은 additive** 다. `initial_message` 는 신규 필드이고 `GET /active` 에서는 nullable —
배포 이전에 열려 있던 세션에는 오프닝을 소급 생성하지 않는다. 기존 필드 제거·타입 변경 없음.

**부수 영향으로 확인한 것**

| 지점 | 판정 |
|---|---|
| `sessions.message_count` | 오프닝이 +1 → `AllocationSensitivityCalculator` 의 배분 드라이버 값이 변한다. 배분 비교 기준선을 다시 잡아야 한다 |
| `last_message_at` | 오프닝이 생성 시각으로 채운다. `SessionTimeoutJob` 은 `lastMessageAt ?: startedAt` 기준이라 동작 변화 없음 |
| `Session.updateAvgEmotionScore` | 호출자 없는 죽은 코드 → 평균 왜곡 없음 |
| `findAvgEmotionScore` | `emotion_score IS NOT NULL` 조건 → 오프닝 제외 |
| `ConversationCheckpointService` | assistant-first 시퀀스가 처음 등장한다. 체크포인트 렌더링 회귀 확인 필요 |
| 로컬 개발 DB | V76 까지 적용된 로컬은 58.1 을 out-of-order 로 건너뛴다 → 수동 적용 또는 DB 재생성 필요. dev 서버 배포 워크플로는 아직 없고 CI 는 매번 빈 DB 라 무관 |

## 테스트

### 실행 커맨드

```bash
# 로컬 mio DB 는 V77 까지 적용돼 있어 이 브랜치(≤V58.1)와 이력이 어긋난다.
# 빈 DB 를 만들어 CI 와 같은 조건으로 돌렸다.
docker exec mio-postgres psql -U mio -d postgres -c "CREATE DATABASE mio_hf530b OWNER mio;"
SPRING_DATASOURCE_URL=jdbc:postgresql://localhost:5432/mio_hf530b ./gradlew build
```

### 확인 내용

- `./gradlew build` 통과 (빈 DB, V1 → V58.1 전량 적용)
- **프로덕션 업그레이드 경로 실증** — 이게 이 PR 의 핵심 리스크라 실제 DB 로 확인했다.
  1. 이 브랜치로 빈 DB 에 마이그레이션 → `flyway_schema_history` 에 `58` 다음 `58.1` (rank 57)
  2. 그 DB 에 `develop` 워크트리 + `V58_1` 조합으로 `SPRING_FLYWAY_VALIDATE_ON_MIGRATE=true`
     (프로덕션과 동일 설정) 로 재적용 → `58 → 58.1 → 59 → … → 76`, **68건 전부 success**
  3. `V77` 을 썼다면 2번에서 out-of-order 로 기동 실패했을 경로다
- 프로덕션 실측: `messages` 144행 / 144 kB → 컬럼 추가·인덱스 생성 락 영향 없음
  (`CONCURRENTLY` 불필요)
- 로테이션은 무작위 선택이라 50회 반복 루프로 "직전 문구가 절대 재선택되지 않음" 을 고정
- 수동 검증은 하지 않았다. 로컬 앱 기동으로 실제 응답을 확인하려면 별도 DB 준비가 필요해
  계약 테스트로 대체했다

## 중점 리뷰 포인트

1. **`V58_1` 번호 선택** — 위 표의 판단이 맞는지. 이 결정이 틀리면 다음 `develop → main` 승격에서
   프로덕션 기동이 막힌다
2. **`SessionConsolidator` 게이트 위치** — `conversationText.isBlank()` 앞에 `hasUserMessage()` 를
   두었다. 오프닝만 있는 세션에서 요약·Todo LLM 이 호출되지 않는지
3. **트랜잭션 경계** — 세션과 오프닝이 한 트랜잭션, WorkingMemory 적재는 `afterCommit`.
   적재 실패를 삼키는 선택이 맞는지
4. **커서 페이지네이션** — 복호화 실패 행을 커서 기준에 포함시킨 이유(무한 루프 방지)와
   `(created_at, id)` tie-break
5. **`GET /{id}/messages` 권한** — 대화 원문을 반환하는 새 경로다. 소유자 검증이 유일한 방어선
6. **문구 카피 30종** — 기획 검수 관점. 특히 재방문 문구의 어조와 닉네임 위치

## 배포 / 롤백

- **Rollout**: `main` 머지 → `cd.yml` 자동 배포. 마이그레이션은 additive 라 구 코드와 호환되므로
  배포 순서 제약 없음. 배포 직후 최대 30분간은 기존 활성 세션의 `initial_message` 가 `null`
  (소급 생성하지 않음) — FE 는 null 을 정상 상태로 처리한다
- **Rollback**: 이미지 롤백(`sha-<이전 커밋>`)만으로 충분하다. `message_kind` 는
  `DEFAULT 'conversation'` 이라 구 코드가 그대로 INSERT 해도 제약을 위반하지 않고,
  `GET /{id}/messages` 는 신규 경로라 사라져도 기존 화면에 영향이 없다. 마이그레이션 되돌림은
  필요하지 않다

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
      (로컬 `docs/` 는 Git 추적 대상이 아니므로 이 PR 에 파일로 포함되지 않는다.
      `api 명세서/04_Session_Message` 1.0 에 선제 인사·이력 조회 계약을 모두 반영했고,
      v1.1 명세·FE 가이드의 이력 조회 반영은 머지 후 진행한다)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [ ] (hotfix 인 경우) 같은 수정을 develop 에도 반영했습니다 — 누락 시 다음 dev 배포에서 버그가 재발합니다.

> 마지막 항목은 **머지 직후** 별도 PR 로 처리한다(머지 전에는 cherry-pick 대상 커밋이 확정되지
> 않는다). 그때 현재 `develop` 에 누락된 `main`-only 커밋 2건(#502 리포트 인지왜곡 집계)도 같이
> 반영한다. `develop` 재반영 시 `SessionConsolidator` 는 충돌이 예상된다(develop 이 +149줄
> 앞서 있음) — 가드 삽입 위치는 양 브랜치 구조가 같아 해결 가능하다. `FlywayMigrationVersionTest`
> 의 정규식도 점 버전을 인식하도록 함께 고쳐야 한다.
