### PR TITLE
fix: 탈퇴 30일 이내 재로그인 시 계정 복구를 지원한다

### DIFF
--- a/src/main/java/com/mio/auth/controller/AuthController.java
+++ b/src/main/java/com/mio/auth/controller/AuthController.java
@@ -27,6 +27,12 @@ public class AuthController {
         return ResponseEntity.ok(ApiResponse.ok(authService.login(request)));
     }
 
+    /** 탈퇴 30일 이내 계정 복구 확정 (이슈 #538). */
+    @PostMapping("/login/restore")
+    public ResponseEntity<ApiResponse<LoginResponse>> restoreLogin(@Valid @RequestBody LoginRequest request) {
+        return ResponseEntity.ok(ApiResponse.ok(authService.restoreAndLogin(request)));
+    }
+
     @GetMapping("/signup/status")
     public ResponseEntity<ApiResponse<SignupStatusResponse>> getSignupStatus(
             @AuthenticationPrincipal String userId) {

--- a/src/main/java/com/mio/auth/dto/LoginResponse.java
+++ b/src/main/java/com/mio/auth/dto/LoginResponse.java
@@ -4,16 +4,27 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.mio.user.domain.SignupStep;
 
+import java.time.OffsetDateTime;
+
+/**
+ * 로그인 응답. {@code status}/{@code withdrawn_at}/{@code recoverable_until}은 탈퇴 30일 이내
+ * 계정 재로그인 감지 시에만 채워진다(이슈 #538) — 이 경우 토큰류는 전부 null이므로 나머지
+ * 필드도 boxed 타입으로 바꿨다({@code @JsonInclude(NON_NULL)}이 실제로 생략하려면 primitive로는
+ * 안 된다).
+ */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record LoginResponse(
         @JsonProperty("access_token") String accessToken,
         @JsonProperty("refresh_token") String refreshToken,
-        @JsonProperty("expires_in") int expiresIn,
-        @JsonProperty("is_new_user") boolean isNewUser,
-        @JsonProperty("is_new_device") boolean isNewDevice,
+        @JsonProperty("expires_in") Integer expiresIn,
+        @JsonProperty("is_new_user") Boolean isNewUser,
+        @JsonProperty("is_new_device") Boolean isNewDevice,
         @JsonProperty("signup_step") SignupStep signupStep,
-        @JsonProperty("onboarding_step") int onboardingStep,
-        UserInfo user
+        @JsonProperty("onboarding_step") Integer onboardingStep,
+        UserInfo user,
+        String status,
+        @JsonProperty("withdrawn_at") OffsetDateTime withdrawnAt,
+        @JsonProperty("recoverable_until") OffsetDateTime recoverableUntil
 ) {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record UserInfo(
@@ -24,5 +35,11 @@ public record LoginResponse(
             @JsonProperty("is_premium") boolean isPremium,
             String status
     ) {
+    }
+
+    /** 탈퇴 30일 이내 계정 감지 — 토큰 미발급, 복구 확인 모달 트리거용 (이슈 #538). */
+    public static LoginResponse withdrawnRecoverable(OffsetDateTime withdrawnAt, OffsetDateTime recoverableUntil) {
+        return new LoginResponse(null, null, null, null, null, null, null, null,
+                "WITHDRAWN_RECOVERABLE", withdrawnAt, recoverableUntil);
     }
 }

--- a/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/mio/auth/filter/JwtAuthenticationFilter.java
@@ -32,6 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     // "METHOD URI" 형식으로 정확히 일치해야 함 — query string은 getRequestURI()에 포함되지 않아 안전
     private static final Set<String> WHITELIST = Set.of(
             "POST /v1/auth/login",
+            "POST /v1/auth/login/restore",
             "POST /v1/auth/refresh",
             "POST /v1/auth/dev/token",
             // actuator 는 관리 포트로 분리됐다. 8080 의 liveness 는 HealthController 가 담당한다.

--- a/src/main/java/com/mio/auth/service/AuthService.java
+++ b/src/main/java/com/mio/auth/service/AuthService.java
@@ -21,9 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -62,10 +65,19 @@ public class AuthService {
                     .ifPresent(u -> { throw new BusinessException(ErrorCode.PROVIDER_MISMATCH); });
         }
 
-        // 탈퇴 유저 재가입 차단 — social_id가 SHA-256으로 익명화되므로 해시 값으로 조회
-        userRepository.findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
-                .filter(u -> "DELETED".equals(u.getStatus()))
-                .ifPresent(u -> { throw new BusinessException(ErrorCode.USER_WITHDRAWN); });
+        // 탈퇴 유저 재로그인 감지 — social_id가 SHA-256으로 익명화되므로 해시 값으로 조회.
+        // 유예 기간(WITHDRAW_RETENTION_DAYS) 이내면 토큰 미발급, 복구 확인 응답만 반환한다.
+        // 지나면 하드 삭제(DataRetentionJob) 대상이라 기존과 동일하게 거절한다 (이슈 #538).
+        Optional<User> withdrawnUser = userRepository
+                .findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
+                .filter(u -> "DELETED".equals(u.getStatus()));
+        if (withdrawnUser.isPresent()) {
+            OffsetDateTime recoverableUntil = withdrawnUser.get().getDeletedAt().plusDays(WITHDRAW_RETENTION_DAYS);
+            if (OffsetDateTime.now(ZoneOffset.UTC).isBefore(recoverableUntil)) {
+                return LoginResponse.withdrawnRecoverable(withdrawnUser.get().getDeletedAt(), recoverableUntil);
+            }
+            throw new BusinessException(ErrorCode.USER_WITHDRAWN);
+        }
 
         // lambda 내에서 변경이 필요하므로 AtomicBoolean 사용 (effectively final 제약 우회)
         AtomicBoolean isNewUser = new AtomicBoolean(false);
@@ -85,23 +97,65 @@ public class AuthService {
         // 신규 유저이거나 가입 미완료 재진입이면 is_new_user = true
         boolean isNewUserResponse = isNewUser.get() || user.getSignupStep() != SignupStep.COMPLETED;
 
+        return issueLoginResponse(user, request.deviceId(), isNewUserResponse);
+    }
+
+    /**
+     * 탈퇴 30일 이내 계정 복구 (이슈 #538).
+     *
+     * <p>사용자가 {@link LoginResponse#withdrawnRecoverable} 응답을 보고 복구를 확정했을
+     * 때만 호출된다. 소셜 토큰을 다시 검증해야 하므로 {@code login()}과 동일한 요청 바디를
+     * 받는다 — provider 쪽 재검증 없이 그냥 복구시키면 남의 계정을 복구시킬 수 있다.
+     */
+    @Transactional
+    public LoginResponse restoreAndLogin(LoginRequest request) {
+        SocialAuthProvider provider = getProvider(request.provider());
+        String token = "apple".equals(request.provider()) ? request.idToken() : request.accessToken();
+        SocialUserInfo socialUser = provider.verify(token);
+
+        User user = userRepository
+                .findBySocialProviderAndSocialId(socialUser.provider(), sha256(socialUser.socialId()))
+                .filter(u -> "DELETED".equals(u.getStatus()))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_WITHDRAWN));
+
+        // 응답 시점과 확정 호출 시점 사이에 유예 기간이 지났을 수 있어 다시 확인한다.
+        OffsetDateTime recoverableUntil = user.getDeletedAt().plusDays(WITHDRAW_RETENTION_DAYS);
+        if (!OffsetDateTime.now(ZoneOffset.UTC).isBefore(recoverableUntil)) {
+            throw new BusinessException(ErrorCode.USER_WITHDRAWN);
+        }
+
+        user.restore(socialUser.socialId(), socialUser.email());
+
+        auditLogService.record(user.getId(), "USER_RESTORE", "user", user.getId().toString(), Map.of(
+                "restored_at", OffsetDateTime.now(ZoneOffset.UTC).toString()
+        ));
+
+        // 예약된 하드 삭제는 별도 스케줄 엔티티가 아니라 DataRetentionJob이 매일
+        // status=DELETED AND deleted_at < cutoff 로 스캔하는 방식이라(main 기준), status를
+        // ACTIVE/PENDING으로 되돌리는 것만으로 다음 실행부터 자동으로 대상에서 빠진다 —
+        // 별도 취소 처리가 필요 없다.
+        return issueLoginResponse(user, request.deviceId(), false);
+    }
+
+    /** 기기 UPSERT + 토큰 발급 + 응답 조립 — 일반 로그인과 탈퇴 계정 복구가 공유한다 (이슈 #538). */
+    private LoginResponse issueLoginResponse(User user, String deviceId, boolean isNewUserResponse) {
         // DB 기반 영구 기기 추적 — Redis TTL 만료로 인한 오판정 방지
         var existingDevice = userDeviceRepository
-                .findByUser_IdAndDeviceId(user.getId(), request.deviceId());
+                .findByUser_IdAndDeviceId(user.getId(), deviceId);
 
         boolean isNewDevice = existingDevice.isEmpty();
         existingDevice.ifPresentOrElse(
                 UserDevice::updateLastActiveAt,
                 () -> userDeviceRepository.save(UserDevice.builder()
                         .user(user)
-                        .deviceId(request.deviceId())
+                        .deviceId(deviceId)
                         .build())
         );
 
         String accessToken = jwtTokenService.generateAccessToken(
-                user.getId().toString(), request.deviceId(), user.isMinor(), user.isAdmin());
+                user.getId().toString(), deviceId, user.isMinor(), user.isAdmin());
         String refreshToken = refreshTokenService.issue(
-                user.getId().toString(), request.deviceId(),
+                user.getId().toString(), deviceId,
                 user.getSocialProvider(), user.getSignupStep());
 
         LoginResponse.UserInfo userInfo = null;
@@ -120,7 +174,7 @@ public class AuthService {
                 accessToken, refreshToken, JWT_EXPIRY_SECONDS,
                 isNewUserResponse, isNewDevice,
                 user.getSignupStep(), user.getOnboardingStep(),
-                userInfo
+                userInfo, null, null, null
         );
     }
 

