### PR TITLE
fix: 리포트 평균 감정 점수를 사용자 입력값 기반으로 교체한다

### DIFF
--- a/src/main/java/com/mio/report/job/ReportAggregationJob.java
+++ b/src/main/java/com/mio/report/job/ReportAggregationJob.java
@@ -117,12 +117,20 @@ public class ReportAggregationJob {
         return count != null ? count : 0;
     }
 
+    /**
+     * CBT 개입 후 사용자가 직접 입력한 감정 점수의 평균이다 (이슈 #540).
+     *
+     * <p>{@code sessions.avg_emotion_score}는 채워주는 코드가 없어 항상 null이었고, AI가
+     * 추정하는 {@code messages.emotion_score}/{@code sessions.emotion_score_ai}는 정책상
+     * Safety/Memory 내부 신호라 사용자에게 노출할 값이 아니다 — 리포트엔 사용자가 실제로
+     * 입력한 값만 집계한다. 그 기간에 CBT 개입이 한 번도 없었으면 null.
+     */
     private Double computeAvgEmotionScore(UUID userId, OffsetDateTime from, OffsetDateTime to) {
         try {
             return jdbcTemplate.queryForObject("""
-                    SELECT AVG(avg_emotion_score) FROM sessions
-                    WHERE user_id = ? AND started_at >= ? AND started_at < ?
-                      AND avg_emotion_score IS NOT NULL
+                    SELECT AVG(emotion_score_after) FROM cbt_reconstructions
+                    WHERE user_id = ? AND created_at >= ? AND created_at < ?
+                      AND emotion_score_after IS NOT NULL
                     """,
                     Double.class, userId, from, to);
         } catch (Exception e) {

--- a/src/main/java/com/mio/report/service/ReportService.java
+++ b/src/main/java/com/mio/report/service/ReportService.java
@@ -13,7 +13,7 @@ import com.mio.report.dto.ReportCommonDto.SessionSummaryDto;
 import com.mio.report.dto.ReportCommonDto.TodoSummaryDto;
 import com.mio.report.dto.WeeklyReportResponse;
 import com.mio.session.domain.Session;
-import com.mio.session.repository.MessageRepository;
+import com.mio.session.repository.CbtReconstructionRepository;
 import com.mio.session.repository.SessionRepository;
 import com.mio.session.repository.SessionSummaryRepository;
 import com.mio.todo.domain.TaskStatus;
@@ -50,7 +50,7 @@ public class ReportService {
     );
 
     private final CheckinRepository checkinRepository;
-    private final MessageRepository messageRepository;
+    private final CbtReconstructionRepository cbtReconstructionRepository;
     private final SessionSummaryRepository sessionSummaryRepository;
     private final SessionRepository sessionRepository;
     private final BehaviorTaskRepository behaviorTaskRepository;
@@ -95,7 +95,7 @@ public class ReportService {
 
             return new ReportDbData(
                     resolvedStart, weekEnd, (int) checkinCount, false,
-                    roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
+                    roundScore(cbtReconstructionRepository.findAvgEmotionScoreAfter(userId, start, end)),
                     buildDistortionTop3(userId, start, end),
                     buildTodoSummary(userId, start, end),
                     buildSessionSummary(userId, start, end)
@@ -141,7 +141,7 @@ public class ReportService {
 
             return new ReportDbData(
                     resolvedStart, monthEnd, (int) checkinCount, false,
-                    roundScore(messageRepository.findAvgEmotionScore(userId, start, end)),
+                    roundScore(cbtReconstructionRepository.findAvgEmotionScoreAfter(userId, start, end)),
                     buildDistortionTop3(userId, start, end),
                     buildTodoSummary(userId, start, end),
                     buildSessionSummary(userId, start, end)

--- a/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
+++ b/src/main/java/com/mio/session/repository/CbtReconstructionRepository.java
@@ -11,6 +11,20 @@ import java.util.UUID;
 
 public interface CbtReconstructionRepository extends JpaRepository<CbtReconstruction, UUID> {
 
+    /**
+     * 리포트용 평균 감정 점수 (이슈 #540) — CBT 개입 후 사용자가 직접 입력한 값만 집계한다.
+     * AI 추정 신호({@code messages.emotion_score})는 Safety/Memory 내부용이라 여기 안 쓴다.
+     */
+    @Query("""
+            SELECT AVG(c.emotionScoreAfter) FROM CbtReconstruction c
+            WHERE c.user.id = :userId AND c.createdAt >= :start AND c.createdAt < :end
+              AND c.emotionScoreAfter IS NOT NULL
+            """)
+    Double findAvgEmotionScoreAfter(
+            @Param("userId") UUID userId,
+            @Param("start") OffsetDateTime start,
+            @Param("end") OffsetDateTime end);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
             UPDATE CbtReconstruction c

--- a/src/main/java/com/mio/session/repository/MessageRepository.java
+++ b/src/main/java/com/mio/session/repository/MessageRepository.java
@@ -15,11 +15,6 @@ import java.util.UUID;
 
 public interface MessageRepository extends JpaRepository<Message, UUID> {
 
-    @Query("SELECT AVG(m.emotionScore) FROM Message m WHERE m.user.id = :userId AND m.createdAt >= :start AND m.createdAt < :end AND m.emotionScore IS NOT NULL")
-    Double findAvgEmotionScore(@Param("userId") UUID userId,
-                               @Param("start") OffsetDateTime start,
-                               @Param("end") OffsetDateTime end);
-
     @Query("SELECT m FROM Message m WHERE m.session.id = :sessionId AND m.role = :role ORDER BY m.createdAt DESC")
     List<Message> findRecentBySessionAndRole(@Param("sessionId") UUID sessionId,
                                              @Param("role") MessageRole role,

--- a/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
+++ b/src/test/java/com/mio/report/job/ReportAggregationJobTest.java
@@ -102,6 +102,41 @@ class ReportAggregationJobTest {
         assertThat(captor.getValue().getWeekEnd()).isEqualTo(EXPECTED_WEEK_END);
     }
 
+    @org.junit.jupiter.api.Test
+    @DisplayName("CBT 개입 후 사용자가 입력한 감정 점수가 있으면 평균을 리포트에 채운다 (이슈 #540)")
+    void computeAvgEmotionScore_withCbtScores_fillsReportAverage() {
+        ReportAggregationJob job = jobAt(Clock.fixed(
+                OffsetDateTime.parse("2026-08-10T03:00:00+09:00").toInstant(), KST));
+        stubOneCandidateUserWithCheckins();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(any(), any())).thenReturn(Optional.empty());
+        when(jdbcTemplate.queryForObject(anyString(), eq(Double.class), any(), any(), any()))
+                .thenReturn(62.5);
+
+        job.run();
+
+        org.mockito.ArgumentCaptor<WeeklyReport> captor =
+                org.mockito.ArgumentCaptor.forClass(WeeklyReport.class);
+        verify(weeklyReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getAvgEmotionScore()).isEqualTo(62.5);
+    }
+
+    @org.junit.jupiter.api.Test
+    @DisplayName("그 주에 CBT 감정 점수 제출이 없으면 리포트 감정 점수는 null이다 (이슈 #540)")
+    void computeAvgEmotionScore_withoutCbtScores_leavesReportAverageNull() {
+        ReportAggregationJob job = jobAt(Clock.fixed(
+                OffsetDateTime.parse("2026-08-10T03:00:00+09:00").toInstant(), KST));
+        stubOneCandidateUserWithCheckins();
+        when(weeklyReportRepository.findByUser_IdAndWeekStart(any(), any())).thenReturn(Optional.empty());
+        // Double.class queryForObject 는 스텁하지 않음 — 실제로도 AVG()가 대상 row 없으면 null 반환
+
+        job.run();
+
+        org.mockito.ArgumentCaptor<WeeklyReport> captor =
+                org.mockito.ArgumentCaptor.forClass(WeeklyReport.class);
+        verify(weeklyReportRepository).save(captor.capture());
+        assertThat(captor.getValue().getAvgEmotionScore()).isNull();
+    }
+
     @SuppressWarnings("unchecked")
     private void stubOneCandidateUser() {
         when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
@@ -110,6 +145,15 @@ class ReportAggregationJobTest {
         // 체크인 수는 임계값 미만이면 INSUFFICIENT_DATA 로 바로 저장되어 흐름이 단순해진다
         when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(), any(), any()))
                 .thenReturn(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void stubOneCandidateUserWithCheckins() {
+        when(jdbcTemplate.query(anyString(), any(RowMapper.class), any(Object[].class)))
+                .thenReturn(List.of(userId));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(newUser()));
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class), any(), any(), any()))
+                .thenReturn(1);
     }
 
     private ReportAggregationJob jobAt(Clock clock) {

--- a/src/test/java/com/mio/report/service/ReportServiceTest.java
+++ b/src/test/java/com/mio/report/service/ReportServiceTest.java
@@ -1,0 +1,119 @@
+package com.mio.report.service;
+
+import com.mio.checkin.repository.CheckinRepository;
+import com.mio.report.dto.WeeklyReportResponse;
+import com.mio.session.repository.CbtReconstructionRepository;
+import com.mio.session.repository.SessionRepository;
+import com.mio.session.repository.SessionSummaryRepository;
+import com.mio.todo.repository.BehaviorTaskRepository;
+import com.mio.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.SimpleTransactionStatus;
+
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * 리포트의 평균 감정 점수 소스가 CBT 사용자 입력값인지 고정한다 (이슈 #540).
+ *
+ * <p>{@code weekly_reports.avg_emotion_score}(배치가 채우는 값)는 이 API 응답 경로에서
+ * 전혀 읽히지 않는다 — {@code GET /v1/reports/weekly}는 매 요청마다 즉석으로 재계산한다.
+ * 이전에는 여기서 {@code messages.emotion_score}(AI 내부 키워드 신호)를 읽어, 정책상
+ * 사용자에게 노출하면 안 되는 값이 그대로 나가고 있었다.
+ */
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@DisplayName("ReportService — 평균 감정 점수 소스 (#540)")
+class ReportServiceTest {
+
+    @Mock private CheckinRepository checkinRepository;
+    @Mock private CbtReconstructionRepository cbtReconstructionRepository;
+    @Mock private SessionSummaryRepository sessionSummaryRepository;
+    @Mock private SessionRepository sessionRepository;
+    @Mock private BehaviorTaskRepository behaviorTaskRepository;
+    @Mock private UserRepository userRepository;
+    @Mock private ReportNarrativeService reportNarrativeService;
+
+    private ReportService reportService;
+    private UUID userId;
+
+    @BeforeEach
+    void setUp() {
+        userId = UUID.randomUUID();
+        reportService = new ReportService(
+                checkinRepository, cbtReconstructionRepository, sessionSummaryRepository,
+                sessionRepository, behaviorTaskRepository, userRepository,
+                reportNarrativeService, directTransactionManager());
+        reportService.init();
+
+        when(userRepository.existsById(userId)).thenReturn(true);
+        when(checkinRepository.countByUser_IdAndCheckinDateBetween(any(), any(), any())).thenReturn(3L);
+        when(sessionSummaryRepository.findBiasTypeDistribution(any(), any(), any())).thenReturn(List.of());
+        when(behaviorTaskRepository.findTodoStatsByUserAndPeriod(any(), any(), any())).thenReturn(List.of());
+        when(sessionRepository.findEndedSessionsByUserAndPeriod(any(), any(), any())).thenReturn(List.of());
+        when(reportNarrativeService.generate(any(), anyInt(), any(), anyList(), any()))
+                .thenReturn(ReportNarrativeService.NarrativeResult.empty());
+    }
+
+    @Test
+    @DisplayName("CBT 사용자 입력 감정 점수 평균을 avg_emotion_score로 반환한다")
+    void getWeeklyReport_usesCbtEmotionScoreAfterAverage() {
+        when(cbtReconstructionRepository.findAvgEmotionScoreAfter(eq(userId), any(), any()))
+                .thenReturn(62.5);
+
+        WeeklyReportResponse response = reportService.getWeeklyReport(userId, LocalDate.of(2026, 8, 10));
+
+        assertThat(response.avgEmotionScore()).isEqualTo(62.5);
+        verify(cbtReconstructionRepository).findAvgEmotionScoreAfter(eq(userId), any(OffsetDateTime.class), any(OffsetDateTime.class));
+    }
+
+    @Test
+    @DisplayName("그 주에 CBT 감정 점수 제출이 없으면 avg_emotion_score는 null이다")
+    void getWeeklyReport_withoutCbtScores_returnsNullAverage() {
+        when(cbtReconstructionRepository.findAvgEmotionScoreAfter(eq(userId), any(), any()))
+                .thenReturn(null);
+
+        WeeklyReportResponse response = reportService.getWeeklyReport(userId, LocalDate.of(2026, 8, 10));
+
+        assertThat(response.avgEmotionScore()).isNull();
+    }
+
+    private static PlatformTransactionManager directTransactionManager() {
+        return new PlatformTransactionManager() {
+            @Override
+            public TransactionStatus getTransaction(TransactionDefinition definition) {
+                return new SimpleTransactionStatus();
+            }
+
+            @Override
+            public void commit(TransactionStatus status) {
+                // no-op
+            }
+
+            @Override
+            public void rollback(TransactionStatus status) {
+                // no-op
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 요약
`GET /v1/reports/weekly`·`/monthly`가 AI 내부 신호(`messages.emotion_score`, 키워드 매칭 기반 25/45/70)를 그대로 노출하고 있었다. 정책상 사용자 보정 대상이 아닌 값이라, CBT 개입 후 사용자가 직접 입력한 점수(`cbt_reconstructions.emotion_score_after`)의 평균으로 소스를 교체한다.

## 관련 이슈
- Closes #540

## 변경 사항
- `CbtReconstructionRepository`에 `findAvgEmotionScoreAfter()` 쿼리 신규 추가
- `ReportService.getWeeklyReport()`/`getMonthlyReport()` — `messageRepository.findAvgEmotionScore()`(AI 신호) 호출을 `cbtReconstructionRepository.findAvgEmotionScoreAfter()`(사용자 입력)로 교체
- 더 이상 쓰지 않는 `MessageRepository.findAvgEmotionScore()` 삭제
- `ReportAggregationJob.computeAvgEmotionScore()`도 동일 소스로 맞춰둠 — 단, 이 배치가 쓰는 `weekly_reports` 테이블 자체를 실제 GET 응답 경로가 안 읽는다는 걸 리뷰 중 발견함(아래 참고). 정책 일관성만 맞춘 것이고 이번 PR로 그 문제를 고치진 않음
- 신규 테스트: `ReportAggregationJobTest` 2건, `ReportServiceTest` 신규 파일 2건

## 영향 범위
- [x] API 스펙 또는 응답 형식이 변경됩니다. (`avg_emotion_score` 값의 의미/출처가 바뀜 — 필드 자체는 동일, Notion `08. Report` v1.8.0 반영 완료)
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [ ] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] Breaking change 가 있습니다.

## 테스트
### 실행 커맨드
`./gradlew compileJava compileTestJava` / `./gradlew test --tests "com.mio.report.*"`
### 확인 내용
- `ReportAggregationJobTest` 6/6, `ReportServiceTest` 2/2 통과 — CBT 점수 있음/없음 케이스 둘 다 검증
- report/session/admin 패키지 전체 166개 중 163개 통과, 나머지 3개는 세션 내내 반복 확인된 기존 로컬 환경 이슈(`DefaultCacheAwareContextLoaderDelegate`)로 무관

## 중점 리뷰 포인트
- `CbtReconstructionRepository.findAvgEmotionScoreAfter()`의 `created_at` 기준 범위가 CBT 트리거 시점 기준인 게 맞는지(제출 시점이 아니라)
- 이번 수정과 별개로 발견한 것 — 리뷰 시 참고만: (1) `weekly_reports` 테이블에 값을 채우는 배치 2개(`ReportAggregationJob`, `WeeklyReflectionJob`)가 있는데 실제 `GET` 경로가 이 테이블을 전혀 안 읽음(`NotificationService`가 row 존재 여부만 확인), (2) `ReportService`가 GET 요청마다 `ReportNarrativeService.generate()`를 동기 호출해서 매번 실제 LLM 호출이 나감(스펙엔 "GET에서 LLM 호출 0회" 명시). 둘 다 이번 PR 범위 밖이라 손 안 댔고 Notion에 현재 실제 동작으로 기록만 해둠

## 배포 / 롤백
- Rollout: main 머지 후 자동 배포
- Rollback: revert 커밋으로 원복 가능. DB 스키마 변경 없음

## 체크리스트
- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다.
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.