### PR TITLE
hotfix: 리포트 생성 최소 체크인 조건을 완화한다 (주간 3→1, 월간 7→3)

### DIFF
--- a/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
@@ -31,7 +31,7 @@ public record MonthlyReportResponse(
 ) {
     public static MonthlyReportResponse insufficientData(LocalDate monthStart, LocalDate monthEnd, int checkinCount) {
         return new MonthlyReportResponse(null, monthStart, monthEnd, "INSUFFICIENT_DATA",
-                null, checkinCount, 7, null, null, null, null, null, null, null,
-                "아직 기록이 부족해요. 체크인을 7회 이상 완료하면 월간 리포트를 볼 수 있어요.");
+                null, checkinCount, 3, null, null, null, null, null, null, null,
+                "아직 기록이 부족해요. 체크인을 3회 이상 완료하면 월간 리포트를 볼 수 있어요.");
     }
 }

--- a/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
@@ -31,7 +31,7 @@ public record WeeklyReportResponse(
 ) {
     public static WeeklyReportResponse insufficientData(LocalDate weekStart, LocalDate weekEnd, int checkinCount) {
         return new WeeklyReportResponse(null, weekStart, weekEnd, "INSUFFICIENT_DATA",
-                null, checkinCount, 3, null, null, null, null, null, null, null,
-                "아직 기록이 부족해요. 체크인을 3회 이상 완료하면 리포트를 볼 수 있어요.");
+                null, checkinCount, 1, null, null, null, null, null, null, null,
+                "아직 기록이 부족해요. 체크인을 1회 이상 완료하면 리포트를 볼 수 있어요.");
     }
 }

--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -29,7 +29,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ReportAggregationJob {
 
-    private static final int MIN_CHECKIN_COUNT = 3;
+    private static final int MIN_CHECKIN_COUNT = 1;
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -36,8 +36,8 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ReportService {
 
-    private static final int WEEKLY_MIN_CHECKINS  = 3;
-    private static final int MONTHLY_MIN_CHECKINS = 7;
+    private static final int WEEKLY_MIN_CHECKINS  = 1;
+    private static final int MONTHLY_MIN_CHECKINS = 3;
     private static final int DAYS_MAX = 90;
 
     private static final Map<String, String> BIAS_LABELS = Map.of(


### PR DESCRIPTION
## 요약
주간 리포트는 그 주 체크인 1회, 월간 리포트는 그 달 체크인 3회만 있으면 생성되도록 문턱을 낮춥니다.

## 관련 이슈
- Closes #535

## 변경 사항
- `ReportService.WEEKLY_MIN_CHECKINS`(3→1), `MONTHLY_MIN_CHECKINS`(7→3)
- `ReportAggregationJob.MIN_CHECKIN_COUNT`(3→1) — 주간 배치가 쓰는 별도 하드코딩값. 안 고치면 실시간 조회는 새 기준(1회)으로 리포트를 보여주는데, "리포트 준비됐어요" 푸시알림(#413)은 옛 기준(3회)으로 계속 게이트되는 불일치가 생김
- `WeeklyReportResponse`/`MonthlyReportResponse`의 하드코딩된 `required_count`와 안내 메시지를 새 기준으로 동기화
- Notion `08_Report_리포트`(API 명세), `Report — 구현 문서` 이미 갱신 완료

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (INSUFFICIENT_DATA 응답의 required_count/message 값만 변경, 필드 구조는 동일)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. (`ReportAggregationJob` 문턱 변경 — 더 많은 유저가 GENERATED로 집계됨)
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava test`
### 확인 내용
- main 코드베이스 기준 컴파일 성공
- `com.mio.report.*`, `NotificationServiceTest`(위기게이트 검증) 전부 통과
- 전체 스위트 1221건 중 68건 실패했으나, 전부 `DeviceTokenIntegrityIntegrationTest`/`NotificationHistoryIntegrationTest`/`StaleSummarySweepIntegrationTest`/`TodoTimezoneIntegrationTest` — Report 도메인과 무관한 통합테스트고, 68건 전부 동일한 `DefaultCacheAwareContextLoaderDelegate` 스택트레이스(로컬 DB flyway 체크섬 드리프트로 Spring 컨텍스트 로딩 자체가 실패, 원인 1개가 캐시 공유 테스트 전체로 번진 것) — 이 변경과 무관함을 확인함
- 코드 전체 grep으로 남은 하드코딩 3/7 임계값 참조 없음을 재확인

## 중점 리뷰 포인트
- `ReportAggregationJob.MIN_CHECKIN_COUNT`도 같이 바꿔야 알림 발송 게이트와 실시간 조회 결과가 어긋나지 않음 — 이 부분 놓치기 쉬움

## 배포 / 롤백
- Rollout: 코드 배포만으로 즉시 적용, 별도 마이그레이션·피처플래그 불필요
- Rollback: 이전 이미지로 롤백하면 즉시 원복 (스키마 변경 없음)

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion 갱신 완료)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.