--- a/src/main/java/com/mio/user/domain/User.java
+++ b/src/main/java/com/mio/user/domain/User.java
@@ -158,10 +158,28 @@ public class User {
 
     public void softDelete(String anonymizedSocialId) {
         this.socialId = anonymizedSocialId;
-        this.nickname = "탈퇴한 사용자";
-        this.email = null;
         this.status = "DELETED";
         this.deletedAt = OffsetDateTime.now(ZoneOffset.UTC);
+    }
+
+    /**
+     * 탈퇴 후 유예 기간(30일) 내 재로그인 시 계정을 복구한다 (이슈 #538).
+     *
+     * <p>닉네임/이메일은 {@link #softDelete}가 더 이상 지우지 않으므로 여기서 복원할 것이
+     * 없다 — {@code email}만 재로그인 시점에 소셜 provider가 새로 준 값으로 갱신한다
+     * (Apple은 최초 로그인 이후 이메일을 다시 안 줄 수 있어 null이면 기존 값을 유지한다).
+     *
+     * <p>{@code status}는 {@code signupStep}이 이미 {@code COMPLETED}였는지로 정한다 — 가입을
+     * 끝내지 못한 채 탈퇴한 계정을 무조건 ACTIVE로 복구하면, ACTIVE는 곧 가입 완료라는
+     * {@link #finalizeSignup} 쪽의 불변식이 깨진다.
+     */
+    public void restore(String originalSocialId, String email) {
+        this.socialId = originalSocialId;
+        this.status = this.signupStep == SignupStep.COMPLETED ? "ACTIVE" : "PENDING";
+        this.deletedAt = null;
+        if (email != null) {
+            this.email = email;
+        }
     }
 
     @PrePersist

--- a/src/main/java/com/mio/user/repository/UserRepository.java
+++ b/src/main/java/com/mio/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.mio.user.repository;
 
 import com.mio.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -12,11 +14,25 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findBySocialProviderAndSocialId(String socialProvider, String socialId);
 
-    Optional<User> findByEmailAndSocialProviderNot(String email, String socialProvider);
+    /**
+     * 이슈 #538 — 탈퇴 계정은 더 이상 이메일을 지우지 않으므로(30일 복구 지원), 탈퇴
+     * 계정의 이메일 때문에 새 가입자가 엉뚱하게 PROVIDER_MISMATCH로 막히지 않도록
+     * status=DELETED는 이 검사에서 제외한다.
+     */
+    @Query("SELECT u FROM User u WHERE u.email = :email AND u.socialProvider <> :socialProvider "
+            + "AND u.status <> 'DELETED'")
+    Optional<User> findByEmailAndSocialProviderNot(@Param("email") String email,
+                                                    @Param("socialProvider") String socialProvider);
 
-    boolean existsByNickname(String nickname);
+    /** 이슈 #538 — 탈퇴 계정의 닉네임이 다른 사용자를 영구히 막지 않도록 제외 (이유는 위와 동일). */
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
+            + "WHERE u.nickname = :nickname AND u.status <> 'DELETED'")
+    boolean existsByNickname(@Param("nickname") String nickname);
 
