### PR TITLE
refactor: 로거 파라미터 객체화 · 민감도 술어 통합 · 테스트 부트스트랩 정리

### DIFF
--- a/src/main/java/com/mio/ai/memory/composer/ContextSanitizer.java
+++ b/src/main/java/com/mio/ai/memory/composer/ContextSanitizer.java
@@ -1,6 +1,7 @@
 package com.mio.ai.memory.composer;
 
 import com.mio.ai.memory.retrieval.RetrievedItem;
+import com.mio.ai.memory.retrieval.SensitivityCap;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -18,11 +19,13 @@ public class ContextSanitizer {
      * 민감도 cap을 초과하는 항목 제거 후 토큰 budget 내로 자름.
      */
     public List<RetrievedItem> sanitize(List<RetrievedItem> items, String sensitivityCap) {
-        String effectiveCap = sensitivityCap != null ? sensitivityCap : "normal";
+        // cap 이 없으면 가장 좁은 등급으로 본다. SensitivityCap 은 null 을 fail-closed
+        // 로 처리하지만, 여기서는 "지정 안 함 = 기본 공개 범위"가 기존 동작이라 유지한다.
+        String effectiveCap = sensitivityCap != null ? sensitivityCap : SensitivityCap.NORMAL;
 
         List<RetrievedItem> filtered = items.stream()
                 .filter(item -> item.content() != null && !item.content().isBlank())
-                .filter(item -> isWithinCap(item.sensitivity(), effectiveCap))
+                .filter(item -> SensitivityCap.allows(effectiveCap, item.sensitivity()))
                 .collect(Collectors.toList());
 
         // 토큰 budget 초과 시 상위 항목 우선 유지
@@ -36,14 +39,4 @@ public class ContextSanitizer {
         return result;
     }
 
-    private boolean isWithinCap(String sensitivity, String cap) {
-        if (cap == null) return false;
-        // null sensitivity → "normal" 처리 (FusionRanker와 동일 정책)
-        String s = sensitivity != null ? sensitivity : "normal";
-        return switch (cap) {
-            case "restricted" -> true;
-            case "sensitive"  -> !"restricted".equals(s);
-            default           -> "normal".equals(s);
-        };
-    }
 }

--- a/src/main/java/com/mio/ai/memory/retrieval/FusionRanker.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/FusionRanker.java
@@ -28,7 +28,7 @@ public class FusionRanker {
             for (int i = 0; i < list.size(); i++) {
                 RetrievedItem item = list.get(i);
                 // 민감도 cap: restricted 이상은 제외
-                if (!isWithinCap(item.sensitivity(), sensitivityCap)) continue;
+                if (!SensitivityCap.allows(sensitivityCap, item.sensitivity())) continue;
 
                 double rrfScore = 1.0 / (RRF_K + i + 1);
                 rrfScores.merge(item.id(), rrfScore, Double::sum);
@@ -49,16 +49,5 @@ public class FusionRanker {
                 });
 
         return ranked;
-    }
-
-    private boolean isWithinCap(String sensitivity, String cap) {
-        if (cap == null) return false;
-        // null sensitivity → "normal" 처리 (ContextSanitizer와 동일 정책)
-        String s = sensitivity != null ? sensitivity : "normal";
-        return switch (cap) {
-            case "restricted" -> true;
-            case "sensitive"  -> !"restricted".equals(s);
-            default           -> "normal".equals(s);
-        };
     }
 }

--- a/src/main/java/com/mio/ai/memory/retrieval/SensitivityCap.java
+++ b/src/main/java/com/mio/ai/memory/retrieval/SensitivityCap.java
@@ -1,0 +1,45 @@
+package com.mio.ai.memory.retrieval;
+
+/**
+ * 기억 항목의 민감도가 이번 턴의 cap 안에 드는지 판정한다 (§12.4, §12.5).
+ *
+ * <p>등급은 {@code normal < sensitive < restricted} 순으로 좁아지고, cap 은 "이번 턴에
+ * 프롬프트로 내보낼 수 있는 최대 등급"이다. 값은 DB {@code CHECK (sensitivity IN (...))}
+ * 제약(V8 · V9 · V22)과 같은 문자열을 그대로 쓴다 — 저장 형식이 계약이라 enum 으로 바꾸더라도
+ * 이 리터럴은 유지돼야 한다.
+ *
+ * <p>이 판정은 검색 랭커와 컨텍스트 새니타이저 양쪽에서 쓰인다. 두 곳이 각자 복사본을 들고
+ * 있으면 한쪽만 고쳐도 컴파일과 테스트가 통과하고, 결과는 사용자가 비공개로 둔 기억이 프롬프트에
+ * 실려 나가는 <b>조용한 유출</b>이다. 호출 지점은 계층 방어를 위해 그대로 두되 판정은 여기 하나만 둔다.
+ */
+public final class SensitivityCap {
+
+    public static final String NORMAL = "normal";
+    public static final String SENSITIVE = "sensitive";
+    public static final String RESTRICTED = "restricted";
+
+    private SensitivityCap() {
+    }
+
+    /**
+     * {@code sensitivity} 등급의 항목을 {@code cap} 아래에서 내보내도 되는지 판정한다.
+     *
+     * <p>{@code cap} 이 null 이면 아무것도 통과시키지 않는다 — cap 을 모르는 상태는 "제한 없음"이
+     * 아니라 "판단 불가"이고, 그때 열어 주면 실패가 유출 방향으로 기운다. 호출부가 기본값을
+     * 원하면 넘기기 전에 스스로 정한다.
+     *
+     * <p>{@code sensitivity} 가 null 이면 {@code normal} 로 본다. 저장 시 기본값이 {@code normal}
+     * 이고, 등급이 비었다는 것은 분류되지 않았다는 뜻이지 민감하다는 뜻이 아니다.
+     *
+     * <p>모르는 cap 문자열은 가장 좁은 {@code normal} 로 해석한다. 오타가 권한 상승이 되면 안 된다.
+     */
+    public static boolean allows(String cap, String sensitivity) {
+        if (cap == null) return false;
+        String level = sensitivity != null ? sensitivity : NORMAL;
+        return switch (cap) {
+            case RESTRICTED -> true;
+            case SENSITIVE -> !RESTRICTED.equals(level);
+            default -> NORMAL.equals(level);
+        };
+    }
+}

--- a/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
+++ b/src/main/java/com/mio/ai/orchestrator/AiDecisionLogger.java
@@ -2,21 +2,17 @@ package com.mio.ai.orchestrator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.mio.ai.crisis.CrisisTrigger;
 import com.mio.ai.domain.AiPolicyDecision;
 import com.mio.ai.judge.InputJudgeResult;
 import com.mio.ai.judge.OutputJudgeResult;
 import com.mio.ai.judge.OutputPreFilterResult;
 import com.mio.ai.llm.LlmCostCalculator;
 import com.mio.ai.llm.LlmUsage;
-import com.mio.ai.memory.retrieval.MemoryContextResult;
-import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.plan.ResponseContractResult;
 import com.mio.ai.plan.ResponsePlan;
 import com.mio.ai.policy.JudgeStatus;
 import com.mio.ai.policy.PolicyDecision;
 import com.mio.ai.repository.AiPolicyDecisionRepository;
