### PR TITLE
chore: main 의 리포트 체크인 문턱 완화 핫픽스를 develop 에 흡수한다

### DIFF
--- a/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/MonthlyReportResponse.java
@@ -33,8 +33,8 @@ public record MonthlyReportResponse(
 ) {
     public static MonthlyReportResponse insufficientData(LocalDate monthStart, LocalDate monthEnd, int checkinCount) {
         return new MonthlyReportResponse(null, monthStart, monthEnd, "INSUFFICIENT_DATA",
-                null, checkinCount, 7, null, null,
+                null, checkinCount, 3, null, null,
                 NarrativeStatus.UNAVAILABLE, null, null, null, null, null,
-                "아직 기록이 부족해요. 체크인을 7회 이상 완료하면 월간 리포트를 볼 수 있어요.");
+                "아직 기록이 부족해요. 체크인을 3회 이상 완료하면 월간 리포트를 볼 수 있어요.");
     }
 }

--- a/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
+++ b/src/main/java/com/mio/report/dto/WeeklyReportResponse.java
@@ -33,8 +33,8 @@ public record WeeklyReportResponse(
 ) {
     public static WeeklyReportResponse insufficientData(LocalDate weekStart, LocalDate weekEnd, int checkinCount) {
         return new WeeklyReportResponse(null, weekStart, weekEnd, "INSUFFICIENT_DATA",
-                null, checkinCount, 3, null, null,
+                null, checkinCount, 1, null, null,
                 NarrativeStatus.UNAVAILABLE, null, null, null, null, null,
-                "아직 기록이 부족해요. 체크인을 3회 이상 완료하면 리포트를 볼 수 있어요.");
+                "아직 기록이 부족해요. 체크인을 1회 이상 완료하면 리포트를 볼 수 있어요.");
     }
 }

--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -29,7 +29,7 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ReportAggregationJob {
 
-    private static final int MIN_CHECKIN_COUNT = 3;
+    private static final int MIN_CHECKIN_COUNT = 1;
     private static final ZoneId KST = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -40,8 +40,8 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ReportService {
 
-    private static final int WEEKLY_MIN_CHECKINS  = 3;
-    private static final int MONTHLY_MIN_CHECKINS = 7;
+    private static final int WEEKLY_MIN_CHECKINS  = 1;
+    private static final int MONTHLY_MIN_CHECKINS = 3;
     private static final int DAYS_MAX = 90;
 
     /**


### PR DESCRIPTION
## 요약
#536(main hotfix)에서 반영한 리포트 최소 체크인 문턱 완화(주간 3→1, 월간 7→3)를 develop 에도 반영합니다. 이 변경은 develop 을 거치지 않고 바로 main hotfix 로 나갔기 때문에, 브랜치 전략에 따라 develop 에 별도로 cherry-pick 합니다.

## 관련 이슈
- Closes #535

## 변경 사항
main 커밋 7766852 cherry-pick. develop 은 #419 리팩터가 반영된 최신 `ReportService`/DTO 구조라 `WeeklyReportResponse`/`MonthlyReportResponse`의 `narrative_status`(NarrativeStatus.UNAVAILABLE) 필드 자리에서만 충돌이 나서, 그 구조는 유지하고 문턱 값(1/3)과 안내 메시지만 반영하도록 직접 해결했습니다.

- `ReportService.WEEKLY_MIN_CHECKINS`(3→1), `MONTHLY_MIN_CHECKINS`(7→3) — 충돌 없이 그대로 적용됨
- `ReportAggregationJob.MIN_CHECKIN_COUNT`(3→1) — 충돌 없이 그대로 적용됨
- `WeeklyReportResponse`/`MonthlyReportResponse`의 `required_count`/안내 메시지 — 충돌 해결하며 반영

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (main과 동일)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [x] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다. (main과 동일)
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava test --tests "com.mio.report.*" --tests "com.mio.notification.service.NotificationServiceTest"`
### 확인 내용
develop 코드베이스 기준 컴파일 성공, `com.mio.report.*`(develop 전용 `ReportServiceWeeklyReadTest` 포함)·알림 게이트 테스트 전부 통과.

## 중점 리뷰 포인트
- 충돌 해결한 두 DTO 파일에서 `narrative_status` 필드 순서/값이 원래 develop 구조 그대로인지

## 배포 / 롤백
- Rollout: develop 은 dev 서버로만 자동배포, 프로덕션(main) 영향 없음(이미 #536으로 반영됨)
- Rollback: 이전 이미지로 롤백하면 즉시 원복

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다. (main #536에서 이미 신규 테스트 불필요로 판단, cherry-pick이라 동일)
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion은 #535/#536에서 이미 갱신)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.