-    boolean existsByNicknameAndIdNot(String nickname, UUID id);
+    /** 이슈 #538 — 위와 동일한 이유로 탈퇴 계정 제외 (마이페이지 닉네임 변경용). */
+    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
+            + "WHERE u.nickname = :nickname AND u.id <> :id AND u.status <> 'DELETED'")
+    boolean existsByNicknameAndIdNot(@Param("nickname") String nickname, @Param("id") UUID id);
 
     List<User> findAllByStatusAndDeletedAtBefore(String status, OffsetDateTime cutoff);
 }

--- a/src/main/java/com/mio/user/repository/UserRepository.java
+++ b/src/main/java/com/mio/user/repository/UserRepository.java
@@ -2,8 +2,6 @@ package com.mio.user.repository;
 
 import com.mio.user.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -14,25 +12,11 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findBySocialProviderAndSocialId(String socialProvider, String socialId);
 
-    /**
-     * 이슈 #538 — 탈퇴 계정은 더 이상 이메일을 지우지 않으므로(30일 복구 지원), 탈퇴
-     * 계정의 이메일 때문에 새 가입자가 엉뚱하게 PROVIDER_MISMATCH로 막히지 않도록
-     * status=DELETED는 이 검사에서 제외한다.
-     */
-    @Query("SELECT u FROM User u WHERE u.email = :email AND u.socialProvider <> :socialProvider "
-            + "AND u.status <> 'DELETED'")
-    Optional<User> findByEmailAndSocialProviderNot(@Param("email") String email,
-                                                    @Param("socialProvider") String socialProvider);
+    Optional<User> findByEmailAndSocialProviderNot(String email, String socialProvider);
 