-import com.mio.ai.safety.SafetyL1Result;
 import com.mio.ai.security.SecurityAssessment;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -55,42 +51,19 @@ public class AiDecisionLogger {
     private final ObjectMapper objectMapper;
     private final LlmCostCalculator costCalculator;
 
+    /**
+     * 이 턴의 정책 결정과 관측값을 {@code ai_policy_decisions} 에 적재한다.
+     *
+     * <p>관측값은 {@link TurnObservation} 하나로 받는다. 이전에는 위치 인자 24개였고,
+     * {@code boolean}·{@code long} 이 연속으로 붙는 구간에서 순서를 바꿔도 컴파일이 통과했다.
+     *
+     * <p>적재 실패는 삼킨다 — 트레이스가 없다고 사용자 응답을 막을 이유가 없다.
+     * 다만 무엇이 실패했는지는 로그로 남긴다.
+     */
     @Async("aiDecisionLoggerExecutor")
-    public void log(
-            UUID userId,
-            UUID sessionId,
-            PolicyDecision decision,
-            ModerationResult moderation,
-            SafetyL1Result l1Result,
-            SecurityAssessment securityAssessment,
-            long totalPipelineMs,
-            long llmTtftMs,
-            boolean crisisFlowTriggered,
-            boolean inputJudgeCalled,
-            OutputGuardOutcome outputGuard,
-            String l1ThresholdSource,
-            boolean safetyProfileCacheHit,
-            MemoryCacheOutcome memoryCache,
-            boolean safetyProfileDegraded,
-            CrisisTrigger appliedCrisisTrigger,
-            LlmUsage llmUsage,
-            ResponseContractResult contractResult,
-            long firstSubstantiveTokenMs,
-            long firstRenderedTokenMs,
-            boolean safePrefixApplied,
-            int heldBackChars,
-            MemoryContextResult memoryContextResult,
-            InputJudgeResult inputJudgeResult) {
-
+    public void log(UUID userId, UUID sessionId, PolicyDecision decision, TurnObservation observation) {
         try {
-            Map<String, Object> trace = buildTrace(
-                    moderation, l1Result, securityAssessment, llmTtftMs, totalPipelineMs,
-                    crisisFlowTriggered, decision,
-                    inputJudgeCalled, outputGuard,
-                    l1ThresholdSource, safetyProfileCacheHit, memoryCache,
-                    safetyProfileDegraded, appliedCrisisTrigger, llmUsage, contractResult,
-                    firstSubstantiveTokenMs, firstRenderedTokenMs, safePrefixApplied,
-                    heldBackChars, memoryContextResult, inputJudgeResult);
+            Map<String, Object> trace = buildTrace(decision, observation);
 
             AiPolicyDecision record = AiPolicyDecision.builder()
                     .userId(userId)
@@ -118,123 +91,54 @@ public class AiDecisionLogger {
         }
     }
 
-    /** 응답 계약 도입 이전 시그니처 — 기존 호출부 호환용 (이슈 #303). */
-    public void log(
-            UUID userId,
-            UUID sessionId,
-            PolicyDecision decision,
-            ModerationResult moderation,
-            SafetyL1Result l1Result,
-            SecurityAssessment securityAssessment,
-            long totalPipelineMs,
-            long llmTtftMs,
-            boolean crisisFlowTriggered,
-            boolean inputJudgeCalled,
-            OutputGuardOutcome outputGuard,
-            String l1ThresholdSource,
-            boolean safetyProfileCacheHit,
-            boolean memoryCacheHit,
-            boolean safetyProfileDegraded,
-            CrisisTrigger appliedCrisisTrigger,
-            LlmUsage llmUsage) {
-        // 편의 오버로드는 staleness 를 받지 않는다 — 폴백 경로를 지나지 않는 호출용이다.
-        log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
-                totalPipelineMs, llmTtftMs, crisisFlowTriggered, inputJudgeCalled,
-                outputGuard, l1ThresholdSource, safetyProfileCacheHit,
-                memoryCacheHit ? MemoryCacheOutcome.fallback(null) : MemoryCacheOutcome.live(),
-                safetyProfileDegraded, appliedCrisisTrigger, llmUsage,
-                ResponseContractResult.notApplicable(), -1, -1, false, 0, null, null);
-    }
-
-    /** Phase 1 호환 오버로드 */
-    @Async("aiDecisionLoggerExecutor")
-    public void log(
-            UUID userId,
-            UUID sessionId,
-            PolicyDecision decision,
-            ModerationResult moderation,
-            SafetyL1Result l1Result,
-            SecurityAssessment securityAssessment,
-            long totalPipelineMs,
-            long llmTtftMs,
-            boolean crisisFlowTriggered) {
-        log(userId, sessionId, decision, moderation, l1Result, securityAssessment,
-                totalPipelineMs, llmTtftMs, crisisFlowTriggered,
-                false, OutputGuardOutcome.preFilterOnly(OutputPreFilterResult.pass()),
-                "default", false, MemoryCacheOutcome.live(), false, decision.crisisTrigger(), null,
-                ResponseContractResult.notApplicable(), -1, -1, false, 0, null, null);
-    }
-
-    private Map<String, Object> buildTrace(
-            ModerationResult moderation,
-            SafetyL1Result l1Result,
-            SecurityAssessment securityAssessment,
-            long ttftMs,
-            long totalMs,
-            boolean crisisFlowTriggered,
-            PolicyDecision decision,
-            boolean inputJudgeCalled,
-            OutputGuardOutcome outputGuard,
-            String l1ThresholdSource,
-            boolean safetyProfileCacheHit,
-            MemoryCacheOutcome memoryCache,
-            boolean safetyProfileDegraded,
-            CrisisTrigger appliedCrisisTrigger,
-            LlmUsage llmUsage,
-            ResponseContractResult contractResult,
-            long firstSubstantiveTokenMs,
-            long firstRenderedTokenMs,
-            boolean safePrefixApplied,
-            int heldBackChars,
-            MemoryContextResult memoryContextResult,
-            InputJudgeResult inputJudgeResult) {
+    private Map<String, Object> buildTrace(PolicyDecision decision, TurnObservation obs) {
 
         Map<String, Object> l1Flags = new LinkedHashMap<>();
-        l1Flags.put("crisis_keyword", l1Result.hardCrisis());
-        l1Flags.put("crisis_unverified", l1Result.hardCrisisUnverified());
+        l1Flags.put("crisis_keyword", obs.l1Result().hardCrisis());
+        l1Flags.put("crisis_unverified", obs.l1Result().hardCrisisUnverified());
         // 어떤 맥락 마커가 강등을 유발했는지 남긴다. 마커 종류만 기록하므로 발화 원문은 포함되지 않는다.
         // 이게 없으면 어느 마커가 오탐·미탐을 만드는지 사후 분석하려면 재현밖에 방법이 없다.
-        l1Result.signals().stream()
+        obs.l1Result().signals().stream()
                 .filter(signal -> signal.startsWith(CRISIS_MARKER_PREFIX))
                 .map(signal -> signal.substring(CRISIS_MARKER_PREFIX.length()))
                 .findFirst()
                 .ifPresent(marker -> l1Flags.put("crisis_context_marker", marker));
-        l1Flags.put("risk_candidate", l1Result.riskCandidate());
-        l1Flags.put("emotion_spike", l1Result.emotionSpike());
-        l1Flags.put("repetitive_negative", l1Result.repetitiveNegative());
-        l1Flags.put("dependency_phrase", l1Result.dependencyHint());
-        l1Flags.put("moderation_flagged", l1Result.moderationFlagged());
+        l1Flags.put("risk_candidate", obs.l1Result().riskCandidate());
+        l1Flags.put("emotion_spike", obs.l1Result().emotionSpike());
+        l1Flags.put("repetitive_negative", obs.l1Result().repetitiveNegative());
+        l1Flags.put("dependency_phrase", obs.l1Result().dependencyHint());
+        l1Flags.put("moderation_flagged", obs.l1Result().moderationFlagged());
 
         Map<String, Object> trace = new LinkedHashMap<>();
         trace.put("schema_version", SCHEMA_VERSION);
-        trace.put("l0_flagged", moderation.flagged());
+        trace.put("l0_flagged", obs.moderation().flagged());
         // l0_flagged=false 가 "안전 판정"인지 "판정을 못 받아온 것"인지 구분한다.
         // 이게 없으면 안전 계층 하나가 통째로 빠진 채 처리된 턴을 사후에 식별할 수 없다 (이슈 #263).
-        trace.put("l0_resolved", moderation.resolved());
+        trace.put("l0_resolved", obs.moderation().resolved());
         // 정책 결정이 실제로 읽은 L0 상태. 위 raw 값과 달리 이 값은 전달 방식의 하한을 만든다 (이슈 #294).
         trace.put("l0_status", decision.moderationStatus().name());
-        trace.put("l0_category_scores", moderation.categoryScores());
-        putSecurityEvidence(trace, securityAssessment);
+        trace.put("l0_category_scores", obs.moderation().categoryScores());
+        putSecurityEvidence(trace, obs.securityAssessment());
         // 강등된 위기 후보의 해제 스위치 입력값 (이슈 #505). 이 값이 없으면 그 경로가
         // 프로덕션에서 발동했는지 사후에 확인할 수 없다. 해제 여부 자체는
         // l1_flags.crisis_unverified 와 action 으로 도출되므로 별도 필드를 만들지 않는다 —
         // 정책 판단을 로거에 복제하지 않는다.
-        trace.put("crisis_attribution", crisisAttribution(inputJudgeResult));
+        trace.put("crisis_attribution", crisisAttribution(obs.inputJudgeResult()));
         trace.put("l1_flags", l1Flags);
-        trace.put("l1_combined_confidence", l1Result.combinedConfidence());
-        trace.put("l1_threshold_source", l1ThresholdSource != null ? l1ThresholdSource : "default");
-        trace.put("input_judge_called", inputJudgeCalled);
+        trace.put("l1_combined_confidence", obs.l1Result().combinedConfidence());
+        trace.put("l1_threshold_source", obs.l1ThresholdSource() != null ? obs.l1ThresholdSource() : "default");
+        trace.put("input_judge_called", obs.inputJudgeCalled());
         trace.put("input_judge_status", decision.judgeStatus().name());
         trace.put("risk_level", decision.riskLevel() != null ? decision.riskLevel().name() : null);
-        trace.put("safety_profile_cache_hit", safetyProfileCacheHit);
+        trace.put("safety_profile_cache_hit", obs.safetyProfileCacheHit());
         // 근거 조회에 실패해 보수적 기본값으로 채운 프로파일인지 (이슈 #261).
         // 위기 이력을 확인하지 못한 턴은 임계값·force_judge 가 실제 이력과 무관하게 결정된다.
-        trace.put("safety_profile_degraded", safetyProfileDegraded);
-        trace.put("memory_cache_hit", memoryCache.fallbackUsed());
+        trace.put("safety_profile_degraded", obs.safetyProfileDegraded());
+        trace.put("memory_cache_hit", obs.memoryCache().fallbackUsed());
         // 폴백이 주입한 문맥의 나이 (이슈 #522). 폴백을 쓰지 않은 턴과 나이를 읽지 못한 턴이
         // 둘 다 null 로 나오는데, 그 구별은 memory_cache_hit 이 한다 — 그래서 두 값을 한
         // 객체로 묶었다. 0 으로 적지 않는다: "방금 구운 문맥" 과 뭉개져 관측을 낙관하게 만든다.
-        trace.put("context_staleness_ms", memoryCache.stalenessMs());
+        trace.put("context_staleness_ms", obs.memoryCache().stalenessMs());
         // 검색이 실패한 턴과 "관련 기억이 없는" 턴을 구분한다 (이슈 #364, §10.1).
         //   retrieval_status == null      → 이 턴은 검색을 돌리지 않았다 (호환 오버로드 경로)
         //   OK                            → 계획한 소스가 전부 응답했다. 결과가 비어도 정상이다
@@ -242,21 +146,21 @@ public class AiDecisionLogger {
         //   FAILED                        → 컨텍스트 조립 자체가 실패했다
         // 이 값이 없으면 DB 장애로 기억 없이 생성된 턴이 신규 사용자와 완전히 동일하게 보인다.
         trace.put("retrieval_status",
-                memoryContextResult != null ? memoryContextResult.status().name() : null);
+                obs.memoryContext() != null ? obs.memoryContext().status().name() : null);
         trace.put("retrieval_failed_sources",
-                memoryContextResult != null ? memoryContextResult.failedSourcesLabel() : null);
+                obs.memoryContext() != null ? obs.memoryContext().failedSourcesLabel() : null);
         // 소스가 아니라 계획이 어긋난 경우. 이력 조회에 실패해 검색 계획을 추측으로 세웠다는 뜻이라,
         // 실패한 소스가 하나도 없는데 PARTIAL 인 이유가 여기 남는다.
         trace.put("retrieval_plan_degraded",
-                memoryContextResult != null ? memoryContextResult.planDegraded() : null);
+                obs.memoryContext() != null ? obs.memoryContext().planDegraded() : null);
         // LLM 관련 필드는 전부 null 이 될 수 있고, null 은 각각 다른 뜻이다.
-        //   llmUsage == null              → 이 턴은 LLM 을 호출하지 않았다 (보안 거절·위기·폴백)
-        //   llmUsage.resolved() == false  → 호출했지만 사용량을 받지 못했다
+        //   obs.llmUsage() == null              → 이 턴은 LLM 을 호출하지 않았다 (보안 거절·위기·폴백)
+        //   obs.llmUsage().resolved() == false  → 호출했지만 사용량을 받지 못했다
         //   cost == null                  → 사용량을 모르거나 단가 미등록 모델이다
         // 이전에는 세 경우 모두 model="gpt-4o", cost=0.0 으로 하드코딩돼 있어서
         // "비용이 0" 과 "비용을 모른다" 가 구분되지 않았고, LLM 을 부르지도 않은 턴까지
         // gpt-4o 를 쓴 것처럼 기록됐다.
-        trace.put("llm_model", llmUsage != null ? llmUsage.model() : null);
+        trace.put("llm_model", obs.llmUsage() != null ? obs.llmUsage().model() : null);
         // 지연은 세 지점을 따로 잰다 (이슈 #306, 14번 검증 리뷰 지적 E). 하나로 재면 서버가
         // 먼저 보내는 문구만으로도 수치가 좋아져 "지연 개선"과 "지연 은폐"를 구분할 수 없다.
         //   llm_ttft_ms                — 첫 생성 토큰
@@ -264,30 +168,30 @@ public class AiDecisionLogger {
         //   first_rendered_token_ms    — 사용자가 무언가를 보기까지
         // 검토된 safe prefix 가 나간 턴에서만 뒤의 두 값이 갈라진다 (P0-4). prefix 가 없는
         // 턴에서 값이 갈라지면 배선이 틀렸다는 뜻이다 — 사용자가 먼저 볼 것이 없기 때문이다.
-        trace.put("llm_ttft_ms", ttftMs >= 0 ? ttftMs : null);
+        trace.put("llm_ttft_ms", obs.llmTtftMs() >= 0 ? obs.llmTtftMs() : null);
         trace.put("first_substantive_token_ms",
-                firstSubstantiveTokenMs >= 0 ? firstSubstantiveTokenMs : null);
+                obs.firstSubstantiveTokenMs() >= 0 ? obs.firstSubstantiveTokenMs() : null);
         trace.put("first_rendered_token_ms",
-                firstRenderedTokenMs >= 0 ? firstRenderedTokenMs : null);
+                obs.firstRenderedTokenMs() >= 0 ? obs.firstRenderedTokenMs() : null);
         // 이 턴에 서버가 검토된 첫 문장을 먼저 보냈는지. 두 지연 값의 차이를 해석하려면
         // 차이의 원인이 함께 있어야 한다.
-        trace.put("safe_prefix_applied", safePrefixApplied);
+        trace.put("safe_prefix_applied", obs.safePrefixApplied());
         // 생성됐지만 위반으로 전달되지 않은 문자 수. 전달 정책의 비용과 효과를 함께 보여준다.
-        trace.put("delivery_held_back_chars", heldBackChars);
-        trace.put("llm_usage_resolved", llmUsage != null ? llmUsage.resolved() : null);
-        trace.put("llm_prompt_tokens", resolvedTokens(llmUsage, LlmUsage::promptTokens));
-        trace.put("llm_completion_tokens", resolvedTokens(llmUsage, LlmUsage::completionTokens));
-        trace.put("llm_cost_usd", costUsd(llmUsage));
+        trace.put("delivery_held_back_chars", obs.heldBackChars());
+        trace.put("llm_usage_resolved", obs.llmUsage() != null ? obs.llmUsage().resolved() : null);
+        trace.put("llm_prompt_tokens", resolvedTokens(obs.llmUsage(), LlmUsage::promptTokens));
+        trace.put("llm_completion_tokens", resolvedTokens(obs.llmUsage(), LlmUsage::completionTokens));
+        trace.put("llm_cost_usd", costUsd(obs.llmUsage()));
         trace.put("delivery_mode", decision.deliveryMode().name().toLowerCase());
         // 응답 계약 (이슈 #303). 계약 위반과 의미 판단 실패를 나눠 기록해야 둘의 비율을 볼 수 있다.
         ResponsePlan plan = decision.responsePlan();
         trace.put("response_act", plan.responseAct().name());
         trace.put("generation_freedom", plan.generationFreedom().name());
-        trace.put("contract_result", contractResult != null
-                ? contractResult.logValue() : ResponseContractResult.notApplicable().logValue());
-        trace.put("contract_violations", contractResult != null ? contractResult.violations() : List.of());
-        OutputPreFilterResult preFilterResult = outputGuard.preFilter();
-        OutputJudgeResult outputJudgeResult = outputGuard.judge();
+        trace.put("contract_result", obs.contractResult() != null
+                ? obs.contractResult().logValue() : ResponseContractResult.notApplicable().logValue());
+        trace.put("contract_violations", obs.contractResult() != null ? obs.contractResult().violations() : List.of());
+        OutputPreFilterResult preFilterResult = obs.outputGuard().preFilter();
+        OutputJudgeResult outputJudgeResult = obs.outputGuard().judge();
         trace.put("output_pre_filter_result", preFilterResult != null
                 ? (preFilterResult.passed() ? "PASS" : "FAIL") : null);
         trace.put("output_pre_filter_fail_reasons", preFilterResult != null
@@ -297,14 +201,14 @@ public class AiDecisionLogger {
         // 판정자가 고쳐 쓴 본문이 다시 위반이어서 거부됐는가 (이슈 #526). 이 값이 없으면
         // "판정이 고쳐 썼다" 와 "고쳐 쓴 것이 다시 위반이었다" 를 구분할 수 없고, 그러면
         // 재검증이 실제로 발동하는지 알 수 없다.
-        trace.put("rewrite_rejected", outputGuard.rewriteRejected());
+        trace.put("rewrite_rejected", obs.outputGuard().rewriteRejected());
         // action 만으로는 "위험하다고 판정해서 REPLACE" 와 "판정을 못 받아서 REPLACE" 가
         // 구별되지 않는다 (이슈 #364). Input Judge 의 judge_status 와 같은 계약이다.
         //   SKIPPED   → Judge 를 부르지 않았다 (pre-filter 통과)
         //   SUCCEEDED → 판정을 받았다
         //   FAILED    → 예외·타임아웃·파싱 실패. 동작은 REPLACE 지만 판정은 없다
         trace.put("output_judge_status", outputJudgeStatus(outputJudgeResult));
-        trace.put("crisis_flow_triggered", crisisFlowTriggered);
+        trace.put("crisis_flow_triggered", obs.crisisFlowTriggered());
         // 위기 진입 경로. 이게 없으면 "왜 위기로 갔는지"를 사후에 알 수 없고, 특히 자해 질의가
         // 거절이 아니라 위기로 라우팅됐는지 확인할 방법이 없다. 조작 시도 쪽은 action 이
         // SECURITY_REFUSAL 로 남으므로 별도 필드가 필요 없다 (이슈 #260).
@@ -312,9 +216,9 @@ public class AiDecisionLogger {
         // PolicyDecision 이 아니라 실제로 적용된 경로를 기록한다. 출력 가드가 승격시킨 위기는
         // decision.action() 이 GENERATE 라 결정에 경로가 없고, decision 만 보면 위기로 갔는데도
         // crisis_trigger 가 null 로 남는다.
-        trace.put("crisis_trigger", appliedCrisisTrigger != null
-                ? appliedCrisisTrigger.name() : null);
-        trace.put("total_pipeline_ms", totalMs);
+        trace.put("crisis_trigger", obs.appliedCrisisTrigger() != null
+                ? obs.appliedCrisisTrigger().name() : null);
+        trace.put("total_pipeline_ms", obs.totalPipelineMs());
 
         return trace;
     }

--- a/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
+++ b/src/main/java/com/mio/ai/orchestrator/ConversationOrchestrator.java
@@ -696,15 +696,28 @@ public class ConversationOrchestrator {
                     firstRenderedMs,
                     heldBackChars,
                     resolveFinishedReason(finishedReasonRef));
-            decisionLogger.log(userId, sessionId, decision, moderation, l1Result,
-                    securityAssessment, totalMs, llmTtftMs, crisisFlowTriggered,
-                    inputJudgeCalled,
-                    new OutputGuardOutcome(preFilterResult, judgeActionResult, rewriteRejected.get()),
-                    profile.source(), safetyProfileCacheHit, memoryCache,
-                    profile.degraded(), appliedCrisisTrigger, llmUsage, contractResult,
-                    firstSubstantiveTokenMs.get(), firstRenderedMs,
-                    firstRenderedTokenMs.get() >= 0, heldBackChars, liveMemoryResult,
-                    judgeResult);  // InputJudge 판정 — trace 의 crisis_attribution 근거
+            decisionLogger.log(userId, sessionId, decision,
+                    TurnObservation.builder(moderation, l1Result, securityAssessment, totalMs)
+                            .l1ThresholdSource(profile.source())
+                            .inputJudgeCalled(inputJudgeCalled)
+                            // InputJudge 판정 — trace 의 crisis_attribution 근거
+                            .inputJudgeResult(judgeResult)
+                            .safetyProfileCacheHit(safetyProfileCacheHit)
+                            .safetyProfileDegraded(profile.degraded())
+                            .memoryCache(memoryCache)
+                            .memoryContext(liveMemoryResult)
+                            .llmTtftMs(llmTtftMs)
+                            .firstSubstantiveTokenMs(firstSubstantiveTokenMs.get())
+                            .firstRenderedTokenMs(firstRenderedMs)
+                            .safePrefixApplied(firstRenderedTokenMs.get() >= 0)
+                            .outputGuard(new OutputGuardOutcome(
+                                    preFilterResult, judgeActionResult, rewriteRejected.get()))
+                            .contractResult(contractResult)
+                            .heldBackChars(heldBackChars)
+                            .llmUsage(llmUsage)
+                            .crisisFlowTriggered(crisisFlowTriggered)
+                            .appliedCrisisTrigger(appliedCrisisTrigger)
+                            .build());
 
             emitter.complete();
 

--- a/src/main/java/com/mio/ai/orchestrator/TurnObservation.java
+++ b/src/main/java/com/mio/ai/orchestrator/TurnObservation.java
@@ -1,0 +1,143 @@
+package com.mio.ai.orchestrator;
+
+import com.mio.ai.crisis.CrisisTrigger;
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.llm.LlmUsage;
+import com.mio.ai.memory.retrieval.MemoryContextResult;
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.plan.ResponseContractResult;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.security.SecurityAssessment;
+
+/**
+ * 한 턴에서 관측된 값들 — {@link AiDecisionLogger} 가 {@code trace} 로 적재하는 입력 전부.
+ *
+ * <p>이전에는 이 값들이 {@code log()} 의 위치 인자 24개였다. {@code boolean} 과 {@code long} 이
+ * 연속으로 붙는 구간이 있어 <b>순서를 바꿔도 컴파일이 통과했고</b>, 잘못된 값이 조용히 적재됐다.
+ * 관측값은 사후 분석의 유일한 근거라 틀려도 그 자리에서 드러나지 않는다 — 타입이 아니라 이름으로
+ * 묶어야 하는 이유다.
+ *
+ * <p>{@link Builder} 로만 만든다. 호출부는 채우는 값만 적고 나머지는 기본값을 받는다.
+ * 기본값은 "그 일이 일어나지 않았음"을 뜻하며, "모름"과 구별해야 하는 값들은 기본값이
+ * {@code null} 이다 — {@link AiDecisionLogger} 가 그 구별을 트레이스에 그대로 옮긴다.
+ */
+public record TurnObservation(
+
+        // --- 안전 판정 입력 ---
+        ModerationResult moderation,
+        SafetyL1Result l1Result,
+        /** L1 임계값의 출처. {@code null} 이면 {@code "default"} 로 적재된다. */
+        String l1ThresholdSource,
+        SecurityAssessment securityAssessment,
+        boolean inputJudgeCalled,
+        /** 판정 결과. {@code null} 은 "귀속 없음"이 아니라 "판정 부재"다. */
+        InputJudgeResult inputJudgeResult,
+        boolean safetyProfileCacheHit,
+        boolean safetyProfileDegraded,
+
+        // --- 기억 ---
+        MemoryCacheOutcome memoryCache,
+        /** {@code null} 이면 이 턴은 검색을 돌리지 않았다 — 실패와 구별된다. */
+        MemoryContextResult memoryContext,
+
+        // --- 지연 (셋을 함께 읽어야 의미가 있다, 이슈 #306) ---
+        long totalPipelineMs,
+        /** 첫 생성 토큰. 재지 않았으면 음수. */
+        long llmTtftMs,
+        /** 승인되어 실제로 전달된 첫 콘텐츠. 재지 않았으면 음수. */
+        long firstSubstantiveTokenMs,
+        /** 사용자가 무언가를 보기까지. 재지 않았으면 음수. */
+        long firstRenderedTokenMs,
+        /** 서버가 검토된 첫 문장을 먼저 보냈는가 — 위 두 값이 갈리는 이유다. */
+        boolean safePrefixApplied,
+
+        // --- 전달·출력 ---
+        OutputGuardOutcome outputGuard,
+        ResponseContractResult contractResult,
+        /** 생성됐지만 위반으로 전달되지 않은 문자 수. */
+        int heldBackChars,
+
+        // --- 생성 결과 ---
+        /** {@code null} 이면 이 턴은 LLM 을 호출하지 않았다 — 사용량 미확인과 구별된다. */
+        LlmUsage llmUsage,
+        boolean crisisFlowTriggered,
+        /** 실제로 적용된 위기 경로. {@code PolicyDecision} 이 아니라 실행 결과를 따라간다. */
+        CrisisTrigger appliedCrisisTrigger
+) {
+
+    public static Builder builder(ModerationResult moderation,
+                                  SafetyL1Result l1Result,
+                                  SecurityAssessment securityAssessment,
+                                  long totalPipelineMs) {
+        return new Builder(moderation, l1Result, securityAssessment, totalPipelineMs);
+    }
+
+    /**
+     * 안전 판정 입력과 총 소요시간은 어느 턴에나 있으므로 생성 시점에 받고,
+     * 나머지는 해당하는 턴만 채운다.
+     */
+    public static final class Builder {
+
+        private final ModerationResult moderation;
+        private final SafetyL1Result l1Result;
+        private final SecurityAssessment securityAssessment;
+        private final long totalPipelineMs;
+
+        private String l1ThresholdSource;
+        private boolean inputJudgeCalled;
+        private InputJudgeResult inputJudgeResult;
+        private boolean safetyProfileCacheHit;
+        private boolean safetyProfileDegraded;
+        private MemoryCacheOutcome memoryCache = MemoryCacheOutcome.live();
+        private MemoryContextResult memoryContext;
+        private long llmTtftMs = -1;
+        private long firstSubstantiveTokenMs = -1;
+        private long firstRenderedTokenMs = -1;
+        private boolean safePrefixApplied;
+        private OutputGuardOutcome outputGuard =
+                OutputGuardOutcome.preFilterOnly(OutputPreFilterResult.pass());
+        private ResponseContractResult contractResult = ResponseContractResult.notApplicable();
+        private int heldBackChars;
+        private LlmUsage llmUsage;
+        private boolean crisisFlowTriggered;
+        private CrisisTrigger appliedCrisisTrigger;
+
+        private Builder(ModerationResult moderation, SafetyL1Result l1Result,
+                        SecurityAssessment securityAssessment, long totalPipelineMs) {
+            this.moderation = moderation;
+            this.l1Result = l1Result;
+            this.securityAssessment = securityAssessment;
+            this.totalPipelineMs = totalPipelineMs;
+        }
+
+        public Builder l1ThresholdSource(String v) { this.l1ThresholdSource = v; return this; }
+        public Builder inputJudgeCalled(boolean v) { this.inputJudgeCalled = v; return this; }
+        public Builder inputJudgeResult(InputJudgeResult v) { this.inputJudgeResult = v; return this; }
+        public Builder safetyProfileCacheHit(boolean v) { this.safetyProfileCacheHit = v; return this; }
+        public Builder safetyProfileDegraded(boolean v) { this.safetyProfileDegraded = v; return this; }
+        public Builder memoryCache(MemoryCacheOutcome v) { this.memoryCache = v; return this; }
+        public Builder memoryContext(MemoryContextResult v) { this.memoryContext = v; return this; }
+        public Builder llmTtftMs(long v) { this.llmTtftMs = v; return this; }
+        public Builder firstSubstantiveTokenMs(long v) { this.firstSubstantiveTokenMs = v; return this; }
+        public Builder firstRenderedTokenMs(long v) { this.firstRenderedTokenMs = v; return this; }
+        public Builder safePrefixApplied(boolean v) { this.safePrefixApplied = v; return this; }
+        public Builder outputGuard(OutputGuardOutcome v) { this.outputGuard = v; return this; }
+        public Builder contractResult(ResponseContractResult v) { this.contractResult = v; return this; }
+        public Builder heldBackChars(int v) { this.heldBackChars = v; return this; }
+        public Builder llmUsage(LlmUsage v) { this.llmUsage = v; return this; }
+        public Builder crisisFlowTriggered(boolean v) { this.crisisFlowTriggered = v; return this; }
+        public Builder appliedCrisisTrigger(CrisisTrigger v) { this.appliedCrisisTrigger = v; return this; }
+
+        public TurnObservation build() {
+            return new TurnObservation(
+                    moderation, l1Result, l1ThresholdSource, securityAssessment,
+                    inputJudgeCalled, inputJudgeResult, safetyProfileCacheHit, safetyProfileDegraded,
+                    memoryCache, memoryContext,
+                    totalPipelineMs, llmTtftMs, firstSubstantiveTokenMs, firstRenderedTokenMs,
+                    safePrefixApplied,
+                    outputGuard, contractResult, heldBackChars,
+                    llmUsage, crisisFlowTriggered, appliedCrisisTrigger);
+        }
+    }
+}

--- a/src/test/java/com/mio/admin/service/AdminReactionRetentionServiceIntegrationTest.java
+++ b/src/test/java/com/mio/admin/service/AdminReactionRetentionServiceIntegrationTest.java
@@ -1,13 +1,12 @@
 package com.mio.admin.service;
 
 import com.mio.admin.dto.ReactionRetentionResponse;
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -21,8 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * <p>LATERAL 조인 같은 DB 함수 의존 로직은 mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class AdminReactionRetentionServiceIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/cost/AiCostEventRepositoryIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/AiCostEventRepositoryIntegrationTest.java
@@ -1,11 +1,10 @@
 package com.mio.ai.cost;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -19,8 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * SUM(cost_usd)가 단가 미등록(cost_usd=null) 이벤트를 조용히 건너뛰어 부분 합계를
  * 완전한 합계처럼 보이게 하는 문제를 막는지 실제 DB에 대해 검증한다 (이슈 #431 리뷰).
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class AiCostEventRepositoryIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/AllocationSensitivityCalculatorIntegrationTest.java
@@ -1,12 +1,11 @@
 package com.mio.ai.cost;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.YearMonth;
@@ -22,8 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
  * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class AllocationSensitivityCalculatorIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/cost/InfraCostAllocatorIntegrationTest.java
@@ -1,12 +1,11 @@
 package com.mio.ai.cost;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -23,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>{@code EXTRACT(EPOCH FROM (ended_at - started_at))} 같은 DB 함수 의존 로직은
  * mock으로는 검증이 안 돼 실제 Postgres에 대해 돌린다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class InfraCostAllocatorIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/crisis/CrisisFlowStateStoreIntegrationTest.java
+++ b/src/test/java/com/mio/ai/crisis/CrisisFlowStateStoreIntegrationTest.java
@@ -1,22 +1,20 @@
 package com.mio.ai.crisis;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class CrisisFlowStateStoreIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/EmbeddingWorkerIntegrationTest.java
@@ -1,16 +1,15 @@
 package com.mio.ai.memory.consolidation;
 
 import com.mio.ai.llm.OpenAiLlmClient;
+import com.mio.support.MioIntegrationTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,8 +33,7 @@ import static org.mockito.Mockito.when;
  * claim 단계의 UPDATE ... SET embedding_status = 'processing' 자체가
  * DataIntegrityViolationException으로 실패한다 → 이 테스트가 RED가 된다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class EmbeddingWorkerIntegrationTest {
 
     private static final int EMBEDDING_DIM = 1536;

--- a/src/test/java/com/mio/ai/memory/consolidation/WeeklyReflectionMemoryStatusIntegrationTest.java
+++ b/src/test/java/com/mio/ai/memory/consolidation/WeeklyReflectionMemoryStatusIntegrationTest.java
@@ -1,12 +1,11 @@
 package com.mio.ai.memory.consolidation;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -24,8 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@code processUser} 의 동의 게이트는 <b>전체 철회</b>만 막으므로 개별 기억 단위 통제는
  * 이 쿼리의 필터가 유일한 방어선이다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class WeeklyReflectionMemoryStatusIntegrationTest {
 
     private static final String ACTIVE_TRIGGER = "work_stress";

--- a/src/test/java/com/mio/ai/memory/retrieval/SensitivityCapTest.java
+++ b/src/test/java/com/mio/ai/memory/retrieval/SensitivityCapTest.java
@@ -1,0 +1,89 @@
+package com.mio.ai.memory.retrieval;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 민감도 cap 판정의 진리표를 고정한다.
+ *
+ * <p>이 술어는 사용자가 비공개로 표시한 기억이 프롬프트로 나가는지를 가르는 마지막 관문이고,
+ * 틀려도 예외가 아니라 <b>조용한 유출</b>로 나타난다. 검색 랭커와 컨텍스트 새니타이저가
+ * 각자 복사본을 들고 있던 동안 이 표를 검증하는 테스트가 하나도 없었다.
+ */
+class SensitivityCapTest {
+
+    @Nested
+    @DisplayName("cap 이 restricted 면")
+    class RestrictedCap {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"normal", "sensitive", "restricted"})
+        @DisplayName("모든 민감도를 통과시킨다")
+        void allowsEverything(String sensitivity) {
+            assertThat(SensitivityCap.allows("restricted", sensitivity)).isTrue();
+        }
+    }
+
+    @Nested
+    @DisplayName("cap 이 sensitive 면")
+    class SensitiveCap {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"normal", "sensitive"})
+        @DisplayName("restricted 를 제외한 나머지를 통과시킨다")
+        void allowsUpToSensitive(String sensitivity) {
+            assertThat(SensitivityCap.allows("sensitive", sensitivity)).isTrue();
+        }
+
+        @Test
+        @DisplayName("restricted 는 막는다")
+        void blocksRestricted() {
+            assertThat(SensitivityCap.allows("sensitive", "restricted")).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("cap 이 normal 이거나 모르는 값이면")
+    class NormalOrUnknownCap {
+
+        @ParameterizedTest
+        @CsvSource({
+                "normal,  normal,     true",
+                "normal,  sensitive,  false",
+                "normal,  restricted, false",
+                // 모르는 cap 은 가장 좁게 해석한다 — 오타가 권한 상승이 되면 안 된다.
+                "'',      sensitive,  false",
+                "unknown, sensitive,  false",
+                "unknown, normal,     true",
+        })
+        @DisplayName("normal 만 통과시킨다")
+        void allowsOnlyNormal(String cap, String sensitivity, boolean expected) {
+            assertThat(SensitivityCap.allows(cap, sensitivity)).isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("null 처리")
+    class NullHandling {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"normal", "sensitive", "restricted"})
+        @DisplayName("cap 이 null 이면 아무것도 통과시키지 않는다 (fail-closed)")
+        void nullCapBlocksEverything(String sensitivity) {
+            assertThat(SensitivityCap.allows(null, sensitivity)).isFalse();
+        }
+
+        @Test
+        @DisplayName("민감도가 null 이면 normal 로 본다")
+        void nullSensitivityIsNormal() {
+            assertThat(SensitivityCap.allows("normal", null)).isTrue();
+            assertThat(SensitivityCap.allows("restricted", null)).isTrue();
+        }
+    }
+}

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionLoggerTest.java
@@ -65,25 +65,13 @@ class AiDecisionLoggerTest {
                 JudgeStatus.SKIPPED
         );
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                false,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                decision.crisisTrigger(),
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -125,25 +113,14 @@ class AiDecisionLoggerTest {
                 JudgeStatus.SUCCEEDED
         );
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.manipulation(List.of("규칙을 잊고")),
-                100,
-                10,
-                false,
-                true,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                decision.crisisTrigger(),
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.manipulation(List.of("규칙을 잊고")), 100)
+                        .llmTtftMs(10)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -195,33 +172,15 @@ class AiDecisionLoggerTest {
                         DeliveryMode.CAUTIOUS_SPECULATIVE, false, CrisisAttribution.THIRD_PARTY),
                 0.8);
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                new SafetyL1Result(false, true, true, false, false, false, false,
-                        List.of("crisis_keyword:죽고싶다", "crisis_context_marker:third_person"), 0.6),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                true,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                MemoryCacheOutcome.live(),
-                false,
-                decision.crisisTrigger(),
-                null,
-                ResponseContractResult.notApplicable(),
-                -1,
-                -1,
-                false,
-                0,
-                null,
-                judgeResult
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), new SafetyL1Result(false, true, true, false, false, false, false, List.of("crisis_keyword:죽고싶다", "crisis_context_marker:third_person"), 0.6), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .inputJudgeResult(judgeResult)
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -252,13 +211,13 @@ class AiDecisionLoggerTest {
                 JudgeStatus.SKIPPED
         );
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(), SecurityAssessment.clean(),
-                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -282,14 +241,14 @@ class AiDecisionLoggerTest {
     void logDoesNotPersistSelfHarmInquiryLabels() {
         PolicyDecision decision = crisisDecision("pd_selfharm");
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘", "단계별 자해 방법")),
-                100, 10, true, false, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘", "단계별 자해 방법")), 100)
+                        .llmTtftMs(10)
+                        .crisisFlowTriggered(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         String trace = capturedTrace();
         assertThat(trace)
@@ -316,14 +275,13 @@ class AiDecisionLoggerTest {
     void logKeepsSecurityEvidenceNullWhenAssessmentAbsent() {
         PolicyDecision decision = generateDecision("pd_no_assessment");
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                null,
-                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), null, 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         assertThat(capturedTrace())
                 .contains("\"security_rule_level\":null")
@@ -339,14 +297,14 @@ class AiDecisionLoggerTest {
     void logPinsUnverifiableByJudgeValue() {
         PolicyDecision decision = generateDecision("pd_unverifiable");
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.suspicious(List.of("역할극"), true),
-                100, 10, false, true, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.suspicious(List.of("역할극"), true), 100)
+                        .llmTtftMs(10)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         assertThat(capturedTrace())
                 .as("원문에서만 드러난 근거가 있었는지는 Judge CLEAN 강등을 사후 판정하는 값이다")
@@ -365,13 +323,13 @@ class AiDecisionLoggerTest {
     void logPinsSecurityTraceKeySet() {
         PolicyDecision decision = generateDecision("pd_schema");
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(), SecurityAssessment.clean(),
-                100, 10, false, false, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         String trace = capturedTrace();
         assertThat(trace)
@@ -398,15 +356,14 @@ class AiDecisionLoggerTest {
     void logKeepsObfuscationSignalsButCountsLabels() {
         PolicyDecision decision = generateDecision("pd_obfuscation");
 
-        logger.log(
-                UUID.randomUUID(), UUID.randomUUID(), decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.suspicious(
-                        List.of("역할극", "zero_width_char", "obfuscated_input"), true),
-                100, 10, false, true, new OutputGuardOutcome(null, null, false), "default",
-                false, false, false, decision.crisisTrigger(), null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.suspicious( List.of("역할극", "zero_width_char", "obfuscated_input"), true), 100)
+                        .llmTtftMs(10)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         String trace = capturedTrace();
         assertThat(trace)
@@ -444,25 +401,14 @@ class AiDecisionLoggerTest {
                 JudgeStatus.SKIPPED
         );
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘")),
-                100,
-                10,
-                true,
-                false,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                decision.crisisTrigger(),
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.selfHarmInquiry(List.of("자살 방법 알려줘")), 100)
+                        .llmTtftMs(10)
+                        .crisisFlowTriggered(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(decision.crisisTrigger())
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -501,25 +447,14 @@ class AiDecisionLoggerTest {
         );
         assertThat(generateDecision.crisisTrigger()).isNull();
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                generateDecision,
-                new ModerationResult(false, Map.of(), Map.of()),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                true,
-                false,
-                new OutputGuardOutcome(OutputPreFilterResult.pass(), null, false),
-                "default",
-                false,
-                false,
-                false,
-                CrisisTrigger.OUTPUT_GUARD,
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), generateDecision,
+                TurnObservation.builder(new ModerationResult(false, Map.of(), Map.of()), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .crisisFlowTriggered(true)
+                        .outputGuard(new OutputGuardOutcome(OutputPreFilterResult.pass(), null, false))
+                        .l1ThresholdSource("default")
+                        .appliedCrisisTrigger(CrisisTrigger.OUTPUT_GUARD)
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -545,25 +480,13 @@ class AiDecisionLoggerTest {
     void logPersistsUnresolvedSafetySignals() {
         PolicyDecision decision = generateDecision("pd_degraded");
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                ModerationResult.failOpen(),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                false,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                true,
-                null,
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(ModerationResult.failOpen(), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .safetyProfileDegraded(true)
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -579,25 +502,12 @@ class AiDecisionLoggerTest {
     void logMarksResolvedModeration() {
         PolicyDecision decision = generateDecision("pd_ok");
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                ModerationResult.clear(),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                false,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                null,
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(ModerationResult.clear(), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -612,25 +522,13 @@ class AiDecisionLoggerTest {
     void logPersistsFailedInputJudgeStatus() {
         PolicyDecision decision = failedJudgeDecision("pd_judge_failed");
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                ModerationResult.clear(),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                true,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                null,
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(ModerationResult.clear(), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());
@@ -771,32 +669,13 @@ class AiDecisionLoggerTest {
     }
 
     private void logWithFailureState(OutputJudgeResult judgeResult, MemoryContextResult memoryResult) {
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                generateDecision("pd_failure_state"),
-                ModerationResult.clear(),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                false,
-                new OutputGuardOutcome(OutputPreFilterResult.pass(), judgeResult, false),
-                "default",
-                false,
-                MemoryCacheOutcome.live(),
-                false,
-                null,
-                null,
-                ResponseContractResult.notApplicable(),
-                -1,
-                -1,
-                false,
-                0,
-                memoryResult,
-                null
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), generateDecision("pd_failure_state"),
+                TurnObservation.builder(ModerationResult.clear(), SafetyL1Result.clear(), SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(OutputPreFilterResult.pass(), judgeResult, false))
+                        .l1ThresholdSource("default")
+                        .memoryContext(memoryResult)
+                        .build());
     }
 
     /** 위기 확정 결정 (이슈 #510 축). */
@@ -829,21 +708,13 @@ class AiDecisionLoggerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 generateDecision("pd_llm"),
-                ModerationResult.clear(),
-                SafetyL1Result.clear(),
-                SecurityAssessment.clean(),
-                100,
-                10,
-                false,
-                false,
-                new OutputGuardOutcome(null, null, false),
-                "default",
-                false,
-                false,
-                false,
-                null,
-                usage
-        );
+                TurnObservation.builder(ModerationResult.clear(), SafetyL1Result.clear(),
+                                SecurityAssessment.clean(), 100)
+                        .llmTtftMs(10)
+                        .outputGuard(new OutputGuardOutcome(null, null, false))
+                        .l1ThresholdSource("default")
+                        .llmUsage(usage)
+                        .build());
     }
 
     private LlmPricingProperties pricedProperties() {

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionTraceSnapshotTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionTraceSnapshotTest.java
@@ -128,40 +128,26 @@ class AiDecisionTraceSnapshotTest {
                 JudgeStatus.SUCCEEDED
         );
 
-        logger.log(
-                UUID.randomUUID(),
-                UUID.randomUUID(),
-                decision,
-                new ModerationResult(true, Map.of("self_harm", true), Map.of("self_harm", 0.91)),
-                new SafetyL1Result(false, true, true, true, false, false, true,
-                        List.of("crisis_context_marker:third_person"), 0.72),
-                SecurityAssessment.suspicious(List.of("zero_width_char"), true),
-                1830,
-                320,
-                true,
-                true,
-                new OutputGuardOutcome(
-                        OutputPreFilterResult.fail(List.of("banned_phrase")),
-                        OutputJudgeResult.rewrite("고쳐 쓴 본문"),
-                        true),
-                "profile",
-                true,
-                MemoryCacheOutcome.fallback(4200L),
-                true,
-                CrisisTrigger.L1_KEYWORD,
-                LlmUsage.of("gpt-5", 1200, 150),
-                ResponseContractResult.violated(List.of("too_long")),
-                410,
-                180,
-                true,
-                37,
-                MemoryContextResult.partial("기억", Set.of(RetrievalSource.VECTOR_EPISODE), true),
-                new InputJudgeResult(
-                        SecurityVerdict.clean(),
-                        new RiskVerdict(RiskLevel.MEDIUM, List.of(), GenerationMode.SUPPORTIVE,
-                                DeliveryMode.CAUTIOUS_SPECULATIVE, false, CrisisAttribution.THIRD_PARTY),
-                        0.8)
-        );
+        logger.log(UUID.randomUUID(), UUID.randomUUID(), decision,
+                TurnObservation.builder(new ModerationResult(true, Map.of("self_harm", true), Map.of("self_harm", 0.91)), new SafetyL1Result(false, true, true, true, false, false, true, List.of("crisis_context_marker:third_person"), 0.72), SecurityAssessment.suspicious(List.of("zero_width_char"), true), 1830)
+                        .llmTtftMs(320)
+                        .crisisFlowTriggered(true)
+                        .inputJudgeCalled(true)
+                        .outputGuard(new OutputGuardOutcome( OutputPreFilterResult.fail(List.of("banned_phrase")), OutputJudgeResult.rewrite("고쳐 쓴 본문"), true))
+                        .l1ThresholdSource("profile")
+                        .safetyProfileCacheHit(true)
+                        .memoryCache(MemoryCacheOutcome.fallback(4200L))
+                        .safetyProfileDegraded(true)
+                        .appliedCrisisTrigger(CrisisTrigger.L1_KEYWORD)
+                        .llmUsage(LlmUsage.of("gpt-5", 1200, 150))
+                        .contractResult(ResponseContractResult.violated(List.of("too_long")))
+                        .firstSubstantiveTokenMs(410)
+                        .firstRenderedTokenMs(180)
+                        .safePrefixApplied(true)
+                        .heldBackChars(37)
+                        .memoryContext(MemoryContextResult.partial("기억", Set.of(RetrievalSource.VECTOR_EPISODE), true))
+                        .inputJudgeResult(new InputJudgeResult( SecurityVerdict.clean(), new RiskVerdict(RiskLevel.MEDIUM, List.of(), GenerationMode.SUPPORTIVE, DeliveryMode.CAUTIOUS_SPECULATIVE, false, CrisisAttribution.THIRD_PARTY), 0.8))
+                        .build());
 
         ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
         verify(repository).save(captor.capture());

--- a/src/test/java/com/mio/ai/orchestrator/AiDecisionTraceSnapshotTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/AiDecisionTraceSnapshotTest.java
@@ -1,0 +1,174 @@
+package com.mio.ai.orchestrator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mio.ai.crisis.CrisisTrigger;
+import com.mio.ai.domain.AiPolicyDecision;
+import com.mio.ai.judge.CrisisAttribution;
+import com.mio.ai.judge.InputJudgeResult;
+import com.mio.ai.judge.OutputJudgeResult;
+import com.mio.ai.judge.OutputPreFilterResult;
+import com.mio.ai.judge.RiskLevel;
+import com.mio.ai.judge.RiskVerdict;
+import com.mio.ai.judge.SecurityVerdict;
+import com.mio.ai.llm.LlmCostCalculator;
+import com.mio.ai.llm.LlmPricingProperties;
+import com.mio.ai.llm.LlmUsage;
+import com.mio.ai.memory.retrieval.MemoryContextResult;
+import com.mio.ai.memory.retrieval.RetrievalSource;
+import com.mio.ai.moderation.ModerationResult;
+import com.mio.ai.plan.ResponseContractResult;
+import com.mio.ai.policy.DecisionAction;
+import com.mio.ai.policy.DeliveryMode;
+import com.mio.ai.policy.GenerationMode;
+import com.mio.ai.policy.InterventionHints;
+import com.mio.ai.policy.JudgeStatus;
+import com.mio.ai.policy.PolicyDecision;
+import com.mio.ai.repository.AiPolicyDecisionRepository;
+import com.mio.ai.safety.SafetyL1Result;
+import com.mio.ai.security.SecurityAssessment;
+import com.mio.ai.security.SecurityLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+/**
+ * {@code ai_policy_decisions.trace} 의 JSON 출력을 통째로 고정한다.
+ *
+ * <p>이 컬럼은 운영이 안전 판정을 사후 분석하는 유일한 근거다. 키 이름이 바뀌거나 순서가
+ * 흔들리면 대시보드와 쿼리가 조용히 어긋나므로, 개별 필드가 아니라 <b>문자열 전체</b>를 비교한다.
+ *
+ * <p>로거 리팩터링(이슈 #543)의 안전망으로 먼저 추가했다. 파라미터를 객체로 묶는 변경이
+ * 출력에 손대지 않았음을 이 테스트 하나로 증명한다. 값이 바뀌어야 하는 변경이라면
+ * 여기 기대값을 <b>의도적으로</b> 갱신하고, 무엇이 왜 바뀌는지 커밋에 남긴다.
+ */
+class AiDecisionTraceSnapshotTest {
+
+    private final AiPolicyDecisionRepository repository = mock(AiPolicyDecisionRepository.class);
+    private final AiDecisionLogger logger = new AiDecisionLogger(
+            repository, new ObjectMapper(), new LlmCostCalculator(new LlmPricingProperties()));
+
+    /**
+     * 모든 키가 기본값이 아닌 값을 갖도록 최대로 채운 턴. 필드가 누락되면 스냅샷이 달라진다.
+     */
+    private static final String EXPECTED_TRACE = """
+            {\
+            "schema_version":"v2.5",\
+            "l0_flagged":true,\
+            "l0_resolved":true,\
+            "l0_status":"RESOLVED",\
+            "l0_category_scores":{"self_harm":0.91},\
+            "security_rule_level":"SUSPICIOUS",\
+            "attack_kind":"NONE",\
+            "security_obfuscation_signals":["zero_width_char"],\
+            "security_pattern_label_count":0,\
+            "security_evidence_unverifiable_by_judge":true,\
+            "crisis_attribution":"THIRD_PARTY",\
+            "l1_flags":{"crisis_keyword":false,"crisis_unverified":true,"crisis_context_marker":"third_person","risk_candidate":true,"emotion_spike":true,"repetitive_negative":false,"dependency_phrase":false,"moderation_flagged":true},\
+            "l1_combined_confidence":0.72,\
+            "l1_threshold_source":"profile",\
+            "input_judge_called":true,\
+            "input_judge_status":"SUCCEEDED",\
+            "risk_level":"MEDIUM",\
+            "safety_profile_cache_hit":true,\
+            "safety_profile_degraded":true,\
+            "memory_cache_hit":true,\
+            "context_staleness_ms":4200,\
+            "retrieval_status":"PARTIAL",\
+            "retrieval_failed_sources":"VECTOR_EPISODE",\
+            "retrieval_plan_degraded":true,\
+            "llm_model":"gpt-5",\
+            "llm_ttft_ms":320,\
+            "first_substantive_token_ms":410,\
+            "first_rendered_token_ms":180,\
+            "safe_prefix_applied":true,\
+            "delivery_held_back_chars":37,\
+            "llm_usage_resolved":true,\
+            "llm_prompt_tokens":1200,\
+            "llm_completion_tokens":150,\
+            "llm_cost_usd":null,\
+            "delivery_mode":"cautious_speculative",\
+            "response_act":"UNPLANNED",\
+            "generation_freedom":"OPEN",\
+            "contract_result":"VIOLATED",\
+            "contract_violations":["too_long"],\
+            "output_pre_filter_result":"FAIL",\
+            "output_pre_filter_fail_reasons":["banned_phrase"],\
+            "output_judge_action":"REWRITE",\
+            "rewrite_rejected":true,\
+            "output_judge_status":"SUCCEEDED",\
+            "crisis_flow_triggered":true,\
+            "crisis_trigger":"L1_KEYWORD",\
+            "total_pipeline_ms":1830}""";
+
+    @Test
+    @DisplayName("완전히 채운 턴의 trace JSON 이 키 이름·순서·값까지 고정되어 있다")
+    void traceJsonIsStable() {
+        PolicyDecision decision = new PolicyDecision(
+                "pd_snapshot",
+                DecisionAction.GENERATE,
+                GenerationMode.SUPPORTIVE,
+                DeliveryMode.CAUTIOUS_SPECULATIVE,
+                SecurityLevel.SUSPICIOUS,
+                true,
+                true,
+                true,
+                InterventionHints.empty(),
+                "snapshot-policy",
+                RiskLevel.MEDIUM,
+                CrisisTrigger.L1_KEYWORD,
+                JudgeStatus.SUCCEEDED
+        );
+
+        logger.log(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                decision,
+                new ModerationResult(true, Map.of("self_harm", true), Map.of("self_harm", 0.91)),
+                new SafetyL1Result(false, true, true, true, false, false, true,
+                        List.of("crisis_context_marker:third_person"), 0.72),
+                SecurityAssessment.suspicious(List.of("zero_width_char"), true),
+                1830,
+                320,
+                true,
+                true,
+                new OutputGuardOutcome(
+                        OutputPreFilterResult.fail(List.of("banned_phrase")),
+                        OutputJudgeResult.rewrite("고쳐 쓴 본문"),
+                        true),
+                "profile",
+                true,
+                MemoryCacheOutcome.fallback(4200L),
+                true,
+                CrisisTrigger.L1_KEYWORD,
+                LlmUsage.of("gpt-5", 1200, 150),
+                ResponseContractResult.violated(List.of("too_long")),
+                410,
+                180,
+                true,
+                37,
+                MemoryContextResult.partial("기억", Set.of(RetrievalSource.VECTOR_EPISODE), true),
+                new InputJudgeResult(
+                        SecurityVerdict.clean(),
+                        new RiskVerdict(RiskLevel.MEDIUM, List.of(), GenerationMode.SUPPORTIVE,
+                                DeliveryMode.CAUTIOUS_SPECULATIVE, false, CrisisAttribution.THIRD_PARTY),
+                        0.8)
+        );
+
+        ArgumentCaptor<AiPolicyDecision> captor = ArgumentCaptor.forClass(AiPolicyDecision.class);
+        verify(repository).save(captor.capture());
+
+        assertThat(captor.getValue().getTrace())
+                .as("trace 는 운영 분석의 유일한 근거다 — 키·순서·값이 바뀌면 쿼리가 조용히 어긋난다")
+                .isEqualTo(EXPECTED_TRACE);
+    }
+
+}

--- a/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/ConversationOrchestratorContractIntegrationTest.java
@@ -16,6 +16,7 @@ import com.mio.ai.plan.ResponseAct;
 import com.mio.session.domain.MessageTurn;
 import com.mio.session.service.SessionMessagePersistenceService;
 import com.mio.ai.support.RecordingSseEmitter;
+import com.mio.support.MioIntegrationTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
@@ -24,10 +25,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
@@ -50,8 +49,7 @@ import static org.mockito.Mockito.when;
  * 있는지</b>는 검증된 적이 없다. trace 필드는 이슈 {@code #305}(계약 준수율 실측)의
  * 입력이므로, 여기가 틀리면 그쪽 결과 전체가 무의미해진다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class ConversationOrchestratorContractIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/orchestrator/CrisisFixedFlowOrchestratorIntegrationTest.java
+++ b/src/test/java/com/mio/ai/orchestrator/CrisisFixedFlowOrchestratorIntegrationTest.java
@@ -8,16 +8,15 @@ import com.mio.ai.llm.OpenAiLlmClient;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.moderation.ModerationResult;
 import com.mio.common.crypto.MessageEncryptor;
+import com.mio.support.MioIntegrationTest;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.util.UUID;
@@ -32,8 +31,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class CrisisFixedFlowOrchestratorIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/ai/qa/QaProductPathReplayTest.java
+++ b/src/test/java/com/mio/ai/qa/QaProductPathReplayTest.java
@@ -10,18 +10,17 @@ import com.mio.ai.moderation.ModerationResult;
 import com.mio.ai.moderation.OpenAiModerationClient;
 import com.mio.ai.orchestrator.ConversationOrchestrator;
 import com.mio.ai.support.RecordingSseEmitter;
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -61,8 +60,7 @@ import static org.mockito.Mockito.when;
  * <p>fixture 형식과 추가 절차는 {@code src/test/resources/qa/fixtures/README.md},
  * {@code docs/qa/04_제품경로_회귀게이트.md} 참조.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 @DisplayName("[QA] 제품 경로 회귀 게이트 — fixture 재생")
 class QaProductPathReplayTest {
 

--- a/src/test/java/com/mio/auth/AuthIntegrationTest.java
+++ b/src/test/java/com/mio/auth/AuthIntegrationTest.java
@@ -6,15 +6,14 @@ import com.mio.auth.dto.LoginRequest;
 import com.mio.auth.dto.SocialUserInfo;
 import com.mio.auth.provider.AppleAuthProvider;
 import com.mio.auth.provider.KakaoAuthProvider;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
@@ -26,9 +25,8 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@MioIntegrationTest
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 class AuthIntegrationTest {
 
     @Autowired MockMvc mockMvc;

--- a/src/test/java/com/mio/config/SchedulingDisabledIntegrationTest.java
+++ b/src/test/java/com/mio/config/SchedulingDisabledIntegrationTest.java
@@ -1,16 +1,15 @@
 package com.mio.config;
 
 import com.mio.session.job.StaleSummarySweepJob;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.job.DataRetentionJob;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor;
 import org.springframework.scheduling.config.ScheduledTaskHolder;
-import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,8 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 동시에 잡 빈은 그대로 주입되어야 한다 — {@code StaleSummarySweepIntegrationTest} 처럼
  * {@code run()} 을 직접 부르는 테스트 방식이 계속 동작해야 하기 때문이다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class SchedulingDisabledIntegrationTest {
 
     @Autowired private ApplicationContext applicationContext;

--- a/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/consent/MemoryConsentGateIntegrationTest.java
@@ -10,14 +10,13 @@ import com.mio.ai.memory.consolidation.SessionEndedEvent;
 import com.mio.common.crypto.MessageEncryptor;
 import com.mio.memorycontrol.service.MemoryControlService;
 import com.mio.report.domain.ReportWeek;
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
@@ -40,8 +39,7 @@ import static org.mockito.Mockito.when;
  * 않아야 하고, LLM 호출 자체가 일어나지 않아야 한다. LLM 을 부른 뒤에 버리는 것은 게이트가
  * 아니다 — 사용자의 대화 원문이 이미 외부로 나간 뒤다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class MemoryConsentGateIntegrationTest {
 
     private static final long WAIT_TIMEOUT_MS = 15_000;

--- a/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
+++ b/src/test/java/com/mio/memorycontrol/service/MemoryControlIntegrationTest.java
@@ -13,13 +13,12 @@ import com.mio.memorycontrol.dto.MemoryItemResponse;
 import com.mio.memorycontrol.dto.MemoryListResponse;
 import com.mio.memorycontrol.dto.MemoryUpdateRequest;
 import com.mio.memorycontrol.dto.MemoryUpdateResponse;
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -37,8 +36,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  * 않아야 하고(회수율 0), 동의 철회 후 기존 기억이 전부 비활성화돼야 한다. 검색기가 하나라도
  * 필터를 빼먹으면 사용자가 지운 기억이 다음 턴 프롬프트에 되살아난다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class MemoryControlIntegrationTest {
 
     private static final String SUMMARY_TEXT = "프로젝트 발표를 망쳤다고 걱정함. 파국화 패턴이 관찰됨.";

--- a/src/test/java/com/mio/notification/repository/NotificationSettingRepositoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/repository/NotificationSettingRepositoryIntegrationTest.java
@@ -1,19 +1,18 @@
 package com.mio.notification.repository;
 
 import com.mio.notification.domain.NotificationSetting;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,8 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 컬럼 매핑이 어긋나도 서비스 단위 테스트는 그대로 통과한다. 탈퇴자에게 푸시가 나가는 것은
  * 개인정보 처리 정지 위반이므로 쿼리 자체를 실행해서 확인한다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class NotificationSettingRepositoryIntegrationTest {
 
     @Autowired private NotificationSettingRepository notificationSettingRepository;

--- a/src/test/java/com/mio/notification/repository/ProactiveCareLogRepositoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/repository/ProactiveCareLogRepositoryIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.mio.notification.repository;
 
 import com.mio.notification.domain.ProactiveCareLog;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -8,9 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -34,8 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *   <li>{@code NO_DEVICE}·{@code UNCONFIRMED} 가 {@code notification_status} CHECK 제약을 통과한다 (V55)</li>
  * </ul>
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class ProactiveCareLogRepositoryIntegrationTest {
 
     private static final String TRIGGER_CODE = "checkin_reminder_morning";

--- a/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/DeviceTokenIntegrityIntegrationTest.java
@@ -4,6 +4,7 @@ import com.mio.common.error.BusinessException;
 import com.mio.common.error.ErrorCode;
 import com.mio.notification.dto.DeviceTokenRegisterRequest;
 import com.mio.notification.dto.StaleDeviceTokenUserResponse;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -11,11 +12,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StreamUtils;
 
 import java.nio.charset.StandardCharsets;
@@ -49,8 +48,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
  *   <li>유효 토큰 0개 유저 집계는 JPQL {@code having} 절이라 문법이 어긋나도 컴파일은 통과한다.</li>
  * </ul>
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class DeviceTokenIntegrityIntegrationTest {
 
     private static final String MIGRATION_PATH = "db/migration/V54__dedupe_device_tokens.sql";

--- a/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
+++ b/src/test/java/com/mio/notification/service/NotificationHistoryIntegrationTest.java
@@ -4,6 +4,7 @@ import com.mio.notification.domain.ProactiveCareLog;
 import com.mio.notification.dto.NotificationHistoryItemResponse;
 import com.mio.notification.dto.NotificationHistoryResponse;
 import com.mio.notification.repository.ProactiveCareLogRepository;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -11,9 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -39,8 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>가장 중요한 회귀 가드는 <b>{@code FAILED} 가 남아 있는 것</b>이다. 명세가 이력 화면의
  * {@code FAILED} 표시를 규정하고 있으므로 과필터링은 그 자체가 계약 위반이다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class NotificationHistoryIntegrationTest {
 
     private static final String TRIGGER_CODE = "checkin_reminder_morning";

--- a/src/test/java/com/mio/session/job/MessageTurnSweepIntegrationTest.java
+++ b/src/test/java/com/mio/session/job/MessageTurnSweepIntegrationTest.java
@@ -1,13 +1,12 @@
 package com.mio.session.job;
 
+import com.mio.support.MioIntegrationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -23,8 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * 통과한다 — 그러면 검증하려던 대상(커밋이 실제로 일어나는가)을 그대로 통과시킨다.
  * {@code #356} 후속 작업에서 확인된 형태다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class MessageTurnSweepIntegrationTest {
 
     @Autowired

--- a/src/test/java/com/mio/session/repository/StaleSummarySweepIntegrationTest.java
+++ b/src/test/java/com/mio/session/repository/StaleSummarySweepIntegrationTest.java
@@ -3,6 +3,7 @@ package com.mio.session.repository;
 import com.mio.session.domain.Session;
 import com.mio.session.domain.SummaryStatus;
 import com.mio.session.job.StaleSummarySweepJob;
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.User;
 import com.mio.user.repository.UserRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -10,9 +11,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -34,8 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  *       Job 을 호출하고, 테스트에 트랜잭션을 걸지 않는다.</li>
  * </ul>
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class StaleSummarySweepIntegrationTest {
 
     @Autowired private StaleSummarySweepJob staleSummarySweepJob;

--- a/src/test/java/com/mio/support/MioIntegrationTest.java
+++ b/src/test/java/com/mio/support/MioIntegrationTest.java
@@ -1,0 +1,52 @@
+package com.mio.support;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 실 PostgreSQL·Redis 를 쓰는 통합 테스트의 공통 부트스트랩.
+ *
+ * <h2>{@code APP_ENCRYPTION_KEY} 를 여기서 다시 선언하는 이유</h2>
+ *
+ * <p>같은 키가 {@code application-integration-test.yml} 에도 있다. 중복처럼 보이지만
+ * <b>지우면 로컬 빌드가 깨진다</b> — 프로파일 yml 로는 이길 수 없는 상위 프로퍼티 소스가
+ * 하나 있기 때문이다.
+ *
+ * <p>{@code build.gradle.kts} 는 개발자의 {@code .env} 를 읽어 테스트 JVM 의 <b>환경 변수</b>로
+ * 주입한다. Spring 의 우선순위에서 환경 변수는 프로파일 yml 보다 위이므로, 개발자의 실제
+ * {@code APP_ENCRYPTION_KEY} 가 테스트용 키를 덮어쓴다. 그 값이 base64 가 아니거나 32바이트가
+ * 아니면 {@code AesGcmMessageEncryptor} 생성자가 터지고, 증상은 암호화 오류가 아니라
+ * <b>Spring 컨텍스트 로드 실패</b>로 나타난다 — 원인을 찾기 어려운 형태다.
+ *
+ * <p>{@code @SpringBootTest(properties = ...)} 는 그 환경 변수보다 우선하는 유일한 선언 지점이라
+ * 여기 남는다. CI 에는 {@code .env} 가 없어 yml 만으로도 통과하므로, 이 방어는 <b>로컬 전용</b>으로
+ * 보이지만 로컬에서만 깨지는 것이야말로 놓치기 쉬운 종류다.
+ *
+ * <p>값을 바꿔야 한다면 이 파일과 {@code application-integration-test.yml} 을 <b>함께</b> 고친다.
+ * 둘이 어긋나면 컨텍스트 캐시가 갈라져 통합 테스트가 컨텍스트를 재기동하고 빌드가 느려진다.
+ *
+ * <h2>쓰지 않는 경우</h2>
+ *
+ * <p>프로퍼티 우선순위 자체를 검증하는 테스트({@code SchedulingCannotBeReEnabledByTestPropertyTest})는
+ * 이 어노테이션을 쓰지 않는다. 검증 대상을 공용 어노테이션 뒤로 숨기면 그 테스트가 무엇을
+ * 주장하는지 읽을 수 없게 된다.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+@SpringBootTest(properties = MioIntegrationTest.ENCRYPTION_KEY_PROPERTY)
+@ActiveProfiles("integration-test")
+public @interface MioIntegrationTest {
+
+    /** {@code application-integration-test.yml} 의 같은 키와 반드시 동일한 값을 유지한다. */
+    String ENCRYPTION_KEY_PROPERTY =
+            "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+}

--- a/src/test/java/com/mio/support/MioIntegrationTestKeyConsistencyTest.java
+++ b/src/test/java/com/mio/support/MioIntegrationTestKeyConsistencyTest.java
@@ -1,0 +1,57 @@
+package com.mio.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link MioIntegrationTest} 의 키와 {@code application-integration-test.yml} 의 키가
+ * 갈라지지 않도록 고정한다.
+ *
+ * <p>둘이 어긋나도 테스트는 통과한다 — 어노테이션 쪽이 이기기 때문이다. 대신 통합 테스트마다
+ * 프로퍼티 조합이 달라져 Spring 컨텍스트 캐시가 갈라지고 빌드만 느려진다. 그래서 증상이
+ * 아니라 값 자체를 여기서 붙들어 둔다.
+ */
+class MioIntegrationTestKeyConsistencyTest {
+
+    private static final String YML = "application-integration-test.yml";
+
+    @Test
+    @DisplayName("메타 어노테이션의 암호화 키가 integration-test 프로파일 yml 값과 같다")
+    void annotationKeyMatchesProfileYml() throws Exception {
+        String annotationValue = MioIntegrationTest.ENCRYPTION_KEY_PROPERTY.split("=", 2)[1];
+        String ymlValue = readYmlKey();
+
+        assertThat(annotationValue)
+                .as("어긋나면 통합 테스트가 컨텍스트를 두 벌 띄운다 — 둘을 함께 고쳐야 한다")
+                .isEqualTo(ymlValue);
+    }
+
+    @Test
+    @DisplayName("암호화 키는 32바이트로 디코드되는 base64 여야 한다")
+    void keyDecodesTo32Bytes() {
+        String annotationValue = MioIntegrationTest.ENCRYPTION_KEY_PROPERTY.split("=", 2)[1];
+
+        assertThat(Base64.getDecoder().decode(annotationValue))
+                .as("AesGcmMessageEncryptor 가 32바이트를 요구한다 — 아니면 컨텍스트 로드가 실패한다")
+                .hasSize(32);
+    }
+
+    private String readYmlKey() throws Exception {
+        try (InputStream in = getClass().getClassLoader().getResourceAsStream(YML)) {
+            assertThat(in).as(YML + " 을 클래스패스에서 찾지 못했다").isNotNull();
+            String text = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+            return text.lines()
+                    .filter(line -> line.startsWith("APP_ENCRYPTION_KEY:"))
+                    .map(line -> line.split(":", 2)[1].trim())
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError(
+                            YML + " 에 APP_ENCRYPTION_KEY 가 없다"));
+        }
+    }
+}

--- a/src/test/java/com/mio/todo/service/TodoTimezoneIntegrationTest.java
+++ b/src/test/java/com/mio/todo/service/TodoTimezoneIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.mio.todo.service;
 
 import com.mio.common.AppConstants;
+import com.mio.support.MioIntegrationTest;
 import com.mio.todo.domain.BehaviorTask;
 import com.mio.todo.dto.TodoResponse;
 import com.mio.todo.repository.BehaviorTaskRepository;
@@ -12,9 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
@@ -33,8 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>Mockito 기반 {@link TodoServiceTest}는 createdAt을 리플렉션으로 직접 주입해 DB
  * 왕복 자체가 없으므로 이 문제를 못 잡는다 — 실제 Postgres에 저장 후 재조회해야 재현된다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class TodoTimezoneIntegrationTest {
 
     @Autowired private TodoService todoService;

--- a/src/test/java/com/mio/user/controller/DataDeletionSecurityIntegrationTest.java
+++ b/src/test/java/com/mio/user/controller/DataDeletionSecurityIntegrationTest.java
@@ -1,14 +1,13 @@
 package com.mio.user.controller;
 
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.service.DataDeletionService;
 import com.mio.user.service.DataDeletionStatusRateLimiter;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Optional;
@@ -19,9 +18,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
+@MioIntegrationTest
 @AutoConfigureMockMvc
-@ActiveProfiles("integration-test")
 class DataDeletionSecurityIntegrationTest {
 
     @Autowired private MockMvc mockMvc;

--- a/src/test/java/com/mio/user/service/DataDeletionIntegrationTest.java
+++ b/src/test/java/com/mio/user/service/DataDeletionIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.mio.user.service;
 
+import com.mio.support.MioIntegrationTest;
 import com.mio.user.domain.DataDeletionRequest;
 import com.mio.user.domain.DeletionStatus;
 import com.mio.user.job.DataRetentionJob;
@@ -9,10 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -30,8 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>{@code @Transactional} 을 쓰지 않는다. 앰비언트 트랜잭션 안에서 확인하면 커밋되지
  * 않은 상태를 보게 되고, Redis 는 애초에 트랜잭션 밖이라 시점이 어긋난다.
  */
-@SpringBootTest(properties = "APP_ENCRYPTION_KEY=AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=")
-@ActiveProfiles("integration-test")
+@MioIntegrationTest
 class DataDeletionIntegrationTest {
 
     @Autowired


### PR DESCRIPTION
## 요약

유지보수·가독성 전수조사에서 나온 항목 중 **동작 변경이 없고 설계 제약과 충돌하지 않는 3건**만 정리한다.
지적 항목 8건 중 5건은 의도적 설계이거나 DB·기술 제약에 묶여 있어 제외했고, 그 근거는 #543 본문에 남겼다.

세 건 모두 오케스트레이터 분해(후속 이슈)의 사전 작업 성격을 가진다.

## 관련 이슈

- Closes #543

## 변경 사항

**A. `AiDecisionLogger` 파라미터 객체화** (`1028370`)
- `log()` 위치 인자 24개 → `log(userId, sessionId, decision, observation)` 4개. `buildTrace` 22개 → 2개.
- 오버로드 3개 → 1개. "기존 호출부 호환용" 주석이 붙어 있었지만 **프로덕션 호출은 24-arg 하나뿐**이었고 나머지 둘은 테스트 전용이었다. 빌더 기본값이 그 역할을 대신한다.
- `AiDecisionLogger` 412 → 320줄.

**B. 민감도 판정 술어 통합** (`2d52bd5`)
- `FusionRanker` · `ContextSanitizer` 가 문자 단위로 동일한 `isWithinCap` 을 각자 들고 있었고, 두 복사본이 서로를 주석으로 참조하며 수동 동기화되고 있었다 → `SensitivityCap.allows` 하나로.
- 진리표를 검증하는 테스트가 **하나도 없어서** 16건을 함께 추가했다.

**C. 통합테스트 부트스트랩 통합** (`18b2375`)
- 23개 파일이 복붙하던 `@SpringBootTest(properties = ...)` + `@ActiveProfiles` 두 줄 → `@MioIntegrationTest` 한 줄.

**안전망** (`2b149df`) — A 이전에 먼저 넣었다.
- `ai_policy_decisions.trace` 의 JSON 35개 키를 **문자열 전체로** 비교하는 스냅샷 테스트. 기존 테스트는 개별 필드를 `contains` 로만 봐서 키 순서가 흔들리거나 필드가 빠지는 변경을 잡지 못했다.

## 영향 범위

- [ ] API 스펙 또는 응답 형식이 변경됩니다.
- [ ] DB 스키마 또는 데이터 마이그레이션이 포함됩니다.
- [ ] 환경 변수 또는 외부 설정 변경이 필요합니다.
- [ ] 배치 / 스케줄러 / 비동기 처리에 영향이 있습니다.
- [x] 로깅 / 모니터링 포인트가 변경됩니다.
- [ ] **안전 판정 경로**(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)가 바뀝니다.
- [ ] Breaking change 가 있습니다.

**로깅 항목에 체크한 이유와, 체크했지만 값은 안 바뀐다는 점:**
`trace` 를 **만드는 코드**가 바뀌었으므로 관측성을 보는 사람이 이 PR 을 봐야 한다. 다만 **출력은 바이트 단위로 동일**하고, 그 사실을 `AiDecisionTraceSnapshotTest` 가 증명한다. 대시보드·쿼리 수정은 필요 없다.

**안전 판정 경로에 체크하지 않은 이유:**
B 가 민감도 cap 을 다루지만, 템플릿이 열거한 다섯 컴포넌트(SafetyL1 / InputJudge / PolicyEngine / OutputPreFilter / OutputJudge)는 **한 줄도 바뀌지 않았다.** 바뀐 것은 검색 랭킹(`FusionRanker`)과 컨텍스트 조립(`ContextSanitizer`)이고, 판정 진리표는 동일하다. 그래도 성격상 민감하므로 아래 중점 리뷰 포인트에 따로 적었다.

## 테스트

### 실행 커맨드

```bash
./gradlew build
```

> 로컬 `mio` DB 는 develop 마이그레이션 체계와 어긋나 있어(아래 참고) 별도 DB 로 돌렸다:
> ```bash
> docker exec mio-postgres psql -U mio -d postgres -c "CREATE DATABASE mio_pr543 OWNER mio;"
> SPRING_DATASOURCE_URL="jdbc:postgresql://localhost:5432/mio_pr543" ./gradlew build
> ```

### 확인 내용

- **1824 tests, 0 failures.** 리팩터링 전 베이스라인 1805 건 전부 그대로 통과하고, 신규 19건(스냅샷 1 · 진리표 16 · 키 일치 가드 2)이 더해졌다. **기존 테스트의 기대값은 하나도 고치지 않았다.**
- `trace` JSON 무변경: `AiDecisionTraceSnapshotTest` 가 모든 키를 비기본값으로 채운 턴 하나의 출력을 문자열 전체로 비교한다. A 커밋 전후로 동일하다.
- 키 일치 가드가 실제로 잡는지 확인: `MioIntegrationTest` 의 키를 일부러 어긋뜨려 RED 를 확인한 뒤 되돌렸다.

## 중점 리뷰 포인트

1. **`SensitivityCap.allows` 의 인자 순서가 뒤집혔다.** 기존 `isWithinCap(sensitivity, cap)` → 새 `allows(cap, sensitivity)`. 둘 다 `String` 이라 **바꿔 넣어도 컴파일이 통과한다.** 두 호출 지점(`FusionRanker:30`, `ContextSanitizer:28`)이 맞게 들어갔는지 봐 주면 좋겠다. `SensitivityCapTest` 가 진리표를 잡고 있어 뒤집히면 실패하긴 한다.

2. **null cap 동작이 호출부마다 다른 것은 의도다.** `FusionRanker` 는 cap 을 그대로 넘겨 fail-closed(전부 제외)이고, `ContextSanitizer` 는 기존대로 넘기기 전에 `normal` 로 정규화한다. 이 차이는 리팩터링 전에도 있었고 그대로 보존했다 — 술어만 합치고 정책은 건드리지 않았다.

3. **`ContextSanitizer` 의 계층 방어는 유지된다.** 호출 지점을 하나로 합치지 않고 양쪽에 남겼다. 프롬프트 직전 마지막 관문이라는 **위치**가 방어의 실체이기 때문이다.

4. **`TurnObservation` 빌더 기본값의 의미.** 기본값은 "그 일이 일어나지 않았음"이다. "모름"과 구별해야 하는 값(`llmUsage` · `memoryContext` · `inputJudgeResult`)은 기본값을 `null` 로 두어 기존 트레이스 규약(`null` = 판정/호출 부재)을 유지했다. 이 구별이 깨지면 "LLM 을 안 불렀다"와 "사용량을 못 받았다"가 뭉개진다.

5. `normal | sensitive | restricted` 리터럴은 DB `CHECK` 제약값(V8 · V9 · V22 · V78)이라 그대로 뒀다. enum 화는 #219 계열 사고 위험이 있어 별도 이슈로 미뤘다.

## 배포 / 롤백

- **Rollout:** 일반 배포. 스키마·설정·API 변경 없음. 마이그레이션 없음.
- **Rollback:** 커밋 revert 만으로 충분하다. 영속 상태를 바꾸지 않으므로 되돌릴 데이터가 없다.

## 후속 작업

- `HybridReranker`(현재 `codex/context-intelligence-eval` 에만 있는 신규 파일)가 `isWithinCap` **세 번째 복사본**을 들고 온다. 그 브랜치가 머지될 때 `SensitivityCap.allows` 를 쓰도록 바꿔야 한다.
- 제외한 5건(오케스트레이터 분해 · Consolidator 단계 헬퍼 · ContextPreWarmer · DAO 추출 · sensitivity enum)은 각각의 설계 제약과 함께 #543 에 근거를 남겼다. 오케스트레이터는 최근 6개월 70커밋으로 변경빈도 1위라 값이 가장 크지만, `@Transactional` 0건 제약 때문에 별도 이슈가 맞다.
- **로컬 개발 환경 참고:** 로컬 `mio` DB 는 feature 브랜치 체계(V88)로 만들어져 있고 develop 은 `V58_1` + 최대 V77 이라, develop 기준 통합테스트가 `messages.message_kind` 누락으로 135건 실패한다. 이 PR 의 문제가 아니라 로컬 flyway 이력 어긋남이다.

## 체크리스트

- [x] 변경 의도와 영향 범위를 스스로 검토했습니다.
- [x] 필요한 테스트를 추가하거나, 불필요한 이유를 명시했습니다.
- [x] 관련 테스트 또는 검증을 직접 수행했습니다.
- [x] API / DB / 설정 변경이 있다면 문서나 마이그레이션 내용을 반영했습니다. (해당 변경 없음)
- [x] 시크릿이나 민감한 정보가 포함되지 않았습니다.
- [ ] (hotfix 인 경우) 같은 수정을 develop 에도 반영했습니다.