-    /** 이슈 #538 — 탈퇴 계정의 닉네임이 다른 사용자를 영구히 막지 않도록 제외 (이유는 위와 동일). */
-    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
-            + "WHERE u.nickname = :nickname AND u.status <> 'DELETED'")
-    boolean existsByNickname(@Param("nickname") String nickname);
+    boolean existsByNickname(String nickname);
 
-    /** 이슈 #538 — 위와 동일한 이유로 탈퇴 계정 제외 (마이페이지 닉네임 변경용). */
-    @Query("SELECT CASE WHEN COUNT(u) > 0 THEN true ELSE false END FROM User u "
-            + "WHERE u.nickname = :nickname AND u.id <> :id AND u.status <> 'DELETED'")
-    boolean existsByNicknameAndIdNot(@Param("nickname") String nickname, @Param("id") UUID id);
+    boolean existsByNicknameAndIdNot(String nickname, UUID id);
 
     List<User> findAllByStatusAndDeletedAtBefore(String status, OffsetDateTime cutoff);
 }

--- a/src/test/java/com/mio/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/mio/auth/service/AuthServiceTest.java
@@ -348,8 +348,22 @@ class AuthServiceTest {
         verify(userDeviceRepository).deleteAllByUser_Id(USER_ID);
         assertThat(user.getStatus()).isEqualTo("DELETED");
         assertThat(user.getSocialId()).isNotEqualTo("original-social-id"); // SHA-256 해시로 대체
-        assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자");
-        assertThat(user.getEmail()).isNull();
+    }
+
+    @Test
+    @DisplayName("회원탈퇴 시 닉네임/이메일은 지우지 않는다 — 30일 이내 계정 복구를 지원하기 위해서다 (이슈 #538)")
+    void withdraw_doesNotEraseNicknameOrEmail() {
+        User user = User.builder()
+                .id(USER_ID).socialProvider("kakao").socialId("original-social-id")
+                .email("user@test.com").nickname("원래닉네임")
+                .privacyConsent(true).signupStep(SignupStep.COMPLETED).status("ACTIVE")
+                .build();
+        when(userRepository.findById(USER_ID)).thenReturn(Optional.of(user));
+
+        authService.withdraw(USER_ID);
+
+        assertThat(user.getNickname()).isEqualTo("원래닉네임");
+        assertThat(user.getEmail()).isEqualTo("user@test.com");
     }
 
     @Test
@@ -383,7 +397,99 @@ class AuthServiceTest {
         verify(deviceTokenRepository, never()).saveAll(any());
     }
 
+    // ──────────────── 탈퇴 계정 복구 (이슈 #538) ────────────────
+
+    @Test
+    @DisplayName("탈퇴 30일 이내 동일 소셜 계정으로 로그인하면 토큰 없이 WITHDRAWN_RECOVERABLE을 반환한다")
+    void login_withdrawnWithinWindow_returnsRecoverableWithoutTokens() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "user@test.com", "kakao");
+        User withdrawnUser = buildUser(USER_ID, "kakao", "hashed-social-id", SignupStep.COMPLETED, "DELETED");
+        withdrawnUser.softDelete("hashed-social-id");
+        // softDelete()가 deletedAt을 now()로 찍으므로 10일 전으로 되돌려 "30일 이내"를 만든다.
+        setDeletedAt(withdrawnUser, java.time.OffsetDateTime.now().minusDays(10));
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findByEmailAndSocialProviderNot(any(), any())).thenReturn(Optional.empty());
+        when(userRepository.findBySocialProviderAndSocialId(eq("kakao"), anyString()))
+                .thenReturn(Optional.of(withdrawnUser));
+
+        LoginResponse response = authService.login(new LoginRequest("kakao", null, "access-token", DEVICE_ID));
+
+        assertThat(response.status()).isEqualTo("WITHDRAWN_RECOVERABLE");
+        assertThat(response.accessToken()).isNull();
+        assertThat(response.refreshToken()).isNull();
+        assertThat(response.recoverableUntil()).isNotNull();
+        verify(jwtTokenService, never()).generateAccessToken(any(), any(), anyBoolean(), anyBoolean());
+    }
+
+    @Test
+    @DisplayName("탈퇴 30일이 지난 계정으로 로그인하면 기존과 동일하게 USER_WITHDRAWN을 던진다")
+    void login_withdrawnPastWindow_throwsUserWithdrawn() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "user@test.com", "kakao");
+        User withdrawnUser = buildUser(USER_ID, "kakao", "hashed-social-id", SignupStep.COMPLETED, "DELETED");
+        withdrawnUser.softDelete("hashed-social-id");
+        setDeletedAt(withdrawnUser, java.time.OffsetDateTime.now().minusDays(31));
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findByEmailAndSocialProviderNot(any(), any())).thenReturn(Optional.empty());
+        when(userRepository.findBySocialProviderAndSocialId(eq("kakao"), anyString()))
+                .thenReturn(Optional.of(withdrawnUser));
+
+        assertThatThrownBy(() -> authService.login(new LoginRequest("kakao", null, "access-token", DEVICE_ID)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_WITHDRAWN);
+    }
+
+    @Test
+    @DisplayName("복구를 확정하면 계정이 ACTIVE로 돌아오고 정상 로그인 응답을 받는다")
+    void restoreAndLogin_withinWindow_restoresAndLogsIn() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "new@test.com", "kakao");
+        User withdrawnUser = buildUser(USER_ID, "kakao", "hashed-social-id", SignupStep.COMPLETED, "DELETED");
+        withdrawnUser.softDelete("hashed-social-id");
+        setDeletedAt(withdrawnUser, java.time.OffsetDateTime.now().minusDays(10));
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findBySocialProviderAndSocialId(eq("kakao"), anyString()))
+                .thenReturn(Optional.of(withdrawnUser));
+        when(userDeviceRepository.findByUser_IdAndDeviceId(any(), any())).thenReturn(Optional.empty());
+        when(jwtTokenService.generateAccessToken(any(), any(), anyBoolean(), anyBoolean())).thenReturn("access-token");
+        when(refreshTokenService.issue(any(), any(), any(), any())).thenReturn("mio_refresh_xxx");
+
+        LoginResponse response = authService.restoreAndLogin(
+                new LoginRequest("kakao", null, "access-token", DEVICE_ID));
+
+        assertThat(withdrawnUser.getStatus()).isEqualTo("ACTIVE");
+        assertThat(withdrawnUser.getSocialId()).isEqualTo("social-123");
+        assertThat(withdrawnUser.getDeletedAt()).isNull();
+        assertThat(response.status()).isNull();
+        assertThat(response.accessToken()).isNotNull();
+        assertThat(response.isNewUser()).isFalse();
+    }
+
+    @Test
+    @DisplayName("복구 확정 시점에 30일이 이미 지났으면 USER_WITHDRAWN을 던진다")
+    void restoreAndLogin_pastWindow_throwsUserWithdrawn() {
+        SocialUserInfo socialUser = new SocialUserInfo("social-123", "user@test.com", "kakao");
+        User withdrawnUser = buildUser(USER_ID, "kakao", "hashed-social-id", SignupStep.COMPLETED, "DELETED");
+        withdrawnUser.softDelete("hashed-social-id");
+        setDeletedAt(withdrawnUser, java.time.OffsetDateTime.now().minusDays(31));
+
+        when(kakaoProvider.verify(any())).thenReturn(socialUser);
+        when(userRepository.findBySocialProviderAndSocialId(eq("kakao"), anyString()))
+                .thenReturn(Optional.of(withdrawnUser));
+
+        assertThatThrownBy(() -> authService.restoreAndLogin(
+                new LoginRequest("kakao", null, "access-token", DEVICE_ID)))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.USER_WITHDRAWN);
+    }
+
     // ──────────────── helpers ────────────────
+
+    /** softDelete()가 찍는 now() 대신 테스트용 시각을 강제로 넣는다 — 도메인에 setter가 없다. */
+    private void setDeletedAt(User user, java.time.OffsetDateTime deletedAt) {
+        org.springframework.test.util.ReflectionTestUtils.setField(user, "deletedAt", deletedAt);
+    }
 
     private DeviceToken buildDeviceToken(User user, String deviceId, String platform, String token) {
         return DeviceToken.builder()

--- a/src/test/java/com/mio/user/domain/UserTest.java
+++ b/src/test/java/com/mio/user/domain/UserTest.java
@@ -58,8 +58,75 @@ class UserTest {
         assertThat(user.getStatus()).isEqualTo("DELETED");
         assertThat(user.getDeletedAt()).isNotNull();
         assertThat(user.getDeletedAt().getOffset()).isEqualTo(ZoneOffset.UTC);
-        assertThat(user.getEmail()).isNull();
-        assertThat(user.getNickname()).isEqualTo("탈퇴한 사용자");
         assertThat(user.getSocialId()).isEqualTo("anonymized-social-id");
+    }
+
+    @Test
+    @DisplayName("softDelete는 닉네임/이메일을 지우지 않는다 (이슈 #538: 30일 내 복구 대비)")
+    void softDelete_doesNotEraseNicknameOrEmail() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .email("test@example.com")
+                .nickname("닉네임")
+                .privacyConsent(true)
+                .build();
+
+        user.softDelete("anonymized-social-id");
+
+        assertThat(user.getEmail()).isEqualTo("test@example.com");
+        assertThat(user.getNickname()).isEqualTo("닉네임");
+    }
+
+    @Test
+    @DisplayName("restore는 탈퇴 이전 socialId를 복원하고 deletedAt을 지운다 (이슈 #538)")
+    void restore_completedSignup_restoresToActive() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .email("test@example.com")
+                .nickname("닉네임")
+                .privacyConsent(true)
+                .build();
+        user.finalizeSignup();
+        user.softDelete("anonymized-social-id");
+
+        user.restore("social-id", "new@example.com");
+
+        assertThat(user.getStatus()).isEqualTo("ACTIVE");
+        assertThat(user.getSocialId()).isEqualTo("social-id");
+        assertThat(user.getDeletedAt()).isNull();
+        assertThat(user.getEmail()).isEqualTo("new@example.com");
+    }
+
+    @Test
+    @DisplayName("restore는 가입을 끝내지 못하고 탈퇴한 계정을 ACTIVE가 아닌 PENDING으로 되돌린다 (이슈 #538)")
+    void restore_incompleteSignup_restoresToPending() {
+        User user = User.builder()
+                .socialProvider("kakao")
+                .socialId("social-id")
+                .privacyConsent(true)
+                .build();
+        user.softDelete("anonymized-social-id");
+
+        user.restore("social-id", null);
+
+        assertThat(user.getStatus()).isEqualTo("PENDING");
+    }
+
+    @Test
+    @DisplayName("restore는 email이 null이면 기존 이메일을 유지한다 (Apple 재동의 미제공 케이스, 이슈 #538)")
+    void restore_nullEmail_keepsExistingEmail() {
+        User user = User.builder()
+                .socialProvider("apple")
+                .socialId("social-id")
+                .email("original@example.com")
+                .privacyConsent(true)
+                .build();
+        user.softDelete("anonymized-social-id");
+
+        user.restore("social-id", null);
+
+        assertThat(user.getEmail()).isEqualTo("original@example.com");
     }
 }


### PR DESCRIPTION
## 요약
탈퇴 후 30일 유예 기간 이내에 동일 소셜 계정으로 재로그인하면, 무조건 신규/거절 처리하던 것을 프론트가 "복구하시겠습니까?" 확인을 받을 수 있도록 변경한다. 승인 시 원래 계정(닉네임·이메일 포함)을 그대로 복구한다.

## 관련 이슈
- Closes #538

## 변경 사항
- `POST /v1/auth/login`: 탈퇴 30일 이내 계정으로 재로그인 시, 토큰 없이 `status: "WITHDRAWN_RECOVERABLE"` + `withdrawn_at` + `recoverable_until`만 반환 (30일 경과 시 기존과 동일하게 410 GONE)
- `POST /v1/auth/login/restore` 신규: 복구 확정 시 소셜 토큰 재검증 후 계정 복구 + 정상 로그인 응답 발급
- `User.softDelete()`가 더 이상 닉네임/이메일을 지우지 않음 — 복구 시 원래 값 유지 (이메일만 재로그인 시점 소셜 provider 값으로 갱신, 없으면 기존 값 유지)
- `User.restore()` 신규 — `signup_step`이 `COMPLETED`였는지에 따라 `ACTIVE`/`PENDING`으로 복구
- `JwtAuthenticationFilter` 화이트리스트에 `/v1/auth/login/restore` 추가 (`SecurityConfig.PUBLIC_ENDPOINTS`는 `/v1/auth/**` 와일드카드라 별도 수정 불필요)
- `UserRepository`의 `existsByNickname`/`existsByNicknameAndIdNot`/`findByEmailAndSocialProviderNot`은 **손대지 않음** (원래 derived query 그대로) — 탈퇴 계정도 계속 중복 검사에 걸려야, 유예 기간 중 남이 그 닉네임/이메일을 선점해서 복구 시 충돌나는 걸 막을 수 있음. 최대 30일 뒤 `DataRetentionJob`이 row를 하드 삭제하면 자연스럽게 풀리므로 별도 예외 처리가 필요 없음 (자체 리뷰 중 반대로 갔다가 되돌림, 아래 "중점 리뷰 포인트" 참고)

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava` / `./gradlew test --tests "com.mio.auth.service.AuthServiceTest"` / `./gradlew test --tests "com.mio.user.domain.UserTest"` / `./gradlew test` (전체 스위트)
### 확인 내용
- `AuthServiceTest` 25/25 통과 (신규 4건 포함: 30일 이내/경과 재로그인, 복구 성공, 복구 확정 시점 유예 마감)
- `UserTest`에 `softDelete` 닉네임/이메일 보존 + `restore()` 3건(정상 복구/미완료 가입 PENDING 복구/이메일 null 시 기존값 유지) 신규 추가, 전부 통과
- 전체 스위트 재실행 결과 68개 실패는 전부 로컬 환경 문제(`DefaultCacheAwareContextLoaderDelegate`/Flyway 스키마 drift, `@SpringBootTest` 통합테스트만 영향, 유닛테스트는 전원 통과) — 이번 변경과 무관, 세션 내내 반복 확인된 기존 이슈
- diff 범위 전수조사로 닉네임/이메일 null 처리 잔존 코드 없음, `WITHDRAW_RETENTION_DAYS` 중복 선언 없음 확인

## 중점 리뷰 포인트
- `restoreAndLogin()`이 소셜 토큰을 재검증하는지(타인 계정 복구 방지)
- `User.restore()`의 `PENDING`/`ACTIVE` 분기 조건
- (자체 리뷰로 발견·수정) 처음엔 닉네임/이메일 보존에 맞춰 `UserRepository`의 중복 검사 3개를 "탈퇴 계정 제외"로 고쳤었는데, 그러면 유예 기간 중 남이 그 닉네임/이메일을 가져갈 수 있게 되고 원래 주인이 복구할 때 충돌(중복 닉네임 등)이 생기는 걸 뒤늦게 발견. `DataRetentionJob`이 30일 뒤 어차피 하드 삭제하므로 굳이 먼저 풀어줄 필요가 없었음 — 원래 쿼리로 되돌림(`cac22a5`). 이 판단이 맞는지 한 번 더 봐주시면 좋겠습니다.

## 배포 / 롤백
- Rollout: main 머지 후 자동 배포. `develop`에는 별도 cherry-pick 필요 — develop은 main과 달리 `DataDeletionRequest`/`DeletionStatus` 인프라(#373)가 있어 그쪽엔 `CANCELLED` 상태 추가가 별도로 필요함 (이번 PR 범위 아님)
- Rollback: revert 커밋으로 원복 가능. DB 스키마 변경 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (Notion `01. Auth` v1.4.0, `Auth — 구현 문서` v1.1.0, 프론트 연동 가이드 신규)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
